### PR TITLE
Issue #205: Fix header dependencies

### DIFF
--- a/src/common/debug_priv.h
+++ b/src/common/debug_priv.h
@@ -34,6 +34,7 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include "util.h"
+#include "public/oscap_debug.h"
 
 OSCAP_HIDDEN_START;
 

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -27,7 +27,6 @@
 #include <stdbool.h>
 #include <assert.h>
 #include "public/oscap.h"
-#include "public/oscap_debug.h"
 #include "alloc.h"
 #include <stdarg.h>
 


### PR DESCRIPTION
The util.h doesn't depend on public/oscap_debug.h, so we should
remove the include from there. On the other hand, debug_priv.h
depends on public/oscap_debug.h, so we should add include there.