### PR TITLE
rhbz#1220262: Modify OVAL-5.11 schema files to be backward compatible

### DIFF
--- a/schemas/oval/5.11/linux-definitions-schema.xsd
+++ b/schemas/oval/5.11/linux-definitions-schema.xsd
@@ -1110,7 +1110,8 @@
                                                   <xsd:documentation>This is the package name to check.</xsd:documentation>
                                              </xsd:annotation>
                                         </xsd:element>
-                                        <xsd:element name="epoch">
+                                        <!-- minOccurs/maxOccurs here is OpenSCAP modification to allow older contents to pass -->
+                                        <xsd:element name="epoch" minOccurs="0" maxOccurs="1">
                                              <xsd:annotation>
                                                   <xsd:documentation>This is the epoch number of the RPM, this is used as a kludge for version-release comparisons where the vendor has done some kind of re-numbering or version forking. For a null epoch (or '(none)' as returned by rpm) the string '(none)' should be used.. This number is not revealed by a normal query of the RPM's information -- you must use a formatted rpm query command to gather this data from the command line, like so. For an already-installed RPM: rpm -q --qf '%{EPOCH}\n' installed_rpm For an RPM file that has not been installed: rpm -qp --qf '%{EPOCH}\n' rpm_file</xsd:documentation>
                                              </xsd:annotation>
@@ -1129,7 +1130,8 @@
                                                   </xsd:simpleContent>
                                              </xsd:complexType>
                                         </xsd:element>
-                                        <xsd:element name="version">
+                                        <!-- minOccurs/maxOccurs here is OpenSCAP modification to allow older contents to pass -->
+                                        <xsd:element name="version" minOccurs="0" maxOccurs="1">
                                              <xsd:annotation>
                                                   <xsd:documentation>This is the version number of the build. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be 2.0.40.</xsd:documentation>
                                              </xsd:annotation>
@@ -1148,7 +1150,8 @@
                                                   </xsd:simpleContent>
                                              </xsd:complexType>
                                         </xsd:element>
-                                        <xsd:element name="release">
+                                        <!-- minOccurs/maxOccurs here is OpenSCAP modification to allow older contents to pass -->
+                                        <xsd:element name="release" minOccurs="0" maxOccurs="1">
                                              <xsd:annotation>
                                                   <xsd:documentation>This is the release number of the build, changed by the vendor/builder.</xsd:documentation>
                                              </xsd:annotation>
@@ -1167,7 +1170,8 @@
                                                   </xsd:simpleContent>
                                              </xsd:complexType>
                                         </xsd:element>
-                                        <xsd:element name="arch" type="oval-def:EntityObjectStringType">
+                                        <!-- minOccurs/maxOccurs here is OpenSCAP modification to allow older contents to pass -->
+                                        <xsd:element name="arch" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="1">
                                              <xsd:annotation>
                                                   <xsd:documentation>This is the architecture for which the RPM was built, like : i386, ppc, sparc, noarch. In the case of an apache rpm named httpd-2.0.40-21.11.4.i686.rpm, this value would be i686.</xsd:documentation>
                                              </xsd:annotation>


### PR DESCRIPTION
Previously, OVAL-5.10 allowed for missing epoch/version/release/arch.
The upstream OVAL-5.11 schema is now more strict and not backward
compatible.

We need to make OVAL-5.11 schema backward compatible to support
DataStream content that includes such OVAL-5.10 content. Note that
DataStream 1.2 schema imports fixed version of OVAL schemas.

Addressing:
File '/tmp/ssg-rhel6-ds.xml' line 8755: Element
'{http://oval.mitre.org/XMLSchema/oval-definitions-5#linux}filepath':
This element is not expected. Expected is (
{http://oval.mitre.org/XMLSchema/oval-definitions-5#linux}epoch ).