### PR TITLE
Plug a memory leak (coverity scan).

### DIFF
--- a/src/OVAL/probes/unix/symlink.c
+++ b/src/OVAL/probes/unix/symlink.c
@@ -67,6 +67,7 @@ static int collect_symlink(SEXP_t *ent, probe_ctx *ctx)
 		}
 		probe_cobj_add_msg(probe_ctx_getresult(ctx), msg);
 		SEXP_free(msg);
+		oscap_free(pathname);
 		return 0;
 	}
 
@@ -77,6 +78,7 @@ static int collect_symlink(SEXP_t *ent, probe_ctx *ctx)
 			"File '%s' is not a symlink.", pathname);
 		probe_cobj_add_msg(probe_ctx_getresult(ctx), msg);
 		SEXP_free(msg);
+		oscap_free(pathname);
 		return 0;
 	}
 
@@ -94,6 +96,7 @@ static int collect_symlink(SEXP_t *ent, probe_ctx *ctx)
 		probe_cobj_add_msg(probe_ctx_getresult(ctx), msg);
 		SEXP_free(msg);
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
+		oscap_free(pathname);
 		return 0;
 	}
 
@@ -105,6 +108,7 @@ static int collect_symlink(SEXP_t *ent, probe_ctx *ctx)
 	probe_item_collect(ctx, item_sexp);
 
 	oscap_free(linkname);
+	oscap_free(pathname);
 	return 0;
 }
 


### PR DESCRIPTION
Variable "pathname" going out of scope leaks the storage it points to.
Function SEXP_string_cstr(ent_val) allocates memory that must be freed.