### PR TITLE
Change category of messages to DEVEL

### DIFF
--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -109,8 +109,8 @@ void *probe_input_handler(void *arg)
 		if (oid != NULL) {
 			SEXP_VALIDATE(oid);
 
-			dI("offline_mode=%08x\n", OSCAP_GSYM(offline_mode));
-			dI("offline_supp=%08x\n", OSCAP_GSYM(offline_mode_supported));
+			dD("offline_mode=%08x\n", OSCAP_GSYM(offline_mode));
+			dD("offline_mode_supported=%08x\n", OSCAP_GSYM(offline_mode_supported));
 
 			if ((OSCAP_GSYM(offline_mode) != PROBE_OFFLINE_NONE) &&
 			    !(OSCAP_GSYM(offline_mode) & OSCAP_GSYM(offline_mode_supported))) {


### PR DESCRIPTION
This will clean of a lot of unimportant mess from the log, if user sets `--verbose INFO`.