### PR TITLE
trac#480: plug a memory leak

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_substitute.c
+++ b/src/XCCDF_POLICY/xccdf_policy_substitute.c
@@ -175,8 +175,10 @@ static int _xccdf_text_substitution_cb(xmlNode **node, void *user_data)
 		if (xccdf_instance_iterator_has_more(instances)) {
 			struct xccdf_instance *instance = xccdf_instance_iterator_next(instances);
 			result = xccdf_instance_get_content(instance);
+			xccdf_instance_iterator_free(instances);
 		}
 		else {
+			xccdf_instance_iterator_free(instances);
 			dW("The xccdf:rule-result/xccdf:instance element was not found.\n");
 			return 1;
 		}


### PR DESCRIPTION
Addressing:
   at 0x4C2B946: calloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x4E7F818: __oscap_calloc (alloc.c:68)
   by 0x4E80DC2: oscap_iterator_new (list.c:242)
   by 0x4EE1D2D: _xccdf_text_substitution_cb (xccdf_policy_substitute.c:174)
   by 0x4E84727: xml_element_dfs_callback (xml_iterate.c:31)
   by 0x4E84775: xml_element_dfs_callback (xml_iterate.c:36)
   by 0x4E8481E: xml_iterate_dfs (xml_iterate.c:70)
   by 0x4EE2124: xccdf_policy_resolve_fix_substitution (xccdf_policy_substitute.c:201)
   by 0x4EE1528: xccdf_policy_rule_result_remediate (xccdf_policy_remediate.c:387)
   by 0x4EE1B44: xccdf_policy_remediate (xccdf_policy_remediate.c:439)
   by 0x40B7B9: app_evaluate_xccdf (oscap-xccdf.c:513)
   by 0x407BFC: oscap_module_call (oscap-tool.c:260)
   by 0x407BFC: oscap_module_process (oscap-tool.c:345)