### PR TITLE
oscap_string fix visibility

### DIFF
--- a/src/common/oscap_string.h
+++ b/src/common/oscap_string.h
@@ -38,19 +38,6 @@ struct oscap_string *oscap_string_new(void);
 void oscap_string_free(struct oscap_string *s);
 
 /**
- * Return pointer to internal string
- * Free oscap_string structure
- * @param s buffer
- */
-char* oscap_string_bequeath(struct oscap_string *s);
-
-/**
- * Erases the contents of the string. Length of string becomes 0
- * @param s string
- */
-void oscap_string_clear(struct oscap_string *s);
-
-/**
  * Append a single char at the end of a string.
  * @param s string
  * @param c to append
@@ -79,6 +66,19 @@ OSCAP_HIDDEN_START;
  * @return true if empty
  */
 bool oscap_string_empty(const struct oscap_string *s);
+
+/**
+ * Return pointer to internal string
+ * Free oscap_string structure
+ * @param s buffer
+ */
+char* oscap_string_bequeath(struct oscap_string *s);
+
+/**
+ * Erases the contents of the string. Length of string becomes 0
+ * @param s string
+ */
+void oscap_string_clear(struct oscap_string *s);
 
 OSCAP_HIDDEN_END;
 


### PR DESCRIPTION
Some functions were not visible from public API in 1.2.5 and we don't want to make them public now.