### PR TITLE
oscap-docker: fix CVE path

### DIFF
--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -136,7 +136,7 @@ class OscapHelpers(object):
         '''
         Scan a chroot for cves
         '''
-        cve_input = "Red_Hat_Enterprise_Linux_{0}.xml".format(dist)
+        cve_input = getInputCVE.dist_cve_name.format(dist)
         tmp_tuple = ('oval', 'eval') + tuple(scan_args) + \
             (os.path.join(self.cve_input_dir, cve_input),)
         return self.oscap_chroot("foo", "bar", chroot, *tmp_tuple)


### PR DESCRIPTION
We have started using packed .bz2 files instead of .xml and there was hard-coded path in code twice. 

So we download content somewhere, but we use different path as oscap argument.

I've probably tested it before with system /usr/lib/*/site-packages by mistake, so it passed the tests.

```
[ybznek@localhost openscap]$ sudo oscap-docker image-cve fedora
OpenSCAP Error: Unable to open file: '/tmp/Red_Hat_Enterprise_Linux_7.xml' [oscap_source.c:221]

Command: oscap oval eval /tmp/Red_Hat_Enterprise_Linux_7.xml failed!

Error was:

Command '['oscap', 'oval', 'eval', '/tmp/Red_Hat_Enterprise_Linux_7.xml']' returned non-zero exit status 1
```