### PR TITLE
Inform users about indirect references of objects

### DIFF
--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1337,13 +1337,13 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_OBJECTREF(oval_ar
 	if (!object)
 		return flag;
 
+	const char *obj_id = oval_object_get_id(object);
+	dI("Variable component references to object '%s'.\n", obj_id);
+
 	if (argu->mode == OVAL_MODE_QUERY) {
 		if (oval_probe_query_object(argu->u.sess, object, 0, &syschar) != 0)
 			return flag;
 	} else {
-		char *obj_id;
-
-		obj_id = oval_object_get_id(object);
 		syschar = oval_syschar_model_get_syschar(argu->u.sysmod, obj_id);
 	}
 

--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -390,6 +390,12 @@ static int oval_probe_query_criteria(oval_probe_session_t *sess, struct oval_cri
 				if (oval_entity_get_varref_type(entity) == OVAL_ENTITY_VARREF_ATTRIBUTE) {
 					oval_syschar_collection_flag_t flag;
 					struct oval_variable *var = oval_entity_get_variable(entity);
+					const char *state_id = oval_state_get_id(state);
+					oval_variable_type_t var_type = oval_variable_get_type(var);
+					const char *var_type_text = oval_variable_type_get_text(var_type);
+					const char *var_id = oval_variable_get_id(var);
+					dI("State '%s' references %s '%s'.\n", state_id,
+						var_type_text, var_id);
 
 					ret = oval_probe_query_variable(sess, var);
 					if (ret == -1) {

--- a/src/OVAL/oval_variable.c
+++ b/src/OVAL/oval_variable.c
@@ -368,6 +368,7 @@ int oval_probe_query_variable(oval_probe_session_t *sess, struct oval_variable *
 	if (var->flag != SYSCHAR_FLAG_UNKNOWN)
 		return 0;
 
+	dI("Querying variable '%s'.\n", var->id);
 	component = var->component;
         if (component) {
 		if (!var->values)
@@ -383,6 +384,7 @@ int oval_probe_query_variable(oval_probe_session_t *sess, struct oval_variable *
 	case SYSCHAR_FLAG_INCOMPLETE:
 		break;
 	default:
+		dI("Variable '%s' has no values.\n", var->id);
 		return 0;
 	}
 


### PR DESCRIPTION
There is a very often used construction in the OVAL language: A state can reference a local variable, which can reference a object. This object needs to be evaluated and affects final result of currently evaluated definitions. This indirect references are often used in SCAP Security Guide, eg. in definition `gid_passwd_group_sane`. That's the reason it should be covered in the verbose log.

This pull request wants to introduce new information messages that will inform user about this process. Together with other messages already introduced in OpenSCAP, this pull request can help to better understand this indirect object referencing in OVAL.