### PR TITLE
oscap_string fix oscap_string_free()

### DIFF
--- a/src/common/oscap_string.c
+++ b/src/common/oscap_string.c
@@ -56,8 +56,10 @@ struct oscap_string *oscap_string_new()
 
 void oscap_string_free(struct oscap_string *s)
 {
-	oscap_free(s->str);
-	oscap_free(s);
+	if (s != NULL) {
+		oscap_free(s->str);
+		oscap_free(s);
+	}
 }
 
 void oscap_string_append_char(struct oscap_string *s, char c)


### PR DESCRIPTION
Every oscap_string_* function check if ptr is NULL, except oscap_string_free()