### PR TITLE
Fix segfault after error during tailoring file loading

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -855,6 +855,7 @@ int xccdf_session_load_tailoring(struct xccdf_session *session)
 					oscap_source_get_schema_version(tailoring_source),
 					oscap_source_readable_origin(tailoring_source));
 			oscap_source_free(tailoring_source);
+			session->tailoring.user_file = NULL;
 			return 1;
 		}
 	}


### PR DESCRIPTION
session->tailoring.user_file is freed again in cleanup section.

if (from_sds == true) and (session->full_validation == true) on xccdf_session.c:851 there could be some unexpected behavior.

Used command: 
oscap xccdf eval --tailoring-file /tmp/empty ./test_xccdf_refine_rule_unchecked.xccdf.xml 

/tmp/empty ~ empty file = invalid file
 ./test_xccdf_refine_rule_unchecked.xccdf.xml ~ some valid xccdf

Segfault stacktrace:
#0  0x00007ffff513a78d in free () from /lib64/libc.so.6
#1  0x00007ffff7b3d6f2 in oscap_source_free (source=0x61dbf0) at oscap_source.c:126
#2  0x00007ffff7b93957 in xccdf_session_free (session=0x61bab0) at xccdf_session.c:223
#3  0x000000000040b5d5 in app_evaluate_xccdf (action=<optimized out>) at oscap-xccdf.c:540
#4  0x0000000000407bee in oscap_module_call (action=0x7fffffffd6a0) at oscap-tool.c:260
#5  oscap_module_process (module=0x614460 <XCCDF_EVAL>, module@entry=0x6139e0 <OSCAP_ROOT_MODULE>, argc=argc@entry=10, argv=argv@entry=0x7fffffffd928) at oscap-tool.c:345
#6  0x0000000000406c8f in main (argc=10, argv=0x7fffffffd928) at oscap.c:80