### PR TITLE
Download bzipped variants of RHSA OVAL data in oscap-docker

### DIFF
--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -501,6 +501,12 @@ else
 fi
 AC_SUBST([vgcheck])
 
+if test "x${util_oscap_docker}" = "xyes"; then
+	if test ! "x${HAVE_BZIP2}" = xyes; then
+		AC_MSG_FAILURE(oscap-docker requires bzip2! Either disable oscap-docker or install bzip2.)
+	fi
+fi
+
 if test "x${perl_bind}" = xyes; then
 	AC_PATH_PROG(PERL, perl)
 	PERL_INCLUDES="`$PERL -e 'use Config; print $Config{archlib}'`/CORE"

--- a/configure.ac
+++ b/configure.ac
@@ -1226,6 +1226,12 @@ else
 fi
 AC_SUBST([vgcheck])
 
+if test "x${util_oscap_docker}" = "xyes"; then
+	if test ! "x${HAVE_BZIP2}" = xyes; then
+		AC_MSG_FAILURE(oscap-docker requires bzip2! Either disable oscap-docker or install bzip2.)
+	fi
+fi
+
 if test "x${perl_bind}" = xyes; then
 	AC_PATH_PROG(PERL, perl)
 	PERL_INCLUDES="`$PERL -e 'use Config; print $Config{archlib}'`/CORE"

--- a/utils/oscap_docker_python/get_cve_input.py
+++ b/utils/oscap_docker_python/get_cve_input.py
@@ -38,7 +38,7 @@ class getInputCVE(object):
     hdr = {'User-agent': 'Mozilla/5.0'}
     hdr2 = [('User-agent', 'Mozilla/5.0')]
     url = "https://www.redhat.com/security/data/oval/"
-    dist_cve_name = "Red_Hat_Enterprise_Linux_{0}.xml"
+    dist_cve_name = "com.redhat.rhsa-RHEL{0}.xml.bz2"
     dists = [5, 6, 7]
     remote_pattern = '%a, %d %b %Y %H:%M:%S %Z'
 


### PR DESCRIPTION
Saves bandwidth and (at least in most cases) time.

We don't do any unbzip-ing because oscap does that on its own.

This change requires recent `oscap` tool with bzip support but I think it's not an issue since we ship both in closely related packages. The only issue I can think of is when somebody compiles openscap with oscap-docker but without bzip support. If we agree that this is a serious issue I suggest we blacklist that combination in `configure`.