### PR TITLE
Changed masking behaviour.

### DIFF
--- a/src/OVAL/oval_entity.c
+++ b/src/OVAL/oval_entity.c
@@ -398,7 +398,10 @@ xmlNode *oval_entity_to_dom(struct oval_entity *entity, xmlDoc * doc, xmlNode * 
 	bool mask = oval_entity_get_mask(entity);
 
 	/* omit the value and operation used for testing in oval_results if mask=true */
-	if (mask && !xmlStrcmp(root_node->name, BAD_CAST OVAL_ROOT_ELM_RESULTS)) {
+	/* Omit it only for older versions of OVAL than 5.10 */
+	oval_version_t oval_version = oval_definition_model_get_schema_version(entity->model);
+	if (oval_version_cmp(oval_version, OVAL_VERSION(5.10)) < 0 &&
+		mask && !xmlStrcmp(root_node->name, BAD_CAST OVAL_ROOT_ELM_RESULTS)) {
 		entity_node = xmlNewTextChild(parent, ent_ns, BAD_CAST tagname, BAD_CAST "");
 	} else {
 		entity_node = xmlNewTextChild(parent, ent_ns, BAD_CAST tagname, BAD_CAST content);

--- a/tests/probes/maskattr/Makefile.am
+++ b/tests/probes/maskattr/Makefile.am
@@ -21,5 +21,7 @@ EXTRA_DIST = \
 	all.sh \
 	test_object_entity_mask.sh \
 	test_object_entity_mask.xml \
+	test_object_entity_mask_oval_5_9.sh \
+	test_object_entity_mask_oval_5_9.xml \
 	test_object_entity_nomask.sh \
 	test_object_entity_nomask.xml

--- a/tests/probes/maskattr/all.sh
+++ b/tests/probes/maskattr/all.sh
@@ -3,6 +3,7 @@
 . ../../test_common.sh
 
 test_init test_maskattr.log
-test_run "object entity with mask" $srcdir/test_object_entity_mask.sh
+test_run "object entity with mask - OVAL 5.10" $srcdir/test_object_entity_mask.sh
+test_run "object entity with mask - OVAL 5.9" $srcdir/test_object_entity_mask_oval_5_9.sh
 test_run "object entity without mask" $srcdir/test_object_entity_nomask.sh
 test_exit

--- a/tests/probes/maskattr/test_object_entity_mask_oval_5_9.sh
+++ b/tests/probes/maskattr/test_object_entity_mask_oval_5_9.sh
@@ -16,8 +16,8 @@ $OSCAP oval eval --results $result $srcdir/${name}.xml || [ $? == 2 ]
 echo "Validating results."
 $OSCAP oval validate-xml --results $result
 
-echo "Testing that oval_definitions are not altered"
-assert_exists 1 '/oval_results/oval_definitions/objects/unix-def:file_object/unix-def:filepath[text()="/etc/passwd"]'
+echo "Testing that oval_definitions are altered"
+assert_exists 0 '/oval_results/oval_definitions/objects/unix-def:file_object/unix-def:filepath[text()="/etc/passwd"]'
 
 echo "Testing results values."
 [ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:x:tst:1"]/@result)')" == "true" ]

--- a/tests/probes/maskattr/test_object_entity_mask_oval_5_9.xml
+++ b/tests/probes/maskattr/test_object_entity_mask_oval_5_9.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oval_definitions xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+  <generator>
+    <oval:schema_version>5.9</oval:schema_version>
+    <oval:timestamp>2009-01-12T10:41:00-05:00</oval:timestamp>
+  </generator>
+  <definitions>
+    <definition id="oval:x:def:1" version="1" class="miscellaneous">
+      <metadata>
+        <title>foo</title>
+        <description>bar</description>
+      </metadata>
+      <notes>
+	<note>A note.</note>
+      </notes>
+      <criteria operator="AND">
+        <criterion comment="a" test_ref="oval:x:tst:1"/>
+        </criteria>
+    </definition>
+  </definitions>
+  <tests>
+    <file_test id="oval:x:tst:1" version="1" comment="a" check_existence="at_least_one_exists" check="all" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+      <object object_ref="oval:x:obj:1"/>
+    </file_test>
+  </tests>
+  <objects>
+    <file_object id="oval:x:obj:1" version="1" comment="a" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+      <filepath mask="true">/etc/passwd</filepath>
+    </file_object>
+  </objects>
+</oval_definitions>


### PR DESCRIPTION
According to the clarified specification, the "mask" attribute
should not affect oval_definitions section in oval_results.
It says: ... the"oval_definitions" section must not be altered
and must be an exact copy of the definitions evaluated.