### PR TITLE
Issue #231: Fix a segmentation fault

### DIFF
--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -239,7 +239,7 @@ xmlDoc *oscap_source_get_xmlDoc(struct oscap_source *source)
 		}
 	}
 
-	initGenericErrorDefaultFunc(NULL);
+	xmlSetGenericErrorFunc(stderr, NULL);
 
 	if (!oscap_string_empty(xml_error_string)) {
 		const char *error_msg = oscap_string_get_cstr(xml_error_string);


### PR DESCRIPTION
We should use here xmlSetGenericErrorFunc instead of initGenericErrorDefaultFunc
because initGenericErrorDefaultFunc resets only error handler, but we must
also reset the error context, which is possible only by xmlSetGenericErrorFunc.