### PR TITLE
Plug a memory leak.

### DIFF
--- a/src/OVAL/probes/SEAP/seap-packet.c
+++ b/src/OVAL/probes/SEAP/seap-packet.c
@@ -730,6 +730,7 @@ eloop_exit:
                         } else {
                                 SEXP_list_free (sexp_buffer);
                                 SEXP_psetup_free (psetup);
+				SEXP_free(sexp_buffer);
                                 dI("eloop_restart\n");
                                 goto eloop_start;
                         }
@@ -763,6 +764,7 @@ eloop_exit:
                                         SEXP_psetup_free (psetup);
                                         SEXP_pstate_free (pstate);
                                 }
+                                SEXP_free(sexp_buffer);
                                 return (-1);
                         }
                 }
@@ -777,6 +779,7 @@ eloop_exit:
 			dI("Invalid SEAP packet received: %s.\n", "not a list");
 
 			SEXP_free (sexp_packet);
+			SEXP_free (sexp_buffer);
 
 			errno = EINVAL;
 			return (-1);
@@ -784,6 +787,7 @@ eloop_exit:
 			dI("Invalid SEAP packet received: %s.\n", "list length < 2");
 
 			SEXP_free (sexp_packet);
+			SEXP_free (sexp_buffer);
 
 			errno = EINVAL;
 			return (-1);
@@ -796,6 +800,7 @@ eloop_exit:
 
 			SEXP_free (psym_sexp);
 			SEXP_free (sexp_packet);
+			SEXP_free (sexp_buffer);
 
 			errno = EINVAL;
 			return (-1);
@@ -804,6 +809,7 @@ eloop_exit:
 
 			SEXP_free (psym_sexp);
 			SEXP_free (sexp_packet);
+			SEXP_free (sexp_buffer);
 
 			errno = EINVAL;
 			return (-1);
@@ -812,6 +818,7 @@ eloop_exit:
 
 			SEXP_free (psym_sexp);
 			SEXP_free (sexp_packet);
+			SEXP_free (sexp_buffer);
 
 			errno = EINVAL;
 			return (-1);
@@ -835,6 +842,7 @@ eloop_exit:
 
 					SEXP_free (sexp_packet);
 					SEAP_packet_free(_packet);
+					SEXP_free (sexp_buffer);
 
 					errno = EINVAL;
 					return (-1);
@@ -854,6 +862,7 @@ eloop_exit:
 					dI("Invalid SEAP packet received: %s.\n", "can't translate to cmd struct");
 					SEXP_free (sexp_packet);
 					SEAP_packet_free(_packet);
+					SEXP_free (sexp_buffer);
 
 					errno = EINVAL;
 					return (-1);
@@ -873,6 +882,7 @@ eloop_exit:
 					dI("Invalid SEAP packet received: %s.\n", "can't translate to err struct");
 					SEXP_free (sexp_packet);
 					SEAP_packet_free(_packet);
+					SEXP_free (sexp_buffer);
 
 					errno = EINVAL;
 					return (-1);
@@ -884,6 +894,7 @@ eloop_exit:
 		invalid:
 			dI("Invalid SEAP packet received: %s.\n", "invalid packet type symbol");
 			SEXP_free (sexp_packet);
+			SEXP_free (sexp_buffer);
 			errno = EINVAL;
 			return (-1);
 		}


### PR DESCRIPTION
Addressing:
12 bytes in 1 blocks are definitely lost in loss record 1 of 2
   at 0x4A0858C: memalign (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x4A08651: posix_memalign (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x4C8DC13: SEXP_val_new (sexp-value.c:38)
   by 0x4C8B2D0: SEXP_parse_kl_string (sexp-parser.c:1638)
   by 0x4C8D8EA: SEXP_parse (sexp-parser.c:525)
   by 0x4C858F4: SEAP_packet_recv (seap-packet.c:721)
   by 0x4C871CA: SEAP_recvmsg (seap.c:356)
   by 0x4C7E998: oval_probe_comm (oval_probe_ext.c:487)
   by 0x4C7FC5E: oval_probe_ext_eval (oval_probe_ext.c:1085)
   by 0x4C7FF19: oval_probe_ext_handler (oval_probe_ext.c:902)
   by 0x4C6EC02: oval_probe_query_object (oval_probe.c:285)
   by 0x4C6EE73: oval_probe_query_criteria (oval_probe.c:374)

16 bytes in 1 blocks are definitely lost in loss record 2 of 2
   at 0x4A0645D: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x4C890DD: SEXP_new (sexp-manip.c:1593)
   by 0x4C8CB48: SEXP_parse (sexp-parser.c:490)
   by 0x4C858F4: SEAP_packet_recv (seap-packet.c:721)
   by 0x4C871CA: SEAP_recvmsg (seap.c:356)
   by 0x4C7E998: oval_probe_comm (oval_probe_ext.c:487)
   by 0x4C7FC5E: oval_probe_ext_eval (oval_probe_ext.c:1085)
   by 0x4C7FF19: oval_probe_ext_handler (oval_probe_ext.c:902)
   by 0x4C6EC02: oval_probe_query_object (oval_probe.c:285)
   by 0x4C6EE73: oval_probe_query_criteria (oval_probe.c:374)
   by 0x4C6EDAF: oval_probe_query_criteria (oval_probe.c:427)
   by 0x4C6EDAF: oval_probe_query_criteria (oval_probe.c:427)
