### PR TITLE
Test oscap oval validate on OVAL 5.11 content.

### DIFF
--- a/tests/probes/systemdunitdependency/Makefile.am
+++ b/tests/probes/systemdunitdependency/Makefile.am
@@ -17,4 +17,5 @@ TESTS = all.sh
 EXTRA_DIST = \
 	all.sh \
 	test_probes_systemdunitdependency.sh \
-	test_probes_systemdunitdependency.xml
+	test_probes_systemdunitdependency.xml \
+	test_validation.sh

--- a/tests/probes/systemdunitdependency/all.sh
+++ b/tests/probes/systemdunitdependency/all.sh
@@ -4,4 +4,5 @@
 
 test_init "test_probes_systemdunitdependency.log"
 test_run "systemdunitdependency general functionality" $srcdir/test_probes_systemdunitdependency.sh
+test_run "OVAL 5.11 validation" $srcdir/test_validation.sh
 test_exit

--- a/tests/probes/systemdunitdependency/test_validation.sh
+++ b/tests/probes/systemdunitdependency/test_validation.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright 2015 Red Hat Inc., Durham, North Carolina.
+# All Rights Reserved.
+#
+# OpenScap Probes Test Suite.
+#
+# Authors:
+#   Jan Černý <jcerny@redhat.com>
+
+. ../../test_common.sh
+set -e
+
+DF="${srcdir}/test_probes_systemdunitdependency.xml"
+
+$OSCAP oval validate --schematron $DF
+


### PR DESCRIPTION
We need to test `oscap oval validate`
and `oscap oval validate --schematron` on OVAL 5.11 content
to avoid mistakes in OVAL 5.11 schematron.