### PR TITLE
Move setting thread names to a right place

### DIFF
--- a/src/OVAL/probes/SEAP/seap.c
+++ b/src/OVAL/probes/SEAP/seap.c
@@ -239,6 +239,7 @@ static void *__SEAP_cmdexec_worker (void *arg)
 
         _A(job != NULL);
         _A(job->cmd != NULL);
+	pthread_setname_np(pthread_self(), "command_worker");
 
         if (job->cmd->flags & SEAP_CMDFLAG_REPLY) {
                 (void) SEAP_cmd_exec (job->ctx, job->sd, SEAP_EXEC_WQUEUE,
@@ -286,7 +287,6 @@ int __SEAP_recvmsg_process_cmd (SEAP_CTX_t *ctx, int sd, SEAP_cmd_t *cmd)
                         return (-1);
                 }
 
-				pthread_setname_np(th, "command_worker");
                 pthread_attr_destroy (&th_attrs);
         } else {
                 if (cmd->flags & SEAP_CMDFLAG_REPLY) {

--- a/src/OVAL/probes/probe/icache.c
+++ b/src/OVAL/probes/probe/icache.c
@@ -92,6 +92,8 @@ static void *probe_icache_worker(void *arg)
 
         assume_d(cache != NULL, NULL);
 
+	pthread_setname_np(pthread_self(), "icache_worker");
+
         if (pthread_mutex_lock(&cache->queue_mutex) != 0) {
                 dE("An error ocured while locking the queue mutex: %u, %s\n",
                    errno, strerror(errno));
@@ -295,7 +297,6 @@ probe_icache_t *probe_icache_new(void)
                 dE("Can't start the icache worker: %u, %s\n", errno, strerror(errno));
                 goto fail;
         }
-		pthread_setname_np(cache->thid, "icache_worker");
 
         return (cache);
 fail:

--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -52,6 +52,8 @@ void *probe_input_handler(void *arg)
         SEAP_msg_t *seap_request, *seap_reply;
         SEXP_t *probe_in, *probe_out, *oid;
 
+	pthread_setname_np(pthread_self(), "input_handler");
+
 #define TH_CANCEL_ON  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &cstate)
 #define TH_CANCEL_OFF pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cstate)
 
@@ -195,7 +197,6 @@ void *probe_input_handler(void *arg)
 
 								goto __error_reply;
 							}
-							pthread_setname_np(pair->pth->tid, "worker");
 						}
 
 						seap_request = NULL;

--- a/src/OVAL/probes/probe/main.c
+++ b/src/OVAL/probes/probe/main.c
@@ -246,7 +246,6 @@ int main(int argc, char *argv[])
 
 	if (pthread_create(&probe.th_signal, &th_attr, &probe_signal_handler, &probe))
 		fail(errno, "pthread_create(probe_signal_handler)", __LINE__ - 1);
-	pthread_setname_np(probe.th_signal, "signal_handler");
 
 	pthread_attr_destroy(&th_attr);
 
@@ -285,7 +284,6 @@ int main(int argc, char *argv[])
 
 	if (pthread_create(&probe.th_input, &th_attr, &probe_input_handler, &probe))
 		fail(errno, "pthread_create(probe_input_handler)", __LINE__ - 1);
-	pthread_setname_np(probe.th_input, "input_handler");
 
 	pthread_attr_destroy(&th_attr);
 

--- a/src/OVAL/probes/probe/signal_handler.c
+++ b/src/OVAL/probes/probe/signal_handler.c
@@ -64,6 +64,8 @@ void *probe_signal_handler(void *arg)
 	siginfo_t siinf;
 	sigset_t  siset;
 
+	pthread_setname_np(pthread_self(), "signal_handler");
+
 	sigemptyset(&siset);
 	sigaddset(&siset, SIGHUP);
 	sigaddset(&siset, SIGUSR1);

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -47,6 +47,7 @@ void *probe_worker_runfn(void *arg)
 	SEXP_t *probe_res, *obj, *oid;
 	int     probe_ret;
 
+	pthread_setname_np(pthread_self(), "probe_worker");
 	dI("handling SEAP message ID %u\n", pair->pth->sid);
 	//
 	probe_ret = -1;


### PR DESCRIPTION
Thread names should be set inside the thread routine.
This fixes a segfault which might happen when a thread terminates
sooner than its name could be set.