### PR TITLE
test: glob-to-regex fix #include <config.h>

### DIFF
--- a/tests/API/OVAL/glob_to_regex/test_glob_to_regex.c
+++ b/tests/API/OVAL/glob_to_regex/test_glob_to_regex.c
@@ -1,3 +1,7 @@
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
solve linking errors "undefined reference to `__oscap_alloc_dbg'" with --enable-debug