### PR TITLE
Fix invalid CPE content

### DIFF
--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -557,18 +557,8 @@
             </rpminfo_test>
             <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.sled:tst:1" version="1" check="at least one" comment="/etc/sled-release is provided by sled-release package"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-                  <object object_ref="oval:org.open-scap.cpe.sles-release:obj:1"/>
-                  <state state_ref="oval:org.open-scap.cpe.sled:ste:1"/>
-            </rpminfo_test>
-            <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.sles:tst:2" version="1" check="at least one" comment="/etc/sles-release is provided by sles-release package"
-                  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-                  <object object_ref="oval:org.open-scap.cpe.sles-release:obj:1"/>
-                  <state state_ref="oval:org.open-scap.cpe.sles:ste:2"/>
-            </rpminfo_test>
-            <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.sled:tst:2" version="1" check="at least one" comment="/etc/sles-release is provided by sles-release package"
-                  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <object object_ref="oval:org.open-scap.cpe.sled-release:obj:1"/>
-                  <state state_ref="oval:org.open-scap.cpe.sled:ste:2"/>
+                  <state state_ref="oval:org.open-scap.cpe.sled:ste:1"/>
             </rpminfo_test>
 
             <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.sles:tst:10" version="1" check="at least one" comment="sles-release is version 10"
@@ -593,12 +583,12 @@
             </rpminfo_test>
             <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.sled:tst:11" version="1" check="at least one" comment="sled-release is version 11"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-                  <object object_ref="oval:org.open-scap.cpe.sled-release:obj:3"/>
+                  <object object_ref="oval:org.open-scap.cpe.sled-release:obj:1"/>
                   <state state_ref="oval:org.open-scap.cpe.sled:ste:11"/>
             </rpminfo_test>
             <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.sled:tst:12" version="1" check="at least one" comment="sled-release is version 12"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-                  <object object_ref="oval:org.open-scap.cpe.sled-release:obj:3"/>
+                  <object object_ref="oval:org.open-scap.cpe.sled-release:obj:1"/>
                   <state state_ref="oval:org.open-scap.cpe.sled:ste:12"/>
             </rpminfo_test>
             <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.opensuse:tst:1" version="1" check="at least one" comment="openSUSE-release is version 11.4"
@@ -719,10 +709,10 @@
             <rpminfo_state id="oval:org.open-scap.cpe.fedora:ste:24" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <version operation="pattern match">^24$</version>
             </rpminfo_state>
-            <rpminfo_state id="oval:org.open-scap.cpe.sles:ste:2" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+            <rpminfo_state id="oval:org.open-scap.cpe.sles:ste:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <name operation="pattern match">^sles-release</name>
             </rpminfo_state>
-            <rpminfo_state id="oval:org.open-scap.cpe.sled:ste:2" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+            <rpminfo_state id="oval:org.open-scap.cpe.sled:ste:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <name operation="pattern match">^sled-release</name>
             </rpminfo_state>
             <rpminfo_state id="oval:org.open-scap.cpe.sles:ste:10" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">


### PR DESCRIPTION
This OVAL file was invalid. There were missing objects and states.
It was one of causes of issue #191 (segfault on oscap xccdf eval).