### PR TITLE
Improve caching and fetching of CVE input data

### DIFF
--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -198,10 +198,10 @@ class OscapScan(object):
 
         # Fetch the CVE input data for the dist
         fetch = getInputCVE(self.tmp_dir)
-        if not fetch._is_recent_enough(self.hours_old, dist):
-            # TODO
-            # This should probably be in a try/except
-            fetch._fetch_single(dist)
+
+        # TODO
+        # This should probably be in a try/except
+        fetch._fetch_single(dist)
 
         # Scan the chroot
         sys.stdout.write(self.helper._scan_cve(chroot, dist, scan_args))


### PR DESCRIPTION
    Previously, we determined if new CVE data should be
    fetched by specificying the max age of the files in
    units of hours.

    The new implementation uses the following to determine
    if it should fetch the new file:

        * If the file isn't in the local cache dir, fetch it
        * If the file is local, check the mtime of the remote
          file and compare it to the local file.  If they
          differ by more than two seconds, fetch a new one.
        * Else, do not fetch a new one.

    We also now return the fully qualified file name in question
    from _fetch_single.  And in the case of fetch_dist_data, we
    return a list of all the filenames.  This is in preparation
    of the files being compressed upstream as we will want to know
    which file(s) we are dealing with.

    And finally, debug was added to the time related functions so
    they are easier to debug.  This will also come in handy when
    we contemplate handling of compressed and/or uncompressed
    files.