### PR TITLE
Plug a memory leak.

### DIFF
--- a/src/OVAL/probes/unix/linux/systemdunitproperty.c
+++ b/src/OVAL/probes/unix/linux/systemdunitproperty.c
@@ -108,11 +108,13 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 
 		if (dbus_message_iter_next(&dict_entry) == false) {
 			dW("Expected another field in dict_entry.");
+			oscap_free(property_name);
 			goto cleanup;
 		}
 
 		if (dbus_message_iter_get_arg_type(&dict_entry) != DBUS_TYPE_VARIANT) {
 			dI("Expected variant as value in dict_entry. Instead received: %s.\n", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&dict_entry)));
+			oscap_free(property_name);
 			goto cleanup;
 		}
 


### PR DESCRIPTION
 18. openscap-1.1.1/src/OVAL/probes/unix/linux/systemdunitproperty.c:107: alloc_fn: Storage is returned from allocation function "oscap_strdup".
21. openscap-1.1.1/src/common/util.c:65:2: alloc_fn: Storage is returned from allocation function "strdup".
22. openscap-1.1.1/src/common/util.c:65:2: var_assign: Assigning: "m" = "strdup(str)".
25. openscap-1.1.1/src/common/util.c:70:2: return_alloc: Returning allocated memory "m".
26. openscap-1.1.1/src/OVAL/probes/unix/linux/systemdunitproperty.c:107: var_assign: Assigning: "property_name" = storage returned from "oscap_strdup(value.str)".
33. openscap-1.1.1/src/OVAL/probes/unix/linux/systemdunitproperty.c:116: leaked_storage: Variable "property_name" going out of scope leaks the storage it points to.