### PR TITLE
Added OVAL 5.11.1 schemas to Makefile.am

### DIFF
--- a/schemas/Makefile.am
+++ b/schemas/Makefile.am
@@ -8,6 +8,7 @@ oval59dir = $(pkgdatadir)/schemas/oval/5.9/
 oval510dir = $(pkgdatadir)/schemas/oval/5.10/
 oval5101dir = $(pkgdatadir)/schemas/oval/5.10.1/
 oval511dir = $(pkgdatadir)/schemas/oval/5.11/
+oval5111dir = $(pkgdatadir)/schemas/oval/5.11.1/
 sce10dir = $(pkgdatadir)/schemas/sce/1.0/
 xccdf11dir = $(pkgdatadir)/schemas/xccdf/1.1/
 xccdf11tailoringdir = $(pkgdatadir)/schemas/xccdf/1.1-tailoring/
@@ -32,6 +33,7 @@ oval59_DATA = $(wildcard oval/5.9/*.xsd oval/5.9/*.xsl)
 oval510_DATA = $(wildcard oval/5.10/*.xsd oval/5.10/*.xsl)
 oval5101_DATA = $(wildcard oval/5.10.1/*.xsd oval/5.10.1/*.xsl)
 oval511_DATA = $(wildcard oval/5.11/*.xsd oval/5.11/*.xsl)
+oval5111_DATA = $(wildcard oval/5.11.1/*.xsd oval/5.11.1/*.xsl)
 
 sce10_DATA = sce/1.0/sce-result-schema.xsd
 
@@ -63,6 +65,7 @@ EXTRA_DIST = \
 	$(oval510_DATA) \
 	$(oval5101_DATA) \
 	$(oval511_DATA) \
+	$(oval5111_DATA) \
 	$(sce10_DATA) \
 	$(xccdf11_DATA) \
 	$(xccdf11tailoring_DATA) \


### PR DESCRIPTION
This fixes the `make distcheck` when performing (not yet available, but soon proposed) tests with content in OVAL 5.11.1. This commit used to be part of pull request 107. That PR handles schema_version elements. However, this commit doesn't have any connection with schema_version elements. Since that PR is large and it would likely require some more time before it will be merged, I have decided to remove this commit from pull request 107 and introduce the commit as a separate pull request. Because there is a possibility that this would block something in future, I would like to make it easy to merge this fix.