### PR TITLE
Don't print the same error messages multiple times

### DIFF
--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -223,14 +223,16 @@ xmlDoc *oscap_source_get_xmlDoc(struct oscap_source *source)
 int oscap_source_validate(struct oscap_source *source, xml_reporter reporter, void *user)
 {
 	oscap_document_type_t scap_type = oscap_source_get_scap_type(source);
-	int ret = oscap_source_validate_priv(source, scap_type, oscap_source_get_schema_version(source), reporter, user);
+	const char *schema_version = oscap_source_get_schema_version(source);
+	
+	int ret = oscap_source_validate_priv(source, scap_type, schema_version, reporter, user);
 	if (ret != 0) {
 		const char *type_name = oscap_document_type_to_string(scap_type);
 		if (type_name == NULL) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Unrecognized document type for: %s", oscap_source_readable_origin(source));
 		} else {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Invalid %s (%s) content in %s.", type_name,
-				oscap_source_get_schema_version(source), oscap_source_readable_origin(source));
+				schema_version, oscap_source_readable_origin(source));
 		}
 	}
 	return ret;

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -222,17 +222,19 @@ xmlDoc *oscap_source_get_xmlDoc(struct oscap_source *source)
 
 int oscap_source_validate(struct oscap_source *source, xml_reporter reporter, void *user)
 {
+	int ret;
 	oscap_document_type_t scap_type = oscap_source_get_scap_type(source);
-	const char *schema_version = oscap_source_get_schema_version(source);
 	
-	int ret = oscap_source_validate_priv(source, scap_type, schema_version, reporter, user);
-	if (ret != 0) {
-		const char *type_name = oscap_document_type_to_string(scap_type);
-		if (type_name == NULL) {
-			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Unrecognized document type for: %s", oscap_source_readable_origin(source));
-		} else {
-			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Invalid %s (%s) content in %s.", type_name,
-				schema_version, oscap_source_readable_origin(source));
+	if (scap_type == OSCAP_DOCUMENT_UNKNOWN) {
+		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Unrecognized document type for: %s", oscap_source_readable_origin(source));
+		ret = -1;
+	} else {
+		const char *schema_version = oscap_source_get_schema_version(source);
+		ret = oscap_source_validate_priv(source, scap_type, schema_version, reporter, user);
+		if (ret != 0) {
+			const char *type_name = oscap_document_type_to_string(scap_type);
+			const char *origin = oscap_source_readable_origin(source);
+			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Invalid %s (%s) content in %s.", type_name, schema_version, origin);
 		}
 	}
 	return ret;

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -222,10 +222,10 @@ xmlDoc *oscap_source_get_xmlDoc(struct oscap_source *source)
 
 int oscap_source_validate(struct oscap_source *source, xml_reporter reporter, void *user)
 {
-	int ret = oscap_source_validate_priv(source, oscap_source_get_scap_type(source),
-			oscap_source_get_schema_version(source), reporter, user);
+	oscap_document_type_t scap_type = oscap_source_get_scap_type(source);
+	int ret = oscap_source_validate_priv(source, scap_type, oscap_source_get_schema_version(source), reporter, user);
 	if (ret != 0) {
-		const char *type_name = oscap_document_type_to_string(oscap_source_get_scap_type(source));
+		const char *type_name = oscap_document_type_to_string(scap_type);
 		if (type_name == NULL) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Unrecognized document type for: %s", oscap_source_readable_origin(source));
 		} else {


### PR DESCRIPTION
    Multiple calls cause that oscap tries to parse non-valid xml again and again
    And stderr contains the same error messages many times