### PR TITLE
Refine-rule

### DIFF
--- a/src/XCCDF_POLICY/Makefile.am
+++ b/src/XCCDF_POLICY/Makefile.am
@@ -3,7 +3,9 @@ noinst_LTLIBRARIES = libxccdf_policy.la
 libxccdf_policy_la_SOURCES = \
 	reporter.c \
 	reporter_priv.h \
+	xccdf_policy_resolve.c \
 	xccdf_policy.c \
+	xccdf_policy_resolve.h \
 	xccdf_policy_engine.c \
 	xccdf_policy_engine_priv.h \
 	xccdf_policy_model_priv.h \

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -1119,7 +1119,7 @@ _xccdf_policy_rule_evaluate(struct xccdf_policy * policy, const struct xccdf_rul
 
 	struct xccdf_refine_rule_internal* r_rule = oscap_htable_get(policy->refine_rules_internal, rule_id);
 
-	xccdf_role_t role = _get_final_role(rule,r_rule);
+	xccdf_role_t role = _get_final_role(rule, r_rule);
 	if (role  == XCCDF_ROLE_UNCHECKED )
 		return _xccdf_policy_report_rule_result(policy, result, rule, NULL, XCCDF_RESULT_NOT_CHECKED, NULL);
 
@@ -2660,6 +2660,11 @@ void xccdf_policy_model_free(struct xccdf_policy_model * model) {
         oscap_free(model);
 }
 
+static void _refine_rule_internal_free(struct xccdf_refine_rule_internal *item){
+	oscap_free(item->selector);
+	oscap_free(item);
+}
+
 void xccdf_policy_free(struct xccdf_policy * policy) {
 
         /* If ID of policy's profile is NULL then this
@@ -2674,7 +2679,7 @@ void xccdf_policy_free(struct xccdf_policy * policy) {
 	oscap_list_free(policy->results, (oscap_destruct_func) xccdf_result_free);
 	oscap_htable_free0(policy->selected_internal);
 	oscap_htable_free0(policy->selected_final);
-	oscap_htable_free0(policy->refine_rules_internal);
+	oscap_htable_free(policy->refine_rules_internal, (oscap_destruct_func)_refine_rule_internal_free);
         oscap_free(policy);
 }
 

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -587,7 +587,7 @@ _xccdf_policy_rule_get_applicable_check(struct xccdf_policy *policy, struct xccd
 		// Check Processing Algorithm -- Check.Initialize
 		// Check Processing Algorithm -- Check.Selector
 		struct xccdf_refine_rule_internal *r_rule = xccdf_policy_get_refine_rule_by_item(policy, rule);
-		char *selector = (r_rule == NULL) ? NULL : r_rule->selector;
+		char *selector = (r_rule == NULL) ? NULL : xccdf_refine_rule_internal_get_selector(r_rule);
 		struct xccdf_check_iterator *candidate_it = xccdf_rule_get_checks_filtered(rule, selector);
 		if (selector != NULL && !xccdf_check_iterator_has_more(candidate_it)) {
 			xccdf_check_iterator_free(candidate_it);
@@ -2356,25 +2356,25 @@ struct xccdf_item * xccdf_policy_tailor_item(struct xccdf_policy * policy, struc
     xccdf_type_t type = xccdf_item_get_type(item);
     switch (type) {
         case XCCDF_RULE: {
-	    struct xccdf_refine_rule_internal * r_rule = xccdf_policy_get_refine_rule_by_item(policy, item);
+            struct xccdf_refine_rule_internal * r_rule = xccdf_policy_get_refine_rule_by_item(policy, item);
             if (r_rule == NULL) return item;
 
             new_item = (struct xccdf_item *) xccdf_rule_clone((struct xccdf_rule *) item);
-            if (r_rule->role > 0)
-                xccdf_rule_set_role((struct xccdf_rule *) new_item, r_rule->role);
-            if (r_rule->severity > 0)
-                xccdf_rule_set_severity((struct xccdf_rule *) new_item, r_rule->severity);
-	    if (xccdf_weight_defined(r_rule->weight))
-                xccdf_rule_set_weight((struct xccdf_rule *) new_item, r_rule->weight);
+            if (xccdf_refine_rule_internal_get_role(r_rule) > 0)
+                xccdf_rule_set_role((struct xccdf_rule *) new_item, xccdf_refine_rule_internal_get_role(r_rule));
+            if (xccdf_refine_rule_internal_get_severity(r_rule) > 0)
+                xccdf_rule_set_severity((struct xccdf_rule *) new_item, xccdf_refine_rule_internal_get_severity(r_rule));
+            if (xccdf_weight_defined(xccdf_refine_rule_internal_get_weight(r_rule)))
+                xccdf_rule_set_weight((struct xccdf_rule *) new_item, xccdf_refine_rule_internal_get_weight(r_rule));
                 break;
             }
         case XCCDF_GROUP: {
-	struct xccdf_refine_rule_internal * r_rule = xccdf_policy_get_refine_rule_by_item(policy, item);
+        struct xccdf_refine_rule_internal * r_rule = xccdf_policy_get_refine_rule_by_item(policy, item);
             if (r_rule == NULL) return item;
 
             new_item = (struct xccdf_item *) xccdf_group_clone((struct xccdf_group *) item);
-	    if (xccdf_weight_defined(r_rule->weight))
-                xccdf_group_set_weight((struct xccdf_group *) new_item, r_rule->weight);
+            if (xccdf_weight_defined(xccdf_refine_rule_internal_get_weight(r_rule)))
+                xccdf_group_set_weight((struct xccdf_group *) new_item, xccdf_refine_rule_internal_get_weight(r_rule));
             else {
                 xccdf_group_free(new_item);
                 return item;
@@ -2479,7 +2479,7 @@ void xccdf_policy_free(struct xccdf_policy * policy) {
 	oscap_list_free(policy->results, (oscap_destruct_func) xccdf_result_free);
 	oscap_htable_free0(policy->selected_internal);
 	oscap_htable_free0(policy->selected_final);
-	oscap_htable_free(policy->refine_rules_internal, (oscap_destruct_func) refine_rule_internal_free);
+	oscap_htable_free(policy->refine_rules_internal, (oscap_destruct_func) xccdf_refine_rule_internal_free);
         oscap_free(policy);
 }
 

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -2143,7 +2143,7 @@ bool xccdf_policy_resolve(struct xccdf_policy * policy)
                 /* Perform all changes in rule */
                 if ((int)xccdf_refine_rule_get_role(r_rule) > 0)
                     xccdf_rule_set_role((struct xccdf_rule *) item, xccdf_refine_rule_get_role(r_rule));
-                if ((int)xccdf_refine_rule_get_severity(r_rule) > 0)
+                if ((int)xccdf_refine_rule_get_severity(r_rule) != XCCDF_LEVEL_NOT_DEFINED)
                     xccdf_rule_set_severity((struct xccdf_rule *) item, xccdf_refine_rule_get_severity(r_rule));
 
             } else {}/* TODO oscap_err ? */;
@@ -2362,7 +2362,7 @@ struct xccdf_item * xccdf_policy_tailor_item(struct xccdf_policy * policy, struc
             new_item = (struct xccdf_item *) xccdf_rule_clone((struct xccdf_rule *) item);
             if (xccdf_refine_rule_internal_get_role(r_rule) > 0)
                 xccdf_rule_set_role((struct xccdf_rule *) new_item, xccdf_refine_rule_internal_get_role(r_rule));
-            if (xccdf_refine_rule_internal_get_severity(r_rule) > 0)
+            if (xccdf_refine_rule_internal_get_severity(r_rule) != XCCDF_LEVEL_NOT_DEFINED)
                 xccdf_rule_set_severity((struct xccdf_rule *) new_item, xccdf_refine_rule_internal_get_severity(r_rule));
             if (xccdf_weight_defined(xccdf_refine_rule_internal_get_weight(r_rule)))
                 xccdf_rule_set_weight((struct xccdf_rule *) new_item, xccdf_refine_rule_internal_get_weight(r_rule));

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -49,54 +49,11 @@
 #include "common/debug_priv.h"
 #include "common/assume.h"
 #include "common/text_priv.h"
-#include "math.h"
+#include "xccdf_policy_resolve.h"
 
-/**
- * XCCDF policy model structure contains xccdf_benchmark as reference
- * to Benchmark element in XML file and list of policies that are
- * abstract structure of Profile element from benchmark file.
- */
-struct xccdf_policy_model {
-
-        struct xccdf_benchmark  * benchmark;    ///< Benchmark element (root element of XML file)
-	struct xccdf_tailoring * tailoring;     ///< Tailoring element
-	struct oscap_list       * policies;     ///< List of xccdf_policy structures
-	struct oscap_list       * callbacks;    ///< Callbacks for output callbacks (see callback_out_t)
-	struct oscap_list       * engines;      ///< Callbacks for checking engines (see xccdf_policy_engine)
-
-	struct oscap_list       * cpe_dicts; ///< All CPE dictionaries except the one embedded in XCCDF
-	struct oscap_list       * cpe_lang_models; ///< All CPE lang models except the one embedded in XCCDF
-	struct oscap_htable     * cpe_oval_sessions; ///< Caches CPE OVAL check results
-	struct oscap_htable     * cpe_applicable_platforms;
-};
 /* Macros to generate iterators, getters and setters */
 OSCAP_GETTER(struct xccdf_benchmark *, xccdf_policy_model, benchmark)
 OSCAP_IGETINS_GEN(xccdf_policy, xccdf_policy_model, policies, policy)
-
-/**
- * XCCDF policy structure is abstract (class) structure
- * of Profile element from benchmark.
- *
- * Structure contains rules and bound values to abstract
- * these lists from the benchmark file. Can be modified temporaly
- * so changes can be discarded or saved to the existing model.
- */
-struct xccdf_policy {
-
-        struct xccdf_policy_model   * model;    ///< XCCDF Policy model
-        struct xccdf_profile        * profile;  ///< Profile structure (from benchmark)
-	/** A list of all selects. Either from profile or later added through API. */
-        struct oscap_list           * selects;
-        struct oscap_list           * values;   ///< Bound values of profile
-        struct oscap_list           * results;  ///< List of XCCDF results
-	/** A hash which for given item points to the latest selector applicable.
-	 * There might not be one. Note that it migth be a selector for cluster-id. */
-	struct oscap_htable		*selected_internal;
-	/** A hash which for given item defines final selection */
-	struct oscap_htable		*selected_final;
-	/* The hash-table contains the latest refine-rule for specified item-id. */
-	struct oscap_htable		*refine_rules_internal;
-};
 
 /* Macros to generate iterators, getters and setters */
 OSCAP_GETTER(struct xccdf_policy_model *, xccdf_policy, model)
@@ -152,61 +109,12 @@ typedef struct xccdf_flat_score {
 
 } xccdf_flat_score_t;
 
-/*
- * Struct contains final values defined in several xccdf_refine_rule structures.
- * There is no "item" member. Hash-table key is used instead of this member.
- * This structure is used only for internal rule processing.
- */
-struct xccdf_refine_rule_internal {
-	char *selector;
-	xccdf_role_t role;
-	xccdf_level_t severity;
-	xccdf_numeric weight;
-};
-
-static void _merge_refine_rules(struct xccdf_refine_rule_internal* dst, const struct xccdf_refine_rule* src)
-{
-	bool new_weight_defined = xccdf_refine_rule_weight_defined(src);
-	if ( new_weight_defined ) {
-		xccdf_numeric new_weight = xccdf_refine_rule_get_weight(src);
-		dst->weight = new_weight;
-	}
-
-
-	const char* new_selector = xccdf_refine_rule_get_selector(src);
-	if (new_selector != NULL) {
-		oscap_free(dst->selector);
-		dst->selector = strdup( new_selector );
-	}
-
-	xccdf_role_t new_role = xccdf_refine_rule_get_role(src);
-	if ( new_role != 0 ) {
-		dst->role = new_role;
-	}
-
-	xccdf_level_t new_severity = xccdf_refine_rule_get_severity(src);
-	if ( new_severity != 0 ) {
-		dst->severity = new_severity;
-	}
- }
-
-static struct xccdf_refine_rule_internal* xccdf_refine_rule_internal_new_from_refine_rule(const struct xccdf_refine_rule* rr)
-{
-	struct xccdf_refine_rule_internal* new_rr = oscap_calloc(1, sizeof(struct xccdf_refine_rule_internal));
-	new_rr->selector = oscap_strdup(xccdf_refine_rule_get_selector(rr));
-	new_rr->weight = rr->weight;
-	new_rr->role = rr->role;
-	new_rr->severity = rr->severity;
-	return new_rr;
-}
-
 
 /*==========================================================================*/
 /* Declaration of static (private to this file) functions
  * These function shoud not be called from outside. For exporting these 
  * elements has to call parent element's 
  */
-static struct xccdf_refine_rule_internal * xccdf_policy_get_refine_rules_by_rule(struct xccdf_policy * policy, struct xccdf_item * item);
 
 /**
  * Filter function returning true if the item is selected, false otherwise
@@ -223,36 +131,6 @@ static bool xccdf_policy_filter_selected(void *item, void *policy)
         }
 	return ((xccdf_item_get_type(titem) == XCCDF_RULE) &&
 		(xccdf_select_get_selected((struct xccdf_select *) item)));
-}
-
-static xccdf_role_t _get_final_role(const struct xccdf_rule *rule, const struct xccdf_refine_rule_internal* r_rule){
-	if (r_rule == NULL){
-		return xccdf_rule_get_role(rule);
-	} else {
-		return r_rule->role;
-	}
-}
-
-static inline bool _weight_defined(xccdf_numeric weight){
-	return (!isnan(weight));
-}
-
-static float _get_final_weight(const struct xccdf_rule *rule, const struct xccdf_refine_rule_internal* r_rule){
-	if (r_rule != NULL){
-		if ( _weight_defined(r_rule->weight) ) {
-			return r_rule->weight;
-		}
-	}
-	return xccdf_rule_get_weight(rule);
-
-}
-
-static xccdf_level_t _get_final_severity(const struct xccdf_rule *rule, const struct xccdf_refine_rule_internal* r_rule){
-	if (r_rule == NULL){
-		return xccdf_rule_get_severity(rule);
-	} else {
-		return r_rule->severity;
-	}
 }
 
 /**
@@ -708,7 +586,7 @@ _xccdf_policy_rule_get_applicable_check(struct xccdf_policy *policy, struct xccd
 	if (result == NULL) {
 		// Check Processing Algorithm -- Check.Initialize
 		// Check Processing Algorithm -- Check.Selector
-		struct xccdf_refine_rule_internal *r_rule = xccdf_policy_get_refine_rules_by_rule(policy, rule);
+		struct xccdf_refine_rule_internal *r_rule = xccdf_policy_get_refine_rule_by_item(policy, rule);
 		char *selector = (r_rule == NULL) ? NULL : r_rule->selector;
 		struct xccdf_check_iterator *candidate_it = xccdf_rule_get_checks_filtered(rule, selector);
 		if (selector != NULL && !xccdf_check_iterator_has_more(candidate_it)) {
@@ -787,10 +665,10 @@ static struct xccdf_rule_result * _xccdf_rule_result_new_from_rule(const struct 
 	/* --Set rule-- */
 	xccdf_rule_result_set_result(rule_ritem, eval_result);
 	xccdf_rule_result_set_idref(rule_ritem, xccdf_rule_get_id(rule));
-	xccdf_rule_result_set_weight(rule_ritem, _get_final_weight(rule, r_rule));
+	xccdf_rule_result_set_weight(rule_ritem, xccdf_get_final_weight(rule, r_rule));
 	xccdf_rule_result_set_version(rule_ritem, xccdf_rule_get_version(rule));
-	xccdf_rule_result_set_severity(rule_ritem, _get_final_severity(rule, r_rule));
-	xccdf_rule_result_set_role(rule_ritem, _get_final_role(rule, r_rule));
+	xccdf_rule_result_set_severity(rule_ritem, xccdf_get_final_severity(rule, r_rule));
+	xccdf_rule_result_set_role(rule_ritem, xccdf_get_final_role(rule, r_rule));
 
 	xccdf_rule_result_set_time_current(rule_ritem);
 
@@ -1119,7 +997,7 @@ _xccdf_policy_rule_evaluate(struct xccdf_policy * policy, const struct xccdf_rul
 
 	struct xccdf_refine_rule_internal* r_rule = oscap_htable_get(policy->refine_rules_internal, rule_id);
 
-	xccdf_role_t role = _get_final_role(rule, r_rule);
+	xccdf_role_t role = xccdf_get_final_role(rule, r_rule);
 	if (role  == XCCDF_ROLE_UNCHECKED )
 		return _xccdf_policy_report_rule_result(policy, result, rule, NULL, XCCDF_RESULT_NOT_CHECKED, NULL);
 
@@ -2032,54 +1910,6 @@ _xccdf_policy_add_selector_internal(struct xccdf_policy *policy, struct xccdf_be
 	return result;
 }
 
-/**
- * Add refine rule to item
- *
- * Add refine-rule to item ID. If item has some previous refine-rule,
- * new refine-rule (partially) override the old one
- * @param refine_rules_internal
- * @param new_rr refine-rule to add
- * @param item_id
- */
-static void _add_refine_rule(struct oscap_htable* refine_rules_internal, const struct xccdf_refine_rule* new_rr, const char* item_id)
-{
-	struct xccdf_refine_rule_internal* old = oscap_htable_get(refine_rules_internal, item_id);
-	if ( old != NULL ) { // modify refine-rule in hash table
-		_merge_refine_rules(old, new_rr);
-	} else { // add new refine-rule
-		struct xccdf_refine_rule_internal* new_internal_rr = xccdf_refine_rule_internal_new_from_refine_rule(new_rr);
-		oscap_htable_add(refine_rules_internal, item_id, new_internal_rr);
-	}
-}
-
-static inline void _xccdf_policy_add_refine_rule_internal(struct xccdf_policy *policy, struct xccdf_benchmark *benchmark, const struct xccdf_refine_rule *refine_rule)
-{
-	const char * rr_item_id = xccdf_refine_rule_get_item(refine_rule);
-	struct xccdf_item *item = xccdf_benchmark_get_member(benchmark, XCCDF_ITEM, rr_item_id);
-	if ( item != NULL ) { // get by id
-		_add_refine_rule(policy->refine_rules_internal, refine_rule, rr_item_id);
-		return;
-	}
-
-	// try to get by cluster-id
-	struct oscap_htable_iterator *hit = xccdf_benchmark_get_cluster_items(benchmark, rr_item_id);
-	if (hit == NULL) {
-		oscap_seterr(OSCAP_EFAMILY_XCCDF, "Selector ID(%s) does not exist in Benchmark.", rr_item_id);
-		return;
-	}
-
-	while (oscap_htable_iterator_has_more(hit)) { // iterate through every item in cluster
-		const char *item_id = oscap_htable_iterator_next_key(hit);
-		if (item_id == NULL) {
-			assert(item_id != NULL);
-			continue;
-		}
-		_add_refine_rule(policy->refine_rules_internal,refine_rule, item_id);
-	}
-	oscap_htable_iterator_free(hit);
-}
-
-
 bool
 xccdf_policy_add_select(struct xccdf_policy *policy, struct xccdf_select *sel)
 {
@@ -2128,28 +1958,6 @@ static void _xccdf_policy_add_profile_selectors(struct xccdf_policy* policy, str
 }
 
 /**
- * @brief _xccdf_policy_add_profile_refine_rules
- * @param policy
- * @param benchmark
- * @param profile
- */
-static void _xccdf_policy_add_profile_refine_rules(struct xccdf_policy* policy, struct xccdf_benchmark *benchmark, struct xccdf_profile *profile)
-{
-	struct xccdf_refine_rule_iterator *rr_it = xccdf_profile_get_refine_rules(profile);
-	/* Iterate through refine_rules in profile */
-	while (xccdf_refine_rule_iterator_has_more(rr_it)) {
-		struct xccdf_refine_rule *rr = xccdf_refine_rule_iterator_next(rr_it);
-		if (rr == NULL) {
-			assert(false);
-			continue;
-		}
-		struct xccdf_refine_rule *clone = xccdf_refine_rule_clone(rr);
-		_xccdf_policy_add_refine_rule_internal(policy, benchmark, clone);
-	}
-	xccdf_refine_rule_iterator_free(rr_it);
-}
-
-/**
  * Constructor for structure XCCDF Policy. Create the structure and resolve all rules
  * from benchmark that are not present in selectors. This step is necessary because of 
  * default values of groups / rules that can be added to Policy whether or not they have
@@ -2182,7 +1990,7 @@ struct xccdf_policy * xccdf_policy_new(struct xccdf_policy_model * model, struct
 
 	if (profile) {
 		_xccdf_policy_add_profile_selectors(policy, benchmark, profile);
-		_xccdf_policy_add_profile_refine_rules(policy, benchmark, profile);
+		xccdf_policy_add_profile_refine_rules(policy, benchmark, profile);
 	}
 
         /* Iterate through items in benchmark and resolve rules */
@@ -2397,8 +2205,8 @@ struct xccdf_result * xccdf_policy_evaluate(struct xccdf_policy * policy)
         sprintf(rid, "xccdf_org.open-scap_testresult_%s", id);
         xccdf_result_set_id(result, rid);
     }
-    else
-    {
+    else {
+
     	// previous behaviour for backwards compatibility
 
         char rid[11+strlen(id)];
@@ -2479,11 +2287,6 @@ struct xccdf_score * xccdf_policy_get_score(struct xccdf_policy * policy, struct
     return score;
 }
 
-static struct xccdf_refine_rule_internal * xccdf_policy_get_refine_rules_by_rule(struct xccdf_policy * policy, struct xccdf_item * rule)
-{
-	const char* item_id = xccdf_item_get_id(rule);
-	return oscap_htable_get(policy->refine_rules_internal, item_id);
-}
 
 const char *xccdf_policy_get_value_of_item(struct xccdf_policy * policy, struct xccdf_item * item)
 {
@@ -2553,7 +2356,7 @@ struct xccdf_item * xccdf_policy_tailor_item(struct xccdf_policy * policy, struc
     xccdf_type_t type = xccdf_item_get_type(item);
     switch (type) {
         case XCCDF_RULE: {
-            struct xccdf_refine_rule_internal * r_rule = xccdf_policy_get_refine_rules_by_rule(policy, item);
+	    struct xccdf_refine_rule_internal * r_rule = xccdf_policy_get_refine_rule_by_item(policy, item);
             if (r_rule == NULL) return item;
 
             new_item = (struct xccdf_item *) xccdf_rule_clone((struct xccdf_rule *) item);
@@ -2561,16 +2364,16 @@ struct xccdf_item * xccdf_policy_tailor_item(struct xccdf_policy * policy, struc
                 xccdf_rule_set_role((struct xccdf_rule *) new_item, r_rule->role);
             if (r_rule->severity > 0)
                 xccdf_rule_set_severity((struct xccdf_rule *) new_item, r_rule->severity);
-            if (_weight_defined(r_rule->weight))
+	    if (xccdf_weight_defined(r_rule->weight))
                 xccdf_rule_set_weight((struct xccdf_rule *) new_item, r_rule->weight);
                 break;
             }
         case XCCDF_GROUP: {
-        struct xccdf_refine_rule_internal * r_rule = xccdf_policy_get_refine_rules_by_rule(policy, item);
+	struct xccdf_refine_rule_internal * r_rule = xccdf_policy_get_refine_rule_by_item(policy, item);
             if (r_rule == NULL) return item;
 
             new_item = (struct xccdf_item *) xccdf_group_clone((struct xccdf_group *) item);
-            if (_weight_defined(r_rule->weight))
+	    if (xccdf_weight_defined(r_rule->weight))
                 xccdf_group_set_weight((struct xccdf_group *) new_item, r_rule->weight);
             else {
                 xccdf_group_free(new_item);
@@ -2660,10 +2463,7 @@ void xccdf_policy_model_free(struct xccdf_policy_model * model) {
         oscap_free(model);
 }
 
-static void _refine_rule_internal_free(struct xccdf_refine_rule_internal *item){
-	oscap_free(item->selector);
-	oscap_free(item);
-}
+
 
 void xccdf_policy_free(struct xccdf_policy * policy) {
 
@@ -2679,7 +2479,7 @@ void xccdf_policy_free(struct xccdf_policy * policy) {
 	oscap_list_free(policy->results, (oscap_destruct_func) xccdf_result_free);
 	oscap_htable_free0(policy->selected_internal);
 	oscap_htable_free0(policy->selected_final);
-	oscap_htable_free(policy->refine_rules_internal, (oscap_destruct_func)_refine_rule_internal_free);
+	oscap_htable_free(policy->refine_rules_internal, (oscap_destruct_func) refine_rule_internal_free);
         oscap_free(policy);
 }
 

--- a/src/XCCDF_POLICY/xccdf_policy_priv.h
+++ b/src/XCCDF_POLICY/xccdf_policy_priv.h
@@ -30,6 +30,53 @@
 
 OSCAP_HIDDEN_START;
 
+
+/**
+ * XCCDF policy model structure contains xccdf_benchmark as reference
+ * to Benchmark element in XML file and list of policies that are
+ * abstract structure of Profile element from benchmark file.
+ */
+struct xccdf_policy_model {
+
+	struct xccdf_benchmark  * benchmark;    ///< Benchmark element (root element of XML file)
+	struct xccdf_tailoring * tailoring;     ///< Tailoring element
+	struct oscap_list       * policies;     ///< List of xccdf_policy structures
+	struct oscap_list       * callbacks;    ///< Callbacks for output callbacks (see callback_out_t)
+	struct oscap_list       * engines;      ///< Callbacks for checking engines (see xccdf_policy_engine)
+
+	struct oscap_list       * cpe_dicts; ///< All CPE dictionaries except the one embedded in XCCDF
+	struct oscap_list       * cpe_lang_models; ///< All CPE lang models except the one embedded in XCCDF
+	struct oscap_htable     * cpe_oval_sessions; ///< Caches CPE OVAL check results
+	struct oscap_htable     * cpe_applicable_platforms;
+};
+
+/**
+ * XCCDF policy structure is abstract (class) structure
+ * of Profile element from benchmark.
+ *
+ * Structure contains rules and bound values to abstract
+ * these lists from the benchmark file. Can be modified temporaly
+ * so changes can be discarded or saved to the existing model.
+ */
+struct xccdf_policy {
+
+	struct xccdf_policy_model   * model;    ///< XCCDF Policy model
+	struct xccdf_profile        * profile;  ///< Profile structure (from benchmark)
+	/** A list of all selects. Either from profile or later added through API. */
+	struct oscap_list           * selects;
+	struct oscap_list           * values;   ///< Bound values of profile
+	struct oscap_list           * results;  ///< List of XCCDF results
+	/** A hash which for given item points to the latest selector applicable.
+	 * There might not be one. Note that it migth be a selector for cluster-id. */
+	struct oscap_htable		*selected_internal;
+	/** A hash which for given item defines final selection */
+	struct oscap_htable		*selected_final;
+	/* The hash-table contains the latest refine-rule for specified item-id. */
+	struct oscap_htable		*refine_rules_internal;
+};
+
+
+
 /**
  * Resolve text substitution in given fix element. Use given xccdf_policy settings
  * for resolving.

--- a/src/XCCDF_POLICY/xccdf_policy_resolve.c
+++ b/src/XCCDF_POLICY/xccdf_policy_resolve.c
@@ -21,6 +21,18 @@
 #include "item.h"
 #include "common/_error.h"
 
+struct xccdf_refine_rule_internal {
+	char* selector;
+	xccdf_role_t role;
+	xccdf_level_t severity;
+	xccdf_numeric weight;
+};
+
+OSCAP_GETTER(char*, xccdf_refine_rule_internal, selector);
+OSCAP_GETTER(xccdf_role_t, xccdf_refine_rule_internal, role);
+OSCAP_GETTER(xccdf_level_t, xccdf_refine_rule_internal, severity);
+OSCAP_GETTER(xccdf_numeric, xccdf_refine_rule_internal, weight);
+
 /**
  * Merge refine rule from profile with internal refine rule
  * Defined src refine-rule will override dst values
@@ -69,7 +81,7 @@ static inline struct xccdf_refine_rule_internal* _xccdf_refine_rule_internal_new
 	return new_rr;
 }
 
-struct xccdf_refine_rule_internal * xccdf_policy_get_refine_rule_by_item(struct xccdf_policy * policy, struct xccdf_item * rule)
+struct xccdf_refine_rule_internal* xccdf_policy_get_refine_rule_by_item(struct xccdf_policy* policy, struct xccdf_item* rule)
 {
 	const char* item_id = xccdf_item_get_id(rule);
 	return oscap_htable_get(policy->refine_rules_internal, item_id);
@@ -127,13 +139,13 @@ static void _add_refine_rule(struct oscap_htable* refine_rules_internal, const s
 	}
 }
 
-void refine_rule_internal_free(struct xccdf_refine_rule_internal* item)
+void xccdf_refine_rule_internal_free(struct xccdf_refine_rule_internal* item)
 {
 	oscap_free(item->selector);
 	oscap_free(item);
 }
 
-static inline void _xccdf_policy_add_refine_rule_internal(struct xccdf_policy* policy, struct xccdf_benchmark* benchmark, const struct xccdf_refine_rule* refine_rule)
+static inline void _xccdf_policy_add_xccdf_refine_rule_internal(struct xccdf_policy* policy, struct xccdf_benchmark* benchmark, const struct xccdf_refine_rule* refine_rule)
 {
 	const char* rr_item_id = xccdf_refine_rule_get_item(refine_rule);
 	struct xccdf_item* item = xccdf_benchmark_get_member(benchmark, XCCDF_ITEM, rr_item_id);
@@ -165,13 +177,13 @@ void xccdf_policy_add_profile_refine_rules(struct xccdf_policy* policy, struct x
 	struct xccdf_refine_rule_iterator* rr_it = xccdf_profile_get_refine_rules(profile);
 	/* Iterate through refine_rules in profile */
 	while (xccdf_refine_rule_iterator_has_more(rr_it)) {
-		struct xccdf_refine_rule *rr = xccdf_refine_rule_iterator_next(rr_it);
+		struct xccdf_refine_rule* rr = xccdf_refine_rule_iterator_next(rr_it);
 		if (rr == NULL) {
 			assert(false);
 			continue;
 		}
 		struct xccdf_refine_rule* clone = xccdf_refine_rule_clone(rr);
-		_xccdf_policy_add_refine_rule_internal(policy, benchmark, clone);
+		_xccdf_policy_add_xccdf_refine_rule_internal(policy, benchmark, clone);
 	}
 	xccdf_refine_rule_iterator_free(rr_it);
 }

--- a/src/XCCDF_POLICY/xccdf_policy_resolve.c
+++ b/src/XCCDF_POLICY/xccdf_policy_resolve.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright 1015 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+#include "xccdf_policy_resolve.h"
+#include "item.h"
+#include "common/_error.h"
+
+/**
+ * Merge refine rule from profile with internal refine rule
+ * Defined src refine-rule will override dst values
+ * @param dst Internal refine rule
+ * @param src Refine rule from profile
+ */
+static void _merge_refine_rules(struct xccdf_refine_rule_internal* dst, const struct xccdf_refine_rule* src)
+{
+	bool new_weight_defined = xccdf_refine_rule_weight_defined(src);
+	if (new_weight_defined) {
+		xccdf_numeric new_weight = xccdf_refine_rule_get_weight(src);
+		dst->weight = new_weight;
+	}
+
+	const char* new_selector = xccdf_refine_rule_get_selector(src);
+	if (new_selector != NULL) {
+		oscap_free(dst->selector);
+		dst->selector = oscap_strdup( new_selector );
+	}
+
+	xccdf_role_t new_role = xccdf_refine_rule_get_role(src);
+	if (new_role != 0) {
+		dst->role = new_role;
+	}
+
+	xccdf_level_t new_severity = xccdf_refine_rule_get_severity(src);
+	if (new_severity != XCCDF_LEVEL_NOT_DEFINED) {
+		dst->severity = new_severity;
+	}
+}
+
+/**
+ * Allocate memory for new struct and init it with refine-rule values
+ * @param rr Refine rule from profile
+ * @return allocated internal refine-rule
+ */
+static inline struct xccdf_refine_rule_internal* _xccdf_refine_rule_internal_new_from_refine_rule(const struct xccdf_refine_rule* rr)
+{
+	struct xccdf_refine_rule_internal* new_rr = oscap_calloc(1, sizeof(struct xccdf_refine_rule_internal));
+	if (new_rr != NULL) {
+		new_rr->selector = oscap_strdup(xccdf_refine_rule_get_selector(rr));
+		new_rr->weight = rr->weight;
+		new_rr->role = rr->role;
+		new_rr->severity = rr->severity;
+	}
+	return new_rr;
+}
+
+struct xccdf_refine_rule_internal * xccdf_policy_get_refine_rule_by_item(struct xccdf_policy * policy, struct xccdf_item * rule)
+{
+	const char* item_id = xccdf_item_get_id(rule);
+	return oscap_htable_get(policy->refine_rules_internal, item_id);
+}
+
+xccdf_role_t xccdf_get_final_role(const struct xccdf_rule* rule, const struct xccdf_refine_rule_internal* r_rule)
+{
+	if (r_rule == NULL) {
+		return xccdf_rule_get_role(rule);
+	} else {
+		return r_rule->role;
+	}
+}
+
+/**
+ * Return true, if value of weight is valid
+ */
+bool xccdf_weight_defined(xccdf_numeric weight){
+	return (!isnan(weight));
+}
+
+float xccdf_get_final_weight(const struct xccdf_rule* rule, const struct xccdf_refine_rule_internal* r_rule)
+{
+	if (r_rule != NULL){
+		if (xccdf_weight_defined(r_rule->weight) ) {
+			return r_rule->weight;
+		}
+	}
+	return xccdf_rule_get_weight(rule);
+}
+
+xccdf_level_t xccdf_get_final_severity(const struct xccdf_rule* rule, const struct xccdf_refine_rule_internal* r_rule)
+{
+	if (r_rule == NULL){
+		return xccdf_rule_get_severity(rule);
+	} else {
+		return r_rule->severity;
+	}
+}
+
+/**
+ * Put refine-rule into hash table with item_id as key. Refine-rules are with same key are merged.
+ * @param refine_rules_internal hash table
+ * @param new_rr refine-rule to add
+ * @param item_id key to hash table
+ */
+static void _add_refine_rule(struct oscap_htable* refine_rules_internal, const struct xccdf_refine_rule* new_rr, const char* item_id)
+{
+	struct xccdf_refine_rule_internal* old = oscap_htable_get(refine_rules_internal, item_id);
+	if (old != NULL) { // modify refine-rule in hash-table
+		_merge_refine_rules(old, new_rr);
+	} else { // add new refine-rule to hash-table
+		struct xccdf_refine_rule_internal* new_internal_rr = _xccdf_refine_rule_internal_new_from_refine_rule(new_rr);
+		oscap_htable_add(refine_rules_internal, item_id, new_internal_rr);
+	}
+}
+
+void refine_rule_internal_free(struct xccdf_refine_rule_internal* item)
+{
+	oscap_free(item->selector);
+	oscap_free(item);
+}
+
+static inline void _xccdf_policy_add_refine_rule_internal(struct xccdf_policy* policy, struct xccdf_benchmark* benchmark, const struct xccdf_refine_rule* refine_rule)
+{
+	const char* rr_item_id = xccdf_refine_rule_get_item(refine_rule);
+	struct xccdf_item* item = xccdf_benchmark_get_member(benchmark, XCCDF_ITEM, rr_item_id);
+	if (item != NULL) { // get item by id
+		_add_refine_rule(policy->refine_rules_internal, refine_rule, rr_item_id);
+		return;
+	}
+
+	// try to get items by cluster-id
+	struct oscap_htable_iterator* hit = xccdf_benchmark_get_cluster_items(benchmark, rr_item_id);
+	if (hit == NULL) {
+		oscap_seterr(OSCAP_EFAMILY_XCCDF, "Selector ID(%s) does not exist in Benchmark.", rr_item_id);
+		return;
+	}
+
+	while (oscap_htable_iterator_has_more(hit)) { // iterate through every item in cluster
+		const char* item_id = oscap_htable_iterator_next_key(hit);
+		if (item_id == NULL) {
+			assert(item_id != NULL);
+			continue;
+		}
+		_add_refine_rule(policy->refine_rules_internal,refine_rule, item_id);
+	}
+	oscap_htable_iterator_free(hit);
+}
+
+void xccdf_policy_add_profile_refine_rules(struct xccdf_policy* policy, struct xccdf_benchmark* benchmark, struct xccdf_profile* profile)
+{
+	struct xccdf_refine_rule_iterator* rr_it = xccdf_profile_get_refine_rules(profile);
+	/* Iterate through refine_rules in profile */
+	while (xccdf_refine_rule_iterator_has_more(rr_it)) {
+		struct xccdf_refine_rule *rr = xccdf_refine_rule_iterator_next(rr_it);
+		if (rr == NULL) {
+			assert(false);
+			continue;
+		}
+		struct xccdf_refine_rule* clone = xccdf_refine_rule_clone(rr);
+		_xccdf_policy_add_refine_rule_internal(policy, benchmark, clone);
+	}
+	xccdf_refine_rule_iterator_free(rr_it);
+}

--- a/src/XCCDF_POLICY/xccdf_policy_resolve.h
+++ b/src/XCCDF_POLICY/xccdf_policy_resolve.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifndef XCCDF_POLICY_RESOLVE_H_
+#define XCCDF_POLICY_RESOLVE_H_
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <xccdf_benchmark.h>
+#include <xccdf_policy_priv.h>
+#include <math.h>
+
+/*
+ * Struct contains final values defined in several xccdf_refine_rule structures.
+ * There is no "item" member. Hash-table key is used instead of this member.
+ * This structure is used only for internal rule processing.
+ */
+struct xccdf_refine_rule_internal {
+	char* selector;
+	xccdf_role_t role;
+	xccdf_level_t severity;
+	xccdf_numeric weight;
+};
+
+/**
+ * Return refine-rule belonging to an item (by item ID)
+ * @return refine-rule or NULL
+ */
+struct xccdf_refine_rule_internal*  xccdf_policy_get_refine_rule_by_item(struct xccdf_policy * policy, struct xccdf_item* item);
+
+/**
+ * Return true, if value of weight is valid
+ */
+bool xccdf_weight_defined(xccdf_numeric weight);
+
+/**
+ * Return final role of rule (role set by role potentially refined by refine-rule)
+ */
+xccdf_role_t xccdf_get_final_role(const struct xccdf_rule* rule, const struct xccdf_refine_rule_internal* r_rule);
+
+/**
+ * Return final weight of rule (role set by role potentially refined by refine-rule)
+ */
+float xccdf_get_final_weight(const struct xccdf_rule* rule, const struct xccdf_refine_rule_internal* r_rule);
+
+/**
+ * Return final severity of rule (role set by role potentially refined by refine-rule)
+ */
+xccdf_level_t xccdf_get_final_severity(const struct xccdf_rule* rule, const struct xccdf_refine_rule_internal* r_rule);
+
+/**
+ * Process refine-rules from profile and fill hash table with final value of refine-rules for specific item-id
+ */
+void xccdf_policy_add_profile_refine_rules(struct xccdf_policy* policy, struct xccdf_benchmark* benchmark, struct xccdf_profile* profile);
+
+/**
+ * Free function for xccdf_refine_rule_internal
+ */
+void refine_rule_internal_free(struct xccdf_refine_rule_internal* item);
+
+#endif

--- a/src/XCCDF_POLICY/xccdf_policy_resolve.h
+++ b/src/XCCDF_POLICY/xccdf_policy_resolve.h
@@ -29,23 +29,24 @@
 #include <xccdf_policy_priv.h>
 #include <math.h>
 
+
 /*
  * Struct contains final values defined in several xccdf_refine_rule structures.
  * There is no "item" member. Hash-table key is used instead of this member.
  * This structure is used only for internal rule processing.
  */
-struct xccdf_refine_rule_internal {
-	char* selector;
-	xccdf_role_t role;
-	xccdf_level_t severity;
-	xccdf_numeric weight;
-};
+struct xccdf_refine_rule_internal;
+
+char* xccdf_refine_rule_internal_get_selector(const struct xccdf_refine_rule_internal*);
+xccdf_role_t xccdf_refine_rule_internal_get_role(const struct xccdf_refine_rule_internal*);
+xccdf_level_t xccdf_refine_rule_internal_get_severity(const struct xccdf_refine_rule_internal*);
+xccdf_numeric xccdf_refine_rule_internal_get_weight(const struct xccdf_refine_rule_internal*);
 
 /**
  * Return refine-rule belonging to an item (by item ID)
  * @return refine-rule or NULL
  */
-struct xccdf_refine_rule_internal*  xccdf_policy_get_refine_rule_by_item(struct xccdf_policy * policy, struct xccdf_item* item);
+struct xccdf_refine_rule_internal*  xccdf_policy_get_refine_rule_by_item(struct xccdf_policy* policy, struct xccdf_item* item);
 
 /**
  * Return true, if value of weight is valid
@@ -75,6 +76,6 @@ void xccdf_policy_add_profile_refine_rules(struct xccdf_policy* policy, struct x
 /**
  * Free function for xccdf_refine_rule_internal
  */
-void refine_rule_internal_free(struct xccdf_refine_rule_internal* item);
+void xccdf_refine_rule_internal_free(struct xccdf_refine_rule_internal* item);
 
 #endif

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -154,6 +154,8 @@ EXTRA_DIST += \
 	test_xccdf_notchecked_has_check.sh \
 	test_xccdf_notchecked_has_check.xccdf.xml \
 	test_xccdf_overlaping_IDs.xccdf.xml \
+	test_xccdf_refine_rule_refine.sh \
+	test_xccdf_refine_rule_refine.xccdf.xml \
 	test_xccdf_refine_rule.sh \
 	test_xccdf_refine_rule.xccdf.xml \
 	test_xccdf_selectors_cluster1.sh \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -30,6 +30,7 @@ test_run "check/@multi-check that has zero definitions" $srcdir/test_xccdf_check
 test_run "xccdf:check-content-ref without @name" $srcdir/test_xccdf_check_content_ref_without_name_attr.sh
 test_run "without xccdf:check-content-refs" $srcdir/test_xccdf_check_without_content_refs.sh
 test_run "xccdf:refine-rule/@weight shall not be exported" $srcdir/test_xccdf_refine_rule.sh
+test_run "xccdf:refine-rule shall refine rules" $srcdir/test_xccdf_refine_rule_refine.sh
 test_run "xccdf:fix/@distruption|@complexity shall not be exported" $srcdir/test_xccdf_fix_attr_export.sh
 test_run "xccdf:complex-check/@operator=AND -- notchecked" $srcdir/test_xccdf_complex_check_and_notchecked.sh
 test_run "Check Processing Algorithm -- complex-check priority" $srcdir/test_xccdf_check_processing_complex_priority.sh

--- a/tests/API/XCCDF/unittests/test_xccdf_refine_rule_refine.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_refine_rule_refine.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+# Test <refine-rule> element
+# 1st phase use xccdf profile with refine-rules
+# 2nd phase generate tailoring file from xccdf and use tailoring file's profiles
+
+# Return XPath expression of <rule-result>
+xpath_rule_result() {
+	local id_ref="$1"
+	echo '//TestResult/rule-result[ @idref="'"${id_ref}"'" ]'
+}
+
+# Assert <rule_result> has "notchecked" in <result>
+assert_notchecked() {
+	local id_ref="$1"
+	local rule_result="`xpath_rule_result \"${id_ref}\"`"
+	assert_exists 1 "${rule_result}"'/result[ text()="notchecked" ]' > /dev/stdout
+}
+
+# Assert <rule_result> has NOT "nonchecked" in <result>
+assert_checked() {
+	local id_ref="$1"
+	local rule_result="`xpath_rule_result \"${id_ref}\"`"
+	assert_exists 1 "${rule_result}"'/result[ text()!="notchecked" ]' > /dev/stdout
+}
+
+# Assert weight of <rule-result>
+assert_weight() {
+	local id_ref="$1"
+	local weight="$2"
+	assert_exists 1 "//rule-result[ @idref=\"${id_ref}\" and starts-with(@weight, \"${weight}\") ]" > /dev/stdout
+}
+
+# Create tailoring file from xccdf profiles
+# Add "tailor-" prefix before profile names
+# Return tailoring file content
+create_tailoring() {
+	local xccdf_filename="$1"
+	echo '<?xml version="1.0" encoding="UTF-8"?>'
+	echo '<cdf-11-tailoring:Tailoring xmlns:cdf-11-tailoring="http://open-scap.org/page/Xccdf-1.1-tailoring" xmlns="http://checklists.nist.gov/xccdf/1.1" id="xccdf_scap-workbench_tailoring_default">'
+	echo '<cdf-11-tailoring:version time="2014-03-13T12:22:15">1</cdf-11-tailoring:version>'
+	cat "$xccdf_filename" |\
+		tr '\t' '  ' |\
+		tr '\n' '\t '  |\
+		sed -E 's;<Profile(.*)</Profile>.*;<NEW><Profile\1</Profile>;' |\
+		sed -E 's;^.*<NEW>(.*);\1;' |\
+		sed -E 's;"(child|parent|grandparent)";"tailor-\1";g' |\
+		tr '\t' '\n'
+	echo ''
+	echo '</cdf-11-tailoring:Tailoring>'
+}
+
+
+check_results() {
+	local result="$1"
+	### 1. Grandparent refine selector of rule and child refine role of rule
+	#assert_exists 1 "`xpath_rule_result rule-id-selected-and-role`"'//check-content-ref[ @name="oval:moc.elpmaxe.www:def:2" ]'
+	assert_checked rule-id-selected-and-role
+
+	### 2. <refine-rule @weight> is two times overrided by extending of profile
+	assert_weight rule-id-override-refine 8
+
+	### 3. two refine-rules partially override themselves
+	assert_exists 1 '//rule-result[ @idref="rule-id-partially-refined" ]/result[ text()!="notchecked" ]'
+	#assert_exists 1 '//rule-result[ @idref="rule-id-partially-refined" and starts-with(@weight, "5") ]/result[ text()!="notchecked" ]'
+
+	### 4. The rule should be checked (no refine-rule is used)
+	assert_checked rule-id-checked
+
+	### 5. <refine-rule> enable check
+	assert_checked rule-id-checked
+
+	### 6. <refine-rule> from parent profile enable check
+	assert_checked rule-id-enable-parent-check
+
+	### 7.
+	assert_notchecked rule-id-without-refine
+
+	### 8.
+	assert_notchecked rule-id-inherited
+
+	### 9.
+	assert_notchecked rule-id-simple
+
+	### 10.
+	assert_notchecked rule-id-cluster
+
+	### 11. <refine-rule> for @weight
+	assert_weight rule-id-weight 2
+
+	### 12. <refine-rule> for @selector
+	assert_exists 1 "`xpath_rule_result rule-id-multiple-check`"'//check-content-ref[ @name="oval:moc.elpmaxe.www:def:2" ]'
+	assert_checked rule-id-multiple-check
+
+	### 13. two refine-rules partially override themselves
+	assert_exists 1 '//rule-result[ @idref="rule-id-partially-refined-2" ]/result[ text()="notchecked" ]'
+	#assert_exists 1 '//rule-result[ @idref="rule-id-partially-refined-2" and starts-with(@weight, "5") ]/result[ text()="notchecked" ]'
+
+	### 14. severity should be redefined
+	assert_exists 1 '//rule-result[ @idref="rule-id-severity" and @severity="high" ]'
+
+	### 15. weight should be overrided
+	assert_exists 1 '//rule-result[ @idref="rule-id-weight-override" and starts-with(@weight, "4") ]'
+
+	### 16. unscored should be checked
+	assert_checked rule-id-unscored
+}
+
+set -o pipefail
+
+name=$(basename $0 .sh)
+xccdf="$srcdir/${name}.xccdf.xml"
+
+########################################################################
+## Test refine-rules in profiles
+########################################################################
+echo "Test refine-rules in profiles:"
+
+result=$(mktemp -t ${name}.res.XXXXXX)
+stderr=$(mktemp -t ${name}.err.XXXXXX)
+stdout=$(mktemp -t ${name}.out.XXXXXX)
+
+echo "Stderr file = $stderr"
+echo "Result file = $result"
+
+$OSCAP xccdf eval --profile child --results $result $xccdf > $stdout 2> $stderr
+
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
+$OSCAP xccdf validate-xml $result
+
+RULE_COUNT=16
+
+# Same count of results as rules
+assert_exists ${RULE_COUNT} '//Rule'
+assert_exists ${RULE_COUNT} '//TestResult/rule-result/result'
+
+assert_exists 4 '//Rule[ @role="unchecked" ]' # Refine-rule does not modify rules values directly
+check_results $result
+
+rm $result
+########################################################################
+## Test refine-rules in tailoring file
+########################################################################
+echo ""
+echo "Test refine-rules in tailoring file:"
+
+result=$(mktemp -t ${name}.res.XXXXXX)
+stderr=$(mktemp -t ${name}.err.XXXXXX)
+stdout=$(mktemp -t ${name}.out.XXXXXX)
+tailoring=$(mktemp -t ${name}.in.XXXXXX)
+
+echo "Stderr file = $stderr"
+echo "Stdout file = $stdout"
+echo "Result file = $result"
+echo "Tailoring file = $tailoring"
+
+echo "`create_tailoring \"$xccdf\"`" > $tailoring
+
+$OSCAP xccdf eval --tailoring-file $tailoring --profile tailor-child --results $result $xccdf > $stdout 2> $stderr
+
+check_results $result
+
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+rm $result $tailoring

--- a/tests/API/XCCDF/unittests/test_xccdf_refine_rule_refine.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_xccdf_refine_rule_refine.xccdf.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.1" id="testing-xcccdf" resolved="false">
+  <status>incomplete</status>
+  <version>1.0</version>
+
+  <Profile id="grandparent">
+    <title>Grand parent</title>
+    <!-- 2. -->
+    <refine-rule idref="rule-id-override-refine" weight="6" />
+  </Profile>
+
+  <Profile id="parent" extends="grandparent">
+    <title>Parent profile</title>
+    <!-- 1. -->
+    <refine-rule idref="rule-id-selected-and-role" selector="selected" />
+    <!-- 2. -->
+    <refine-rule idref="rule-id-override-refine" weight="7" />
+    <!-- 3. -->
+    <refine-rule idref="rule-id-partially-refined" weight="5" role="unchecked" />
+    <!-- 6. -->
+    <refine-rule idref="rule-id-enable-parent-check" role="unchecked" />
+    <!-- 8. -->
+    <refine-rule idref="rule-id-inherited" role="unchecked" />
+    <!-- 13. -->
+    <refine-rule idref="rule-id-partially-refined-2" weight="5" role="full" />
+  </Profile>
+
+  <Profile id="child" extends="parent">
+    <title>Child profile</title>
+    <!-- 1. -->
+    <refine-rule idref="rule-id-selected-and-role" role="full" />
+    <!-- 2. -->
+    <refine-rule idref="rule-id-override-refine" weight="8" />
+    <!-- 3. -->
+    <refine-rule idref="rule-id-partially-refined" role="full" />
+    <!-- 5. -->
+    <refine-rule idref="rule-id-enable-check" role="full" />
+    <!-- 6. -->
+    <refine-rule idref="rule-id-enable-parent-check" role="full" />
+    <!-- 9. -->
+    <refine-rule idref="rule-id-simple" role="unchecked" />
+    <!-- 10. -->
+    <refine-rule idref="cluster-id-1" role="unchecked" />
+    <!-- 11. -->
+    <refine-rule idref="rule-id-weight" weight="2" />
+    <!-- 12. -->
+    <refine-rule idref="rule-id-multiple-check" role="full" selector="selected" />
+    <!-- 13. -->
+    <refine-rule idref="rule-id-partially-refined-2" role="unchecked" />
+    <!-- 14. -->
+    <refine-rule idref="rule-id-severity" severity="high" />
+    <!-- 15. -->
+    <refine-rule idref="rule-id-weight-override" weight="4" />
+    <!-- 16. -->
+    <refine-rule idref="rule-id-unscored" role="unscored" />
+  </Profile>
+
+  <!-- 1. -->
+  <Rule selected="true" id="rule-id-selected-and-role" role="unchecked">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:1" />
+    </check>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" selector="selected">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 2. @weight should be two times refined -->
+  <Rule selected="true" id="rule-id-override-refine">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 3. the rule should be checked -->
+  <Rule selected="true" id="rule-id-partially-refined">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 4. the rule should be checked -->
+  <Rule selected="true" id="rule-id-checked">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 5. enable-check -->
+  <Rule selected="true" id="rule-id-enable-check" role="unchecked">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 6. enable-parent-check -->
+  <Rule selected="true" id="rule-id-enable-parent-check">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 7. without refine-rule - should not be checked -->
+  <Rule selected="true" id="rule-id-without-refine" role="unchecked">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 8. refine-rule for Rule[@id] - from inherited profile -->
+  <Rule selected="true" id="rule-id-inherited">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 9. refine-rule for Rule[@id] -->
+  <Rule selected="true" id="rule-id-simple">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 10. refine-rule for Rule[@cluster-id] -->
+  <Rule selected="true" id="rule-id-cluster" cluster-id="cluster-id-1">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 11. the rule should have modified weight -->
+  <Rule id="rule-id-weight">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 12. refine-rule for Rule[@id and @selector="..."] -->
+  <Rule selected="true" id="rule-id-multiple-check" role="unchecked">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:1" />
+    </check>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" selector="selected">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" selector="nonselected">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:3" />
+    </check>
+  </Rule>
+  <!-- 13. the rule should not be checked -->
+  <Rule selected="true" id="rule-id-partially-refined-2">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:2" />
+    </check>
+  </Rule>
+  <!-- 14. severity should be set -->
+  <Rule selected="true" id="rule-id-severity">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:1" />
+    </check>
+  </Rule>
+  <!-- 15. weight should be overrided -->
+  <Rule selected="true" id="rule-id-weight-override" weight="23">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:1" />
+    </check>
+  </Rule>
+  <!-- 16. -->
+  <Rule selected="true" id="rule-id-unscored">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_xccdf_check_content_ref_without_name_attr.oval.xml" name="oval:moc.elpmaxe.www:def:1" />
+    </check>
+  </Rule>
+</Benchmark>


### PR DESCRIPTION
Should solve this ticket:
https://fedorahosted.org/openscap/ticket/439
Add support for  refine rule @weight, @severity @selector, but there are some unsolved issues with partially overriding refine-rules and refining @weight for groups. 