### PR TITLE
Add a new test for SCE module

### DIFF
--- a/tests/sce/Makefile.am
+++ b/tests/sce/Makefile.am
@@ -8,11 +8,14 @@ TESTS_ENVIRONMENT= \
 		$(top_builddir)/run
 
 TESTS = test_sce.sh \
-		test_passing_vars.sh
+		test_passing_vars.sh \
+		test_check_engine_results.sh
 
 EXTRA_DIST +=	test_sce.sh \
 		sce_xccdf.xml \
 		bash_passer.sh \
 		lua_passer.lua \
 		python_passer.py \
-		python_is16.py
+		python_is16.py \
+		test_check_engine_results.xccdf.xml \
+		empty_stdout.sh

--- a/tests/sce/empty_stdout.sh
+++ b/tests/sce/empty_stdout.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+exit $XCCDF_RESULT_PASS

--- a/tests/sce/test_check_engine_results.sh
+++ b/tests/sce/test_check_engine_results.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+
+# Test generating results and reports from SCE
+# Uses check which produce empty output to test
+# retreiving results from an external file.
+#
+# Author:
+#	Jan Černý <jcerny@redhat.com>
+
+. ../test_common.sh
+
+set -e -o pipefail
+
+# Test Cases.
+function test_check_engine_results {
+
+    xccdf_file=${srcdir}/$1
+    stderr=$(mktemp)
+    report=$(mktemp)
+    results="empty_stdout.sh.result.xml"
+
+    [ -f $results ] && rm -f $results
+
+    $OSCAP xccdf eval --check-engine-results --report $report "$xccdf_file" 2> $stderr
+    [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+    [ -f $results ]; [ -s $results ]; rm $results
+    [ -f $report ]; [ -s $report ]; rm $report
+}
+
+# Testing.
+test_init "test_check_engine_results.log"
+
+test_run "check_engine_results" test_check_engine_results test_check_engine_results.xccdf.xml
+
+test_exit
+

--- a/tests/sce/test_check_engine_results.xccdf.xml
+++ b/tests/sce/test_check_engine_results.xccdf.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+  <status>incomplete</status>
+  <version>1.0</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <model system="urn:xccdf:scoring:flat"/>
+  <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_1">
+    <title>Test SCE Rule</title>
+    <check system="http://open-scap.org/page/SCE">
+      <check-import import-name="stdout" />
+      <check-content-ref href="empty_stdout.sh"/>
+    </check>
+  </Rule>
+</Benchmark>


### PR DESCRIPTION
This pull request proposes a test to test "--check-engine-results" together with "--report" options on SCE content. The test is performed with SCE check which doesn't produce any output. Such checks caused segfaults or warnings in past when OpenSCAP tried to use the empty output in reports.  See issue #231 and RHBZ #1275369. These issues are fixed now, but we should have a test to avoid regression in future.