### PR TITLE
Plug a memory leak.

### DIFF
--- a/src/source/bz2.c
+++ b/src/source/bz2.c
@@ -36,6 +36,7 @@
 #include "common/_error.h"
 
 struct bz2_file {
+	FILE *f;
 	BZFILE *file;
 	bool eof;
 };
@@ -49,6 +50,7 @@ static struct bz2_file *bz2_open(const char *filename)
 	f = fopen (filename, "r" );
 	if (f) {
 		b = malloc(sizeof(struct bz2_file));
+		b->f = f;
 		b->file = BZ2_bzReadOpen(&bzerror, f, 0, 0, NULL, 0);
 		if (bzerror != BZ_OK) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not build BZ2FILE from %s: %s",
@@ -88,6 +90,7 @@ static int bz2_close(void *bzfile)
 {
 	int bzerror;
 	BZ2_bzReadClose(&bzerror, ((struct bz2_file *)bzfile)->file);
+	fclose(((struct bz2_file *)bzfile)->f);
 	oscap_free(bzfile);
 	return bzerror == BZ_OK ? 0 : -1;
 }


### PR DESCRIPTION
Addressing:
568 bytes in 1 blocks are still reachable in loss record 1 of 1
   at 0x4A0645D: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x3C2B46C17C: __fopen_internal (iofopen.c:73)
   by 0x4C63FEC: bz2_open (bz2.c:49)
   by 0x4C641D1: bz2_read_doc (bz2.c:97)
   by 0x4C6499B: oscap_source_get_xmlDoc (oscap_source.c:143)
   by 0x4C6483B: oscap_source_get_xmlTextReader (oscap_source.c:110)
   by 0x4C648E4: oscap_source_get_scap_type (oscap_source.c:125)
   by 0x40E226: app_info (oscap-info.c:81)
   by 0x407E28: oscap_module_call (oscap-tool.c:260)
   by 0x4082A5: oscap_module_process (oscap-tool.c:345)
   by 0x406CB6: main (oscap.c:80)
LEAK SUMMARY:
   definitely lost: 0 bytes in 0 blocks
   indirectly lost: 0 bytes in 0 blocks
     possibly lost: 0 bytes in 0 blocks
   still reachable: 568 bytes in 1 blocks
        suppressed: 0 bytes in 0 blocks
