### PR TITLE
Do not wipe last_fqdn out in each iteration

### DIFF
--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -355,6 +355,7 @@ static xmlNodePtr ds_rds_add_ai_from_xccdf_results(xmlDocPtr doc, xmlNodePtr ass
 
 	xmlNodePtr test_result_child = test_result->children;
 
+	xmlNodePtr last_fqdn = NULL;
 	for (; test_result_child != NULL; test_result_child = test_result_child->next)
 	{
 		if (test_result_child->type != XML_ELEMENT_NODE)
@@ -363,7 +364,6 @@ static xmlNodePtr ds_rds_add_ai_from_xccdf_results(xmlDocPtr doc, xmlNodePtr ass
 		// Order for the output to be valid:
 		// 1) All fqdn-s
 		// 2) All hostnames
-		xmlNodePtr last_fqdn = NULL;
 		if (strcmp((const char*)(test_result_child->name), "target") == 0)
 		{
 			// content is a full copy


### PR DESCRIPTION
Addressing coverity findings:
1. openscap-1.1.0/src/DS/rds.c:366:assignment – Assigning: "last_fqdn" = "NULL".
2. openscap-1.1.0/src/DS/rds.c:374:null – At condition "last_fqdn", the value of "last_fqdn" must be NULL.
3. openscap-1.1.0/src/DS/rds.c:374:dead_error_condition – The condition "!last_fqdn" must be true.
4. openscap-1.1.0/src/DS/rds.c:378:dead_error_line – Execution cannot reach this statement "xmlAddNextSibling(last_fqdn...".
