### PR TITLE
Refactor + fix a segfault

### DIFF
--- a/src/OVAL/oval_definitions_impl.h
+++ b/src/OVAL/oval_definitions_impl.h
@@ -40,6 +40,7 @@
 OSCAP_HIDDEN_START;
 
 oval_family_t oval_family_parse(xmlTextReaderPtr);
+xmlNs *oval_family_to_namespace(oval_family_t family, const char *schema_ns, xmlDoc *doc, xmlNode *parent);
 oval_subtype_t oval_subtype_parse(xmlTextReaderPtr);
 oval_affected_family_t oval_affected_family_parse(xmlTextReaderPtr);
 oval_operator_t oval_operator_parse(xmlTextReaderPtr, char *, oval_operator_t);

--- a/src/OVAL/oval_enumerations.c
+++ b/src/OVAL/oval_enumerations.c
@@ -399,6 +399,9 @@ const char *oval_family_get_text(oval_family_t family)
 xmlNs *oval_family_to_namespace(oval_family_t family, const char *schema_ns, xmlDoc *doc, xmlNode *parent)
 {
 	const char *family_text = oval_family_get_text(family);
+	if (family_text == NULL) {
+		return NULL;
+	}
 	/* We need to allocate memory also for '#' and '\0'. */
 	char family_uri[strlen(schema_ns) + 1 + strlen(family_text) + 1];
 	sprintf(family_uri,"%s#%s", schema_ns, family_text);

--- a/src/OVAL/oval_enumerations.c
+++ b/src/OVAL/oval_enumerations.c
@@ -396,6 +396,15 @@ const char *oval_family_get_text(oval_family_t family)
 	return oval_enumeration_get_text(OVAL_FAMILY_MAP, family);
 }
 
+xmlNs *oval_family_to_namespace(oval_family_t family, const char *schema_ns, xmlDoc *doc, xmlNode *parent)
+{
+	const char *family_text = oval_family_get_text(family);
+	/* We need to allocate memory also for '#' and '\0'. */
+	char family_uri[strlen(schema_ns) + 1 + strlen(family_text) + 1];
+	sprintf(family_uri,"%s#%s", schema_ns, family_text);
+	return xmlSearchNsByHref(doc, parent, BAD_CAST family_uri);
+}
+
 static const struct oscap_string_map OVAL_SUBTYPE_AIX_MAP[] = {
 	{OVAL_AIX_FILESET, "fileset"},
 	{OVAL_AIX_FIX, "fix"},

--- a/src/OVAL/oval_object.c
+++ b/src/OVAL/oval_object.c
@@ -391,14 +391,10 @@ xmlNode *oval_object_to_dom(struct oval_object *object, xmlDoc * doc, xmlNode * 
 	char object_name[strlen(subtype_text) + 8];
 	sprintf(object_name, "%s_object", subtype_text);
 
-	/* get family URI */
 	oval_family_t family = oval_object_get_family(object);
-	const char *family_text = oval_family_get_text(family);
-	char family_uri[strlen((const char *)OVAL_DEFINITIONS_NAMESPACE) + strlen(family_text) + 2];
-	sprintf(family_uri,"%s#%s", OVAL_DEFINITIONS_NAMESPACE, family_text);
 
 	/* search namespace & create child */
-	xmlNs *ns_family = xmlSearchNsByHref(doc, parent, BAD_CAST family_uri);
+	xmlNs *ns_family = oval_family_to_namespace(family, (const char *) OVAL_DEFINITIONS_NAMESPACE, doc, parent);
 	object_node = xmlNewTextChild(parent, ns_family, BAD_CAST object_name, NULL);
 
 	char *id = oval_object_get_id(object);

--- a/src/OVAL/oval_state.c
+++ b/src/OVAL/oval_state.c
@@ -330,14 +330,10 @@ xmlNode *oval_state_to_dom(struct oval_state *state, xmlDoc * doc, xmlNode * par
 	char state_name[strlen(subtype_text) + 7];
 	sprintf(state_name, "%s_state", subtype_text);
 
-	/* get family URI */
 	oval_family_t family = oval_state_get_family(state);
-	const char *family_text = oval_family_get_text(family);
-	char family_uri[strlen((const char *)OVAL_DEFINITIONS_NAMESPACE) + strlen(family_text) + 2];
-	sprintf(family_uri,"%s#%s", OVAL_DEFINITIONS_NAMESPACE, family_text);
 
 	/* search namespace & create child */ 
-	xmlNs *ns_family = xmlSearchNsByHref(doc, parent, BAD_CAST family_uri);
+	xmlNs *ns_family = oval_family_to_namespace(family, (const char *) OVAL_DEFINITIONS_NAMESPACE, doc, parent);
 	xmlNode *state_node = xmlNewTextChild(parent, ns_family, BAD_CAST state_name, NULL);
 
 	char *id = oval_state_get_id(state);

--- a/src/OVAL/oval_sysItem.c
+++ b/src/OVAL/oval_sysItem.c
@@ -260,13 +260,10 @@ void oval_sysitem_to_dom(struct oval_sysitem *sysitem, xmlDoc * doc, xmlNode * p
 			char tagname[strlen(subtype_text) + 6];
 			sprintf(tagname, "%s_item", subtype_text);
 
-			 /* get family URI */
-			const char *family = oval_family_get_text(oval_subtype_get_family(subtype));
-			char family_uri[strlen((const char *)OVAL_SYSCHAR_NAMESPACE) + strlen(family) + 2];
-			sprintf(family_uri, "%s#%s", OVAL_SYSCHAR_NAMESPACE, family);
+			oval_family_t family = oval_subtype_get_family(subtype);
 
 			/* search namespace & create child */
-			xmlNs *ns_family = xmlSearchNsByHref(doc, parent, BAD_CAST family_uri);
+			xmlNs *ns_family = oval_family_to_namespace(family, (const char *) OVAL_SYSCHAR_NAMESPACE, doc, parent);
 			xmlNode *tag_sysitem = xmlNewTextChild(parent, ns_family, BAD_CAST tagname, NULL);
 
 			/* attributes */

--- a/src/OVAL/oval_test.c
+++ b/src/OVAL/oval_test.c
@@ -433,14 +433,10 @@ xmlNode *oval_test_to_dom(struct oval_test *test, xmlDoc * doc, xmlNode * parent
 	char test_name[strlen(subtype_text) + 6];
 	sprintf(test_name, "%s_test", subtype_text);
 
-	/* get family URI */
 	oval_family_t family = oval_test_get_family(test);
-	const char *family_text = oval_family_get_text(family);
-	char family_uri[strlen((const char *)OVAL_DEFINITIONS_NAMESPACE) + strlen(family_text) + 2];
-	sprintf(family_uri,"%s#%s", OVAL_DEFINITIONS_NAMESPACE, family_text);
 
 	/* search namespace & create child */
-	xmlNs *ns_family = xmlSearchNsByHref(doc, parent, BAD_CAST family_uri);
+	xmlNs *ns_family = oval_family_to_namespace(family, (const char *) OVAL_DEFINITIONS_NAMESPACE, doc, parent);
 	test_node = xmlNewTextChild(parent, ns_family, BAD_CAST test_name, NULL);
 
 	char *id = oval_test_get_id(test);


### PR DESCRIPTION
This code repeats 4 times in OpenSCAP. This commit refactors it out
to a single function. This functions converts oval family to a XML namespace.