### PR TITLE
Change category of some debug messages to DEVEL verbosity level

### DIFF
--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -994,21 +994,21 @@ int oval_probe_ext_init(oval_pext_t *pext)
 
 		pext->pdsc = oscap_alloc(sizeof(oval_pdsc_t) * OSCAP_GSYM(__probe_meta_count));
 
-                dI("__probe_meta_count = %zu\n", OSCAP_GSYM(__probe_meta_count));
+                dD("__probe_meta_count = %zu\n", OSCAP_GSYM(__probe_meta_count));
 
 		for (r = 0, i = 0; i < OSCAP_GSYM(__probe_meta_count); ++i) {
                         if (!(OSCAP_GSYM(__probe_meta)[i].flags & OVAL_PROBEMETA_EXTERNAL)) {
-                                dI("skipped: %s (not an external probe)\n", OSCAP_GSYM(__probe_meta)[i].stype);
+                                dD("skipped: %s (not an external probe)\n", OSCAP_GSYM(__probe_meta)[i].stype);
                                 continue;
                         }
 
 			if (stat(OSCAP_GSYM(__probe_meta)[i].pname, &st) != 0) {
-				dW("skipped: %s (stat failed, errno=%d)\n", OSCAP_GSYM(__probe_meta)[i].stype, errno);
+				dD("skipped: %s (stat failed, errno=%d)\n", OSCAP_GSYM(__probe_meta)[i].stype, errno);
 				continue;
 			}
 
 			if (!S_ISREG(st.st_mode)) {
-				dW("skipped: %s (not a regular file)\n", OSCAP_GSYM(__probe_meta)[i].stype);
+				dD("skipped: %s (not a regular file)\n", OSCAP_GSYM(__probe_meta)[i].stype);
 				continue;
 			}
 

--- a/src/OVAL/oval_probe_session.c
+++ b/src/OVAL/oval_probe_session.c
@@ -134,7 +134,7 @@ oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model)
 
         __init_once();
 
-        dI("__probe_meta_count = %zu\n", OSCAP_GSYM(__probe_meta_count));
+        dD("__probe_meta_count = %zu\n", OSCAP_GSYM(__probe_meta_count));
 
         for (i = 0; i < OSCAP_GSYM(__probe_meta_count); ++i) {
                 handler_arg = NULL;

--- a/src/OVAL/probes/SEAP/generic/strbuf.c
+++ b/src/OVAL/probes/SEAP/generic/strbuf.c
@@ -291,18 +291,18 @@ ssize_t strbuf_write (strbuf_t *buf, int fd)
         cur   = buf->beg;
 	iot   = (buf->size / buf->blkmax) + 1;
 
-	dI("total I/O vectors = %d\n", iot);
+	dD("total I/O vectors = %d\n", iot);
 
 	while (iot > 0) {
 		/*
 		 * Prepare I/O vector
 		 */
 		if (iot > IOV_MAX) {
-			dI("iot (%d) > IOV_MAX (%d)\n", iot, IOV_MAX);
+			dD("iot (%d) > IOV_MAX (%d)\n", iot, IOV_MAX);
 			iow  = IOV_MAX;
 			iot -= IOV_MAX;
 		} else {
-			dI("iot (%d) < IOV_MAX (%d)\n", iot, IOV_MAX);
+			dD("iot (%d) < IOV_MAX (%d)\n", iot, IOV_MAX);
 			iow  = iot;
 			iot  = 0;
 		}
@@ -318,7 +318,7 @@ ssize_t strbuf_write (strbuf_t *buf, int fd)
 			cur = cur->next;
 		}
 
-		dI("ioc = %d\n", ioc);
+		dD("ioc = %d\n", ioc);
 
 		/*
 		 * Write
@@ -335,7 +335,7 @@ ssize_t strbuf_write (strbuf_t *buf, int fd)
 	}
 
         free (iov);
-	dI("total bytes written: %zu\n", (size_t)rsize);
+	dD("total bytes written: %zu\n", (size_t)rsize);
 
         return (rsize);
 }


### PR DESCRIPTION
These messages describe implementation details and can be ignored
by users who are interested in OVAL evaluation.