### PR TITLE
Avoid traceback on rpmbuild errors

### DIFF
--- a/utils/scap-as-rpm
+++ b/utils/scap-as-rpm
@@ -322,7 +322,7 @@ def main():
 
         ret = subprocess.call(["rpmbuild", "-ba", spec_file_path], stdout = sys.stdout)
         if ret != 0:
-            raise RuntimeError("Failed to build RPM and SRPM for %s" % spec_file_path)
+            raise CannotContinueError("Failed to build RPM and SRPM for %s" % spec_file_path)
 
     finally:
         shutil.rmtree(temp_dir)


### PR DESCRIPTION
Chances are that the rpmbuild failure is not a problem in our source,
but in the inputs given to the tool.

Otherwise, we receive unneeded Abrt reports like
https://retrace.fedoraproject.org/faf/reports/723484/