### PR TITLE
String improved

### DIFF
--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -579,6 +579,7 @@ AC_CONFIG_FILES([Makefile
 		src/OVAL/results/Makefile
                  tests/API/OVAL/Makefile
 		tests/API/OVAL/glob_to_regex/Makefile
+		tests/oscap_string/Makefile
                  tests/API/OVAL/unittests/Makefile
 		 tests/API/OVAL/validate/Makefile
 		 tests/API/OVAL/report_variable_values/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -1382,6 +1382,7 @@ AC_CONFIG_FILES([Makefile
 		src/OVAL/results/Makefile
                  tests/API/OVAL/Makefile
 		tests/API/OVAL/glob_to_regex/Makefile
+		tests/oscap_string/Makefile
                  tests/API/OVAL/unittests/Makefile
 		 tests/API/OVAL/validate/Makefile
 		 tests/API/OVAL/report_variable_values/Makefile

--- a/src/OVAL/oval_glob_to_regex.c
+++ b/src/OVAL/oval_glob_to_regex.c
@@ -139,8 +139,7 @@ char *oval_glob_to_regex (const char *glob, int noescape)
 				oscap_string_append_char(regex, '^');
 			} else if (c == '\0') {
 				oscap_dlprintf(DBG_E, "Can't convert glob '%s' to regular expression. '[' at position %d has no closing brace - ']'.\n", glob, left_bracket - 1);
-				free(regex->str);
-				free(regex);
+				oscap_string_free(regex);
 				return NULL;
 			} else {
 				oscap_string_append_char(regex, c);
@@ -156,8 +155,7 @@ char *oval_glob_to_regex (const char *glob, int noescape)
 				state = NORMAL;
 			} else if (c == '\0') {
 				oscap_dlprintf(DBG_E, "Can't convert glob '%s' to regular expression. '[' at position %d has no closing brace - ']'.\n", glob, left_bracket - 1);
-				free(regex->str);
-				free(regex);
+				oscap_string_free(regex);
 				return NULL;
 			}
 			oscap_string_append_char(regex, c);
@@ -223,7 +221,7 @@ char *oval_glob_to_regex (const char *glob, int noescape)
 	}
 finish:
 	oscap_string_append_char(regex, '$'); // regex must match only whole string
-	result = regex->str;
-	free(regex);
+	result = oscap_strdup(oscap_string_get_cstr(regex));
+	oscap_string_free(regex);
 	return result;
 }

--- a/src/OVAL/oval_glob_to_regex.c
+++ b/src/OVAL/oval_glob_to_regex.c
@@ -47,7 +47,7 @@ typedef enum {
 
 char *oval_glob_to_regex (const char *glob, int noescape)
 {
-	oscap_string *regex;
+	struct oscap_string *regex;
 	char * result;
 	char c;
 	int i = 0;

--- a/src/common/oscap_string.c
+++ b/src/common/oscap_string.c
@@ -27,9 +27,23 @@
 
 #define INITIAL_CAPACITY 64
 
-oscap_string *oscap_string_new() {
-	oscap_string *s;
-	s = malloc(sizeof(oscap_string));
+/**
+ * String with unlimited length
+ * contains:
+ * - pointer to data,
+ * - actual length of string,
+ * - capacity of allocated memory
+ */
+struct oscap_string {
+	char *str;
+	unsigned int length;
+	unsigned int capacity;
+};
+
+struct oscap_string *oscap_string_new()
+{
+	struct oscap_string *s;
+	s = malloc(sizeof(struct oscap_string));
 	if (s == NULL)
 		return NULL;
 	s->str = malloc(INITIAL_CAPACITY);
@@ -43,13 +57,13 @@ oscap_string *oscap_string_new() {
 	return s;
 }
 
-void oscap_string_free(oscap_string *s)
+void oscap_string_free(struct oscap_string *s)
 {
 	free(s->str);
 	free(s);
 }
 
-bool oscap_string_append_char(oscap_string *s, char c)
+bool oscap_string_append_char(struct oscap_string *s, char c)
 {
 	if (s == NULL)
 		return false;
@@ -63,7 +77,7 @@ bool oscap_string_append_char(oscap_string *s, char c)
 	return true;
 }
 
-bool oscap_string_append_string(oscap_string *s, const char *t)
+bool oscap_string_append_string(struct oscap_string *s, const char *t)
 {
 	if (s == NULL || t == NULL)
 		return false;
@@ -78,4 +92,9 @@ bool oscap_string_append_string(oscap_string *s, const char *t)
 	}
 	s->str[s->length] = '\0';
 	return true;
+}
+
+const char *oscap_string_get_cstr(const struct oscap_string *s)
+{
+	return s->str;
 }

--- a/src/common/oscap_string.c
+++ b/src/common/oscap_string.c
@@ -22,7 +22,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 #include "oscap_string.h"
 
 #define INITIAL_CAPACITY 64
@@ -43,14 +42,8 @@ struct oscap_string {
 struct oscap_string *oscap_string_new()
 {
 	struct oscap_string *s;
-	s = malloc(sizeof(struct oscap_string));
-	if (s == NULL)
-		return NULL;
-	s->str = malloc(INITIAL_CAPACITY);
-	if (s->str == NULL) {
-		free(s);
-		return NULL;
-	}
+	s = oscap_alloc(sizeof(struct oscap_string));
+	s->str = oscap_alloc(INITIAL_CAPACITY);
 	s->str[0] = '\0';
 	s->length = 0;
 	s->capacity = INITIAL_CAPACITY;
@@ -59,39 +52,33 @@ struct oscap_string *oscap_string_new()
 
 void oscap_string_free(struct oscap_string *s)
 {
-	free(s->str);
-	free(s);
+	oscap_free(s->str);
+	oscap_free(s);
 }
 
-bool oscap_string_append_char(struct oscap_string *s, char c)
+void oscap_string_append_char(struct oscap_string *s, char c)
 {
 	if (s == NULL)
-		return false;
-	if (s->length + 1 >= s->capacity) {
-		if ((s->str = realloc(s->str, s->capacity + INITIAL_CAPACITY)) == NULL)
-			return false;
+		return;
+	if ((s->length + 1) + 1 > s->capacity) {
 		s->capacity += INITIAL_CAPACITY;
+		s->str = oscap_realloc(s->str, s->capacity);
 	}
 	s->str[s->length++] = c;
 	s->str[s->length] = '\0';
-	return true;
 }
 
-bool oscap_string_append_string(struct oscap_string *s, const char *t)
+void oscap_string_append_string(struct oscap_string *s, const char *t)
 {
 	if (s == NULL || t == NULL)
-		return false;
+		return;
 	int append_length = strlen(t);
-	if (s->length + append_length >= s->capacity)  {
-		if ((s->str = realloc(s->str, s->capacity + append_length)) == NULL)
-			return false;
+	if (s->length + append_length + 1 > s->capacity)  {
 		s->capacity += append_length;
+		s->str = oscap_realloc(s->str, s->capacity);
 	}
-	for (int i = 0; t[i] != '\0'; i++) {
-		s->str[s->length++] = t[i];
-	}
-	s->str[s->length] = '\0';
-	return true;
+	strcpy(s->str + s->length, t);
+	s->length += append_length;
 }
 
 const char *oscap_string_get_cstr(const struct oscap_string *s)

--- a/src/common/oscap_string.h
+++ b/src/common/oscap_string.h
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include "util.h"
 
-OSCAP_HIDDEN_START;
 
 /**
  * Create a new string.
@@ -60,6 +59,5 @@ void oscap_string_append_string(struct oscap_string *s, const char *t);
  */
 const char *oscap_string_get_cstr(const struct oscap_string *s);
 
-OSCAP_HIDDEN_END;
 
 #endif

--- a/src/common/oscap_string.h
+++ b/src/common/oscap_string.h
@@ -23,7 +23,6 @@
 #ifndef OSCAP_STRING_
 #define OSCAP_STRING_
 #include <stdlib.h>
-#include <stdbool.h>
 #include "util.h"
 
 OSCAP_HIDDEN_START;
@@ -44,17 +43,15 @@ void oscap_string_free(struct oscap_string *s);
  * Append a single char at the end of a string.
  * @param s string
  * @param c to append
- * @return true on succes, false on failure
  */
-bool oscap_string_append_char(struct oscap_string *s, char c);
+void oscap_string_append_char(struct oscap_string *s, char c);
 
 /**
  * Append multiple characters at the end of string.
  * @param s string
  * @param t to append
- * @return true on succes, false on failure
  */
-bool oscap_string_append_string(struct oscap_string *s, const char *t);
+void oscap_string_append_string(struct oscap_string *s, const char *t);
 
 /**
  * Get string data as constant pointer to char

--- a/src/common/oscap_string.h
+++ b/src/common/oscap_string.h
@@ -29,29 +29,16 @@
 OSCAP_HIDDEN_START;
 
 /**
- * String with unlimited length
- * definition of data type - contains:
- * - pointer to data,
- * - actual length of string,
- * - capacity of allocated memory
- */
-typedef struct {
-	char *str;
-	unsigned int length;
-	unsigned int capacity;
-} oscap_string;
-
-/**
  * Create a new string.
  * @return pointer to a string on success, NULL on failure
  */
-oscap_string *oscap_string_new(void);
+struct oscap_string *oscap_string_new(void);
 
 /**
  * Free the string from memory.
  * @param s string
  */
-void oscap_string_free(oscap_string *s);
+void oscap_string_free(struct oscap_string *s);
 
 /**
  * Append a single char at the end of a string.
@@ -59,7 +46,7 @@ void oscap_string_free(oscap_string *s);
  * @param c to append
  * @return true on succes, false on failure
  */
-bool oscap_string_append_char(oscap_string *s, char c);
+bool oscap_string_append_char(struct oscap_string *s, char c);
 
 /**
  * Append multiple characters at the end of string.
@@ -67,7 +54,14 @@ bool oscap_string_append_char(oscap_string *s, char c);
  * @param t to append
  * @return true on succes, false on failure
  */
-bool oscap_string_append_string(oscap_string *s, const char *t);
+bool oscap_string_append_string(struct oscap_string *s, const char *t);
+
+/**
+ * Get string data as constant pointer to char
+ * @param s string
+ * @return pointer to data
+ */
+const char *oscap_string_get_cstr(const struct oscap_string *s);
 
 OSCAP_HIDDEN_END;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,6 +23,7 @@ SUBDIRS = \
 	codestyle \
 	DS \
 	schemas \
+	oscap_string \
 	oval_details \
 	$(PROBE_SUBDIRS) $(SCE_SUBDIRS) $(BINDINGS_SUBDIRS)
 

--- a/tests/oscap_string/Makefile.am
+++ b/tests/oscap_string/Makefile.am
@@ -1,0 +1,31 @@
+AM_CPPFLAGS =   -I$(top_srcdir)/tests/include \
+		-I$(top_srcdir)/src/CVE/public \
+		-I${top_srcdir}/src/CVSS/public \
+		-I$(top_srcdir)/src/CPE/public \
+		-I$(top_srcdir)/src/CCE/public \
+		-I$(top_srcdir)/src/OVAL/public \
+		-I$(top_srcdir)/src/XCCDF/public \
+	 	-I$(top_srcdir)/src/common/public \
+		-I$(top_srcdir)/src/OVAL/probes/public \
+		-I$(top_srcdir)/src/OVAL/probes/SEAP/public \
+		-I$(top_srcdir)/src/source/public \
+		-I$(top_srcdir)/src \
+		@xml2_CFLAGS@
+
+LDADD = $(top_builddir)/src/libopenscap_testing.la @pcre_LIBS@
+
+DISTCLEANFILES = *.log *.out* oscap_debug.log.*
+CLEANFILES = *.log *.out* oscap_debug.log.*
+
+TESTS = test_oscap_string.sh
+check_PROGRAMS = test_oscap_string
+
+test_oscap_string_SOURCES = test_oscap_string.c
+
+TESTS_ENVIRONMENT= \
+	builddir=$(top_builddir) \
+	$(top_builddir)/run
+
+EXTRA_DIST = test_oscap_string.sh \
+              test_oscap_string.c
+

--- a/tests/oscap_string/test_oscap_string.c
+++ b/tests/oscap_string/test_oscap_string.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright 2015 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors:
+ *      Jan Černý <jcerny@redhat.com>
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/oscap_string/test_oscap_string.c
+++ b/tests/oscap_string/test_oscap_string.c
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "common/oscap_string.h"
+
+int test_append_char(void);
+int test_append_string(void);
+
+int test_append_char()
+{
+	const unsigned int limit = 1000;
+	int retval = 0;
+	struct oscap_string *s = oscap_string_new();
+	for (unsigned int i = 0; i < limit; i++) {
+		oscap_string_append_char(s, 'a');
+	}
+	if (strlen(oscap_string_get_cstr(s)) != limit) {
+		fprintf(stderr, "Length of result does not match the required length.\n");
+		retval = 1;
+	}
+	oscap_string_free(s);
+	return retval;
+}
+
+int test_append_string()
+{
+	const int count_of_strings = 7;
+	const char *strings[] = {
+		"",
+		"A",
+		"ABCD",
+		"ABCDEFGH",
+		"012345678901234567890123456789012345678901234567890123456789012",
+		"0123456789012345678901234567890123456789012345678901234567890123",
+		"01234567890123456789012345678901234567890123456789012345678901234"
+	};
+	unsigned int length = 0;
+	int retval = 0;
+	struct oscap_string *s = oscap_string_new();
+	for (int i = 0; i < count_of_strings; i++) {
+		oscap_string_append_string(s, strings[i]);
+		length += strlen(strings[i]);
+	}
+	if (strlen(oscap_string_get_cstr(s)) != length) {
+		fprintf(stderr, "Length of result does not match the required length.\n");
+		retval = 1;
+	}
+	oscap_string_free(s);
+	return retval;
+}
+
+int main (int argc, char *argv[])
+{
+	int retval = 0;
+	retval = test_append_char();
+	retval = test_append_string();
+	return retval;
+}

--- a/tests/oscap_string/test_oscap_string.sh
+++ b/tests/oscap_string/test_oscap_string.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2015 Red Hat Inc., Durham, North Carolina.
+# All Rights Reserved.
+#
+# OpenScap Test Suite
+#
+# Authors:
+#      Jan Černý <jcerny@redhat.com>
+
+. ../test_common.sh
+
+# Test cases.
+
+function test_oscap_string {
+    ./test_oscap_string
+}
+
+# Testing.
+
+test_init "test_oscap_string.log"
+test_run "test_oscap_string" test_oscap_string
+test_exit


### PR DESCRIPTION
We had oscap_string_free, but we didn't use it nowhere.
We hide the definition of struct oscap_string from other modules.