### PR TITLE
The original regex skiped all the files before */source/oscap_source.c.

### DIFF
--- a/tests/codestyle/all.sh
+++ b/tests/codestyle/all.sh
@@ -21,7 +21,7 @@ function test_illicit_function_use {
 		echo "xmlTextReaderReadString is not allowed within OpenSCAP project. Its implementation in libxml does not play well with xmlWalkerReader."
 		return 1;
 	fi
-	whitelisted=$(echo $codebase | sed 's/\w.*\/source\/oscap_source.c / /g' -)
+	whitelisted=$(echo $codebase | sed 's/\S*\/source\/oscap_source.c / /g' -)
 	if grep xmlReadFile $whitelisted; then
 		echo "xmlReadFile is not allowed within OpenSCAP project. Please make a use of oscap_source facility."
 		return 1;


### PR DESCRIPTION
See https://fedorahosted.org/openscap/ticket/470