### PR TITLE
Add test for loading OVAL using relative path

### DIFF
--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -153,6 +153,8 @@ EXTRA_DIST += \
 	test_xccdf_multiple_testresults.xccdf.xml \
 	test_xccdf_notchecked_has_check.sh \
 	test_xccdf_notchecked_has_check.xccdf.xml \
+	test_xccdf_oval_relative_path.sh \
+	test_xccdf_oval_relative_path.xccdf.xml \
 	test_xccdf_overlaping_IDs.xccdf.xml \
 	test_xccdf_refine_rule_refine.sh \
 	test_xccdf_refine_rule_refine.xccdf.xml \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -38,6 +38,7 @@ test_run "Check Processing Algorithm -- bad refine must select check without @se
 test_run "Check Processing Algorithm -- none selected for candidate" $srcdir/test_xccdf_check_processing_selector_empty.sh
 test_run "Check Processing Algorithm -- none check-content-ref resolvable." $srcdir/test_xccdf_check_processing_invalid_content_refs.sh
 test_run "Check Processing Algorithm -- always include xccdf:check" $srcdir/test_xccdf_notchecked_has_check.sh
+test_run "Load OVAL using relative path" $srcdir/test_xccdf_oval_relative_path.sh
 test_run "xccdf:select and @cluster-id -- disable group" $srcdir/test_xccdf_selectors_cluster1.sh
 test_run "xccdf:select and @cluster-id -- enable a set of items" $srcdir/test_xccdf_selectors_cluster2.sh
 test_run "xccdf:select and @cluster-id -- complex example" $srcdir/test_xccdf_selectors_cluster3.sh

--- a/tests/API/XCCDF/unittests/test_xccdf_oval_relative_path.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_oval_relative_path.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Test loading of OVAL files located relatively to xccdf file
+
+set -e
+set -o pipefail
+
+name=$(basename $0 .sh)
+
+XCCDF="$(realpath "$srcdir/${name}.xccdf.xml")"
+
+# cd to directory and run test
+function testInDirectory(){
+	local directory="$1"
+
+	pushd "$directory"
+
+	local result=$(mktemp -t ${name}.out.XXXXXX)
+	local stderr=$(mktemp -t ${name}.out.XXXXXX)
+
+	echo "Stderr file = $stderr"
+	echo "Result file = $result"
+
+	$OSCAP xccdf eval --results $result --oval-results "$XCCDF" 2> $stderr 
+
+	[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
+	assert_exists 2 '//rule-result/result'
+	assert_exists 2 '//rule-result/result[text()="pass" or text()="fail"]'
+
+	rm $result
+
+	popd
+}
+
+# test in XCCDF's directory
+XCCDF_DIR="$(dirname "$XCCDF")"
+testInDirectory "$XCCDF_DIR"
+
+# test in random directory
+RANDOM_DIRECTORY=`mktemp -d`
+testInDirectory $RANDOM_DIRECTORY
+rmdir $RANDOM_DIRECTORY
+
+
+
+

--- a/tests/API/XCCDF/unittests/test_xccdf_oval_relative_path.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_xccdf_oval_relative_path.xccdf.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+    <status>incomplete</status>
+    <version>1.0</version>
+
+    <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_1">
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <check-content-ref href="oval/pass/oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
+        </check>
+    </Rule>
+    
+    <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_2">
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <check-content-ref href="test_default_selector.oval.xml" name="oval:x:def:1"/>
+        </check>    
+    </Rule>
+
+</Benchmark>


### PR DESCRIPTION
If you reference OVAL file from XCCDF using relative path, oscap will load OVAL file correctly.
But when your $PWD != dirname \`file.xccdf.xml\` oscap doesn't load it.

https://fedorahosted.org/openscap/ticket/507

Only non-passing test for now. 

Do not merge now.

[skip ci]