### PR TITLE
Inform about referencing variable in a object component

### DIFF
--- a/src/OVAL/oval_sexp.c
+++ b/src/OVAL/oval_sexp.c
@@ -479,6 +479,9 @@ int oval_object_to_sexp(void *sess, const char *typestr, struct oval_syschar *sy
 			ret = 0;
 			vr_type = oval_entity_get_varref_type(entity);
 			if (vr_type == OVAL_ENTITY_VARREF_ATTRIBUTE) {
+				const char *var_id = oval_variable_get_id(oval_entity_get_variable(entity));
+				const char *field_name = oval_object_content_get_field_name(content);
+				dI("Object '%s' references variable '%s' in '%s' field.\n", obj_id, var_id, field_name);
 				ret = oval_varref_attr_to_sexp(sess, entity, syschar, &stmp);
 
 				if (ret == 0) {


### PR DESCRIPTION
In OVAL objects, object components can have var_ref attribute,
using him it is possible to reference a variable. This variable
affects the final content of a collected object. This is one of
tricky things in OVAL, so it may be useful to report it in log.