### PR TITLE
Change category of a message to devel

### DIFF
--- a/src/OVAL/oval_sexp.c
+++ b/src/OVAL/oval_sexp.c
@@ -937,8 +937,8 @@ static struct oval_sysitem *oval_sexp_to_sysitem(struct oval_syschar_model *mode
 
 	int type = oval_str_to_subtype(name);
 
-	dI("Syschar entry type: %d '%s' => %s\n", type, name,
-	   ((type != OVAL_SUBTYPE_UNKNOWN) ? "OK" : "FAILED to decode"));
+	dD("Syschar entry type: %d '%s' => %s\n", type, name,
+	   ((type != OVAL_SUBTYPE_UNKNOWN) ? "decoded OK" : "FAILED to decode"));
 #ifndef NDEBUG
 	if (type == OVAL_SUBTYPE_UNKNOWN)
 		abort();


### PR DESCRIPTION
For the evaluation process it is not useful to know that
an object was decoded from SEXP successfully. It seems
to be a message for a developer.