### PR TITLE
Report errors on evaluation of object component of a variable + TEST

### DIFF
--- a/tests/API/OVAL/unittests/Makefile.am
+++ b/tests/API/OVAL/unittests/Makefile.am
@@ -58,6 +58,8 @@ EXTRA_DIST += \
 	test_float_comparison.syschar.xml \
 	test_oval_empty_variable_evaluation.sh \
 	test_oval_empty_variable_evaluation.xml \
+	test_object_component_type.oval.xml \
+	test_object_component_type.sh \
 	test_skip_valid.sh \
 	test_skip_valid.oval.xml \
 	test_xmlns_missing.oval.xml \

--- a/tests/API/OVAL/unittests/all.sh
+++ b/tests/API/OVAL/unittests/all.sh
@@ -25,4 +25,5 @@ test_run "textfilecontent: 'line' comparison" $srcdir/test_filecontent_line.sh
 test_run "anyxml element" $srcdir/test_anyxml.sh
 test_run "invalid regular expression" $srcdir/test_invalid_regex.sh
 test_run "skip validation" $srcdir/test_skip_valid.sh
+test_run "object component data type evaluation" $srcdir/test_object_component_type.sh
 test_exit

--- a/tests/API/OVAL/unittests/test_object_component_type.oval.xml
+++ b/tests/API/OVAL/unittests/test_object_component_type.oval.xml
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<oval_definitions xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" >
+    <generator>
+        <oval:product_name>human</oval:product_name>
+        <oval:product_version>0.1</oval:product_version>
+        <oval:schema_version>5.10</oval:schema_version>
+        <oval:timestamp>2015-12-08T08:08:08+01:00</oval:timestamp>
+    </generator>
+
+    <definitions>
+        <definition class="compliance" id="oval:oscap:def:1" version="1">
+            <metadata>
+                <title>Test the ObjectComponentType complex type</title>
+                <description>The ObjectComponentType complex type should work as defined in OVAL specification. However the test does not test fields of the record data type, because the record data type is used only within ldap_item and sql57_item which we don't test in upstream.</description>
+            </metadata>
+            <criteria>
+                <criterion comment="A well-written test." negate="false" test_ref="oval:oscap:tst:1"/>
+                <criterion comment="A test that will report an error due to entity name in textfilecontent_item." negate="false" test_ref="oval:oscap:tst:2"/>
+                <criterion comment="A test that will report an error because it expects record data type of 'subexpression' entity in textfilecontent_item." negate="false" test_ref="oval:oscap:tst:3"/>
+            </criteria>
+        </definition>
+    </definitions>
+
+    <tests>
+        <ind:variable_test id="oval:oscap:tst:1" check="all" comment="A well-written test." version="1">
+            <ind:object object_ref="oval:oscap:obj:1" />
+            <ind:state state_ref="oval:oscap:ste:1" />
+        </ind:variable_test>
+        <ind:variable_test id="oval:oscap:tst:2" check="all" comment="A test that will cause report an error due to entity name in textfilecontent_item." version="1">
+            <ind:object object_ref="oval:oscap:obj:2" />
+            <ind:state state_ref="oval:oscap:ste:1" />
+        </ind:variable_test>
+        <ind:variable_test id="oval:oscap:tst:3" check="all" comment="The value of PASS_MIN_LEN should be set appropriately in /etc/login.defs" version="1">
+            <ind:object object_ref="oval:oscap:obj:3" />
+            <ind:state state_ref="oval:oscap:ste:1" />
+        </ind:variable_test>
+    </tests>
+
+    <objects>
+        <ind:variable_object id="oval:oscap:obj:1" version="1">
+            <ind:var_ref>oval:oscap:var:1</ind:var_ref>
+        </ind:variable_object>
+        <ind:variable_object id="oval:oscap:obj:2" version="1">
+            <ind:var_ref>oval:oscap:var:2</ind:var_ref>
+        </ind:variable_object>
+        <ind:variable_object id="oval:oscap:obj:3" version="1">
+            <ind:var_ref>oval:oscap:var:3</ind:var_ref>
+        </ind:variable_object>
+        <ind:textfilecontent54_object id="oval:oscap:obj:10" version="1">
+            <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_MIN_LEN directive occurrence -->
+            <ind:behaviors singleline="true" />
+            <ind:filepath>/etc/login.defs</ind:filepath>
+            <!-- Retrieve last (uncommented) occurrence of PASS_MIN_LEN directive -->
+            <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MIN_LEN\s+\d+)\s*\n</ind:pattern>
+            <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+        </ind:textfilecontent54_object>
+    </objects>
+
+    <states>
+        <ind:variable_state id="oval:oscap:ste:1" version="1">
+            <ind:value operation="greater than or equal" datatype="int">4</ind:value>
+        </ind:variable_state>
+    </states>
+
+    <variables>
+        <!-- variable with a meaningfully specified object_component/@item_field attribute -->
+        <local_variable id="oval:oscap:var:1" datatype="int" comment="The value of last PASS_MIN_LEN directive in /etc/login.defs" version="1">
+            <regex_capture pattern="PASS_MIN_LEN\s+(\d+)">
+               <object_component item_field="subexpression" object_ref="oval:oscap:obj:10" />
+            </regex_capture>
+        </local_variable>
+        <!-- variable with a nonsense in the object_component/@item_field attribute -->
+        <local_variable id="oval:oscap:var:2" datatype="int" comment="Reference to not existing entity within textfilecontent_item. Should report an error when evaluating." version="1">
+            <regex_capture pattern="PASS_MIN_LEN\s+(\d+)">
+               <object_component item_field="something_bogus" object_ref="oval:oscap:obj:10" />
+            </regex_capture>
+        </local_variable>
+        <!-- variable that requires a record data type in OVAL Item -->
+        <local_variable id="oval:oscap:var:3" datatype="int" comment="Record_field attribute suggest than an record data type is expected, but actually string data type will be provided. Should report an error when evaluating." version="1">
+            <regex_capture pattern="PASS_MIN_LEN\s+(\d+)">
+               <object_component item_field="subexpression" record_field="some_record_field_name" object_ref="oval:oscap:obj:10" />
+            </regex_capture>
+        </local_variable>
+    </variables>
+
+</oval_definitions>

--- a/tests/API/OVAL/unittests/test_object_component_type.sh
+++ b/tests/API/OVAL/unittests/test_object_component_type.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+stderr=`mktemp`
+
+set -e
+set -o pipefail
+
+$OSCAP oval eval $srcdir/test_object_component_type.oval.xml 2> $stderr || ret=$?
+[ $ret -eq 1 ]
+
+stderr_line_count=`cat $stderr | wc -l`
+[ $stderr_line_count -eq 2 ]
+grep -q "Entity [']something_bogus['] has not been found in textfilecontent_item (id: [0-9]\+) specified by object [']oval:oscap:obj:10[']." $stderr
+grep -q "Expected record data type, but found string data type in subexpression entity in textfilecontent_item (id: [0-9]\+) specified by object [']oval:oscap:obj:10[']."  $stderr
+
+rm $stderr
+


### PR DESCRIPTION
This pull request wants to introduce two commits to improve experience of indirect referencing of OVAL object within an OVAL variable, which is often considered as difficult part of the OVAL language.

First commit removes TODOs in _oval_component_evaluate_OBJECTREF() function by implementing error reporting as required by OVAL specification:

> If an entity is not found with a name that matches the value of the item_field an error should be reported when determining the value of an variable.

Similar statement applies also for entities of the record data type.

Second commit implements a test for this feature.  It tests whether The ObjectComponentType complex type is processed correctly.  It contains one correct case and two cases which should lead to report an error. For details see comments in supplied OVAL content. However the test does not test fields of the record data type, because the record data type is used only within `ldap_item` and `sql57_item` which are generated by probes which we don't test in upstream.
