### PR TITLE
oscap-ssh - enable remote sudo operation by non-privileged users

### DIFF
--- a/utils/oscap-ssh
+++ b/utils/oscap-ssh
@@ -76,9 +76,13 @@ function usage()
     echo "  --variables"
     echo "  --skip-valid"
     echo
+    echo "specific option for oscap-ssh (must be first argument):"
+    echo "  --sudo"
+    echo
     echo "See \`man oscap\` to learn more about semantics of these options."
 }
 
+OSCAP_SUDO=""
 if [ $# -lt 1 ]; then
     echo "No arguments provided."
     usage
@@ -86,7 +90,11 @@ if [ $# -lt 1 ]; then
 elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     usage
     die
-elif [ $# -lt 2 ]; then
+elif [ "$1" == "sudo" ] || [ "$1" == "--sudo" ]; then
+    OSCAP_SUDO="sudo"
+    shift
+fi
+if [ $# -lt 2 ]; then
     echo "Missing ssh host and ssh port."
     usage
     die
@@ -209,8 +217,9 @@ if [ "$LOCAL_DIRECTIVES_PATH" != "" ]; then
     scp -o ControlPath=$MASTER_SOCKET -P "$SSH_PORT" "$LOCAL_DIRECTIVES_PATH" "$SSH_HOST:$REMOTE_TEMP_DIR/directives.xml" || die "Failed to copy OVAL directives file to remote temporary directory!"
 fi
 
+# Use 'sudo' if SSH_HOST user is not root
 echo "Starting the evaluation..."
-ssh -o ControlPath=$MASTER_SOCKET -p "$SSH_PORT" "$SSH_HOST" "oscap ${args[*]}"
+ssh -o ControlPath=$MASTER_SOCKET -p "$SSH_PORT" "$SSH_HOST" "$OSCAP_SUDO oscap ${args[*]}"
 OSCAP_EXIT_CODE=$?
 echo "oscap exit code: $OSCAP_EXIT_CODE"
 

--- a/utils/oscap-ssh.8
+++ b/utils/oscap-ssh.8
@@ -57,16 +57,25 @@ Supported options are:
   --variables
   --skip-valid
 
+Specific option for oscap-ssh (must be first argument):
+  --sudo
+
 .SH EXEMPLARY USAGE
 .SS Simple XCCDF evaluation
 The following command evaluates a remote Fedora machine as root. HTML report is written out as report.html on the local machine. Can be executed from any machine that has ssh, scp and bash. The local machine does not need to have openscap installed.
 
 $ oscap-ssh root@192.168.1.13 22 xccdf eval --profile xccdf_org.ssgproject.content_profile_common --report report.html /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml
 
-.SS XCCDF Evaluation with tailoring file.
+.SS XCCDF Evaluation with tailoring file
 The following command uses a tailoring file and also copies back ARF and XCCDF results. The tailoring file is automatically copied from local machine to remote.
 
-oscap-ssh root@192.168.1.13 22 xccdf eval --profile xccdf_org.ssgproject.content_profile_common --report report.html --results results.xml --results-arf arf.xml --tailoring-file ssg-fedora-ds-tailoring.xml /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml
+$ oscap-ssh --sudo oscap-user@192.168.1.13 22 xccdf eval --profile xccdf_org.ssgproject.content_profile_common --report report.html --results results.xml --results-arf arf.xml --tailoring-file ssg-fedora-ds-tailoring.xml /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml
+
+.SS Running remotely as root
+Note that the openscap scanner is best run by the 'root' user as in the first example above. To do this, the "PermitRootLogin" directive must be enabled in /etc/ssh/sshd_config, which is itself a security violation. A safer approach is to enable a non-privileged user ('oscap-user' in the second example above) to run only the oscap binary as root (with the '--sudo' flag) by updating the remote machine's 'sudoers' file or adding a file like /etc/sudoers.d/99-oscap-user:
+  # allow oscap-user to run openscap scanner
+  Defaults!/bin/oscap !requiretty
+  oscap-user ALL=(root) NOPASSWD: /bin/oscap
 
 .SH REPORTING BUGS
 .nf


### PR DESCRIPTION
Apologies if you see this twice (I had committed to the wrong branch initially). This patch allows both root and a non-root user (via sudo) to use oscap-ssh.