### PR TITLE
RHBZ#1275369: Fix retrieving SCE results from external results file

### DIFF
--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -625,7 +625,7 @@ Authors:
         <xsl:otherwise>
             <xsl:variable name="filename">
                 <xsl:choose>
-                    <xsl:when test='contains($sce-tmpl, "%")'><xsl:value-of select='concat(substring-before($sce-tmpl, "%"), $check/@href, substring-after($sce-tmpl, "%"))'/></xsl:when>
+                    <xsl:when test='contains($sce-tmpl, "%")'><xsl:value-of select='concat(substring-before($sce-tmpl, "%"), $check/cdf:check-content-ref/@href, substring-after($sce-tmpl, "%"))'/></xsl:when>
                     <xsl:otherwise><xsl:value-of select='$sce-tmpl'/></xsl:otherwise>
                 </xsl:choose>
             </xsl:variable>


### PR DESCRIPTION
OpenSCAP was not able to show SCE results from external SCE results file
in the HTML report, because incorrect XPath expression was in our XSLT
template which is used to genarate the HTML report.
According to the XCCDF specification, the path to the external SCE results file
should be found in a "href" attribute of a "check-content-ref" element.
But we were trying to get it from a "check" element, where it shouldn't be.
This caused I/O warnings. In my opinion there must be some cases when
some information would be missing in a HTML report.