### PR TITLE
Small message improvements

### DIFF
--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -795,7 +795,7 @@ int oval_probe_sys_handler(oval_subtype_t type, void *ptr, int act, ...)
 
                         ret = -1;
                 } else {
-                        oscap_dlprintf(DBG_I, "URI: %s.\n", probe_uri);
+                        dI("Starting probe on URI '%s'.\n", probe_uri);
 
                         if (oval_pdtbl_add(pext->pdtbl, type, -1, probe_uri) != 0) {
                                 oscap_seterr (OSCAP_EFAMILY_OVAL, "%s probe not supported", probe_dsc->name);
@@ -863,7 +863,7 @@ int oval_probe_ext_handler(oval_subtype_t type, void *ptr, int act, ...)
                                 return (-1);
                         }
 
-                        oscap_dlprintf(DBG_I, "URI: %s.\n", probe_uri);
+                        dI("Starting probe on URI '%s'.\n", probe_uri);
 
                         if (oval_pdtbl_add(pext->pdtbl, oval_object_get_subtype(obj), -1, probe_uri) != 0) {
 				oval_syschar_add_new_message(sys, "OVAL object not supported", OVAL_MESSAGE_LEVEL_WARNING);

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -34,6 +34,7 @@
 #include "common/alloc.h"
 #include "common/elements.h"
 #include "common/_error.h"
+#include "common/debug_priv.h"
 #include "common/public/oscap.h"
 #include "common/util.h"
 #include "CPE/public/cpe_lang.h"
@@ -259,10 +260,11 @@ int oscap_source_validate(struct oscap_source *source, xml_reporter reporter, vo
 		ret = -1;
 	} else {
 		const char *schema_version = oscap_source_get_schema_version(source);
+		const char *type_name = oscap_document_type_to_string(scap_type);
+		const char *origin = oscap_source_readable_origin(source);
+		dD("Validating %s (%s) document from %s.\n", type_name, schema_version, origin);
 		ret = oscap_source_validate_priv(source, scap_type, schema_version, reporter, user);
 		if (ret != 0) {
-			const char *type_name = oscap_document_type_to_string(scap_type);
-			const char *origin = oscap_source_readable_origin(source);
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Invalid %s (%s) content in %s.", type_name, schema_version, origin);
 		}
 	}


### PR DESCRIPTION
This pull request brings two very small improvements to verbose output, This pull request contains two commits. First commit improves a message regarding URI probe that is going to be started. Second commit adds a message that a SCAP content validation will be proceeded. It can be quite useful when we would like to see in log which documents are evaluated and which schema version  is used.