### PR TITLE
Fix issue #264: Path to 'oscap_source.h' header file is missing

### DIFF
--- a/src/CCE/Makefile.am
+++ b/src/CCE/Makefile.am
@@ -4,7 +4,7 @@ libcce_la_SOURCES  = cce.c
 libcce_la_SOURCES += cce_priv.c
 libcce_la_SOURCES += cce_priv.h
 
-libcce_la_CPPFLAGS   = @xml2_CFLAGS@ -I$(srcdir)/public -I$(top_srcdir)/src/common/public -I$(top_srcdir)/src/
+libcce_la_CPPFLAGS   = @xml2_CFLAGS@ -I$(srcdir)/public -I$(top_srcdir)/src/common/public -I$(top_srcdir)/src/ -I$(top_srcdir)/src/source/public
 libcce_la_LDFLAGS  = @xml2_LIBS@
 
 pkginclude_HEADERS = public/cce.h


### PR DESCRIPTION
When configuring OpenSCAP with the --enable-cce flag and building OpenSCAP, the following error message is produced: "cce.c:40:26: fatal error: oscap_source.h: No such file or directory".

Solution to this problem consists in adding the '-I$(top_srcdir)/src/source/public' to the 'libcce_la_CPPFLAGS' directive of the "src/CCE/Makefile.am" file.