### PR TITLE
Use HTTPS for fetching the CVE OVALs in oscap-docker

### DIFF
--- a/utils/oscap_docker_python/get_cve_input.py
+++ b/utils/oscap_docker_python/get_cve_input.py
@@ -37,7 +37,7 @@ class getInputCVE(object):
 
     hdr = {'User-agent': 'Mozilla/5.0'}
     hdr2 = [('User-agent', 'Mozilla/5.0')]
-    url = "http://www.redhat.com/security/data/oval/"
+    url = "https://www.redhat.com/security/data/oval/"
     dist_cve_name = "Red_Hat_Enterprise_Linux_{0}.xml"
     dists = [5, 6, 7]
     remote_pattern = '%a, %d %b %Y %H:%M:%S %Z'
@@ -102,6 +102,7 @@ class getInputCVE(object):
             return False
         opener = urllib.OpenerDirector()
         opener.add_handler(urllib.HTTPHandler())
+        opener.add_handler(urllib.HTTPSHandler())
         opener.add_handler(urllib.HTTPDefaultErrorHandler())
         # Extra for handling redirects
         opener.add_handler(urllib.HTTPErrorProcessor())


### PR DESCRIPTION
Added HTTPSHandler in case other people want to use https for fetching
and they want to change the URL. This is useful for the custom URL feature in `atomic scan` and `oscapd`. It also makes sense to prefer https over http.

How to test easily:
```
$ mkdir /tmp/cve
$ python -i oscap_docker_python/get_cve_input.py 
>>> a = getInputCVE("/tmp/cve")
>>> a.fetch_dist_data()
['/tmp/cve/Red_Hat_Enterprise_Linux_5.xml', '/tmp/cve/Red_Hat_Enterprise_Linux_6.xml', '/tmp/cve/Red_Hat_Enterprise_Linux_7.xml']
>>> a.fetch_dist_data()
['/tmp/cve/Red_Hat_Enterprise_Linux_5.xml', '/tmp/cve/Red_Hat_Enterprise_Linux_6.xml', '/tmp/cve/Red_Hat_Enterprise_Linux_7.xml']
```

First run fetches everything from scratch, the second run finds the cached files and requests HEAD for each of them, checking `Last-modified` against returned headers.