### PR TITLE
Remove dead code

### DIFF
--- a/src/OVAL/oval_session.c
+++ b/src/OVAL/oval_session.c
@@ -440,8 +440,6 @@ int oval_session_export(struct oval_session *session)
 cleanup:
 	if (result)
 		oscap_source_free(result);
-	if (dir_model)
-		oval_directives_model_free(dir_model);
 	return ret;
 }
 


### PR DESCRIPTION
Coverity scan has reported a dead code here.
Variable "dir_model" is assigned only once, to a constant
NULL value, and doesn't change throughout its scope.
This condition will never be evaluated as true, because
dir_model is always NULL and therefore this code is useless.