### PR TITLE
Maint 1.0 arf export segfault - add check  oscap_htable_iterator_has_more

### DIFF
--- a/src/common/list.c
+++ b/src/common/list.c
@@ -565,6 +565,8 @@ bool
 oscap_htable_iterator_has_more(struct oscap_htable_iterator *hit)
 {
 	__attribute__nonnull__(hit);
+	if (hit->htable == NULL)
+		return false;
 	size_t i = hit->hpos;
 	if (hit->cur != NULL) {
 		if (hit->cur->next != NULL)

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -158,6 +158,8 @@ EXTRA_DIST += \
 	test_xccdf_refine_rule_refine.xccdf.xml \
 	test_xccdf_refine_rule.sh \
 	test_xccdf_refine_rule.xccdf.xml \
+	test_xccdf_results_arf_no_oval.sh \
+	test_xccdf_results_arf_no_oval.xccdf.xml \
 	test_xccdf_selectors_cluster1.sh \
 	test_xccdf_selectors_cluster1.xccdf.xml \
 	test_xccdf_selectors_cluster2.sh \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -50,6 +50,7 @@ test_run "Unsupported Check System" $srcdir/test_xccdf_check_unsupported_check_s
 test_run "Multiple xccdf:TestResult elements" $srcdir/test_xccdf_multiple_testresults.sh
 test_run "default selector for xccdf value" $srcdir/test_default_selector.sh
 test_run "inherit selector for xccdf value" $srcdir/test_inherit_selector.sh
+test_run "Exported arf results from xccdf without reference to oval" $srcdir/test_xccdf_results_arf_no_oval.sh
 test_run "XCCDF Substitute within Title" $srcdir/test_xccdf_sub_title.sh
 
 test_run "libxml errors handled correctly" $srcdir/test_unfinished.sh

--- a/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+name=$(basename $0 .sh)
+result=$(mktemp -t ${name}.out.XXXXXX)
+resultArf=$(mktemp -t ${name}.arf.out.XXXXXX)
+stderr=$(mktemp -t ${name}.out.XXXXXX)
+
+$OSCAP xccdf eval --results $result --results-arf $resultArf $srcdir/${name}.xccdf.xml 2> $stderr
+
+echo "Stderr file = $stderr"
+echo "Result file = $result"
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
+$OSCAP xccdf validate-xml $result
+$OSCAP ds rds-validate $resultArf
+
+rm $result $resultArf

--- a/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.xccdf.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_arf_benchmark_1" resolved="true">
+  <status>incomplete</status>
+  <version>1.0</version>
+  <Profile id="xccdf_arf_profile_1">
+    <title>is kinda compulsory</title>
+  </Profile>
+</Benchmark>


### PR DESCRIPTION
Fix issue from maint-1.2
(more info): https://github.com/OpenSCAP/openscap/pull/145

Fix issue with adding check to oscap_htable_iterator_has_more()