### PR TITLE
Turn the search engine on in Doxygen documentation

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1414,4 +1414,4 @@ DOT_CLEANUP            = YES
 # The SEARCHENGINE tag specifies whether or not a search engine should be 
 # used. If set to NO the values of all tags below this one will be ignored.
 
-SEARCHENGINE           = NO
+SEARCHENGINE           = YES


### PR DESCRIPTION
This will enable us to easily search through the Doxygen documentation.

See: https://fedorahosted.org/openscap/ticket/493