### PR TITLE
Fix bad #include in oscap_acquire

### DIFF
--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -36,7 +36,7 @@
 
 #include "oscap_acquire.h"
 #include "common/_error.h"
-#include "oscap_buffer.h"
+#include "oscap_string.h"
 
 #ifndef P_tmpdir
 #define P_tmpdir "/tmp"


### PR DESCRIPTION
oscap_string* functions are used, but oscap_buffer header file is included.
should be replaced in
- maint-1.0
- maint-1.1

- in maint-1.2 should be both - oscap_string.h and oscap_buffer.h