### PR TITLE
 Issue #272: XCCDF rule unscored role is not working

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -1164,6 +1164,10 @@ static struct xccdf_default_score * xccdf_item_get_default_score(struct xccdf_it
 			dE("Rule result ID(%s) not fount", rule_id);
 			return NULL;
 		}
+		if (xccdf_rule_result_get_role(rule_result) == XCCDF_ROLE_UNSCORED) {
+			return NULL;
+		}
+
 
 		/* Ignore these rules */
 		if ((xccdf_rule_result_get_result(rule_result) == XCCDF_RESULT_NOT_SELECTED) ||
@@ -1258,6 +1262,9 @@ static struct xccdf_flat_score * xccdf_item_get_flat_score(struct xccdf_item * i
 		rule_result = xccdf_result_get_rule_result_by_id(test_result, rule_id);
 		if (rule_result == NULL) {
 			dE("Rule result ID(%s) not fount", rule_id);
+			return NULL;
+		}
+		if (xccdf_rule_result_get_role(rule_result) == XCCDF_ROLE_UNSCORED) {
 			return NULL;
 		}
 

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -162,6 +162,8 @@ EXTRA_DIST += \
 	test_xccdf_resolve.xccdf.xml \
 	test_xccdf_results_arf_no_oval.sh \
 	test_xccdf_results_arf_no_oval.xccdf.xml \
+	test_xccdf_role_unscored.sh \
+	test_xccdf_role_unscored.xccdf.xml \
 	test_xccdf_selectors_cluster1.sh \
 	test_xccdf_selectors_cluster1.xccdf.xml \
 	test_xccdf_selectors_cluster2.sh \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -19,6 +19,7 @@ test_run "Assert for environment better" $OSCAP oval eval --id oval:moc.elpmaxe.
 #
 # General XCCDF Tests. (Mostly, oscap xccdf eval)
 #
+test_run "Test unscored roles" $srcdir/test_xccdf_role_unscored.sh
 test_run "Fix containing unresolved elements" $srcdir/test_remediate_unresolved.sh
 test_run "Empty XCCDF variable element" $srcdir/test_empty_variable.sh
 test_run "Test xccdf:fix/xccdf:instance elements" $srcdir/test_fix_instance.sh

--- a/tests/API/XCCDF/unittests/test_xccdf_role_unscored.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_role_unscored.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+name=$(basename $0 .sh)
+result=$(mktemp -t ${name}.out.XXXXXX)
+report=$(mktemp -t ${name}.out.XXXXXX)
+stderr=$(mktemp -t ${name}.out.XXXXXX)
+
+$OSCAP xccdf eval --results $result --report $report $srcdir/${name}.xccdf.xml 2> $stderr
+
+echo "Stderr file = $stderr"
+echo "Result file = $result"
+echo "Report file = $report"
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+[ -f $report ]; [ -s $report ]; rm $report
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 1 '//rule-result'
+assert_exists 1 '//rule-result/result'
+assert_exists 1 '//rule-result/result[text()="pass"]'
+assert_exists 1 '//rule-result/check'
+assert_exists 1 '//rule-result/check/check-content-ref'
+assert_exists 1 '//score[@system="urn:xccdf:scoring:default" and text()="0.000000"]'
+assert_exists 1 '//score[@system="urn:xccdf:scoring:flat" and text()="0.000000"]'
+assert_exists 1 '//score[@system="urn:xccdf:scoring:flat-unweighted" and text()="0.000000"]'
+assert_exists 1 '//score[@system="urn:xccdf:scoring:absolute" and text()="1.000000"]'
+
+rm $result

--- a/tests/API/XCCDF/unittests/test_xccdf_role_unscored.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_xccdf_role_unscored.xccdf.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+  <status>incomplete</status>
+  <version>1.0</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <model system="urn:xccdf:scoring:flat"/>
+  <model system="urn:xccdf:scoring:flat-unweighted"/>
+  <model system="urn:xccdf:scoring:absolute"/>
+  <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_1" role="unscored">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="oval/pass/oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
+    </check>
+  </Rule>
+</Benchmark>


### PR DESCRIPTION
A rule with unscored role should not be counted in score.
XCCDF sepcification says about xccdf:Rule/@role="unscored":
if the rule is selected, then check it and include the results in
any report, but do not include the result in score computations.
This pull request fixes counting scores to be in line with specification.
This pull request also adds test tests counting scores of rules with role attribute set
to "unscored" on all 4 scoring models.
