### PR TITLE
Test behavior of OVAL module with invalid OVAL content

### DIFF
--- a/tests/API/OVAL/unittests/Makefile.am
+++ b/tests/API/OVAL/unittests/Makefile.am
@@ -58,6 +58,8 @@ EXTRA_DIST += \
 	test_float_comparison.syschar.xml \
 	test_oval_empty_variable_evaluation.sh \
 	test_oval_empty_variable_evaluation.xml \
+	test_skip_valid.sh \
+	test_skip_valid.oval.xml \
 	test_xmlns_missing.oval.xml \
 	test_xmlns_missing.sh \
 	test_xsinil_envv58_pid.oval.xml \

--- a/tests/API/OVAL/unittests/all.sh
+++ b/tests/API/OVAL/unittests/all.sh
@@ -24,4 +24,5 @@ test_run "ipv4_address: comparison" $srcdir/test_ipv4_comparison.sh
 test_run "textfilecontent: 'line' comparison" $srcdir/test_filecontent_line.sh
 test_run "anyxml element" $srcdir/test_anyxml.sh
 test_run "invalid regular expression" $srcdir/test_invalid_regex.sh
+test_run "skip validation" $srcdir/test_skip_valid.sh
 test_exit

--- a/tests/API/OVAL/unittests/test_skip_valid.oval.xml
+++ b/tests/API/OVAL/unittests/test_skip_valid.oval.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oval_definitions xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd      http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+  <generator>
+    <oval:schema_version>5.10</oval:schema_version>
+    <oval:timestamp>2015-12-12T10:41:00+01:00</oval:timestamp>
+  </generator>
+  <definitions>
+    <definition id="oval:x:def:282" version="3" class="miscellaneous">
+      <metadata>
+        <title>Test presence /etc/passwd</title>
+        <description>Test presence /etc/passwd</description>
+      </metadata>
+      <criteria>
+        <criterion comment="Test that /etc/passwd exists." test_ref="oval:x:tst:1288"/>
+      </criteria>
+    </definition>
+  </definitions>
+  <tests>
+    <file_test id="oval:x:tst:1288" version="1" comment="Test that /etc/passwd is collected if filename in object was empty." check_existence="at_least_one_exists" check="only one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+      <object object_ref="oval:x:obj:512"/>
+      <state state_ref="oval:x:ste:1"/>
+    </file_test>
+  </tests>
+  <objects>
+    <file_object id="oval:x:obj:512" version="1" comment="File /etc/passwd" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+      <path operation="pattern match">^/etc$</path>
+      <filename operation="pattern match">^passwd$</filename>
+    </file_object>
+  </objects>
+</oval_definitions>

--- a/tests/API/OVAL/unittests/test_skip_valid.sh
+++ b/tests/API/OVAL/unittests/test_skip_valid.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
 result=`mktemp`
+stderr=`mktemp`
 
 set -e
 set -o pipefail
 
-$OSCAP oval eval --results $result --skip-valid $srcdir/test_skip_valid.oval.xml
+$OSCAP oval eval --results $result --skip-valid $srcdir/test_skip_valid.oval.xml 2> $stderr
+
+grep -q "\*\*INVALID\*\*_state" $result
+grep -q "OpenSCAP Error: Invalid OVAL family" $stderr
 
 rm $result
+rm $stderr
 

--- a/tests/API/OVAL/unittests/test_skip_valid.sh
+++ b/tests/API/OVAL/unittests/test_skip_valid.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+result=`mktemp`
+
+set -e
+set -o pipefail
+
+$OSCAP oval eval --results $result --skip-valid $srcdir/test_skip_valid.oval.xml
+
+rm $result
+


### PR DESCRIPTION
This test tests "oscap oval eval" with "--skip-valid" option
on invalid OVAL content. The tested content references a not
existent state. This situation was one of two reasons of
a segmentation fault, described in issue #191.
The issue #191 has been fixed already. This commit wants to
test it to avoid regressions in future.