### PR TITLE
Fix wrong check of return value

### DIFF
--- a/src/source/bz2.c
+++ b/src/source/bz2.c
@@ -193,7 +193,11 @@ bool bz2_memory_is_bzip(const char* memory, const size_t size){
 
 bool bz2_fd_is_bzip(int fd)
 {
-	FILE* file = fdopen(dup(fd), "r");
+	int fd_dup = dup(fd);
+	if (fd_dup == -1) {
+		return false;
+	}
+	FILE* file = fdopen(fd_dup, "r");
 	bool is_bzip;
 	if (file == NULL) {
 		return false; // cannot open/determine file type


### PR DESCRIPTION
Coverity scan has reported NEGATIVE_RETURNS defect.
The "dup(fd)" was passed to a parameter that cannot be negative.
This commit fixes the issue by checking the value for possible -1.