### PR TITLE
Maint 1.0 fix oscap string test

### DIFF
--- a/tests/oscap_string/test_oscap_string.c
+++ b/tests/oscap_string/test_oscap_string.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright 2015 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors:
+ *      Jan Černý <jcerny@redhat.com>
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/oscap_string/test_oscap_string.c
+++ b/tests/oscap_string/test_oscap_string.c
@@ -20,6 +20,10 @@
  *      Jan Černý <jcerny@redhat.com>
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Licence file is already in maint-1.2

absence of #include <config.h> caused linker errors