### PR TITLE
Add libcurl leak to valgrind suppression file

### DIFF
--- a/tests/suppressions.supp
+++ b/tests/suppressions.supp
@@ -18,3 +18,12 @@
    fun:dlerror
    ...
 }
+
+{
+   curl
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:curl_easy_init
+   ...
+}


### PR DESCRIPTION
Valgrind reports memory leaks when using curl_easy_init(),
but we clean the memory correctly.