### PR TITLE
Distribute the html version of the oscap user manual

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -73,6 +73,7 @@ EXTRA_DIST =	m4/gnulib-cache.m4 \
 		docs/examples/oval_probes.py \
 		docs/examples/package-test.xml \
                 docs/oscap-scan.cron \
+		docs/manual/manual.adoc \
 		dist/fedora/sectool-xccdf/00_integrity.sh \
 		dist/fedora/sectool-xccdf/01_bootloader.sh \
 		dist/fedora/sectool-xccdf/01_disk_usage.sh \
@@ -102,6 +103,7 @@ EXTRA_DIST =	m4/gnulib-cache.m4 \
 
 dist-hook: ChangeLog
 	cd $(distdir)/docs && doxygen Doxyfile
+	cd $(distdir)/docs/manual && asciidoctor -b html5 manual.adoc
 
 ChangeLog:
 	git log | sed '/^commit/d; /^Merge/d' > ChangeLog


### PR DESCRIPTION
There is no asciidoctor in the RHEL5 so we have to distribute the oscap user manual in the HTML format.