### PR TITLE
Push libxml parsing to oscap_seterr

### DIFF
--- a/tests/API/XCCDF/unittests/test_unfinished.sh
+++ b/tests/API/XCCDF/unittests/test_unfinished.sh
@@ -22,6 +22,6 @@ $OSCAP info ${srcdir}/${name}.xccdf.xml 2> $stderr || ret=$?
 [ $ret -eq 1 ]
 [ -f $stderr ]
 [ -s $stderr ]
-cat $stderr | tail -n +4 | grep '^OpenSCAP Error:'
+cat $stderr | tail -n +1 | grep '^OpenSCAP Error:'
 
 rm $stderr


### PR DESCRIPTION
Libxml (parsing) errors were leaking to stderr.

It catch them and pass them to oscap_seterr.

It has similar behavior than before for oscap. But it is important for workbench and other programs using the lib.