### PR TITLE
trac#505: Plug memory leaks

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_resolve.c
+++ b/src/XCCDF_POLICY/xccdf_policy_resolve.c
@@ -187,8 +187,7 @@ void xccdf_policy_add_profile_refine_rules(struct xccdf_policy* policy, struct x
 			assert(false);
 			continue;
 		}
-		struct xccdf_refine_rule* clone = xccdf_refine_rule_clone(rr);
-		_xccdf_policy_add_xccdf_refine_rule_internal(policy, benchmark, clone);
+		_xccdf_policy_add_xccdf_refine_rule_internal(policy, benchmark, rr);
 	}
 	xccdf_refine_rule_iterator_free(rr_it);
 }


### PR DESCRIPTION
Addressing:

11 bytes in 1 blocks are indirectly lost in loss record 1 of 5
   at 0x4C29BFD: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x757E529: strdup (in /usr/lib64/libc-2.17.so)
   by 0x4E84D9A: oscap_strdup (util.c:65)
   by 0x4ED3DDF: xccdf_refine_rule_clone (profile.c:107)
   by 0x4EE1780: xccdf_policy_add_profile_refine_rules (xccdf_policy_resolve.c:190)
   by 0x4EE4676: xccdf_policy_new (xccdf_policy.c:1773)
   by 0x4EE42AD: xccdf_policy_model_get_policy_by_id (xccdf_policy.c:1880)
   by 0x4EDF7B4: xccdf_session_set_profile_id (xccdf_session.c:363)
   by 0x40B91B: app_evaluate_xccdf (oscap-xccdf.c:482)
   by 0x407E37: oscap_module_call (oscap-tool.c:260)
   by 0x407E37: oscap_module_process (oscap-tool.c:345)
   by 0x406D5E: main (oscap.c:80)
24 bytes in 1 blocks are indirectly lost in loss record 2 of 5
   at 0x4C2B974: calloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x4E80488: __oscap_calloc (alloc.c:68)
   by 0x4E81883: oscap_list_clone (list.c:130)
   by 0x4ED3E09: xccdf_refine_rule_clone (profile.c:111)
   by 0x4EE1780: xccdf_policy_add_profile_refine_rules (xccdf_policy_resolve.c:190)
   by 0x4EE4676: xccdf_policy_new (xccdf_policy.c:1773)
   by 0x4EE42AD: xccdf_policy_model_get_policy_by_id (xccdf_policy.c:1880)
   by 0x4EDF7B4: xccdf_session_set_profile_id (xccdf_session.c:363)
   by 0x40B91B: app_evaluate_xccdf (oscap-xccdf.c:482)
   by 0x407E37: oscap_module_call (oscap-tool.c:260)
   by 0x407E37: oscap_module_process (oscap-tool.c:345)
   by 0x406D5E: main (oscap.c:80)
29 bytes in 1 blocks are indirectly lost in loss record 3 of 5
   at 0x4C29BFD: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x757E529: strdup (in /usr/lib64/libc-2.17.so)
   by 0x4E84D9A: oscap_strdup (util.c:65)
   by 0x4ED3DD3: xccdf_refine_rule_clone (profile.c:106)
   by 0x4EE1780: xccdf_policy_add_profile_refine_rules (xccdf_policy_resolve.c:190)
   by 0x4EE4676: xccdf_policy_new (xccdf_policy.c:1773)
   by 0x4EE42AD: xccdf_policy_model_get_policy_by_id (xccdf_policy.c:1880)
   by 0x4EDF7B4: xccdf_session_set_profile_id (xccdf_session.c:363)
   by 0x40B91B: app_evaluate_xccdf (oscap-xccdf.c:482)
   by 0x407E37: oscap_module_call (oscap-tool.c:260)
   by 0x407E37: oscap_module_process (oscap-tool.c:345)
   by 0x406D5E: main (oscap.c:80)
104 (40 direct, 64 indirect) bytes in 1 blocks are definitely lost in loss record 5 of 5
   at 0x4C2B974: calloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x4E80488: __oscap_calloc (alloc.c:68)
   by 0x4ED3DC7: xccdf_refine_rule_clone (profile.c:105)
   by 0x4EE1780: xccdf_policy_add_profile_refine_rules (xccdf_policy_resolve.c:190)
   by 0x4EE4676: xccdf_policy_new (xccdf_policy.c:1773)
   by 0x4EE42AD: xccdf_policy_model_get_policy_by_id (xccdf_policy.c:1880)
   by 0x4EDF7B4: xccdf_session_set_profile_id (xccdf_session.c:363)
   by 0x40B91B: app_evaluate_xccdf (oscap-xccdf.c:482)
   by 0x407E37: oscap_module_call (oscap-tool.c:260)
   by 0x407E37: oscap_module_process (oscap-tool.c:345)
   by 0x406D5E: main (oscap.c:80)