### PR TITLE
Use OScap source for remote resources

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -644,36 +644,26 @@ static int _xccdf_session_get_oval_from_model(struct xccdf_session *session)
 				printable_path = (char *) oscap_file_entry_get_file(file_entry);
 
 				if (session->oval.fetch_remote_resources) {
-					if (session->temp_dir == NULL)
-						session->temp_dir = oscap_acquire_temp_dir();
-					if (session->temp_dir == NULL) {
-						oscap_file_entry_iterator_free(files_it);
-						oscap_file_entry_list_free(files);
-						free(tmp_path);
-						_oval_content_resources_free(resources);
-						free(xccdf_path_cpy);
-						return 1;
-					}
-
 					if (session->oval.progress != NULL)
 						session->oval.progress(false, "Downloading: %s ... ", printable_path);
-					char *file = oscap_acquire_url_download(session->temp_dir, printable_path);
-					if (file == NULL) {
+
+					size_t data_size;
+					char *data = oscap_acquire_url_download(printable_path, &data_size);
+					if (data == NULL) {
 						if (session->oval.progress != NULL)
 							session->oval.progress(false, "error\n");
-					}
-					else {
+					} else {
 						if (session->oval.progress != NULL)
 							session->oval.progress(false, "ok\n");
+
 						resources[idx] = malloc(sizeof(struct oval_content_resource));
 						resources[idx]->href = strdup(printable_path);
-						resources[idx]->source = oscap_source_new_from_file(file);
+						resources[idx]->source = oscap_source_new_take_memory(data, data_size, printable_path);
 						resources[idx]->source_owned = true;
 						idx++;
 						resources = realloc(resources, (idx + 1) * sizeof(struct oval_content_resource *));
 						resources[idx] = NULL;
 						free(tmp_path);
-						free(file);
 						continue;
 					}
 				}
@@ -704,9 +694,9 @@ static void _xccdf_session_free_oval_agents(struct xccdf_session *session)
 		for (int i=0; session->oval.agents[i]; i++) {
 			struct oval_definition_model *def_model = oval_agent_get_definition_model(session->oval.agents[i]);
 			oval_definition_model_free(def_model);
-                        oval_agent_destroy_session(session->oval.agents[i]);
+			oval_agent_destroy_session(session->oval.agents[i]);
 		}
-                free(session->oval.agents);
+		free(session->oval.agents);
 		session->oval.agents = NULL;
 	}
 }

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -75,6 +75,15 @@ oscap_acquire_cleanup_dir(char **dir_path)
 	}
 }
 
+/**
+ * Struct used for downloading to memory via CURL
+ */
+struct download_memory{
+	size_t size;
+	size_t used;
+	char* ptr;
+};
+
 int
 oscap_acquire_temp_file(const char *dir, const char *template, char **filename)
 {
@@ -96,63 +105,6 @@ oscap_acquire_temp_file(const char *dir, const char *template, char **filename)
 		*filename = NULL;
 	}
 	return fd;
-}
-
-char *
-oscap_acquire_url_download(const char *temp_dir, const char *url)
-{
-	/* SADLY, we create a tempfile which we use later.
-	 * Much greater solution would be to use unliked
-	 * file descriptors, but the library interface is
-	 * not yet prepared for that. */
-	char *output_filename = NULL;
-	int output_fd;
-	FILE *fp;
-	CURL *curl;
-	CURLcode res;
-
-	output_fd = oscap_acquire_temp_file(temp_dir, TEMP_URL_TEMPLATE, &output_filename);
-	if (output_fd == -1) {
-		return NULL;
-	}
-
-	fp = fdopen(output_fd, "w");
-	if (fp == NULL) {
-		oscap_seterr(OSCAP_EFAMILY_GLIBC, "fdopen failed, %s", strerror(errno));
-		if (remove(output_filename))
-			oscap_seterr(OSCAP_EFAMILY_GLIBC, "fdopen failed. Failed to remove temp file %s. %s",
-				output_filename, strerror(errno));
-		close(output_fd);
-		free(output_filename);
-		return NULL;
-	}
-
-	curl = curl_easy_init();
-	if (curl == NULL) {
-		oscap_seterr(OSCAP_EFAMILY_NET, "Failed to initialize libcurl.");
-
-		if (remove(output_filename))
-			oscap_seterr(OSCAP_EFAMILY_GLIBC, "Failed to initialize libcurl. Failed to remove temp file %s. %s",
-				output_filename, strerror(errno));
-		fclose(fp);
-		free(output_filename);
-		return NULL;
-	}
-
-	curl_easy_setopt(curl, CURLOPT_URL, url);
-	curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
-	res = curl_easy_perform(curl);
-	if (res != 0) {
-		oscap_seterr(OSCAP_EFAMILY_NET, "Download failed: %s", curl_easy_strerror(res));
-		if (remove(output_filename))
-			oscap_seterr(OSCAP_EFAMILY_GLIBC, "Download failed: %s. Failed to remove temp file %s. %s",
-				curl_easy_strerror(res), output_filename, strerror(errno));
-		free(output_filename);
-		output_filename = NULL;
-	}
-	curl_easy_cleanup(curl);
-	fclose(fp);
-	return output_filename;
 }
 
 bool
@@ -184,6 +136,63 @@ oscap_acquire_url_to_filename(const char *url)
 	curl_free(curl_filename);
 	curl_easy_cleanup(curl);
 	return filename;
+}
+
+char* oscap_acquire_url_download(const char *url, size_t* memory_size)
+{
+	CURL *curl;
+	struct download_memory data_struct = {.size=0, .used=0, .ptr = NULL };
+
+	curl = curl_easy_init();
+	if (curl == NULL) {
+		oscap_seterr(OSCAP_EFAMILY_NET, "Failed to initialize libcurl.");
+		return NULL;
+	}
+
+
+	curl_easy_setopt(curl, CURLOPT_URL, url);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_to_memory_callback);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &data_struct);
+
+	CURLcode res = curl_easy_perform(curl);
+	curl_easy_cleanup(curl);
+
+	if (res != 0) {
+		oscap_seterr(OSCAP_EFAMILY_NET, "Download failed: %s", curl_easy_strerror(res));
+		oscap_free(data_struct.ptr);
+		return NULL;
+	}
+	
+	*memory_size = data_struct.used;
+	return data_struct.ptr;
+}
+
+size_t write_to_memory_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+	struct download_memory* const dest = (struct download_memory* ) userdata;
+
+	size_t new_received_size = size * nmemb; // total size of newly received data
+	size_t new_size = dest->used + new_received_size; // size of old + new data
+
+	if (dest->size < new_size){
+		char* new_ptr = oscap_realloc(dest->ptr, new_size);
+
+		// Failed to allocate new memory
+		if (new_ptr == NULL){
+			return 0; // cause CURLE_WRITE_ERROR
+		}
+
+		dest->size = new_size;
+		dest->ptr = new_ptr;
+
+	}
+
+	// Add newly received data
+	memcpy( &(dest->ptr[dest->used]) , ptr, new_received_size);
+	dest->used += new_received_size;
+
+	return new_received_size;
+
 }
 
 char *

--- a/src/common/oscap_acquire.h
+++ b/src/common/oscap_acquire.h
@@ -54,14 +54,6 @@ void oscap_acquire_cleanup_dir(char **dir_path);
 int oscap_acquire_temp_file(const char *dir, const char *template, char **filename);
 
 /**
- * Download the given url to a random file in the given directory.
- * @param temp_dir Directory to store the result in.
- * @param url The url to acquire.
- * @return the filename of the newly created file or NULL on error.
- */
-char *oscap_acquire_url_download(const char *temp_dir, const char *url);
-
-/**
  * Is the given url supported by OpenSCAP?
  * @param url Requested url
  * @return true if the given string reminds supported url.
@@ -74,6 +66,15 @@ bool oscap_acquire_url_is_supported(const char *url);
  * @return escaped url or NULL
  */
 char *oscap_acquire_url_to_filename(const char *url);
+
+/**
+ * Download the given url to memory
+ * @param url The url to acquire
+ * @param memory_size Size of memory. If NULL is returned, variable is not modified.
+ * @return the pointer to memory with downloaded data or NULL on error
+ */
+char *
+oscap_acquire_url_download(const char *url, size_t* memory_size);
 
 /**
  * Guess how the realpath of given file may look like. Do your best!
@@ -98,6 +99,17 @@ int oscap_acquire_mkdir_p(const char* path);
  * @returns the zero on success
  */
 int oscap_acquire_ensure_parent_dir(const char *filepath);
+
+/**
+ * CURL WRITEFUNCTION callback
+ * @param ptr The pointer to received data
+ * @param size_t
+ * @param nmemb
+ * @param userdata Pointer to storage of received data
+ * @return Number of stored bytes
+ */
+size_t
+write_to_memory_callback(char *ptr, size_t size, size_t nmemb, void *userdata);
 
 // FIXME: SCE engine uses this particular function
 OSCAP_HIDDEN_END;

--- a/src/source/bz2_priv.h
+++ b/src/source/bz2_priv.h
@@ -33,12 +33,13 @@
 
 OSCAP_HIDDEN_START;
 
+
 /**
  * Parse *.xml.bz2 file to XML DOM
- * @param filepath The path to *.xml.bz2 file
+ * @param fd The file descriptor to bz2 file
  * @returns DOM representation of the file
  */
-xmlDoc *bz2_file_read_doc(const char *filepath);
+xmlDoc *bz2_fd_read_doc(int fd);
 
 /**
  * Parse bzip2ed memory to XML DOM.
@@ -50,11 +51,20 @@ xmlDoc *bz2_mem_read_doc(const char *buffer, size_t size);
 
 /**
  * Recognize whether the file can be parsed by this
- * bz2 parser.
- * @param filepath The path to *.xml.bz2 file
+ * bz2 parser. Do not close the file.
+ * @param file descriptor to opened file
  * @returns true if can be parsed.
  */
-bool bz2_file_is_bzip(const char *filepath);
+bool bz2_fd_is_bzip(int fd);
+
+/**
+ * @brief Recognize whether the file can be parsed by this
+ * bz2 parser
+ * @param memory Raw memory with file content
+ * @param size Size of memory
+ * @return true if can be parsed
+ */
+bool bz2_memory_is_bzip(const char* memory, const size_t size);
 
 OSCAP_HIDDEN_END;
 

--- a/src/source/oscap_source_priv.h
+++ b/src/source/oscap_source_priv.h
@@ -36,6 +36,20 @@
 OSCAP_HIDDEN_START;
 
 /**
+ * Create new oscap_source from raw memory. The memory can contain \0 bytes
+ * and they are not considered NULL-terminations! Always pass the correct
+ * size. This constructor is meant as a last resort when no other constructor
+ * will work for your use case. If at all possible you should use the more
+ * specialized constructors.
+ * oscap_source will will not allocate memory new memory buffer
+ * @param buffer Memory buffer with raw data
+ * @param size size of the memory buffer
+ * @param filepath Suggested filename for the file or NULL
+ * @returns newly created oscap_source_structure
+ */
+struct oscap_source *oscap_source_new_take_memory(char *buffer, size_t size, const char *filepath);
+
+/**
  * Build new oscap_source from existing xmlDoc. The xmlDoc becomes owned
  * by oscap_source.
  * @memberof oscap_source


### PR DESCRIPTION
#436 Downloading OVAL file only into memory not to temp file
#473 --fetch-remote-resources support bz2 now