### PR TITLE
Fix issue #262: Docs: Missing build dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Build dependencies:
  * python-devel
  * rpm-devel
  * swig
+ * bzip2-devel
 
 3) Run library self-checks by executing the following command:
 ```


### PR DESCRIPTION
Add bzip2-devel build dependency to the 'README.md' file.