### PR TITLE
Fix a resource leak reported by coverity scan

### DIFF
--- a/src/OVAL/probes/unix/sysctl.c
+++ b/src/OVAL/probes/unix/sysctl.c
@@ -175,6 +175,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 					dI("Skippping file %s\n", mibpath);
 					oval_ftsent_free(ofts_ent);
 					SEXP_free(se_mib);
+					fclose(fp);
 					continue;
 				} else {
 					dE("An error ocured when reading from \"%s\" (fp=%p): l=%ld, %u, %s\n",


### PR DESCRIPTION
Variable "fp" going out of scope leaks the storage it points to.
We should close the file.