### PR TITLE
Remove unused oval_gen_report function

### DIFF
--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -198,11 +198,6 @@ static struct oscap_module* OVAL_SUBMODULES[] = {
     NULL
 };
 
-static int oval_gen_report(const char *infile, const char *outfile)
-{
-    return app_xslt(infile, "oval-results-report.xsl", outfile, NULL);
-}
-
 static int app_oval_callback(const struct oval_result_definition * res_def, void *arg)
 {
 	oval_result_t result =  oval_result_definition_get_result(res_def);


### PR DESCRIPTION
Functionality of this function was moved into the OVAL Sesssion during the
refactoring of app_evaluate_oval (see 42895cc157905036b0c7e11772fa9e9cbabb3f30)
and it's not used anymore. The function wasn't remove during the refactoring
because the warning complaining about it got lost among other warnings.