### PR TITLE
Fix and test openscap-cpe-oval.xml

### DIFF
--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -521,6 +521,7 @@ AC_CONFIG_FILES([Makefile
                  tests/API/SEAP/Makefile
                  tests/API/probes/Makefile
 		tests/sources/Makefile
+		tests/CPE/Makefile
                  tests/probes/file/Makefile
                  tests/probes/fileextendedattribute/Makefile
                  tests/probes/uname/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -1277,6 +1277,7 @@ AC_CONFIG_FILES([Makefile
                  tests/API/SEAP/Makefile
                  tests/API/probes/Makefile
 		tests/sources/Makefile
+		tests/CPE/Makefile
                  tests/probes/file/Makefile
                  tests/probes/fileextendedattribute/Makefile
                  tests/probes/uname/Makefile

--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -202,26 +202,26 @@
                   <object object_ref="oval:org.open-scap.cpe.unix:obj:1"/>
                   <state state_ref="oval:org.open-scap.cpe.unix:ste:1"/>
             </family_test>
-            <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:2" version="1" check="at least one" comment="/etc/redhat-release is provided by redhat-release package"
+            <rpmverifyfile_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:2" version="1" check="at least one" comment="/etc/redhat-release is provided by redhat-release package"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <object object_ref="oval:org.open-scap.cpe.redhat-release:obj:3"/>
                   <state state_ref="oval:org.open-scap.cpe.rhel:ste:2"/>
-            </rpminfo_test>
+            </rpmverifyfile_test>
             <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:5" version="1" check="at least one" comment="redhat-release is version 5"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <object object_ref="oval:org.open-scap.cpe.redhat-release:obj:1"/>
                   <state state_ref="oval:org.open-scap.cpe.rhel:ste:5"/>
             </rpminfo_test>
-            <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:6" version="1" check="at least one" comment="redhat-release is version 6"
+            <rpmverifyfile_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:6" version="1" check="at least one" comment="redhat-release is version 6"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <object object_ref="oval:org.open-scap.cpe.redhat-release:obj:3"/>
                   <state state_ref="oval:org.open-scap.cpe.rhel:ste:6"/>
-            </rpminfo_test>
-            <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:7" version="1" check="at least one" comment="redhat-release is version 7"
+            </rpmverifyfile_test>
+            <rpmverifyfile_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:7" version="1" check="at least one" comment="redhat-release is version 7"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <object object_ref="oval:org.open-scap.cpe.redhat-release:obj:3"/>
                   <state state_ref="oval:org.open-scap.cpe.rhel:ste:7"/>
-            </rpminfo_test>
+            </rpmverifyfile_test>
             <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.fedora:tst:16" version="1" check="at least one" comment="fedora-release is version Fedora 16"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <object object_ref="oval:org.open-scap.cpe.fedora-release:obj:2"/>
@@ -291,20 +291,20 @@
             <family_state id="oval:org.open-scap.cpe.unix:ste:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
                   <family>unix</family>
             </family_state>
-            <rpminfo_state id="oval:org.open-scap.cpe.rhel:ste:2" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+            <rpmverifyfile_state id="oval:org.open-scap.cpe.rhel:ste:2" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <name operation="pattern match">^redhat-release</name>
-            </rpminfo_state>
+            </rpmverifyfile_state>
             <rpminfo_state id="oval:org.open-scap.cpe.rhel:ste:5" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <version operation="pattern match">^5[^\d]</version>
             </rpminfo_state>
-            <rpminfo_state id="oval:org.open-scap.cpe.rhel:ste:6" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+            <rpmverifyfile_state id="oval:org.open-scap.cpe.rhel:ste:6" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <name operation="pattern match">^redhat-release</name>
                   <version operation="pattern match">^6[^\d]</version>
-            </rpminfo_state>
-            <rpminfo_state id="oval:org.open-scap.cpe.rhel:ste:7" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+            </rpmverifyfile_state>
+            <rpmverifyfile_state id="oval:org.open-scap.cpe.rhel:ste:7" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <name operation="pattern match">^redhat-release</name>
                   <version operation="pattern match">^7[^\d]</version>
-            </rpminfo_state>
+            </rpmverifyfile_state>
             <rpminfo_state id="oval:org.open-scap.cpe.fedora:ste:16" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <version operation="pattern match">^16$</version>
             </rpminfo_state>

--- a/tests/CPE/Makefile.am
+++ b/tests/CPE/Makefile.am
@@ -1,0 +1,12 @@
+DISTCLEANFILES = *.log *.out* oscap_debug.log.* $(check_DATA)
+CLEANFILES = *.log *.out* oscap_debug.log.* $(check_DATA)
+
+TESTS_ENVIRONMENT= \
+		top_srcdir=$(top_srcdir) \
+		builddir=$(top_builddir) \
+		OSCAP_FULL_VALIDATION=1 \
+		$(top_builddir)/run
+
+TESTS = all.sh
+
+EXTRA_DIST = all.sh

--- a/tests/CPE/all.sh
+++ b/tests/CPE/all.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2015 Red Hat Inc., Durham, North Carolina.
+# All Rights Reserved.
+
+set -e -o pipefail
+
+. ${srcdir}/../test_common.sh
+
+function test_cpe() {
+    $OSCAP oval validate --schematron ${srcdir}/../../cpe/openscap-cpe-oval.xml
+    $OSCAP cpe validate ${srcdir}/../../cpe/openscap-cpe-dict.xml
+}
+
+test_init "test_cpe.log"
+
+test_run "Check validity of cpe/openscap-cpe-oval.xml" test_cpe
+test_exit

--- a/tests/CPE/all.sh
+++ b/tests/CPE/all.sh
@@ -8,8 +8,8 @@ set -e -o pipefail
 . ${srcdir}/../test_common.sh
 
 function test_cpe() {
-    $OSCAP oval validate --schematron ${srcdir}/../../cpe/openscap-cpe-oval.xml
-    $OSCAP cpe validate ${srcdir}/../../cpe/openscap-cpe-dict.xml
+    $OSCAP oval validate --schematron ${top_srcdir}/cpe/openscap-cpe-oval.xml
+    $OSCAP cpe validate ${top_srcdir}/cpe/openscap-cpe-dict.xml
 }
 
 test_init "test_cpe.log"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -19,6 +19,7 @@ endif
 
 SUBDIRS = \
 	API \
+	CPE \
 	DS \
 	sources \
 	schemas \


### PR DESCRIPTION
This OVAL file did not pass validation by schematron.
A rpminfo_test should not reference a rpmverifyfile_object,
it can be referenced only from a rpmverifyfile_test.
We must change tests to rpmverifyfile_test and
also change respective states.