### PR TITLE
Show process name and thread name in debug logs

### DIFF
--- a/src/OVAL/probes/SEAP/seap.c
+++ b/src/OVAL/probes/SEAP/seap.c
@@ -286,6 +286,7 @@ int __SEAP_recvmsg_process_cmd (SEAP_CTX_t *ctx, int sd, SEAP_cmd_t *cmd)
                         return (-1);
                 }
 
+				pthread_setname_np(th, "command_worker");
                 pthread_attr_destroy (&th_attrs);
         } else {
                 if (cmd->flags & SEAP_CMDFLAG_REPLY) {

--- a/src/OVAL/probes/probe/icache.c
+++ b/src/OVAL/probes/probe/icache.c
@@ -295,6 +295,7 @@ probe_icache_t *probe_icache_new(void)
                 dE("Can't start the icache worker: %u, %s\n", errno, strerror(errno));
                 goto fail;
         }
+		pthread_setname_np(cache->thid, "icache_worker");
 
         return (cache);
 fail:

--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -195,6 +195,7 @@ void *probe_input_handler(void *arg)
 
 								goto __error_reply;
 							}
+							pthread_setname_np(pair->pth->tid, "worker");
 						}
 
 						seap_request = NULL;

--- a/src/OVAL/probes/probe/main.c
+++ b/src/OVAL/probes/probe/main.c
@@ -246,6 +246,7 @@ int main(int argc, char *argv[])
 
 	if (pthread_create(&probe.th_signal, &th_attr, &probe_signal_handler, &probe))
 		fail(errno, "pthread_create(probe_signal_handler)", __LINE__ - 1);
+	pthread_setname_np(probe.th_signal, "signal_handler");
 
 	pthread_attr_destroy(&th_attr);
 
@@ -284,6 +285,7 @@ int main(int argc, char *argv[])
 
 	if (pthread_create(&probe.th_input, &th_attr, &probe_input_handler, &probe))
 		fail(errno, "pthread_create(probe_input_handler)", __LINE__ - 1);
+	pthread_setname_np(probe.th_input, "input_handler");
 
 	pthread_attr_destroy(&th_attr);
 

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -34,6 +34,7 @@
 # include <sys/file.h>
 # include <unistd.h>
 # include <time.h>
+# include <errno.h>
 
 # include <sexp.h>
 # include <sexp-output.h>
@@ -59,6 +60,8 @@ static int __debuglog_pstrip = -1;
 # define __LOCK_FP   while(0)
 # define __UNLOCK_FP while(0)
 #endif
+
+#define THREAD_NAME_LEN 16
 
 static void __oscap_debuglog_close(void)
 {
@@ -168,9 +171,13 @@ static void __oscap_vdlprintf(int level, const char *file, const char *fn, size_
 		l = '0';
 	}
 #if defined(OSCAP_THREAD_SAFE)
+	char thread_name[THREAD_NAME_LEN];
+	pthread_t thread = pthread_self();
+	pthread_getname_np(thread, thread_name, THREAD_NAME_LEN);
 	/* XXX: non-portable usage of pthread_t */
-	fprintf(__debuglog_fp, "(%ld:%llx) [%c:%s:%zu:%s] ", (long) getpid(),
-		(unsigned long long) pthread_self(), l, f, line, fn);
+	fprintf(__debuglog_fp, "(%s(%ld):%s(%llx)) [%c:%s:%zu:%s] ",
+		program_invocation_short_name, (long) getpid(), thread_name,
+		(unsigned long long) thread, l, f, line, fn);
 #else
 	fprintf(__debuglog_fp, "(%ld) [%c:%s:%zu:%s] ", (long) getpid(),
 		l, f, line, fn);


### PR DESCRIPTION
I was playing a bit with threads and processes. For my better understanding, I gave threads some names and I showed the process and thread names in debug logs. I thought that this might be useful also for other people, so I propose it as a pull request.

Debug log before:
`(22827:7f9815527700) [I:seap-packet.c:903:SEAP_packet_recv] Received packet`
And after:
`(lt-probe_file(22827):input_handler(7f9815527700)) [I:seap-packet.c:903:SEAP_packet_recv] Received packet`