### PR TITLE
oscap-vm - scan virtual machines and their images

### DIFF
--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -482,6 +482,14 @@ AC_ARG_ENABLE([util-oscap-docker],
        *) AC_MSG_ERROR([bad value ${enableval} for --enable-util-oscap-docker]) ;;
      esac],[util_oscap_docker=yes])
 
+AC_ARG_ENABLE([util-oscap-vm],
+     [AC_HELP_STRING([--enable-util-oscap-vm], [enable compilation of the oscap-vm utility (default=yes)])],
+     [case "${enableval}" in
+       yes) util_oscap_vm=yes ;;
+       no)  util_oscap_vm=no  ;;
+       *) AC_MSG_ERROR([bad value ${enableval} for --enable-util-oscap-vm]) ;;
+     esac],[util_oscap_vm=yes])
+
 if test "$vgdebug" = "yes"; then
  if test "$HAVE_VALGRIND" = "yes"; then
    vgcheck="yes"
@@ -553,6 +561,7 @@ AM_CONDITIONAL([WANT_UTIL_OSCAP], test "$util_oscap" = yes)
 AM_CONDITIONAL([WANT_UTIL_SCAP_AS_RPM], test "$util_scap_as_rpm" = yes)
 AM_CONDITIONAL([WANT_UTIL_OSCAP_SSH], test "$util_oscap_ssh" = yes)
 AM_CONDITIONAL([WANT_UTIL_OSCAP_DOCKER], test "$util_oscap_docker" = yes)
+AM_CONDITIONAL([WANT_UTIL_OSCAP_VM], test "$util_oscap_vm" = yes)
 AM_CONDITIONAL([WANT_PYTHON], test "$python_bind" = yes)
 AM_CONDITIONAL([WANT_PYTHON3], test "$python3_bind" = yes)
 AM_CONDITIONAL([WANT_PERL], test "$perl_bind" = yes)
@@ -694,6 +703,7 @@ echo "oscap tool:                    $util_oscap"
 echo "scap-as-rpm tool:              $util_scap_as_rpm"
 echo "oscap-ssh tool:                $util_oscap_ssh"
 echo "oscap-docker tool:             $util_oscap_docker"
+echo "oscap-vm tool:                 $util_oscap_vm"
 echo "python2 bindings enabled:      $python_bind"
 echo "python3 bindings enabled:      $python3_bind"
 echo "perl bindings enabled:         $perl_bind"

--- a/configure.ac
+++ b/configure.ac
@@ -1207,6 +1207,14 @@ AC_ARG_ENABLE([util-oscap-docker],
        *) AC_MSG_ERROR([bad value ${enableval} for --enable-util-oscap-docker]) ;;
      esac],[util_oscap_docker=yes])
 
+AC_ARG_ENABLE([util-oscap-vm],
+     [AC_HELP_STRING([--enable-util-oscap-vm], [enable compilation of the oscap-vm utility (default=yes)])],
+     [case "${enableval}" in
+       yes) util_oscap_vm=yes ;;
+       no)  util_oscap_vm=no  ;;
+       *) AC_MSG_ERROR([bad value ${enableval} for --enable-util-oscap-vm]) ;;
+     esac],[util_oscap_vm=yes])
+
 if test "$vgdebug" = "yes"; then
  if test "$HAVE_VALGRIND" = "yes"; then
    vgcheck="yes"
@@ -1366,6 +1374,7 @@ AM_CONDITIONAL([WANT_UTIL_OSCAP], test "$util_oscap" = yes)
 AM_CONDITIONAL([WANT_UTIL_SCAP_AS_RPM], test "$util_scap_as_rpm" = yes)
 AM_CONDITIONAL([WANT_UTIL_OSCAP_SSH], test "$util_oscap_ssh" = yes)
 AM_CONDITIONAL([WANT_UTIL_OSCAP_DOCKER], test "$util_oscap_docker" = yes)
+AM_CONDITIONAL([WANT_UTIL_OSCAP_VM], test "$util_oscap_vm" = yes)
 AM_CONDITIONAL([WANT_PYTHON], test "$python_bind" = yes)
 AM_CONDITIONAL([WANT_PYTHON3], test "$python3_bind" = yes)
 AM_CONDITIONAL([WANT_PERL], test "$perl_bind" = yes)
@@ -1507,6 +1516,7 @@ echo "oscap tool:                    $util_oscap"
 echo "scap-as-rpm tool:              $util_scap_as_rpm"
 echo "oscap-ssh tool:                $util_oscap_ssh"
 echo "oscap-docker tool:             $util_oscap_docker"
+echo "oscap-vm tool:                 $util_oscap_vm"
 echo "python2 bindings enabled:      $python_bind"
 echo "python3 bindings enabled:      $python3_bind"
 echo "perl bindings enabled:         $perl_bind"

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -55,6 +55,7 @@ man_MANS += oscap-ssh.8
 endif
 if WANT_UTIL_OSCAP_VM
 bin_SCRIPTS += oscap-vm
+man_MANS += oscap-vm.8
 endif
 
 CONFIG_CLEAN_FILES = oscap-docker

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -53,6 +53,9 @@ if WANT_UTIL_OSCAP_SSH
 bin_SCRIPTS += oscap-ssh
 man_MANS += oscap-ssh.8
 endif
+if WANT_UTIL_OSCAP_VM
+bin_SCRIPTS += oscap-vm
+endif
 
 CONFIG_CLEAN_FILES = oscap-docker
 

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -28,7 +28,7 @@ which mktemp > /dev/null || die "Cannot find mktemp, please install coreutils."
 
 function usage()
 {
-    echo "oscap-vm -- Tool for offline evaluation of virtual machine storage images."
+    echo "oscap-vm -- Tool for offline SCAP evaluation of virtual machines."
     echo ""
     echo "Your VM must use /dev/sda1 as the root partition for this script to"
     echo "work. We think that other configurations are rare enough to limit"
@@ -70,7 +70,7 @@ function usage()
     echo "  --skip-valid"
     echo "  --datastream-id"
     echo "  --oval-id"
-    echo "  --probe-root (has to be remote probe root!)"
+    echo "  --probe-root"
     echo
     echo "$ oscap-vm image VM_STORAGE_IMAGE oval collect [options] INPUT_CONTENT"
     echo "$ oscap-vm domain VM_DOMAIN oval collect [options] INPUT_CONTENT"

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -23,6 +23,7 @@ function die()
 }
 
 which guestmount > /dev/null || die "Cannot find guestmount, please install libguestfs utilities."
+which guestunmount > /dev/null || die "Cannot find guestunmount, please install libguestfs utilities."
 which umount > /dev/null || die "Cannot find umount, please install coreutils."
 which mktemp > /dev/null || die "Cannot find mktemp, please install coreutils."
 
@@ -118,6 +119,6 @@ shift 2
 oscap "$@"
 EXIT_CODE=$?
 echo "Unmounting '$MOUNTPOINT'..."
-umount "$MOUNTPOINT"
+guestunmount "$MOUNTPOINT"
 rmdir "$MOUNTPOINT"
 exit $EXIT_CODE

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -112,14 +112,14 @@ elif [ "$1" == "domain" ]; then
 fi
 
 # Learn more at https://www.redhat.com/archives/open-scap-list/2013-July/msg00000.html
-export OSCAP_PROBE_ROOT="$(cd $MOUNTPOINT; pwd)"
+export OSCAP_PROBE_ROOT="$(cd "$MOUNTPOINT"; pwd)"
 export OSCAP_PROBE_OS_NAME="Linux" # TODO: This may be wrong!
-export OSCAP_PROBE_OS_VERSION=$(uname --kernel-release) # TODO
-export OSCAP_PROBE_ARCHITECTURE=$(uname --hardware-platform) # TODO
+export OSCAP_PROBE_OS_VERSION="$(uname --kernel-release)" # TODO
+export OSCAP_PROBE_ARCHITECTURE="$(uname --hardware-platform)" # TODO
 export OSCAP_PROBE_PRIMARY_HOST_NAME="oscap-vm $1 $2"
 shift 2
 
-oscap $*
+oscap "$@"
 EXIT_CODE=$?
 echo "Unmounting '$MOUNTPOINT'..."
 umount "$MOUNTPOINT"

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -53,7 +53,6 @@ function usage()
     echo "  --datastream-id"
     echo "  --xccdf-id"
     echo "  --benchmark-id"
-    echo "  --remediate"
     echo
     echo "$ oscap-vm image VM_STORAGE_IMAGE oval eval [options] INPUT_CONTENT"
     echo "$ oscap-vm domain VM_DOMAIN oval eval [options] INPUT_CONTENT"

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -105,10 +105,10 @@ MOUNTPOINT=$(mktemp -d)
 
 if [ "$1" == "image" ]; then
     echo "Mounting guestfs image '$2' to '$MOUNTPOINT'..."
-    guestmount -a "$2" -m /dev/sda1 -i --ro "$MOUNTPOINT"
+    guestmount -a "$2" -i --ro "$MOUNTPOINT"
 elif [ "$1" == "domain" ]; then
     echo "Mounting guestfs domain '$2' to '$MOUNTPOINT'..."
-    guestmount -d "$2" -m /dev/sda1 -i --ro "$MOUNTPOINT"
+    guestmount -d "$2" -i --ro "$MOUNTPOINT"
 fi
 
 # Learn more at https://www.redhat.com/archives/open-scap-list/2013-July/msg00000.html

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# Copyright 2015 Martin Preisler <martin@preisler.me>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+function die()
+{
+    echo "$*" >&2
+    exit 1
+}
+
+which guestmount > /dev/null || die "Cannot find guestmount, please install libguestfs utilities."
+which umount > /dev/null || die "Cannot find umount, please install coreutils."
+which mktemp > /dev/null || die "Cannot find mktemp, please install coreutils."
+
+function usage()
+{
+    echo "oscap-vm -- Tool for offline evaluation of virtual machine storage images."
+    echo ""
+    echo "Your VM must use /dev/sda1 as the root partition for this script to"
+    echo "work. We think that other configurations are rare enough to limit"
+    echo "the script like that."
+    echo
+    echo "Usage:"
+    echo
+    echo "$ oscap-vm image VM_STORAGE_IMAGE xccdf eval [options] INPUT_CONTENT"
+    echo "$ oscap-vm domain VM_DOMAIN xccdf eval [options] INPUT_CONTENT"
+    echo
+    echo "supported oscap xccdf eval options are:"
+    echo "  --profile"
+    echo "  --tailoring-file"
+    echo "  --tailoring-id"
+    echo "  --cpe (external OVAL dependencies are not supported yet!)"
+    echo "  --oval-results"
+    echo "  --sce-results"
+    echo "  --check-engine-results"
+    echo "  --results"
+    echo "  --results-arf"
+    echo "  --report"
+    echo "  --skip-valid"
+    echo "  --fetch-remote-resources"
+    echo "  --progress"
+    echo "  --datastream-id"
+    echo "  --xccdf-id"
+    echo "  --benchmark-id"
+    echo "  --remediate"
+    echo
+    echo "$ oscap-vm image VM_STORAGE_IMAGE oval eval [options] INPUT_CONTENT"
+    echo "$ oscap-vm domain VM_DOMAIN oval eval [options] INPUT_CONTENT"
+    echo
+    echo "supported oscap oval eval options are:"
+    echo "  --id"
+    echo "  --variables"
+    echo "  --directives"
+    echo "  --results"
+    echo "  --report"
+    echo "  --skip-valid"
+    echo "  --datastream-id"
+    echo "  --oval-id"
+    echo "  --probe-root (has to be remote probe root!)"
+    echo
+    echo "$ oscap-vm image VM_STORAGE_IMAGE oval collect [options] INPUT_CONTENT"
+    echo "$ oscap-vm domain VM_DOMAIN oval collect [options] INPUT_CONTENT"
+    echo
+    echo "supported oscap oval collect options are:"
+    echo "  --id"
+    echo "  --syschar"
+    echo "  --variables"
+    echo "  --skip-valid"
+    echo
+    echo "See \`man oscap\` to learn more about semantics of these options."
+}
+
+if [ $# -lt 1 ]; then
+    echo "No arguments provided."
+    usage
+    die
+elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+    usage
+    die
+elif [ "$1" == "image" ] && [ $# -gt 2 ]; then
+    true
+elif [ "$1" == "domain" ] && [ $# -gt 2 ]; then
+    true
+else
+    echo "Invalid arguments provided."
+    usage
+    die
+fi
+
+MOUNTPOINT=$(mktemp -d)
+
+if [ "$1" == "image" ]; then
+    echo "Mounting guestfs image '$2' to '$MOUNTPOINT'..."
+    guestmount -a "$2" -m /dev/sda1 -i --ro "$MOUNTPOINT"
+elif [ "$1" == "domain" ]; then
+    echo "Mounting guestfs domain '$2' to '$MOUNTPOINT'..."
+    guestmount -d "$2" -m /dev/sda1 -i --ro "$MOUNTPOINT"
+fi
+
+# Learn more at https://www.redhat.com/archives/open-scap-list/2013-July/msg00000.html
+export OSCAP_PROBE_ROOT="$(cd $MOUNTPOINT; pwd)"
+export OSCAP_PROBE_OS_NAME="Linux" # TODO: This may be wrong!
+export OSCAP_PROBE_OS_VERSION=$(uname --kernel-release) # TODO
+export OSCAP_PROBE_ARCHITECTURE=$(uname --hardware-platform) # TODO
+export OSCAP_PROBE_PRIMARY_HOST_NAME="oscap-vm $1 $2"
+shift 2
+
+oscap $*
+EXIT_CODE=$?
+echo "Unmounting '$MOUNTPOINT'..."
+umount "$MOUNTPOINT"
+exit $EXIT_CODE

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -123,4 +123,5 @@ oscap $*
 EXIT_CODE=$?
 echo "Unmounting '$MOUNTPOINT'..."
 umount "$MOUNTPOINT"
+rmdir "$MOUNTPOINT"
 exit $EXIT_CODE

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -29,10 +29,6 @@ which mktemp > /dev/null || die "Cannot find mktemp, please install coreutils."
 function usage()
 {
     echo "oscap-vm -- Tool for offline SCAP evaluation of virtual machines."
-    echo ""
-    echo "Your VM must use /dev/sda1 as the root partition for this script to"
-    echo "work. We think that other configurations are rare enough to limit"
-    echo "the script like that."
     echo
     echo "Usage:"
     echo

--- a/utils/oscap-vm.8
+++ b/utils/oscap-vm.8
@@ -32,7 +32,6 @@ supported oscap xccdf eval options are:
   --datastream-id
   --xccdf-id
   --benchmark-id
-  --remediate
 
 .SS Evaluation of OVAL content
 $ oscap-vm image VM_STORAGE_IMAGE oval eval [options] INPUT_CONTENT

--- a/utils/oscap-vm.8
+++ b/utils/oscap-vm.8
@@ -1,0 +1,72 @@
+.TH oscap-vm "8" "October 2015" "Red Hat, Inc." "System Administration Utilities"
+.SH NAME
+oscap-vm \- Tool for offline SCAP evaluation of virtual machines.
+.SH DESCRIPTION
+oscap-vm mounts given virtual machine and runs oscap tool on it.
+
+The tool requires bash, guestmount, mktemp and umount to perform OVAL and XCCDF
+evaluation of virtual machines.
+
+Usage of the tool mimics usage and options of oscap(8) tool.
+
+.SH USAGE
+.SS Evaluation of XCCDF content
+$ oscap-vm image VM_STORAGE_IMAGE xccdf eval [options] INPUT_CONTENT
+
+$ oscap-vm domain VM_DOMAIN xccdf eval [options] INPUT_CONTENT
+
+supported oscap xccdf eval options are:
+  --profile
+  --tailoring-file
+  --tailoring-id
+  --cpe (external OVAL dependencies are not supported yet!)
+  --oval-results
+  --sce-results
+  --check-engine-results
+  --results
+  --results-arf
+  --report
+  --skip-valid
+  --fetch-remote-resources
+  --progress
+  --datastream-id
+  --xccdf-id
+  --benchmark-id
+  --remediate
+
+.SS Evaluation of OVAL content
+$ oscap-vm image VM_STORAGE_IMAGE oval eval [options] INPUT_CONTENT
+
+$ oscap-vm domain VM_DOMAIN oval eval [options] INPUT_CONTENT
+
+supported oscap oval eval options are:
+  --id
+  --variables
+  --directives
+  --results
+  --report
+  --skip-valid
+  --datastream-id
+  --oval-id
+  --probe-root
+
+.SS Collection of OVAL System Characteristic
+$ oscap-vm image VM_STORAGE_IMAGE oval collect [options] INPUT_CONTENT
+
+$ oscap-vm domain VM_DOMAIN oval collect [options] INPUT_CONTENT
+
+supported oscap oval collect options are:
+  --id
+  --syschar
+  --variables
+  --skip-valid
+
+
+.SH REPORTING BUGS
+.nf
+Please report bugs using https://github.com/OpenSCAP/openscap/issues
+
+.SH AUTHORS
+.nf
+Martin Preisler <mpreisle@redhat.com>
+.fi


### PR DESCRIPTION
Offline SCAP scanning for VMs that are shutdown or running. Uses guestfs tools. My aim was to be as consistent as possible, the tool is similar to oscap-ssh and oscap-docker.

Example usage:
```
# ./oscap-vm image /var/lib/libvirt/images/rhel7.2.qcow2 xccdf eval --profile xccdf_org.ssgproject.content_profile_stig-rhel7-server-upstream /usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml 
Mounting guestfs image '/var/lib/libvirt/images/rhel7.2.qcow2' to '/tmp/tmp.PgfWcB0R4g'...
Title   Encrypt Partitions
Rule    xccdf_org.ssgproject.content_rule_encrypt_partitions
Ident   CCE-27128-8
Result  notchecked

[snip]

Title   Enable SSH Warning Banner
Rule    xccdf_org.ssgproject.content_rule_sshd_enable_warning_banner
Ident   CCE-27314-4
Result  fail

Title   Create Warning Banners for All FTP Users
Rule    xccdf_org.ssgproject.content_rule_ftp_present_banner
Ident   CCE-RHEL7-CCE-TBD
Result  pass

Unmounting '/tmp/tmp.PgfWcB0R4g'...
```

```
# ./oscap-vm domain rhel7.2 xccdf eval --profile xccdf_org.ssgproject.content_profile_stig-rhel7-server-upstream /usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml 
Mounting guestfs domain 'rhel7.2' to '/tmp/tmp.c69yOdlBNZ'...
Title   Encrypt Partitions
Rule    xccdf_org.ssgproject.content_rule_encrypt_partitions
Ident   CCE-27128-8
Result  notchecked

[snip]

Title   Create Warning Banners for All FTP Users
Rule    xccdf_org.ssgproject.content_rule_ftp_present_banner
Ident   CCE-RHEL7-CCE-TBD
Result  pass

Unmounting '/tmp/tmp.c69yOdlBNZ'...
```

I will let the documentation speak for itself:
```
$ ./oscap-vm 
No arguments provided.
oscap-vm -- Tool for offline SCAP evaluation of virtual machines.

Your VM must use /dev/sda1 as the root partition for this script to
work. We think that other configurations are rare enough to limit
the script like that.

Usage:

$ oscap-vm image VM_STORAGE_IMAGE xccdf eval [options] INPUT_CONTENT
$ oscap-vm domain VM_DOMAIN xccdf eval [options] INPUT_CONTENT

supported oscap xccdf eval options are:
  --profile
  --tailoring-file
  --tailoring-id
  --cpe (external OVAL dependencies are not supported yet!)
  --oval-results
  --sce-results
  --check-engine-results
  --results
  --results-arf
  --report
  --skip-valid
  --fetch-remote-resources
  --progress
  --datastream-id
  --xccdf-id
  --benchmark-id
  --remediate

$ oscap-vm image VM_STORAGE_IMAGE oval eval [options] INPUT_CONTENT
$ oscap-vm domain VM_DOMAIN oval eval [options] INPUT_CONTENT

supported oscap oval eval options are:
  --id
  --variables
  --directives
  --results
  --report
  --skip-valid
  --datastream-id
  --oval-id
  --probe-root

$ oscap-vm image VM_STORAGE_IMAGE oval collect [options] INPUT_CONTENT
$ oscap-vm domain VM_DOMAIN oval collect [options] INPUT_CONTENT

supported oscap oval collect options are:
  --id
  --syschar
  --variables
  --skip-valid

See `man oscap` to learn more about semantics of these options.
```