### PR TITLE
Solve --results-arf segfault with xccdf without oval

### DIFF
--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -720,16 +720,18 @@ static int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr x
 			relationships, assets, "collection1");
 
 	unsigned int oval_report_suffix = 2;
-	struct oscap_htable_iterator *hit = oscap_htable_iterator_new(oval_result_sources);
-	while (oscap_htable_iterator_has_more(hit)) {
-		struct oscap_source *oval_source = oscap_htable_iterator_next_value(hit);
-		xmlDoc *oval_result_doc = oscap_source_get_xmlDoc(oval_source);
+	if ( oval_result_sources != NULL ) {
+		struct oscap_htable_iterator *hit = oscap_htable_iterator_new(oval_result_sources);
+		while (oscap_htable_iterator_has_more(hit)) {
+			struct oscap_source *oval_source = oscap_htable_iterator_next_value(hit);
+			xmlDoc *oval_result_doc = oscap_source_get_xmlDoc(oval_source);
 
-		char* report_id = oscap_sprintf("oval%i", oval_report_suffix++);
-		ds_rds_create_report(doc, reports, oval_result_doc, report_id);
-		oscap_free(report_id);
+			char* report_id = oscap_sprintf("oval%i", oval_report_suffix++);
+			ds_rds_create_report(doc, reports, oval_result_doc, report_id);
+			oscap_free(report_id);
+		}
+		oscap_htable_iterator_free(hit);
 	}
-	oscap_htable_iterator_free(hit);
 
 	xmlAddChild(root, reports);
 

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -165,6 +165,8 @@ EXTRA_DIST += \
 	test_xccdf_refine_rule.xccdf.xml \
 	test_xccdf_refine_value_bad.sh \
 	test_xccdf_refine_value_bad.xccdf.xml \
+	test_xccdf_results_arf_no_oval.sh \
+	test_xccdf_results_arf_no_oval.xccdf.xml \
 	test_xccdf_selectors_cluster1.sh \
 	test_xccdf_selectors_cluster1.xccdf.xml \
 	test_xccdf_selectors_cluster2.sh \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -52,6 +52,7 @@ test_run "Multiple xccdf:TestResult elements" $srcdir/test_xccdf_multiple_testre
 test_run "default selector for xccdf value" $srcdir/test_default_selector.sh
 test_run "inherit selector for xccdf value" $srcdir/test_inherit_selector.sh
 test_run "incorrect selector for xccdf value" $srcdir/test_xccdf_refine_value_bad.sh
+test_run "Exported arf results from xccdf without reference to oval" $srcdir/test_xccdf_results_arf_no_oval.sh
 test_run "XCCDF Substitute within Title" $srcdir/test_xccdf_sub_title.sh
 
 test_run "libxml errors handled correctly" $srcdir/test_unfinished.sh

--- a/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+name=$(basename $0 .sh)
+result=$(mktemp -t ${name}.out.XXXXXX)
+resultArf=$(mktemp -t ${name}.arf.out.XXXXXX)
+stderr=$(mktemp -t ${name}.out.XXXXXX)
+
+$OSCAP xccdf eval --results $result --results-arf $resultArf $srcdir/${name}.xccdf.xml 2> $stderr
+
+echo "Stderr file = $stderr"
+echo "Result file = $result"
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
+$OSCAP xccdf validate-xml $result
+$OSCAP ds rds-validate $resultArf
+
+rm $result $resultArf

--- a/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.xccdf.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_arf_benchmark_1" resolved="true">
+  <status>incomplete</status>
+  <version>1.0</version>
+  <Profile id="xccdf_arf_profile_1">
+    <title>is kinda compulsory</title>
+    <select idref="def-20120006" selected="true"/>
+    <refine-rule idref="def-20120006" selector="failing-check"/>
+  </Profile>
+</Benchmark>


### PR DESCRIPTION
Before  commit c7b718b394d0e049e556002c295973e08a5a1d8d (sep 2014) function **ds_rds_create_source** was called through **ds_rds_create** which initialized **oval_result_sources**.

Now **ds_rds_create_source** is called from **xccdf_session_export_arf** directly and "sometimes" oval_result_sources stay uninitialized (=NULL);



Fix: https://fedorahosted.org/openscap/ticket/500, maybe fix https://bugzilla.redhat.com/show_bug.cgi?id=1255654
