### PR TITLE
Fix loading oval results from relative path

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1023,7 +1023,7 @@ static char *_xccdf_session_get_unique_oval_result_filename(struct xccdf_session
 		return NULL;
 	}
 
-	if (oscap_acquire_url_is_supported(filename) || filename[0] == '/') {
+	if (oscap_acquire_url_is_supported(filename) || strchr(filename, '/')) {
 		// We need escaping if:
 		// - filename is a URL
 		// - filename is an absolute path

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1018,27 +1018,29 @@ int xccdf_session_export_xccdf(struct xccdf_session *session)
 		return 1;
 	}
 
+	if (session->export.report_file == NULL)
+		return 0;
+
 	struct oscap_source* results = session->xccdf.result_source;
 	struct oscap_source* arf = NULL;
 	if (session->export.oval_results) {
 		arf = xccdf_session_create_arf_source(session);
 		if (arf == NULL) {
-			 return 1;
+			return 1;
 		}
 		results = arf;
 	}
-	
 
 	/* generate report */
-	if (session->export.report_file != NULL)
-		_xccdf_gen_report(results,
-				xccdf_result_get_id(session->xccdf.result),
-				session->export.report_file,
-				"",
-				(session->export.oval_results ? "%.result.xml" : ""),
-				(session->export.check_engine_plugins_results ? "%.result.xml" : ""),
-				session->xccdf.profile_id == NULL ? "" : session->xccdf.profile_id
-		);
+	_xccdf_gen_report(results,
+			xccdf_result_get_id(session->xccdf.result),
+			session->export.report_file,
+			"",
+			(session->export.oval_results ? "%.result.xml" : ""),
+			(session->export.check_engine_plugins_results ? "%.result.xml" : ""),
+			session->xccdf.profile_id == NULL ? "" : session->xccdf.profile_id
+	);
+
 	oscap_source_free(arf);
 	return 0;
 }

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1018,9 +1018,20 @@ int xccdf_session_export_xccdf(struct xccdf_session *session)
 		return 1;
 	}
 
+	struct oscap_source* results = session->xccdf.result_source;
+	struct oscap_source* arf = NULL;
+	if (session->export.oval_results) {
+		arf = xccdf_session_create_arf_source(session);
+		if (arf == NULL) {
+			 return 1;
+		}
+		results = arf;
+	}
+	
+
 	/* generate report */
 	if (session->export.report_file != NULL)
-		_xccdf_gen_report(session->xccdf.result_source,
+		_xccdf_gen_report(results,
 				xccdf_result_get_id(session->xccdf.result),
 				session->export.report_file,
 				"",
@@ -1028,6 +1039,7 @@ int xccdf_session_export_xccdf(struct xccdf_session *session)
 				(session->export.check_engine_plugins_results ? "%.result.xml" : ""),
 				session->xccdf.profile_id == NULL ? "" : session->xccdf.profile_id
 		);
+	oscap_source_free(arf);
 	return 0;
 }
 

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -965,13 +965,13 @@ static int _app_xslt(struct oscap_source *infile, const char *xsltfile, const ch
 	return oscap_source_apply_xslt_path(infile, xsltfile, outfile, par, oscap_path_to_xslt()) == -1;
 }
 
-static inline int _xccdf_gen_report(struct oscap_source *infile, const char *id, const char *outfile, const char *show, const char *oval_template, const char* sce_template, const char* profile)
+static inline int _xccdf_gen_report(struct oscap_source *infile, const char *id, const char *outfile, const char *show, const char* sce_template, const char* profile)
 {
 	const char *params[] = {
 		"result-id",		id,
 		"show",			show,
 		"profile",		profile,
-		"oval-template",	oval_template,
+		"oval-template",	"",
 		"sce-template",		sce_template,
 		"verbosity",		"",
 		"hide-profile-info",	NULL,
@@ -1043,7 +1043,6 @@ int xccdf_session_export_xccdf(struct xccdf_session *session)
 			xccdf_result_get_id(session->xccdf.result),
 			session->export.report_file,
 			"",
-			(session->export.oval_results ? "%.result.xml" : ""),
 			(session->export.check_engine_plugins_results ? "%.result.xml" : ""),
 			session->xccdf.profile_id == NULL ? "" : session->xccdf.profile_id
 	);

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -156,6 +156,8 @@ EXTRA_DIST += \
 	test_xccdf_multiple_testresults.xccdf.xml \
 	test_xccdf_notchecked_has_check.sh \
 	test_xccdf_notchecked_has_check.xccdf.xml \
+	test_xccdf_oval_relative_path.sh \
+	test_xccdf_oval_relative_path.xccdf.xml \
 	test_xccdf_overlaping_IDs.xccdf.xml \
 	test_xccdf_overrides.arf.xml \
 	test_xccdf_overrides.sh \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -39,6 +39,7 @@ test_run "Check Processing Algorithm -- bad refine must select check without @se
 test_run "Check Processing Algorithm -- none selected for candidate" $srcdir/test_xccdf_check_processing_selector_empty.sh
 test_run "Check Processing Algorithm -- none check-content-ref resolvable." $srcdir/test_xccdf_check_processing_invalid_content_refs.sh
 test_run "Check Processing Algorithm -- always include xccdf:check" $srcdir/test_xccdf_notchecked_has_check.sh
+test_run "Load OVAL using relative path" $srcdir/test_xccdf_oval_relative_path.sh
 test_run "xccdf:select and @cluster-id -- disable group" $srcdir/test_xccdf_selectors_cluster1.sh
 test_run "xccdf:select and @cluster-id -- enable a set of items" $srcdir/test_xccdf_selectors_cluster2.sh
 test_run "xccdf:select and @cluster-id -- complex example" $srcdir/test_xccdf_selectors_cluster3.sh

--- a/tests/API/XCCDF/unittests/oval/always-fail/oval.xml
+++ b/tests/API/XCCDF/unittests/oval/always-fail/oval.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oval_definitions xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
+	xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+	xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
+	xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+	xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd
+		http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd
+		http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd
+		http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd
+		http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
+	<generator>
+		<oval:product_name>Text Editors</oval:product_name>
+		<oval:schema_version>5.8</oval:schema_version>
+		<oval:timestamp>2010-06-08T12:00:00-04:00</oval:timestamp>
+	</generator>
+	<definitions>
+		<definition class="compliance" id="oval:moc.elpmaxe.www:def:1" version="1">
+			<metadata><title>PASS</title><description>Bla.</description></metadata>
+			<criteria><criterion test_ref="oval:moc.elpmaxe.www:tst:1" comment="Is not executable"/></criteria>
+		</definition>
+	</definitions>
+	<tests>
+		<unix-def:file_test check_existence="all_exist" id="oval:moc.elpmaxe.www:tst:1" version="1" check="all" comment="Testing permissions on /not_executable">
+			<unix-def:object object_ref="oval:moc.elpmaxe.www:obj:1"/>
+			<unix-def:state state_ref="oval:moc.elpmaxe.www:ste:1"/>
+		</unix-def:file_test>
+	</tests>
+	<objects>
+		<unix-def:file_object id="oval:moc.elpmaxe.www:obj:1" version="1" comment="not_executable">
+			<unix-def:path>/</unix-def:path>
+			<unix-def:filename>tmp</unix-def:filename>
+		</unix-def:file_object>
+	</objects>
+	<states>
+		<unix-def:file_state id="oval:moc.elpmaxe.www:ste:1" version="1">
+			<unix-def:oexec datatype="boolean">false</unix-def:oexec>
+		</unix-def:file_state>
+	</states>
+</oval_definitions>

--- a/tests/API/XCCDF/unittests/test_xccdf_oval_relative_path.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_oval_relative_path.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Test loading of OVAL results files located relatively to XCCDF file
+
+set -e
+set -o pipefail
+
+# cd to directory and run test
+function testInDirectory(){
+	local directory="$1"
+	local xccdf="$2"
+
+	pushd "$directory"
+
+	local result=$(mktemp -t ${name}.out.result.XXXXXX)
+	local report=$(mktemp -t ${name}.out.report.XXXXXX)
+	local stderr=$(mktemp -t ${name}.err.XXXXXX)
+
+	echo "Stderr file = $stderr"
+	echo "Result file = $result"
+	echo "Report file = $report"
+
+	$OSCAP xccdf eval --oval-results --results $result --report $report "$xccdf" 2> $stderr 
+
+	# Check existence of oval-results
+	[ -f $directory/*oval*always-fail*oval.xml.result.xml ]
+
+	[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
+	# Check result
+	assert_exists 2 '//rule-result/result'
+	assert_exists 2 '//rule-result/result[text()="pass" or text()="fail"]'
+
+	# Check report
+	grep "Testing permissions on /not_executable" "$report" --quiet
+
+	rm -f $result $report
+
+	popd
+}
+
+name=$(basename $0 .sh)
+ORIGINAL_XCCDF="$(realpath "$srcdir/${name}.xccdf.xml")"
+
+### test in XCCDF's directory
+
+# We don't have write access to directory with XCCDF (after make distcheck),
+# so we have to copy required files to directory with right access and do tests there
+testDir=`mktemp -d`
+mkdir -p "$testDir/oval/always-fail"
+cp "$ORIGINAL_XCCDF" "$srcdir/test_default_selector.oval.xml" "$testDir"
+cp "$srcdir/oval/always-fail/oval.xml" "$testDir/oval/always-fail"
+
+XCCDF="$(realpath "$testDir/${name}.xccdf.xml")"
+testInDirectory "$testDir" "$XCCDF"
+rm -rf "$testDir"
+
+
+### test in random directory - different from directory of XCCDF
+RANDOM_DIRECTORY=`mktemp -d`
+testInDirectory "$RANDOM_DIRECTORY" "$ORIGINAL_XCCDF"
+rm -rf $RANDOM_DIRECTORY

--- a/tests/API/XCCDF/unittests/test_xccdf_oval_relative_path.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_oval_relative_path.sh
@@ -40,7 +40,7 @@ function testInDirectory(){
 }
 
 name=$(basename $0 .sh)
-ORIGINAL_XCCDF="$(realpath "$srcdir/${name}.xccdf.xml")"
+ORIGINAL_XCCDF="$(readlink -e "$srcdir/${name}.xccdf.xml")"
 
 ### test in XCCDF's directory
 
@@ -51,7 +51,7 @@ mkdir -p "$testDir/oval/always-fail"
 cp "$ORIGINAL_XCCDF" "$srcdir/test_default_selector.oval.xml" "$testDir"
 cp "$srcdir/oval/always-fail/oval.xml" "$testDir/oval/always-fail"
 
-XCCDF="$(realpath "$testDir/${name}.xccdf.xml")"
+XCCDF="$(readlink -e "$testDir/${name}.xccdf.xml")"
 testInDirectory "$testDir" "$XCCDF"
 rm -rf "$testDir"
 

--- a/tests/API/XCCDF/unittests/test_xccdf_oval_relative_path.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_xccdf_oval_relative_path.xccdf.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+	<status>incomplete</status>
+	<version>1.0</version>
+
+	<Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_1">
+		<check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" negate="true">
+			<check-content-ref href="oval/always-fail/oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
+		</check>
+	</Rule>
+
+	<Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_2">
+		<check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+			<check-content-ref href="test_default_selector.oval.xml" name="oval:x:def:1"/>
+		</check>
+	</Rule>
+
+</Benchmark>


### PR DESCRIPTION
https://fedorahosted.org/openscap/ticket/504

When you want to create HTML report from XCCDF which references OVAL using relative path using --oval-details, oscap tries to create file e.g. ./my/path/file.oval.xml.result.xml
- when the folder "./my/path/" doesn't exist, it was causing segfault - the folder usually exists (because it is the same directory as directory of existing oval file) - but when your cwd is different from directory of xccdf, the relative directories won't match

This pull requst:
- add tests (other tests are in beakerlib format)
- fix path when generating of oval-results files
- add OVAL details to HTML report from (internally generated) ARF not from oval result.files - which fix problem with loading oval-details from escaped path.