### PR TITLE
Remove EOLs from messages and use macros everywhere

### DIFF
--- a/src/OVAL/adt/oval_collection.c
+++ b/src/OVAL/adt/oval_collection.c
@@ -128,7 +128,7 @@ struct oval_iterator *oval_collection_iterator(struct oval_collection *collectio
 
 	if ((iterator_count++) < 0) {
 		_debugStack[iterator_count - 1] = iterator;
-		oscap_dlprintf(DBG_W, "iterator_count: %d.\n", iterator_count);
+		dW("iterator_count: %d.", iterator_count);
 	}
 
 	iterator->item_iterator_frame = NULL;
@@ -192,7 +192,7 @@ void oval_collection_iterator_free(struct oval_iterator *iterator)
 {
 	if (iterator) {		//NOOP if iterator is NULL
 		if ((--iterator_count) < 0) {
-			oscap_dlprintf(DBG_W, "iterator_count: %d.\n", iterator_count);
+			dW("iterator_count: %d.", iterator_count);
 			if (iterator != _debugStack[iterator_count]) {
 				debug = false;
 			}
@@ -219,7 +219,7 @@ struct oval_iterator *oval_collection_iterator_new()
 
 	if ((iterator_count++) < 0) {
 		_debugStack[iterator_count - 1] = iterator;
-		oscap_dlprintf(DBG_W, "iterator_count: %d.\n", iterator_count);
+		dW("iterator_count: %d.", iterator_count);
 	}
 	iterator->item_iterator_frame = NULL;
 	return iterator;

--- a/src/OVAL/adt/oval_string_map.c
+++ b/src/OVAL/adt/oval_string_map.c
@@ -208,7 +208,7 @@ void oval_string_map_put(struct oval_string_map *map, const char *key, void *val
 	assume_d(key != NULL, /* void */);
 
 	if (rbt_str_add((rbt_t *)map, key_copy = strdup(key), val) != 0) {
-		dW("rbt_str_add: non-zero return code\n");
+		dW("rbt_str_add: non-zero return code");
                 oscap_free(key_copy);
         }
 }

--- a/src/OVAL/oval_affected.c
+++ b/src/OVAL/oval_affected.c
@@ -214,7 +214,7 @@ static int _oval_affected_parse_tag(xmlTextReaderPtr reader, struct oval_parser_
 			oscap_free(product);
 		}
 	} else {
-		oscap_dlprintf(DBG_I, "Skipping tag: %s\n", tagname);
+		dI("Skipping tag: %s", tagname);
 		return_code = oval_parser_skip_tag(reader, context);
 	}
 	oscap_free(tagname);

--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -499,13 +499,13 @@ int oval_agent_resolve_variables(struct oval_agent_session * session, struct xcc
 			/* Add variable to variable model */
 			oval_variable_model_add(session->cur_var_model, name, "Unknown", o_type, value);
 			oval_variable_bind_ext_var(variable, session->cur_var_model, name);
-			oscap_dlprintf(DBG_I, "Adding external variable %s.\n", name);
+			dI("Adding external variable %s.", name);
 		} else {
 			/* Skip this variable (we assume it has same values otherwise conflict was detected) */
-			oscap_dlprintf(DBG_W, "Skipping external variable %s.\n", name);
+			dW("Skipping external variable %s.", name);
 		}
         } else {
-                oscap_dlprintf(DBG_W, "Variable %s does not exist, skipping.\n", name);
+                dW("Variable %s does not exist, skipping.", name);
         }
     }
 

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -320,7 +320,7 @@ void oval_component_set_record_field(struct oval_component *component, char *fie
 	__attribute__nonnull__(component);
 
 	if (oval_component_get_type(component) != OVAL_COMPONENT_OBJECTREF) {
-		dW("Wrong component type: %d.\n", oval_component_get_type(component));
+		dW("Wrong component type: %d.", oval_component_get_type(component));
 		return;
 	}
 
@@ -1102,7 +1102,7 @@ int oval_component_parse_tag(xmlTextReaderPtr reader,
 		component = oval_component_new(model, OVAL_FUNCTION_REGEX_CAPTURE);
 		return_code = _oval_component_parse_REGEX_CAPTURE_tag(reader, context, component);
 	} else {
-		oscap_dlprintf(DBG_I, "Tag <%s> not handled, line: %d.\n", tagname,
+		dI("Tag <%s> not handled, line: %d.", tagname,
                               xmlTextReaderGetParserLineNumber(reader));
 		return_code = oval_parser_skip_tag(reader, context);
 	}
@@ -1110,7 +1110,7 @@ int oval_component_parse_tag(xmlTextReaderPtr reader,
 		(*consumer) (component, user);
 
 	if (return_code != 0 ) {
-		dW("Parsing of <%s> terminated by an error at line %d.\n", tagname, xmlTextReaderGetParserLineNumber(reader));
+		dW("Parsing of <%s> terminated by an error at line %d.", tagname, xmlTextReaderGetParserLineNumber(reader));
 	}
 	oscap_free(tagname);
 	return return_code;
@@ -1786,23 +1786,23 @@ static long unsigned int _parse_datetime(char *datetime, const char *fmt[], size
         size_t    i;
         char     *r;
 
-        dI("Parsing datetime string \"%s\"\n", datetime);
+        dI("Parsing datetime string \"%s\"", datetime);
 
         for (i = 0; i < fmtcnt; ++i) {
-                dI("%s\n", fmt[i]);
+                dI("%s", fmt[i]);
                 memset(&t, 0, sizeof t);
                 r = strptime(datetime, fmt[i], &t);
 
                 if (r != NULL) {
                         if (*r == '\0') {
-                                dI("Success!\n");
+                                dI("Success!");
                                 return _comp_sec(t.tm_year, t.tm_mon, t.tm_mday,
                                                  t.tm_hour, t.tm_min, t.tm_sec);
                         }
                 }
         }
 
-        dE("Unable to interpret \"%s\" as a datetime string\n");
+        dE("Unable to interpret \"%s\" as a datetime string");
 
         return (0);
 }
@@ -1989,7 +1989,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_REGEX_CAPTURE(ova
 	pattern = oval_component_get_regex_pattern(component);
 	re = pcre_compile(pattern, PCRE_UTF8, &error, &erroffset, NULL);
 	if (re == NULL) {
-		oscap_dlprintf(DBG_E, "pcre_compile() failed: \"%s\".\n", error);
+		dE("pcre_compile() failed: \"%s\".", error);
 		return SYSCHAR_FLAG_ERROR;
 	}
 #elif defined USE_REGEX_POSIX
@@ -1997,7 +1997,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_REGEX_CAPTURE(ova
 
 	pattern = oval_component_get_regex_pattern(component);
 	if ((rc = regcomp(&re, pattern, REG_EXTENDED | REG_NEWLINE)) != 0) {
-		oscap_dlprintf(DBG_E, "regcomp() failed: %d.\n", rc);
+		dE("regcomp() failed: %d.", rc);
 		return SYSCHAR_FLAG_ERROR;
 	}
 #endif
@@ -2019,7 +2019,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_REGEX_CAPTURE(ova
 
 			rc = pcre_exec(re, NULL, text, strlen(text), 0, 0, ovector, ovector_len);
 			if (rc < -1) {
-				oscap_dlprintf(DBG_E, "pcre_exec() failed: %d.\n", rc);
+				dE("pcre_exec() failed: %d.", rc);
 				flag = SYSCHAR_FLAG_ERROR;
 				break;
 			}

--- a/src/OVAL/oval_criteriaNode.c
+++ b/src/OVAL/oval_criteriaNode.c
@@ -428,7 +428,7 @@ int oval_criteria_parse_tag(xmlTextReaderPtr reader, struct oval_parser_context 
 		(*consumer) (node, user);
 	} else {
 		return_code = 1;
-		oscap_dlprintf(DBG_W, "Invalid node type: OVAL_NODETYPE_UNKNOWN.\n");
+		dW("Invalid node type: OVAL_NODETYPE_UNKNOWN.");
 		oval_parser_skip_tag(reader, context);
 	}
 	oscap_free(tagname);

--- a/src/OVAL/oval_defModel.c
+++ b/src/OVAL/oval_defModel.c
@@ -214,7 +214,7 @@ struct oval_definition_model * oval_definition_model_import(const char *file)
         struct oval_definition_model *model = oval_definition_model_new();
         int ret = oval_definition_model_merge(model,file);
         if (ret == -1 ) {
-		oscap_dlprintf(DBG_E, "Failed to merge the definition model from: %s.\n", file);
+		dE("Failed to merge the definition model from: %s.", file);
                 oval_definition_model_free(model);
                 model = NULL;
         }

--- a/src/OVAL/oval_definition.c
+++ b/src/OVAL/oval_definition.c
@@ -426,7 +426,7 @@ static int _oval_definition_parse_tag(xmlTextReaderPtr reader, struct oval_parse
 	} else if ((strcmp(tagname, "criteria") == 0)) {
 		return_code = oval_criteria_parse_tag(reader, context, &_oval_definition_criteria_consumer, definition);
 	} else {
-		oscap_dlprintf(DBG_I, "Skipping tag: %s.\n", tagname);
+		dI("Skipping tag: %s.", tagname);
 		return_code = oval_parser_skip_tag(reader, context);
 	}
 	oscap_free(tagname);

--- a/src/OVAL/oval_directives.c
+++ b/src/OVAL/oval_directives.c
@@ -326,7 +326,7 @@ static int oval_directives_model_parse(xmlTextReaderPtr reader, struct oval_pars
                                 ret = oval_parser_parse_tag(reader, context, &oval_result_directives_parse_tag, class_dir);
 				oscap_free(class_str);
 			} else {
-				dW("Unprocessed tag: <%s:%s>.\n", namespace, tagname);
+				dW("Unprocessed tag: <%s:%s>.", namespace, tagname);
 				oval_parser_skip_tag(reader, context);
 			}
 
@@ -379,7 +379,7 @@ int oval_result_directives_parse_tag(xmlTextReaderPtr reader, struct oval_parser
 			if (content != OVAL_DIRECTIVE_CONTENT_UNKNOWN) {
 				oval_result_directives_set_content(directives, type, content);
 			} else {
-				oscap_dlprintf(DBG_W, "Cannot resolve @content: \"%s\".\n", contentstr);
+				dW("Cannot resolve @content: \"%s\".", contentstr);
 				retcode = 1;
 			}
 			oscap_free(contentstr);
@@ -387,7 +387,7 @@ int oval_result_directives_parse_tag(xmlTextReaderPtr reader, struct oval_parser
 			content = OVAL_DIRECTIVE_CONTENT_FULL;
 		}
 	} else {
-		oscap_dlprintf(DBG_W, "Cannot resolve <%s>.\n", name);
+		dW("Cannot resolve <%s>.", name);
 		retcode = 1;
 	}
 	oscap_free(name);

--- a/src/OVAL/oval_entity.c
+++ b/src/OVAL/oval_entity.c
@@ -368,7 +368,7 @@ int oval_entity_parse_tag(xmlTextReaderPtr reader,
 	(*consumer) (entity, user);
 
 	if (return_code != 0) {
-		dW("Parsing of <%s> terminated by an error at line %d.\n", name, xmlTextReaderGetParserLineNumber(reader));
+		dW("Parsing of <%s> terminated by an error at line %d.", name, xmlTextReaderGetParserLineNumber(reader));
 	}
 
 	oscap_free(name);

--- a/src/OVAL/oval_enumerations.c
+++ b/src/OVAL/oval_enumerations.c
@@ -375,7 +375,7 @@ oval_family_t oval_family_parse(xmlTextReaderPtr reader)
 	}
 	char *family_text = strrchr(namespace, '#');
 	if (family_text == NULL) {
-		dW("No OVAL family for namespace: %s\n", namespace);
+		dW("No OVAL family for namespace: %s", namespace);
 		oscap_free(namespace);
 		return OVAL_FAMILY_UNKNOWN;
 	}
@@ -383,7 +383,7 @@ oval_family_t oval_family_parse(xmlTextReaderPtr reader)
 	int ret = oscap_string_to_enum(OVAL_FAMILY_MAP, ++family_text);
 
 	if (ret == OVAL_ENUMERATION_INVALID) {
-		dW("Unknown OVAL family: %s\n", family_text);
+		dW("Unknown OVAL family: %s", family_text);
 		ret = OVAL_FAMILY_UNKNOWN;
 	}
 
@@ -645,7 +645,7 @@ oval_subtype_t oval_subtype_parse(xmlTextReaderPtr reader)
 
 	int subtype_s = oscap_string_to_enum(map, tagname);
 	if (subtype < 0) {
-		dW("Unknown OVAL family subtype: %s\n", tagname);
+		dW("Unknown OVAL family subtype: %s", tagname);
 		subtype = OVAL_ENUMERATION_INVALID;
 	}
 	else {

--- a/src/OVAL/oval_object.c
+++ b/src/OVAL/oval_object.c
@@ -328,7 +328,7 @@ static int _oval_object_parse_tag(xmlTextReaderPtr reader, struct oval_parser_co
 	}
 
 	if (return_code != 0) {
-		dW("Parsing of <%s> terminated by an error at line %d.\n", tagname, xmlTextReaderGetParserLineNumber(reader));
+		dW("Parsing of <%s> terminated by an error at line %d.", tagname, xmlTextReaderGetParserLineNumber(reader));
 	}
 
 	oscap_free(tagname);
@@ -349,7 +349,7 @@ int oval_object_parse_tag(xmlTextReaderPtr reader, struct oval_parser_context *c
 
 	oval_subtype_t subtype = oval_subtype_parse(reader);
 	if ( subtype == OVAL_SUBTYPE_UNKNOWN) {
-		oscap_dlprintf(DBG_E,  "Unknown object %s.\n", id);
+		dE("Unknown object %s.", id);
 		ret = -1;
 		goto cleanup;
 	}
@@ -382,7 +382,7 @@ xmlNode *oval_object_to_dom(struct oval_object *object, xmlDoc * doc, xmlNode * 
 	/* skip unknown object */
 	oval_subtype_t subtype = oval_object_get_subtype(object);
         if ( subtype == OVAL_SUBTYPE_UNKNOWN ) {
-                oscap_dlprintf(DBG_E, "Unknown Object %s.\n", oval_object_get_id(object));
+                dE("Unknown Object %s.", oval_object_get_id(object));
                 return object_node;
         }
 

--- a/src/OVAL/oval_objectContent.c
+++ b/src/OVAL/oval_objectContent.c
@@ -193,7 +193,7 @@ struct oval_object_content
 		}
 		break;
 	default:
-		dE("Unsupported object content type: %d.\n", type);
+		dE("Unsupported object content type: %d.", type);
 		return NULL;
 	}
 	content->model = model;
@@ -389,7 +389,7 @@ int oval_object_content_parse_tag(xmlTextReaderPtr reader,
 	(*consumer) (content, user);
 
 	if (return_code != 0)
-		dW("Parsing of <%s> terminated by an error at line %d.\n",tagname, xmlTextReaderGetParserLineNumber(reader));
+		dW("Parsing of <%s> terminated by an error at line %d.",tagname, xmlTextReaderGetParserLineNumber(reader));
 
 	oscap_free(namespace);
 	return return_code;

--- a/src/OVAL/oval_parser.c
+++ b/src/OVAL/oval_parser.c
@@ -186,7 +186,7 @@ int oval_definition_model_parse(xmlTextReaderPtr reader, struct oval_parser_cont
 				gen = oval_definition_model_get_generator(context->definition_model);
 				ret = oval_parser_parse_tag(reader, context, &oval_generator_parse_tag, gen);
 			} else {
-				dW("Unprocessed tag: <%s:%s>.\n", namespace, tagname);
+				dW("Unprocessed tag: <%s:%s>.", namespace, tagname);
 				oval_parser_skip_tag(reader, context);
 			}
 

--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -237,13 +237,13 @@ int oval_probe_query_object(oval_probe_session_t *psess, struct oval_object *obj
 	oid = oval_object_get_id(object);
 	model = psess->sys_model;
 
-	dI("Querying object id: \"%s\", flags: %u.\n", oid, flags);
+	dI("Querying object id: \"%s\", flags: %u.", oid, flags);
 
 	sysc = oval_syschar_model_get_syschar(model, oid);
 	if (sysc != NULL) {
 		int variable_instance_hint = oval_syschar_get_variable_instance_hint(sysc);
 		if (oval_syschar_get_variable_instance_hint(sysc) != oval_syschar_get_variable_instance(sysc)) {
-			dI("Creating another syschar for variable_instance=%d)\n", variable_instance_hint);
+			dI("Creating another syschar for variable_instance=%d)", variable_instance_hint);
 			sysc = oval_syschar_new(model, object);
 			oval_syschar_set_variable_instance(sysc, variable_instance_hint);
 			oval_syschar_set_variable_instance_hint(sysc, variable_instance_hint);
@@ -253,7 +253,7 @@ int oval_probe_query_object(oval_probe_session_t *psess, struct oval_object *obj
 
 			sc_flg = oval_syschar_get_flag(sysc);
 
-			dI("Syschar already exists, flag: %u, '%s'.\n", sc_flg, oval_syschar_collection_flag_get_text(sc_flg));
+			dI("Syschar already exists, flag: %u, '%s'.", sc_flg, oval_syschar_collection_flag_get_text(sc_flg));
 
 			if (sc_flg != SYSCHAR_FLAG_UNKNOWN || (flags & OVAL_PDFLAG_NOREPLY)) {
 				if (out_syschar)
@@ -273,7 +273,7 @@ int oval_probe_query_object(oval_probe_session_t *psess, struct oval_object *obj
         if (ph == NULL) {
                 char *msg = "OVAL object not supported.";
 
-		dW("%s\n", msg);
+		dW("%s", msg);
 		oval_syschar_add_new_message(sysc, msg, OVAL_MESSAGE_LEVEL_WARNING);
 		oval_syschar_set_flag(sysc, SYSCHAR_FLAG_NOT_COLLECTED);
 
@@ -479,9 +479,9 @@ void oval_probe_meta_list(FILE *output, int flags)
 			strncat(probe_path, meta[i].pname, PATH_MAX - strlen(probe_dir) - 1);
 
 			if (flags & OVAL_PROBEMETA_LIST_DYNAMIC) {
-				dI("Checking access to \"%s\"\n", probe_path);
+				dI("Checking access to \"%s\"", probe_path);
 				if (access(probe_path, X_OK) != 0) {
-					dW("access: errno=%d, %s\n", errno, strerror(errno));
+					dW("access: errno=%d, %s", errno, strerror(errno));
 					continue;
 				}
 			}

--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -190,13 +190,13 @@ static int oval_probe_cmd_init(oval_pext_t *pext)
 	if (SEAP_cmd_register(pext->pdtbl->ctx, PROBECMD_OBJ_EVAL, SEAP_CMDREG_USEARG,
                               &oval_probe_cmd_obj_eval, (void *)pext) != 0)
         {
-		oscap_dlprintf(DBG_E, "Can't register command: %s: errno=%u, %s.\n", "obj_eval", errno, strerror(errno));
+		dE("Can't register command: %s: errno=%u, %s.", "obj_eval", errno, strerror(errno));
 		return (-1);
 	}
 
 	if (SEAP_cmd_register(pext->pdtbl->ctx, PROBECMD_STE_FETCH, SEAP_CMDREG_USEARG,
 			      &oval_probe_cmd_ste_fetch, (void *)pext) != 0) {
-		oscap_dlprintf(DBG_E, "Can't register command: %s: errno=%u, %s.\n", "ste_fetch", errno, strerror(errno));
+		dE("Can't register command: %s: errno=%u, %s.", "ste_fetch", errno, strerror(errno));
 
 		/* FIXME: unregister the first command */
 
@@ -220,7 +220,7 @@ static SEXP_t *oval_probe_cmd_obj_eval(SEXP_t *sexp, void *arg)
         assume_d (arg  != NULL, NULL);
 
 	if (!SEXP_stringp(sexp)) {
-		oscap_dlprintf(DBG_E, "Invalid argument: type=%s.\n", SEXP_strtype(sexp));
+		dE("Invalid argument: type=%s.", SEXP_strtype(sexp));
 		return (NULL);
 	}
 
@@ -229,10 +229,10 @@ static SEXP_t *oval_probe_cmd_obj_eval(SEXP_t *sexp, void *arg)
 	obj    = oval_definition_model_get_object(defs, id_str);
 	ret    = SEXP_list_new (sexp, NULL);
 
-	oscap_dlprintf(DBG_I, "Get_object: %s.\n", id_str);
+	dI("Get_object: %s.", id_str);
 
 	if (obj == NULL) {
-		oscap_dlprintf(DBG_E, "Can't find obj: id=%s.\n", id_str);
+		dE("Can't find obj: id=%s.", id_str);
 		oscap_free(id_str);
                 SEXP_free(ret);
 
@@ -250,7 +250,7 @@ static SEXP_t *oval_probe_cmd_obj_eval(SEXP_t *sexp, void *arg)
 	SEXP_free(ret_code);
 
 	if (oscap_err()) {
-		oscap_dlprintf(DBG_E, "Failed: id: %s, err: %d, %s.\n",
+		dE("Failed: id: %s, err: %d, %s.",
 			       id_str, oscap_err_family(), oscap_err_desc());
 		oscap_clearerr();
 		oscap_free(id_str);
@@ -285,7 +285,7 @@ static SEXP_t *oval_probe_cmd_ste_fetch(SEXP_t *sexp, void *arg)
 			ste = oval_definition_model_get_state(definition_model, id_str);
 
 			if (ste == NULL) {
-				oscap_dlprintf(DBG_E, "Can't find ste: id: %s.\n", id_str);
+				dE("Can't find ste: id: %s.", id_str);
 				SEXP_list_free(ste_list);
 				oscap_free(id_str);
                                 SEXP_free(id);
@@ -295,7 +295,7 @@ static SEXP_t *oval_probe_cmd_ste_fetch(SEXP_t *sexp, void *arg)
 
 			ret = oval_state_to_sexp(pext->sess_ptr, ste, &ste_sexp);
 			if (ret !=0) {
-				oscap_dlprintf(DBG_E, "Failed to convert OVAL state to SEXP, id: %s.\n",
+				dE("Failed to convert OVAL state to SEXP, id: %s.",
 					       id_str);
 				SEXP_list_free(ste_list);
 				oscap_free(id_str);
@@ -362,7 +362,7 @@ static inline const char *_probe_strerror(uint32_t error_code)
 static inline int _handle_SEAP_receive_failure(SEAP_CTX_t *ctx, oval_pd_t *pd, SEAP_msg_t *s_omsg, int flags)
 {
 	protect_errno {
-		oscap_dlprintf(DBG_W, "Can't receive message: %u, %s.\n", errno, strerror(errno));
+		dW("Can't receive message: %u, %s.", errno, strerror(errno));
 	}
 
 	if (errno == ECANCELED) {
@@ -374,11 +374,11 @@ static inline int _handle_SEAP_receive_failure(SEAP_CTX_t *ctx, oval_pd_t *pd, S
 		case  0:
 			break;
 		case  1: /* no error found */
-			dE("Internal error: An error was signaled on sd=%d but the error queue is empty.\n");
+			dE("Internal error: An error was signaled on sd=%d but the error queue is empty.");
 			oscap_seterr(OSCAP_EFAMILY_OVAL, "SEAP_recverr_byid: internal error: empty error queue.");
 			return (-1);
 		case -1: /* internal error */
-			dE("Internal error: SEAP_recverr_byid returned -1\n");
+			dE("Internal error: SEAP_recverr_byid returned -1");
 			oscap_seterr(OSCAP_EFAMILY_OVAL, "SEAP_recverr_byid: internal error.");
 			return (-1);
 		}
@@ -417,7 +417,7 @@ static inline int _handle_SEAP_receive_failure(SEAP_CTX_t *ctx, oval_pd_t *pd, S
 		char errbuf[__ERRBUF_SIZE];
 
 		protect_errno {
-			oscap_dlprintf(DBG_E, "Can't close sd: %u, %s.\n", errno, strerror(errno));
+			dE("Can't close sd: %u, %s.", errno, strerror(errno));
 		}
 
 		if (strerror_r (errno, errbuf, sizeof errbuf - 1) != 0)
@@ -451,17 +451,17 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 
 			if (pd->sd < 0) {
                                 protect_errno {
-                                        oscap_dlprintf(DBG_W, "Can't connect: %u, %s.\n", errno, strerror(errno));
+                                        dW("Can't connect: %u, %s.", errno, strerror(errno));
                                 }
 
 				if (++retry <= OVAL_PROBE_MAXRETRY) {
-					oscap_dlprintf(DBG_I, "Connect: retry %u/%u.\n", retry, OVAL_PROBE_MAXRETRY);
+					dI("Connect: retry %u/%u.", retry, OVAL_PROBE_MAXRETRY);
 					continue;
 				} else {
                                         char errbuf[__ERRBUF_SIZE];
 
                                         protect_errno {
-                                                oscap_dlprintf(DBG_E, "Connect: retry limit (%u) reached.\n", OVAL_PROBE_MAXRETRY);
+                                                dE("Connect: retry limit (%u) reached.", OVAL_PROBE_MAXRETRY);
                                         }
 
                                         if (strerror_r (errno, errbuf, sizeof errbuf - 1) != 0)
@@ -480,7 +480,7 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 		if (flags & OVAL_PDFLAG_NOREPLY) {
 			if (SEAP_msgattr_set(s_omsg, "no-reply", NULL) != 0) {
                                 protect_errno {
-                                        oscap_dlprintf(DBG_E, "Can't set no-reply attribute.\n");
+                                        dE("Can't set no-reply attribute.");
                                 }
 
                                 SEAP_msg_free(s_omsg);
@@ -490,12 +490,12 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 			}
 		}
 
-		oscap_dlprintf(DBG_I, "Sending message.\n");
+		dI("Sending message.");
 
 		ret = SEAP_sendmsg(ctx, pd->sd, s_omsg);
 		if (ret != 0) {
                         protect_errno {
-                                oscap_dlprintf(DBG_W, "Can't send message: %u, %s.\n", errno, strerror(errno));
+                                dW("Can't send message: %u, %s.", errno, strerror(errno));
                         }
 
 			if (flags & OVAL_PDFLAG_SLAVE) {
@@ -514,7 +514,7 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
                                 char errbuf[__ERRBUF_SIZE];
 
                                 protect_errno {
-                                        oscap_dlprintf(DBG_E, "Can't close sd: %u, %s.\n", errno, strerror(errno));
+                                        dE("Can't close sd: %u, %s.", errno, strerror(errno));
                                         SEAP_msg_free(s_omsg);
                                 }
 
@@ -530,13 +530,13 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 			pd->sd = -1;
 
 			if (++retry <= OVAL_PROBE_MAXRETRY) {
-				oscap_dlprintf(DBG_I, "Send: retry %u/%u.\n", retry, OVAL_PROBE_MAXRETRY);
+				dI("Send: retry %u/%u.", retry, OVAL_PROBE_MAXRETRY);
 				continue;
 			} else {
                                 char errbuf[__ERRBUF_SIZE];
 
                                 protect_errno {
-                                        oscap_dlprintf(DBG_E, "Send: retry limit (%u) reached.\n", OVAL_PROBE_MAXRETRY);
+                                        dE("Send: retry limit (%u) reached.", OVAL_PROBE_MAXRETRY);
                                         SEAP_msg_free(s_omsg);
                                 }
 
@@ -549,7 +549,7 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 			}
 		}
 
-		oscap_dlprintf(DBG_I, "Waiting for reply.\n");
+		dI("Waiting for reply.");
 
 		/* recv_retry: */
 		s_imsg = NULL;
@@ -562,15 +562,15 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 				SEAP_msg_free(s_omsg);
 			}
 			if (errno == ECONNABORTED) {
-				oscap_dlprintf(DBG_I, "Connection was aborted.\n");
+				dI("Connection was aborted.");
 				return (-2);
 			} else {
 				if (++retry <= OVAL_PROBE_MAXRETRY) {
-					oscap_dlprintf(DBG_I, "Recv: retry %u/%u.\n", retry, OVAL_PROBE_MAXRETRY);
+					dI("Recv: retry %u/%u.", retry, OVAL_PROBE_MAXRETRY);
 					continue;
 				} else {
 					protect_errno {
-						oscap_dlprintf(DBG_E, "Recv: retry limit (%u) reached.\n", OVAL_PROBE_MAXRETRY);
+						dE("Recv: retry limit (%u) reached.", OVAL_PROBE_MAXRETRY);
 					}
 
 					char errbuf[__ERRBUF_SIZE];
@@ -583,7 +583,7 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 			}
 		}
 
-		oscap_dlprintf(DBG_I, "Message received.\n");
+		dI("Message received.");
 		break;
 	}
 
@@ -663,12 +663,12 @@ static int oval_probe_sys_eval(SEAP_CTX_t *ctx, oval_pd_t *pd, struct oval_sysch
                 val = probe_obj_getentval (obj, __STRING(name), 1);     \
                                                                         \
                 if (val == NULL) {                                      \
-                        dI("No entity or value: %s\n", __STRING(name)); \
+                        dI("No entity or value: %s", __STRING(name)); \
                         goto fail;                                      \
                 }                                                       \
                                                                         \
                 if (SEXP_string_cstr_r (val, buf, sizeof buf) >= sizeof buf) { \
-                        dI("Value too large: %s\n", __STRING(name));    \
+                        dI("Value too large: %s", __STRING(name));    \
                         SEXP_free (val);                                \
                         goto fail;                                      \
                 }                                                       \
@@ -699,12 +699,12 @@ static int oval_probe_sys_eval(SEAP_CTX_t *ctx, oval_pd_t *pd, struct oval_sysch
                                 val = probe_ent_getattrval (ent, __STRING(name)); \
                                                                         \
                                 if (val == NULL) {                      \
-                                        dI("No value: %s\n", __STRING(name)); \
+                                        dI("No value: %s", __STRING(name)); \
                                         goto fail;                      \
                                 }                                       \
                                                                         \
                                 if (SEXP_string_cstr_r (val, buf, sizeof buf) >= sizeof buf) { \
-                                        dI("Value too large: %s\n", __STRING(name)); \
+                                        dI("Value too large: %s", __STRING(name)); \
                                         SEXP_free (val);                \
                                         goto fail;                      \
                                 }                                       \
@@ -795,7 +795,7 @@ int oval_probe_sys_handler(oval_subtype_t type, void *ptr, int act, ...)
 
                         ret = -1;
                 } else {
-                        oscap_dlprintf(DBG_I, "URI: %s.\n", probe_uri);
+                        dI("URI: %s.", probe_uri);
 
                         if (oval_pdtbl_add(pext->pdtbl, type, -1, probe_uri) != 0) {
                                 oscap_seterr (OSCAP_EFAMILY_OVAL, "%s probe not supported", probe_dsc->name);
@@ -863,7 +863,7 @@ int oval_probe_ext_handler(oval_subtype_t type, void *ptr, int act, ...)
                                 return (-1);
                         }
 
-                        oscap_dlprintf(DBG_I, "URI: %s.\n", probe_uri);
+                        dI("URI: %s.", probe_uri);
 
                         if (oval_pdtbl_add(pext->pdtbl, oval_object_get_subtype(obj), -1, probe_uri) != 0) {
 				oval_syschar_add_new_message(sys, "OVAL object not supported", OVAL_MESSAGE_LEVEL_WARNING);
@@ -981,34 +981,34 @@ int oval_probe_ext_init(oval_pext_t *pext)
 		register unsigned int i, r;
 
 		if (getcwd(curdir, PATH_MAX) == NULL) {
-			dE("getcwd() failed\n");
+			dE("getcwd() failed");
                         ret = -1;
                         goto _ret;
 		}
 
 		if (chdir(pext->probe_dir) != 0) {
-			dE("Can't chdir to \"%s\"\n", pext->probe_dir);
+			dE("Can't chdir to \"%s\"", pext->probe_dir);
                         ret = -1;
                         goto _ret;
 		}
 
 		pext->pdsc = oscap_alloc(sizeof(oval_pdsc_t) * OSCAP_GSYM(__probe_meta_count));
 
-                dI("__probe_meta_count = %zu\n", OSCAP_GSYM(__probe_meta_count));
+                dI("__probe_meta_count = %zu", OSCAP_GSYM(__probe_meta_count));
 
 		for (r = 0, i = 0; i < OSCAP_GSYM(__probe_meta_count); ++i) {
                         if (!(OSCAP_GSYM(__probe_meta)[i].flags & OVAL_PROBEMETA_EXTERNAL)) {
-                                dI("skipped: %s (not an external probe)\n", OSCAP_GSYM(__probe_meta)[i].stype);
+                                dI("skipped: %s (not an external probe)", OSCAP_GSYM(__probe_meta)[i].stype);
                                 continue;
                         }
 
 			if (stat(OSCAP_GSYM(__probe_meta)[i].pname, &st) != 0) {
-				dW("skipped: %s (stat failed, errno=%d)\n", OSCAP_GSYM(__probe_meta)[i].stype, errno);
+				dW("skipped: %s (stat failed, errno=%d)", OSCAP_GSYM(__probe_meta)[i].stype, errno);
 				continue;
 			}
 
 			if (!S_ISREG(st.st_mode)) {
-				dW("skipped: %s (not a regular file)\n", OSCAP_GSYM(__probe_meta)[i].stype);
+				dW("skipped: %s (not a regular file)", OSCAP_GSYM(__probe_meta)[i].stype);
 				continue;
 			}
 
@@ -1027,7 +1027,7 @@ int oval_probe_ext_init(oval_pext_t *pext)
 		      (int(*)(const void *, const void *))oval_pdsc_cmp);
 
 		if (chdir(curdir) != 0) {
-			dE("Can't chdir back to \"%s\"\n", curdir);
+			dE("Can't chdir back to \"%s\"", curdir);
 			oscap_free(pext->pdsc);
 			pext->pdsc_cnt = 0;
                         ret = -1;
@@ -1070,7 +1070,7 @@ int oval_probe_ext_eval(SEAP_CTX_t *ctx, oval_pd_t *pd, oval_pext_t *pext, struc
 	if (ret != 0) {
 		switch (errno) {
 		case ECONNABORTED:
-			dI("Closing sd=%d (pd=%p) after abort\n", pd->sd, pd);
+			dI("Closing sd=%d (pd=%p) after abort", pd->sd, pd);
 
 			SEAP_close(ctx, pd->sd);
 			pd->sd = -1;
@@ -1085,7 +1085,7 @@ int oval_probe_ext_eval(SEAP_CTX_t *ctx, oval_pd_t *pd, oval_pext_t *pext, struc
                          * The no-reply flag is set and oval_probe_comm returned some
                          * data. This is considered a non-fatal error.
                          */
-                        oscap_dlprintf(DBG_W, "Obtrusive data from probe!\n");
+                        dW("Obtrusive data from probe!");
                         SEXP_free(s_sys);
 		}
 		return (0);
@@ -1124,7 +1124,7 @@ int oval_probe_ext_abort(SEAP_CTX_t *ctx, oval_pd_t *pd, oval_pext_t *pext)
 	assume_d(pd   != NULL, -1);
 	assume_d(pext != NULL, -1);
 
-	dI("Sending abort to sd=%d\n", pd->sd);
+	dI("Sending abort to sd=%d", pd->sd);
 
 	dsc = SEAP_desc_get(ctx->sd_table, pd->sd);
 
@@ -1136,10 +1136,10 @@ int oval_probe_ext_abort(SEAP_CTX_t *ctx, oval_pd_t *pd, oval_pext_t *pext)
 	{
 		sch_pipedata_t *pipeinfo = (sch_pipedata_t *)dsc->scheme_data;
 
-		dI("Sending SIGUSR1 to pid=%u\n", pipeinfo->pid);
+		dI("Sending SIGUSR1 to pid=%u", pipeinfo->pid);
 
 		if (kill(pipeinfo->pid, SIGUSR1) != 0)
-			dW("kill(SIGUSR1, %u): %u, %s\n", errno, strerror(errno));
+			dW("kill(SIGUSR1, %u): %u, %s", errno, strerror(errno));
 
 		break;
 	}

--- a/src/OVAL/oval_probe_session.c
+++ b/src/OVAL/oval_probe_session.c
@@ -134,7 +134,7 @@ oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model)
 
         __init_once();
 
-        dI("__probe_meta_count = %zu\n", OSCAP_GSYM(__probe_meta_count));
+        dI("__probe_meta_count = %zu", OSCAP_GSYM(__probe_meta_count));
 
         for (i = 0; i < OSCAP_GSYM(__probe_meta_count); ++i) {
                 handler_arg = NULL;
@@ -154,7 +154,7 @@ oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model)
 void oval_probe_session_destroy(oval_probe_session_t *sess)
 {
 	if (sess == NULL) {
-		dE("Invalid session (NULL)\n");
+		dE("Invalid session (NULL)");
 		return;
 	}
 
@@ -174,7 +174,7 @@ int oval_probe_session_reset(oval_probe_session_t *sess, struct oval_syschar_mod
         oval_ph_t *ph;
 
         if ((ph = oval_probe_handler_get(sess->ph, OVAL_SUBTYPE_ALL)) == NULL) {
-		dE("No probe handler for OVAL_SUBTYPE_ALL\n");
+		dE("No probe handler for OVAL_SUBTYPE_ALL");
 		return (-1);
 	}
 
@@ -192,7 +192,7 @@ int oval_probe_session_abort(oval_probe_session_t *sess)
 	oval_ph_t *ph;
 
 	if ((ph = oval_probe_handler_get(sess->ph, OVAL_SUBTYPE_ALL) ) == NULL) {
-		dE("No probe handler for OVAL_SUBTYPE_ALL\n");
+		dE("No probe handler for OVAL_SUBTYPE_ALL");
 		return (-1);
 	}
 
@@ -201,14 +201,14 @@ int oval_probe_session_abort(oval_probe_session_t *sess)
 
 int oval_probe_session_sethandler(oval_probe_session_t *sess, oval_subtype_t type, oval_probe_handler_t handler, void *ptr)
 {
-	dE("Operation not supported\n");
+	dE("Operation not supported");
         return(-1);
 }
 
 struct oval_syschar_model *oval_probe_session_getmodel(oval_probe_session_t *sess)
 {
 	if (sess == NULL) {
-		dE("Invalid session (NULL)\n");
+		dE("Invalid session (NULL)");
 		return (NULL);
 	}
 

--- a/src/OVAL/oval_recordField.c
+++ b/src/OVAL/oval_recordField.c
@@ -113,7 +113,7 @@ struct oval_record_field *oval_record_field_new(oval_record_field_type_t type)
 		break;
 	}
 	default:
-		dE("Unsupported record field type: %d.\n", type);
+		dE("Unsupported record field type: %d.", type);
 		return NULL;
 	}
 
@@ -161,7 +161,7 @@ struct oval_record_field *oval_record_field_clone(struct oval_record_field *old_
 		break;
 	}
 	default:
-		dE("Unsupported record field type: %d.\n", old_rf->record_field_type);
+		dE("Unsupported record field type: %d.", old_rf->record_field_type);
 		return NULL;
 	}
 
@@ -211,7 +211,7 @@ void oval_record_field_set_mask(struct oval_record_field *rf, int mask)
 void oval_record_field_set_operation(struct oval_record_field *rf, oval_operation_t operation)
 {
 	if (rf->record_field_type != OVAL_RECORD_FIELD_STATE) {
-		dE("Wrong record field type: %d.\n", rf->record_field_type);
+		dE("Wrong record field type: %d.", rf->record_field_type);
 		return;
 	}
 
@@ -221,7 +221,7 @@ void oval_record_field_set_operation(struct oval_record_field *rf, oval_operatio
 void oval_record_field_set_variable(struct oval_record_field *rf, struct oval_variable *var)
 {
 	if (rf->record_field_type != OVAL_RECORD_FIELD_STATE) {
-		dE("Wrong record field type: %d.\n", rf->record_field_type);
+		dE("Wrong record field type: %d.", rf->record_field_type);
 		return;
 	}
 
@@ -231,7 +231,7 @@ void oval_record_field_set_variable(struct oval_record_field *rf, struct oval_va
 void oval_record_field_set_var_check(struct oval_record_field *rf, oval_check_t var_check)
 {
 	if (rf->record_field_type != OVAL_RECORD_FIELD_STATE) {
-		dE("Wrong record field type: %d.\n", rf->record_field_type);
+		dE("Wrong record field type: %d.", rf->record_field_type);
 		return;
 	}
 
@@ -241,7 +241,7 @@ void oval_record_field_set_var_check(struct oval_record_field *rf, oval_check_t 
 void oval_record_field_set_ent_check(struct oval_record_field *rf, oval_check_t ent_check)
 {
 	if (rf->record_field_type != OVAL_RECORD_FIELD_STATE) {
-		dE("Wrong record field type: %d.\n", rf->record_field_type);
+		dE("Wrong record field type: %d.", rf->record_field_type);
 		return;
 	}
 
@@ -251,7 +251,7 @@ void oval_record_field_set_ent_check(struct oval_record_field *rf, oval_check_t 
 void oval_record_field_set_status(struct oval_record_field *rf, oval_syschar_status_t status)
 {
 	if (rf->record_field_type != OVAL_RECORD_FIELD_ITEM) {
-		dE("Wrong record field type: %d.\n", rf->record_field_type);
+		dE("Wrong record field type: %d.", rf->record_field_type);
 		return;
 	}
 
@@ -286,7 +286,7 @@ int oval_record_field_get_mask(struct oval_record_field *rf)
 oval_operation_t oval_record_field_get_operation(struct oval_record_field *rf)
 {
 	if (rf->record_field_type != OVAL_RECORD_FIELD_STATE) {
-		dE("Wrong record field type: %d.\n", rf->record_field_type);
+		dE("Wrong record field type: %d.", rf->record_field_type);
 		return OVAL_OPERATION_UNKNOWN;
 	}
 
@@ -296,7 +296,7 @@ oval_operation_t oval_record_field_get_operation(struct oval_record_field *rf)
 struct oval_variable *oval_record_field_get_variable(struct oval_record_field *rf)
 {
 	if (rf->record_field_type != OVAL_RECORD_FIELD_STATE) {
-		dE("Wrong record field type: %d.\n", rf->record_field_type);
+		dE("Wrong record field type: %d.", rf->record_field_type);
 		return NULL;
 	}
 
@@ -306,7 +306,7 @@ struct oval_variable *oval_record_field_get_variable(struct oval_record_field *r
 oval_check_t oval_record_field_get_var_check(struct oval_record_field *rf)
 {
 	if (rf->record_field_type != OVAL_RECORD_FIELD_STATE) {
-		dE("Wrong record field type: %d.\n", rf->record_field_type);
+		dE("Wrong record field type: %d.", rf->record_field_type);
 		return OVAL_CHECK_UNKNOWN;
 	}
 
@@ -316,7 +316,7 @@ oval_check_t oval_record_field_get_var_check(struct oval_record_field *rf)
 oval_check_t oval_record_field_get_ent_check(struct oval_record_field *rf)
 {
 	if (rf->record_field_type != OVAL_RECORD_FIELD_STATE) {
-		dE("Wrong record field type: %d.\n", rf->record_field_type);
+		dE("Wrong record field type: %d.", rf->record_field_type);
 		return OVAL_CHECK_UNKNOWN;
 	}
 
@@ -326,7 +326,7 @@ oval_check_t oval_record_field_get_ent_check(struct oval_record_field *rf)
 oval_syschar_status_t oval_record_field_get_status(struct oval_record_field *rf)
 {
 	if (rf->record_field_type != OVAL_RECORD_FIELD_ITEM) {
-		dE("Wrong record field type: %d.\n", rf->record_field_type);
+		dE("Wrong record field type: %d.", rf->record_field_type);
 		return SYSCHAR_STATUS_UNKNOWN;
 	}
 
@@ -401,7 +401,7 @@ int oval_record_field_parse_tag(xmlTextReaderPtr reader, struct oval_parser_cont
 		break;
 	}
 	default:
-		dE("Impossible happened.\n");
+		dE("Impossible happened.");
 	}
 
 	(*consumer) (rf, user);
@@ -418,7 +418,7 @@ xmlNode *oval_record_field_to_dom(struct oval_record_field *rf, bool parent_mask
 
 	if (rf->record_field_type != OVAL_RECORD_FIELD_STATE
 	    && rf->record_field_type != OVAL_RECORD_FIELD_ITEM) {
-		dE("Unsupported record field type: %d.\n", rf->record_field_type);
+		dE("Unsupported record field type: %d.", rf->record_field_type);
 		return NULL;
 	}
 
@@ -479,7 +479,7 @@ xmlNode *oval_record_field_to_dom(struct oval_record_field *rf, bool parent_mask
 		break;
 	}
 	default:
-		dE("Impossible happened.\n");
+		dE("Impossible happened.");
 	}
 
 	return node;

--- a/src/OVAL/oval_set.c
+++ b/src/OVAL/oval_set.c
@@ -316,14 +316,14 @@ static int _oval_set_parse_tag(xmlTextReaderPtr reader, struct oval_parser_conte
 		} else if (strcmp(tagname, "filter") == 0) {
 			return_code = oval_filter_parse_tag(reader, context, &oval_set_consume_filter, set);
 		} else {
-			oscap_dlprintf(DBG_W, "Unknown tag: <%s>, line: %d.\n", tagname,
+			dW("Unknown tag: <%s>, line: %d.", tagname,
                                       xmlTextReaderGetParserLineNumber(reader));
 			return_code = oval_parser_skip_tag(reader, context);
 		}
 	}
 
 	if (return_code != 0) {
-		dW("Parsing of <%s> terminated by an error at line %d.\n", tagname, xmlTextReaderGetParserLineNumber(reader));
+		dW("Parsing of <%s> terminated by an error at line %d.", tagname, xmlTextReaderGetParserLineNumber(reader));
 	}
 
 	oscap_free(tagname);

--- a/src/OVAL/oval_sexp.c
+++ b/src/OVAL/oval_sexp.c
@@ -165,7 +165,7 @@ static int oval_varref_attr_to_sexp(void *sess, struct oval_entity *entity, stru
 
 	var = oval_entity_get_variable(entity);
 	if (oval_probe_query_variable(sess, var) != 0) {
-		dE("Can't convert variable reference to SEXP.\n");
+		dE("Can't convert variable reference to SEXP.");
 		return -1;
 	}
 
@@ -188,7 +188,7 @@ static int oval_varref_attr_to_sexp(void *sess, struct oval_entity *entity, stru
 	}
 
 	if (ret) {
-		dW("%s\n", msg);
+		dW("%s", msg);
 		oval_syschar_add_new_message(syschar, msg, OVAL_MESSAGE_LEVEL_WARNING);
 		oval_syschar_set_flag(syschar, SYSCHAR_FLAG_DOES_NOT_EXIST);
 		return ret;
@@ -241,7 +241,7 @@ static int oval_varref_elm_to_sexp(void *sess, struct oval_variable *var, oval_d
 	if (flag == SYSCHAR_FLAG_DOES_NOT_EXIST) {
 		char msg[100];
 		snprintf(msg, sizeof(msg), "Referenced variable has no values (%s).", oval_variable_get_id(var));
-		dW("%s\n", msg);
+		dW("%s", msg);
 		if (syschar != NULL)  {
 			oval_syschar_add_new_message(syschar, msg, OVAL_MESSAGE_LEVEL_WARNING);
 			oval_syschar_set_flag(syschar, SYSCHAR_FLAG_DOES_NOT_EXIST);
@@ -661,7 +661,7 @@ int oval_state_to_sexp(void *sess, struct oval_state *state, SEXP_t **out_sexp)
         subtype_name = oval_subtype_to_str(oval_state_get_subtype(state));
 
 	if (subtype_name == NULL) {
-		dI("FAIL: unknown subtype: %d\n", oval_state_get_subtype(state));
+		dI("FAIL: unknown subtype: %d", oval_state_get_subtype(state));
 		return (-1);
 	}
 
@@ -863,7 +863,7 @@ static struct oval_sysent *oval_sexp_to_sysent(struct oval_syschar_model *model,
 				snprintf(val, sizeof(val), "%" PRIu64, SEXP_number_getu_64(sval));
 				break;
 			default:
-				dE("Unexpected SEXP number datatype: %d, name: '%s'.\n", sndt, key);
+				dE("Unexpected SEXP number datatype: %d, name: '%s'.", sndt, key);
 				valp = '\0';
 				break;
 			}
@@ -876,7 +876,7 @@ static struct oval_sysent *oval_sexp_to_sysent(struct oval_syschar_model *model,
 			valp = SEXP_string_cstr(sval);
 			break;
 		default:
-			dE("Unexpected OVAL datatype: %d, '%s', name: '%s'.\n",
+			dE("Unexpected OVAL datatype: %d, '%s', name: '%s'.",
 			   dt, oval_datatype_get_text(dt), key);
 			valp = '\0';
 			break;
@@ -926,7 +926,7 @@ static struct oval_sysitem *oval_sexp_to_sysitem(struct oval_syschar_model *mode
 
 	int type = oval_str_to_subtype(name);
 
-	dI("Syschar entry type: %d '%s' => %s\n", type, name,
+	dI("Syschar entry type: %d '%s' => %s", type, name,
 	   ((type != OVAL_SUBTYPE_UNKNOWN) ? "OK" : "FAILED to decode"));
 #ifndef NDEBUG
 	if (type == OVAL_SUBTYPE_UNKNOWN)

--- a/src/OVAL/oval_sysInfo.c
+++ b/src/OVAL/oval_sysInfo.c
@@ -285,12 +285,12 @@ int oval_sysinfo_parse_tag(xmlTextReaderPtr reader, struct oval_parser_context *
 	if (is_ovalsys) {
 		return_code = oval_parser_parse_tag(reader, context, &_oval_sysinfo_parse_tag, sysinfo);
 	} else {
-		dW("Expected <system_info>, got <%s:%s>\n", namespace, tagname);
+		dW("Expected <system_info>, got <%s:%s>", namespace, tagname);
 		oval_parser_skip_tag(reader, context);
 	}
 
 	if (return_code != 0) {
-		dW("Parsing of <%s> terminated by an error at line %d.\n", tagname, xmlTextReaderGetParserLineNumber(reader));
+		dW("Parsing of <%s> terminated by an error at line %d.", tagname, xmlTextReaderGetParserLineNumber(reader));
 	}
 
 	oval_syschar_model_set_sysinfo(context->syschar_model, sysinfo);

--- a/src/OVAL/oval_sysInterface.c
+++ b/src/OVAL/oval_sysInterface.c
@@ -188,7 +188,7 @@ static int _oval_sysint_parse_tag(xmlTextReaderPtr reader, struct oval_parser_co
 	} else if (is_ovalsys && (strcmp(tagname, "mac_address") == 0)) {
 		return_code = oval_parser_text_value(reader, context, &oval_consume_mac_address, sysint);
 	} else {
-		dW("Skipping tag: <%s:%s>.\n", namespace, tagname);
+		dW("Skipping tag: <%s:%s>.", namespace, tagname);
 		oval_parser_skip_tag(reader, context);
 	}
 
@@ -212,7 +212,7 @@ int oval_sysint_parse_tag(xmlTextReaderPtr reader,
 	if (is_ovalsys && (strcmp(tagname, "interface") == 0)) {
 		return_code = oval_parser_parse_tag(reader, context, &_oval_sysint_parse_tag, sysint);
 	} else {
-		dW("Skipping tag: <%s:%s>.\n", namespace, tagname);
+		dW("Skipping tag: <%s:%s>.", namespace, tagname);
 		oval_parser_skip_tag(reader, context);
 	}
 

--- a/src/OVAL/oval_sysItem.c
+++ b/src/OVAL/oval_sysItem.c
@@ -236,12 +236,12 @@ int oval_sysitem_parse_tag(xmlTextReaderPtr reader, struct oval_parser_context *
 
 		return_code = oval_parser_parse_tag(reader, context, &_oval_sysitem_parse_subtag, sysitem);
 	} else {
-		dW("Unknown sysitem: %s\n", tagname);
+		dW("Unknown sysitem: %s", tagname);
 		return_code = oval_parser_skip_tag(reader, context);
 	}
 
         if (return_code != 0) {
-                dW("Parsing of <%s> terminated by an error at line %d.\n", tagname, xmlTextReaderGetParserLineNumber(reader));
+                dW("Parsing of <%s> terminated by an error at line %d.", tagname, xmlTextReaderGetParserLineNumber(reader));
         }
 
 	oscap_free(tagname);

--- a/src/OVAL/oval_sysModel.c
+++ b/src/OVAL/oval_sysModel.c
@@ -259,7 +259,7 @@ int oval_syschar_model_import(struct oval_syschar_model *model, const char *file
 		ret = oval_syschar_model_parse(reader, &context);
 	} else {
 		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Missing \"oval_system_characteristics\" element");
-		dE("Unprocessed tag: <%s:%s>.\n", namespace, tagname);
+		dE("Unprocessed tag: <%s:%s>.", namespace, tagname);
 		ret = -1;
 	}
 

--- a/src/OVAL/oval_sys_parser.c
+++ b/src/OVAL/oval_sys_parser.c
@@ -69,7 +69,7 @@ int oval_syschar_model_parse(xmlTextReaderPtr reader, struct oval_parser_context
 			} else if (is_ovalsys && (strcmp(tagname, "system_data") == 0)) {
 				ret = oval_parser_parse_tag(reader, context, &oval_sysitem_parse_tag, NULL);
 			} else {
-				dW("Unprocessed tag: <%s:%s>.\n", namespace, tagname);
+				dW("Unprocessed tag: <%s:%s>.", namespace, tagname);
 				oval_parser_skip_tag(reader, context);
 			}
 

--- a/src/OVAL/oval_syschar.c
+++ b/src/OVAL/oval_syschar.c
@@ -276,7 +276,7 @@ static int _oval_syschar_parse_subtag(xmlTextReaderPtr reader, struct oval_parse
 	}
 
 	if (return_code != 0) {
-                dW("Parsing of <%s> terminated by an error at line %d.\n", tagname, xmlTextReaderGetParserLineNumber(reader));
+                dW("Parsing of <%s> terminated by an error at line %d.", tagname, xmlTextReaderGetParserLineNumber(reader));
         }
 
 	oscap_free(tagname);
@@ -307,12 +307,12 @@ int oval_syschar_parse_tag(xmlTextReaderPtr reader, struct oval_parser_context *
 
 		return_code = oval_parser_parse_tag(reader, context, &_oval_syschar_parse_subtag, syschar);
 	} else {
-                dW("Skipping tag: %s\n", tagname);
+                dW("Skipping tag: %s", tagname);
                 oval_parser_skip_tag(reader, context);
 	}
 
         if (return_code != 0) {
-                dW("Parsing of <%s> terminated by an error at line %d.\n", tagname, xmlTextReaderGetParserLineNumber(reader));
+                dW("Parsing of <%s> terminated by an error at line %d.", tagname, xmlTextReaderGetParserLineNumber(reader));
         }
 
 	oscap_free(tagname);

--- a/src/OVAL/oval_test.c
+++ b/src/OVAL/oval_test.c
@@ -345,7 +345,7 @@ static int _oval_test_parse_tag(xmlTextReaderPtr reader, struct oval_parser_cont
 			state_ref = NULL;
 		}
 	} else {
-		oscap_dlprintf(DBG_W, "Skipping tag <%s>.\n", tagname);
+		dW("Skipping tag <%s>.", tagname);
 		return_code = oval_parser_skip_tag(reader, context);
 	}
 
@@ -424,7 +424,7 @@ xmlNode *oval_test_to_dom(struct oval_test *test, xmlDoc * doc, xmlNode * parent
 	/* skip unknown test */
 	oval_subtype_t subtype = oval_test_get_subtype(test);
 	if ( subtype == OVAL_SUBTYPE_UNKNOWN ) {
-		oscap_dlprintf(DBG_E, "Unknown Test %s.\n", oval_test_get_id(test));
+		dE("Unknown Test %s.", oval_test_get_id(test));
 		return test_node;
 	}
 

--- a/src/OVAL/oval_varModel.c
+++ b/src/OVAL/oval_varModel.c
@@ -196,7 +196,7 @@ static int _oval_variable_model_parse_variable_values
 		oval_collection_add(frame->values, ov);
 		oscap_free(value);
 	} else {
-		oscap_dlprintf(DBG_W, "Unprocessed tag: <%s:%s>.\n", namespace, tagname);
+		dW("Unprocessed tag: <%s:%s>.", namespace, tagname);
 		oval_parser_skip_tag(reader, context);
 		return_code = 0;
 	}
@@ -214,7 +214,7 @@ static int _oval_variable_model_parse_variable
 	int return_code = 1;
 	if (frame) {
 		if (frame->datatype != datatype) {
-			oscap_dlprintf(DBG_W, "Unmatched variable datatypes: %s:%s.\n",
+			dW("Unmatched variable datatypes: %s:%s.",
 				      oval_datatype_get_text(frame->datatype), oval_datatype_get_text(datatype));
 			oval_parser_skip_tag(reader, context);
 			return_code = 0;
@@ -240,7 +240,7 @@ static int _oval_variable_model_parse_variables
 	if (is_variable_ns && oscap_strcmp("variable", tagname) == 0) {
 		return_code = _oval_variable_model_parse_variable(reader, context, model);
 	} else {
-		oscap_dlprintf(DBG_W, "Unprocessed tag: <%s:%s>.\n", namespace, tagname);
+		dW("Unprocessed tag: <%s:%s>.", namespace, tagname);
 		oval_parser_skip_tag(reader, context);
 
 		/*oscap_seterr */
@@ -266,7 +266,7 @@ static int _oval_variable_model_parse_tag
 		return_code =
 		    oval_parser_parse_tag(reader, context, (oval_xml_tag_parser) _oval_variable_model_parse_variables, model);
 	} else {
-		oscap_dlprintf(DBG_W, "Unprocessed tag: <%s:%s>.\n", namespace, tagname);
+		dW("Unprocessed tag: <%s:%s>.", namespace, tagname);
 		oval_parser_skip_tag(reader, context);
 		return_code = 0;
 	}
@@ -290,7 +290,7 @@ static int _oval_variable_model_parse(struct oval_variable_model *model, xmlText
 		return_code =
 		    oval_parser_parse_tag(reader, &context, (oval_xml_tag_parser) _oval_variable_model_parse_tag, model);
 	} else {
-		oscap_dlprintf(DBG_W, "Unprocessed tag: <%s:%s>.\n", namespace, tagname);
+		dW("Unprocessed tag: <%s:%s>.", namespace, tagname);
 		return_code = oval_parser_skip_tag(reader, &context);
 	}
 	oscap_free(tagname);

--- a/src/OVAL/oval_variable.c
+++ b/src/OVAL/oval_variable.c
@@ -224,7 +224,7 @@ int oval_syschar_model_compute_variable(struct oval_syschar_model *sysmod, struc
 			var->values = oval_collection_new();
 		var->flag = oval_component_compute(sysmod, component, var->values);
 	} else {
-		oscap_dlprintf(DBG_W, "NULL component bound to a variable, id: %s.\n", var->id);
+		dW("NULL component bound to a variable, id: %s.", var->id);
 		return -1;
         }
 
@@ -265,7 +265,7 @@ int oval_probe_query_variable(oval_probe_session_t *sess, struct oval_variable *
 			var->values = oval_collection_new();
 		var->flag = oval_component_query(sess, component, var->values);
 	} else {
-		oscap_dlprintf(DBG_W, "NULL component bound to a variable, id: %s.\n", var->id);
+		dW("NULL component bound to a variable, id: %s.", var->id);
 		return -1;
         }
 
@@ -507,7 +507,7 @@ void oval_variable_set_datatype(struct oval_variable *variable, oval_datatype_t 
 void oval_variable_set_type(struct oval_variable *variable, oval_variable_type_t new_type)
 {
 	if (variable->type != OVAL_VARIABLE_UNKNOWN) {
-		oscap_dlprintf(DBG_E, "Attempt to reset valid variable type, oldtype: %s, newtype: %s.\n",
+		dE("Attempt to reset valid variable type, oldtype: %s, newtype: %s.",
 			       oval_variable_type_get_text(variable->type), oval_variable_type_get_text(new_type));
 		return;
 	}
@@ -590,7 +590,7 @@ void oval_variable_clear_values(struct oval_variable *variable)
 	__attribute__nonnull__(variable);
 
 	if (variable->type != OVAL_VARIABLE_CONSTANT && variable->type != OVAL_VARIABLE_EXTERNAL) {
-		oscap_dlprintf(DBG_W, "Wrong variable type for this operation: %d.\n", variable->type);
+		dW("Wrong variable type for this operation: %d.", variable->type);
 		return;
         }
 
@@ -633,7 +633,7 @@ int oval_variable_bind_ext_var(struct oval_variable *var, struct oval_variable_m
 	oval_variable_EXTERNAL_t *evar;
 
 	if (var->type != OVAL_VARIABLE_EXTERNAL) {
-		dW("Attemp to bind a non-external variable, id: %s, type: %s.\n", var->id, oval_variable_type_get_text(var->type));
+		dW("Attemp to bind a non-external variable, id: %s, type: %s.", var->id, oval_variable_type_get_text(var->type));
 		return 2;
 	}
 
@@ -671,7 +671,7 @@ static int _oval_variable_parse_local_tag(xmlTextReaderPtr reader, struct oval_p
 	xmlChar *namespace = xmlTextReaderNamespaceUri(reader);
 	int return_code = oval_component_parse_tag(reader, context, &_oval_variable_parse_local_tag_component_consumer, variable);
 	if (return_code != 0) {
-		dW("Parsing of %s terminated by an error at <%s>, line %d.\n", variable->id, tagname, xmlTextReaderGetParserLineNumber(reader));
+		dW("Parsing of %s terminated by an error at <%s>, line %d.", variable->id, tagname, xmlTextReaderGetParserLineNumber(reader));
 	}
 	oscap_free(tagname);
 	oscap_free(namespace);
@@ -696,7 +696,7 @@ static int _oval_variable_parse_constant_tag(xmlTextReaderPtr reader, struct ova
 	struct oval_variable *variable = (struct oval_variable *)user;
 
 	if (strcmp("value", (char *) tagname) || strcmp(DEFINITION_NAMESPACE, (char *) namespace)) {
-		dW("Invalid element <%s:%s> in constant variable %s on line %d.\n",
+		dW("Invalid element <%s:%s> in constant variable %s on line %d.",
 		   namespace, tagname, variable->id, xmlTextReaderGetParserLineNumber(reader));
 		goto out;
 	}
@@ -728,7 +728,7 @@ int oval_variable_parse_tag(xmlTextReaderPtr reader, struct oval_parser_context 
 		type = OVAL_VARIABLE_LOCAL;
 	else {
 		type = OVAL_VARIABLE_UNKNOWN;
-		dW("Unhandled variable type: %s, line: %d.\n", tagname, xmlTextReaderGetParserLineNumber(reader));
+		dW("Unhandled variable type: %s, line: %d.", tagname, xmlTextReaderGetParserLineNumber(reader));
 	}
 	id = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "id");
 	struct oval_variable *variable = oval_definition_model_get_new_variable(model, id, type);

--- a/src/OVAL/probes/SEAP/generic/strbuf.c
+++ b/src/OVAL/probes/SEAP/generic/strbuf.c
@@ -291,18 +291,18 @@ ssize_t strbuf_write (strbuf_t *buf, int fd)
         cur   = buf->beg;
 	iot   = (buf->size / buf->blkmax) + 1;
 
-	dI("total I/O vectors = %d\n", iot);
+	dI("total I/O vectors = %d", iot);
 
 	while (iot > 0) {
 		/*
 		 * Prepare I/O vector
 		 */
 		if (iot > IOV_MAX) {
-			dI("iot (%d) > IOV_MAX (%d)\n", iot, IOV_MAX);
+			dI("iot (%d) > IOV_MAX (%d)", iot, IOV_MAX);
 			iow  = IOV_MAX;
 			iot -= IOV_MAX;
 		} else {
-			dI("iot (%d) < IOV_MAX (%d)\n", iot, IOV_MAX);
+			dI("iot (%d) < IOV_MAX (%d)", iot, IOV_MAX);
 			iow  = iot;
 			iot  = 0;
 		}
@@ -318,7 +318,7 @@ ssize_t strbuf_write (strbuf_t *buf, int fd)
 			cur = cur->next;
 		}
 
-		dI("ioc = %d\n", ioc);
+		dI("ioc = %d", ioc);
 
 		/*
 		 * Write
@@ -326,7 +326,7 @@ ssize_t strbuf_write (strbuf_t *buf, int fd)
 		wsize = writev (fd, iov, ioc);
 
 		if (wsize < 0) {
-			dE("writev(%d, %p, %d) failed: %u, %s.\n", fd, iov, ioc, errno, strerror (errno));
+			dE("writev(%d, %p, %d) failed: %u, %s.", fd, iov, ioc, errno, strerror (errno));
                         free(iov);
 			return (-1);
 		}
@@ -335,7 +335,7 @@ ssize_t strbuf_write (strbuf_t *buf, int fd)
 	}
 
         free (iov);
-	dI("total bytes written: %zu\n", (size_t)rsize);
+	dI("total bytes written: %zu", (size_t)rsize);
 
         return (rsize);
 }

--- a/src/OVAL/probes/SEAP/sch_generic.c
+++ b/src/OVAL/probes/SEAP/sch_generic.c
@@ -165,7 +165,7 @@ int sch_generic_select (SEAP_desc_t *desc, int ev, uint16_t timeout, uint32_t fl
         switch (select (fd + 1, rptr, wptr, NULL, tv_ptr)) {
         case -1:
                 protect_errno {
-                        dI("FAIL: errno=%u, %s.\n", errno, strerror (errno));
+                        dI("FAIL: errno=%u, %s.", errno, strerror (errno));
                 }
                 return (-1);
         case  0:

--- a/src/OVAL/probes/SEAP/seap-command.c
+++ b/src/OVAL/probes/SEAP/seap-command.c
@@ -93,12 +93,12 @@ int SEAP_cmd_register (SEAP_CTX_t *ctx, SEAP_cmdcode_t code, uint32_t flags, SEA
                 /* rec is freed by SEAP_cmdtbl_add */
                 break;
         case SEAP_CMDTBL_ECOLL:
-                dI("Can't register command: code=%u, tbl=%p: already registered.\n",
+                dI("Can't register command: code=%u, tbl=%p: already registered.",
                    code, (void *)tbl);
                 SEAP_cmdrec_free (rec);
                 return (-1);
         case -1:
-                dI("Can't register command: code=%u, func=%p, tbl=%p, arg=%p: errno=%u, %s.\n",
+                dI("Can't register command: code=%u, func=%p, tbl=%p, arg=%p: errno=%u, %s.",
                    code, (void *)func, (void *)tbl, arg, errno, strerror (errno));
                 SEAP_cmdrec_free (rec);
                 return (-1);
@@ -145,7 +145,7 @@ SEAP_cmdtbl_t *SEAP_cmdtbl_new (void)
 
 #if defined(SEAP_THREAD_SAFE)
         if (pthread_rwlock_init (&t->lock, NULL) != 0) {
-                dI("Can't initialize rwlock: %u, %s.\n",
+                dI("Can't initialize rwlock: %u, %s.",
                    errno, strerror (errno));
                 sm_free (t);
                 return (NULL);
@@ -245,7 +245,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
         }
 #endif
 
-        dI("code=%u, args=%p\n", code, args);
+        dI("code=%u, args=%p", code, args);
 
         dsc = SEAP_desc_get (ctx->sd_table, sd);
 
@@ -253,7 +253,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                 return (NULL);
 
         if (flags & (SEAP_EXEC_LOCAL | SEAP_EXEC_WQUEUE)) {
-                dI("EXEC_LOCAL\n");
+                dI("EXEC_LOCAL");
 
                 /* get table pointers */
                 if (flags & SEAP_EXEC_WQUEUE) {
@@ -281,7 +281,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                         if ((rec = SEAP_cmdtbl_get (tbl[i], code)) != NULL)
                                 break;
 
-                dI("rec=%p, w=%u\n", rec, (flags & SEAP_EXEC_WQUEUE) ? 1 : 0);
+                dI("rec=%p, w=%u", rec, (flags & SEAP_EXEC_WQUEUE) ? 1 : 0);
 
                 if (rec == NULL) {
 
@@ -290,13 +290,13 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                 /* execute command */
                 res = rec->func (args, rec->arg);
 
-                dI("res=%p\n", res);
+                dI("res=%p", res);
 
                 /* filter result */
                 if (func != NULL)
                         res = func (res, funcarg);
 
-                dI("func@%p(res)=%p\n", func, res);
+                dI("func@%p(res)=%p", func, res);
 
                 /* delete command from the wait queue */
                 if (flags & SEAP_EXEC_WQUEUE) {
@@ -308,7 +308,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                 SEAP_cmd_t    *cmdptr;
                 SEAP_packet_t *packet;
 
-                dI("EXEC_REMOTE\n");
+                dI("EXEC_REMOTE");
 
                 packet = SEAP_packet_new ();
                 cmdptr = SEAP_packet_settype (packet, SEAP_PACKET_CMD);
@@ -345,12 +345,12 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                         case 0:
                                 break;
                         case SEAP_CMDTBL_ECOLL:
-                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: already registered.\n",
+                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: already registered.",
                                    rec->code, (void *)dsc->cmd_w_table, sd);
                                 SEAP_cmdrec_free (rec);
                                 return (NULL);
                         case -1:
-                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: errno=%u, %s.\n",
+                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: errno=%u, %s.",
                                    rec->code, (void *)dsc->cmd_w_table, sd, errno, strerror (errno));
                                 SEAP_cmdrec_free (rec);
                                 return (NULL);
@@ -362,7 +362,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
 
                         if (SEAP_packet_send (ctx, sd, packet) != 0) {
                                 protect_errno {
-                                        dI("FAIL: errno=%u, %s.\n", errno, strerror (errno));
+                                        dI("FAIL: errno=%u, %s.", errno, strerror (errno));
                                         SEAP_cmdtbl_del(dsc->cmd_w_table, rec);
                                         SEAP_packet_free (packet);
                                 }
@@ -388,7 +388,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                                         pthread_mutex_unlock(&h.mtx);
 
                                         if (SEAP_packet_recv(ctx, sd, &packet_rcv) != 0) {
-                                                dI("FAIL: ctx=%p, sd=%d, errno=%u, %s.\n", ctx, sd, errno, strerror(errno));
+                                                dI("FAIL: ctx=%p, sd=%d, errno=%u, %s.", ctx, sd, errno, strerror(errno));
                                                 return(NULL);
                                         }
 
@@ -430,7 +430,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                                 }
                         }
 
-                        dI("cond return: h.args=%p\n", h.args);
+                        dI("cond return: h.args=%p", h.args);
 
                         if (h.args == NULL)
                                 res = NULL;
@@ -462,12 +462,12 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                         case 0:
                                 break;
                         case SEAP_CMDTBL_ECOLL:
-                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: already registered.\n",
+                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: already registered.",
                                    rec->code, (void *)dsc->cmd_w_table, sd);
                                 SEAP_cmdrec_free (rec);
                                 return (NULL);
                         case -1:
-                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: errno=%u, %s.\n",
+                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: errno=%u, %s.",
                                    rec->code, (void *)dsc->cmd_w_table, sd, errno, strerror (errno));
                                 SEAP_cmdrec_free (rec);
                                 return (NULL);
@@ -479,7 +479,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
 
                         if (SEAP_packet_send (ctx, sd, packet) != 0) {
                                 protect_errno {
-                                        dI("FAIL: errno=%u, %s.\n", errno, strerror (errno));
+                                        dI("FAIL: errno=%u, %s.", errno, strerror (errno));
                                         SEAP_cmdtbl_del(dsc->cmd_w_table, rec);
                                         SEAP_cmdrec_free(rec);
                                         SEAP_packet_free (packet);

--- a/src/OVAL/probes/SEAP/seap-message.c
+++ b/src/OVAL/probes/SEAP/seap-message.c
@@ -71,7 +71,7 @@ void SEAP_msg_free (SEAP_msg_t *msg)
 
         if (msg->attrs != NULL) {
                 for (; msg->attrs_cnt > 0; --msg->attrs_cnt) {
-                        dI("name=%s, value=%p\n",
+                        dI("name=%s, value=%p",
                            msg->attrs[msg->attrs_cnt - 1].name,
                            msg->attrs[msg->attrs_cnt - 1].value);
 
@@ -135,11 +135,11 @@ bool SEAP_msgattr_exists (SEAP_msg_t *msg, const char *name)
         _A(msg  != NULL);
         _A(name != NULL);
 
-        dI("cnt = %u\n", msg->attrs_cnt);
+        dI("cnt = %u", msg->attrs_cnt);
 
         /* FIXME: this is stupid */
         for (i = 0; i < msg->attrs_cnt; ++i) {
-                dI("%s ?= %s\n", name, msg->attrs[i].name);
+                dI("%s ?= %s", name, msg->attrs[i].name);
                 if (strcmp (name, msg->attrs[i].name) == 0)
                         return (true);
         }

--- a/src/OVAL/probes/SEAP/seap-packet.c
+++ b/src/OVAL/probes/SEAP/seap-packet.c
@@ -118,7 +118,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
 
                 attr_name = SEXP_list_nth (sexp_msg, msg_n);
                 if (attr_name == NULL) {
-                        dI("Unexpected error: No S-exp (attr_name) at position %u in the message (%p).\n",
+                        dI("Unexpected error: No S-exp (attr_name) at position %u in the message (%p).",
                            msg_n, sexp_msg);
 
                         sm_free (seap_msg->attrs);
@@ -131,7 +131,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
 
                                 attr_val = SEXP_list_nth (sexp_msg, msg_n + 1);
                                 if (attr_val == NULL) {
-                                        dI("Unexpected error: \"%s\": No attribute value at position %u in the message (%p).\n",
+                                        dI("Unexpected error: \"%s\": No attribute value at position %u in the message (%p).",
                                            "id", msg_n + 1, sexp_msg);
 
                                         sm_free (seap_msg->attrs);
@@ -150,7 +150,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
                                 {
                                         switch (errno) {
                                         case EDOM:
-                                                dI("id: invalid value or type: s_exp=%p, type=%s\n",
+                                                dI("id: invalid value or type: s_exp=%p, type=%s",
                                                    (void *)attr_val, SEXP_strtype (attr_val));
 
                                                 sm_free (seap_msg->attrs);
@@ -159,7 +159,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
 
                                                 return (SEAP_EINVAL);
                                         case EFAULT:
-                                                dI("id: not found\n");
+                                                dI("id: not found");
 
                                                 sm_free (seap_msg->attrs);
                                                 SEXP_free(attr_val);
@@ -175,7 +175,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
                                 seap_msg->attrs[attr_i].value = SEXP_list_nth (sexp_msg, msg_n + 1);
 
                                 if (seap_msg->attrs[attr_i].value == NULL) {
-                                        dI("Unexpected error: \"%s\": No attribute value at position %u in the message (%p).\n",
+                                        dI("Unexpected error: \"%s\": No attribute value at position %u in the message (%p).",
                                            seap_msg->attrs[attr_i].name, msg_n + 1, sexp_msg);
 
                                         sm_free (seap_msg->attrs[attr_i].name);
@@ -258,9 +258,9 @@ static SEXP_t *SEAP_packet_msg2sexp (SEAP_msg_t *msg)
                 SEXP_free(r0);
         }
 
-	dI("MSG -> SEXP\n");
+	dI("MSG -> SEXP");
 	dO(OSCAP_DEBUGOBJ_SEXP, sexp);
-	dI("packet size: %zu\n", SEXP_sizeof(sexp));
+	dI("packet size: %zu", SEXP_sizeof(sexp));
 
         return (sexp);
 }
@@ -437,9 +437,9 @@ static SEXP_t *SEAP_packet_cmd2sexp (SEAP_cmd_t *cmd)
         if (cmd->args != NULL)
                 SEXP_list_add (sexp, cmd->args);
 
-	dI("CMD -> SEXP\n");
+	dI("CMD -> SEXP");
 	dO(OSCAP_DEBUGOBJ_SEXP, sexp);
-	dI("packet size: %zu\n", SEXP_sizeof(sexp));
+	dI("packet size: %zu", SEXP_sizeof(sexp));
 
         SEXP_VALIDATE(sexp);
         return (sexp);
@@ -461,7 +461,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
                 switch (SEXP_typeof (member)) {
                 case SEXP_TYPE_STRING:
                         if (SEXP_string_nth (member, 1) != ':') {
-                                dI("Invalid string/attribute in packet\n");
+                                dI("Invalid string/attribute in packet");
                                 SEXP_free (member);
                                 errno = EINVAL;
                                 return (-1);
@@ -473,7 +473,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
                                 val = SEXP_list_nth (sexp_err, ++n);
 
                                 if (!SEXP_numberp (val)) {
-                                        dI("Invalid type of :orig_id value\n");
+                                        dI("Invalid type of :orig_id value");
                                         SEXP_free (val);
                                         SEXP_free (member);
                                         errno = EINVAL;
@@ -493,7 +493,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
 				seap_err->type = SEXP_number_getu_32(val);
 
 				if (!SEXP_numberp(val)) {
-                                        dI("Invalid type of the :type attribute\n");
+                                        dI("Invalid type of the :type attribute");
                                         SEXP_free (val);
                                         SEXP_free (member);
                                         errno = EINVAL;
@@ -502,7 +502,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
 
                                 if (!(seap_err->type == SEAP_ETYPE_INT ||
 				      seap_err->type == SEAP_ETYPE_USER)) {
-					dI("Invalid value of the :type attribute\n");
+					dI("Invalid value of the :type attribute");
 					SEXP_free(val);
 					SEXP_free(member);
 					errno = EINVAL;
@@ -511,7 +511,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
 
                                 SEXP_free (val);
                         } else {
-                                dI("Unknown packet attribute\n");
+                                dI("Unknown packet attribute");
                                 SEXP_free (member);
                                 errno = EINVAL;
                                 return (-1);
@@ -524,7 +524,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
 
                         goto loop_exit;
                 default:
-                        dI("Unexpected type of packet member: list\n");
+                        dI("Unexpected type of packet member: list");
                         SEXP_free (member);
                         errno = EINVAL;
                         return (-1);
@@ -561,9 +561,9 @@ static SEXP_t *SEAP_packet_err2sexp (SEAP_err_t *err)
         if (err->data != NULL)
                 SEXP_list_add (sexp, err->data);
 
-	dI("ERR -> SEXP\n");
+	dI("ERR -> SEXP");
 	dO(OSCAP_DEBUGOBJ_SEXP, sexp);
-	dI("packet size: %zu\n", SEXP_sizeof(sexp));
+	dI("packet size: %zu", SEXP_sizeof(sexp));
 
         return (sexp);
 }
@@ -634,7 +634,7 @@ eloop_start:
                 if (SCH_SELECT(dsc->scheme, dsc, SEAP_IO_EVREAD, 0, 0) != 0)
                         return (-1);
 
-                dI("return from select\n");
+                dI("return from select");
 
                 switch (DESC_TRYRLOCK (dsc)) {
                 case  1:
@@ -653,7 +653,7 @@ eloop_start:
                         fail_rmutex:
 
                         protect_errno {
-                                dI("An error ocured while locking the read mutex: dsc=%p, errno=%u, %s.\n",
+                                dI("An error ocured while locking the read mutex: dsc=%p, errno=%u, %s.",
                                    dsc, errno, strerror (errno));
                         }
 
@@ -687,7 +687,7 @@ eloop_exit:
 
                 if (data_length < 0) {
                         protect_errno {
-                                dI("FAIL: recv failed: dsc=%p, errno=%u, %s.\n", dsc, errno, strerror (errno));
+                                dI("FAIL: recv failed: dsc=%p, errno=%u, %s.", dsc, errno, strerror (errno));
 
                                 sm_free (data_buffer);
                                 SEXP_psetup_free (psetup);
@@ -697,12 +697,12 @@ eloop_exit:
                         }
                         return (-1);
                 } else if (data_length == 0) {
-                        dI("zero bytes received -> EOF\n");
+                        dI("zero bytes received -> EOF");
                         sm_free (data_buffer);
                         SEXP_psetup_free (psetup);
 
                         if (pstate != NULL) {
-                                dI("FAIL: incomplete S-exp received\n");
+                                dI("FAIL: incomplete S-exp received");
                                 errno = ENETRESET;
                                 return (-1);
                         } else {
@@ -731,12 +731,12 @@ eloop_exit:
                                 SEXP_list_free (sexp_buffer);
                                 SEXP_psetup_free (psetup);
 				SEXP_free(sexp_buffer);
-                                dI("eloop_restart\n");
+                                dI("eloop_restart");
                                 goto eloop_start;
                         }
                 } else {
 			if (pstate == NULL || SEXP_pstate_errorp(pstate)) {
-				dI("FAIL: S-exp parsing error, buffer: length: %ld, content:\n%*.s\n",
+				dI("FAIL: S-exp parsing error, buffer: length: %ld, content:\n%*.s",
 				   data_length, data_length, data_buffer);
 
 				SEXP_psetup_free(psetup);
@@ -752,13 +752,13 @@ eloop_exit:
                         switch (errno) {
                         case ETIMEDOUT:
                                 protect_errno {
-                                        dI("FAIL: recv failed (timeout): dsc=%p, time=%hu, errno=%u, %s.\n",
+                                        dI("FAIL: recv failed (timeout): dsc=%p, time=%hu, errno=%u, %s.",
                                            dsc, ctx->recv_timeout, errno, strerror (errno));
                                 }
                                 /* FALLTHROUGH */
                         default:
                                 protect_errno {
-                                        dI("FAIL: recv failed: dsc=%p, errno=%u, %s.\n",
+                                        dI("FAIL: recv failed: dsc=%p, errno=%u, %s.",
                                            dsc, errno, strerror (errno));
 
                                         SEXP_psetup_free (psetup);
@@ -776,7 +776,7 @@ eloop_exit:
 
         while((sexp_packet = SEXP_list_pop (sexp_buffer)) != NULL) {
 		if (!SEXP_listp(sexp_packet)) {
-			dI("Invalid SEAP packet received: %s.\n", "not a list");
+			dI("Invalid SEAP packet received: %s.", "not a list");
 
 			SEXP_free (sexp_packet);
 			SEXP_free (sexp_buffer);
@@ -784,7 +784,7 @@ eloop_exit:
 			errno = EINVAL;
 			return (-1);
 		} else if (SEXP_list_length (sexp_packet) < 2) {
-			dI("Invalid SEAP packet received: %s.\n", "list length < 2");
+			dI("Invalid SEAP packet received: %s.", "list length < 2");
 
 			SEXP_free (sexp_packet);
 			SEXP_free (sexp_buffer);
@@ -796,7 +796,7 @@ eloop_exit:
 		psym_sexp = SEXP_list_first (sexp_packet);
 
 		if (!SEXP_stringp(psym_sexp)) {
-			dI("Invalid SEAP packet received: %s.\n", "first list item is not a string");
+			dI("Invalid SEAP packet received: %s.", "first list item is not a string");
 
 			SEXP_free (psym_sexp);
 			SEXP_free (sexp_packet);
@@ -805,7 +805,7 @@ eloop_exit:
 			errno = EINVAL;
 			return (-1);
 		} else if (SEXP_string_length (psym_sexp) != (strlen (SEAP_SYM_PREFIX) + 3)) {
-			dI("Invalid SEAP packet received: %s.\n", "invalid packet type symbol length");
+			dI("Invalid SEAP packet received: %s.", "invalid packet type symbol length");
 
 			SEXP_free (psym_sexp);
 			SEXP_free (sexp_packet);
@@ -814,7 +814,7 @@ eloop_exit:
 			errno = EINVAL;
 			return (-1);
 		} else if (SEXP_strncmp (psym_sexp, SEAP_SYM_PREFIX, strlen (SEAP_SYM_PREFIX)) != 0) {
-			dI("Invalid SEAP packet received: %s.\n", "invalid prefix");
+			dI("Invalid SEAP packet received: %s.", "invalid prefix");
 
 			SEXP_free (psym_sexp);
 			SEXP_free (sexp_packet);
@@ -838,7 +838,7 @@ eloop_exit:
 
 				if (SEAP_packet_sexp2msg (sexp_packet, &(_packet->data.msg)) != 0) {
 					/* error */
-					dI("Invalid SEAP packet received: %s.\n", "can't translate to msg struct");
+					dI("Invalid SEAP packet received: %s.", "can't translate to msg struct");
 
 					SEXP_free (sexp_packet);
 					SEAP_packet_free(_packet);
@@ -859,7 +859,7 @@ eloop_exit:
 
 				if (SEAP_packet_sexp2cmd (sexp_packet, &(_packet->data.cmd)) != 0) {
 					/* error */
-					dI("Invalid SEAP packet received: %s.\n", "can't translate to cmd struct");
+					dI("Invalid SEAP packet received: %s.", "can't translate to cmd struct");
 					SEXP_free (sexp_packet);
 					SEAP_packet_free(_packet);
 					SEXP_free (sexp_buffer);
@@ -879,7 +879,7 @@ eloop_exit:
 
 				if (SEAP_packet_sexp2err (sexp_packet, &(_packet->data.err)) != 0) {
 					/* error */
-					dI("Invalid SEAP packet received: %s.\n", "can't translate to err struct");
+					dI("Invalid SEAP packet received: %s.", "can't translate to err struct");
 					SEXP_free (sexp_packet);
 					SEAP_packet_free(_packet);
 					SEXP_free (sexp_buffer);
@@ -892,7 +892,7 @@ eloop_exit:
 			/* FALLTHROUGH */
 		default:
 		invalid:
-			dI("Invalid SEAP packet received: %s.\n", "invalid packet type symbol");
+			dI("Invalid SEAP packet received: %s.", "invalid packet type symbol");
 			SEXP_free (sexp_packet);
 			SEXP_free (sexp_buffer);
 			errno = EINVAL;
@@ -900,9 +900,9 @@ eloop_exit:
 		}
 
 
-		dI("Received packet\n");
+		dI("Received packet");
 		dO(OSCAP_DEBUGOBJ_SEXP, sexp_packet);
-		dI("packet size: %zu\n", SEXP_sizeof(sexp_packet));
+		dI("packet size: %zu", SEXP_sizeof(sexp_packet));
 
 		SEXP_free(sexp_packet);
 
@@ -968,7 +968,7 @@ int SEAP_packet_send (SEAP_CTX_t *ctx, int sd, SEAP_packet_t *packet)
         packet_sexp = SEAP_packet2sexp (packet);
 
         if (packet_sexp == NULL) {
-                dI("Can't convert S-exp to packet\n");
+                dI("Can't convert S-exp to packet");
                 return (-1);
         }
 
@@ -979,7 +979,7 @@ int SEAP_packet_send (SEAP_CTX_t *ctx, int sd, SEAP_packet_t *packet)
                         ret = -1;
 
                         protect_errno {
-                                dI("FAIL: errno=%u, %s.\n", errno, strerror (errno));
+                                dI("FAIL: errno=%u, %s.", errno, strerror (errno));
                         }
                 }
 

--- a/src/OVAL/probes/SEAP/seap.c
+++ b/src/OVAL/probes/SEAP/seap.c
@@ -116,7 +116,7 @@ int SEAP_connect (SEAP_CTX_t *ctx, const char *uri, uint32_t flags)
         sd = SEAP_desc_add (ctx->sd_table, NULL, scheme, NULL);
 
         if (sd < 0) {
-                dI("Can't create/add new SEAP descriptor\n");
+                dI("Can't create/add new SEAP descriptor");
                 return (-1);
         }
 
@@ -128,7 +128,7 @@ int SEAP_connect (SEAP_CTX_t *ctx, const char *uri, uint32_t flags)
         }
 
         if (SCH_CONNECT(scheme, dsc, uri + schstr_len + 1, flags) != 0) {
-                dI("FAIL: errno=%u, %s.\n", errno, strerror (errno));
+                dI("FAIL: errno=%u, %s.", errno, strerror (errno));
                 SEAP_desc_del(ctx->sd_table, sd);
 
                 return (-1);
@@ -157,7 +157,7 @@ int SEAP_openfd2 (SEAP_CTX_t *ctx, int ifd, int ofd, uint32_t flags)
         sd = SEAP_desc_add (ctx->sd_table, NULL, SCH_GENERIC, NULL);
 
         if (sd < 0) {
-                dI("Can't create/add new SEAP descriptor\n");
+                dI("Can't create/add new SEAP descriptor");
                 return (-1);
         }
 
@@ -169,7 +169,7 @@ int SEAP_openfd2 (SEAP_CTX_t *ctx, int ifd, int ofd, uint32_t flags)
         }
 
         if (SCH_OPENFD2(SCH_GENERIC, dsc, ifd, ofd, flags) != 0) {
-                dI("FAIL: errno=%u, %s.\n", errno, strerror (errno));
+                dI("FAIL: errno=%u, %s.", errno, strerror (errno));
                 return (-1);
         }
 
@@ -219,7 +219,7 @@ static int __SEAP_cmdexec_reply (SEAP_CTX_t *ctx, int sd, SEAP_cmd_t *cmd)
 
         if (SEAP_packet_send (ctx, sd, packet) != 0) {
                 protect_errno {
-                        dI("FAIL: errno=%u, %s.\n", errno, strerror (errno));
+                        dI("FAIL: errno=%u, %s.", errno, strerror (errno));
                         SEAP_packet_free (packet);
                 }
                 return (-1);
@@ -280,7 +280,7 @@ int __SEAP_recvmsg_process_cmd (SEAP_CTX_t *ctx, int sd, SEAP_cmd_t *cmd)
                 if (pthread_create (&th, &th_attrs,
                                     &__SEAP_cmdexec_worker, (void *)job) != 0)
                 {
-                        dI("Can't create worker thread: %u, %s.\n", errno, strerror (errno));
+                        dI("Can't create worker thread: %u, %s.", errno, strerror (errno));
                         SEAP_cmdjob_free (job);
                         pthread_attr_destroy (&th_attrs);
 
@@ -356,7 +356,7 @@ int SEAP_recvmsg (SEAP_CTX_t *ctx, int sd, SEAP_msg_t **seap_msg)
         for (;;) {
                 if (SEAP_packet_recv (ctx, sd, &packet) != 0) {
 			protect_errno {
-				dI("FAIL: ctx=%p, sd=%d, errno=%u, %s.\n",
+				dI("FAIL: ctx=%p, sd=%d, errno=%u, %s.",
 				   ctx, sd, errno, strerror (errno));
 			}
                         return (-1);
@@ -466,7 +466,7 @@ int SEAP_reply (SEAP_CTX_t *ctx, int sd, SEAP_msg_t *rep_msg, SEAP_msg_t *req_ms
                         SEAP_msg_t *nil_msg;
                         int         ret;
 
-                        dI("no-reply set: sending empty reply\n");
+                        dI("no-reply set: sending empty reply");
 
                         nil_msg = SEAP_msg_clone (rep_msg);
                         SEAP_msg_unset (nil_msg);
@@ -475,7 +475,7 @@ int SEAP_reply (SEAP_CTX_t *ctx, int sd, SEAP_msg_t *rep_msg, SEAP_msg_t *req_ms
 
                         return (ret);
                 } else {
-                        dI("no-reply not set: sending full reply\n");
+                        dI("no-reply not set: sending full reply");
                         return SEAP_sendmsg (ctx, sd, rep_msg);
                 }
         } else {
@@ -500,7 +500,7 @@ static int __SEAP_senderr (SEAP_CTX_t *ctx, int sd, SEAP_err_t *err, unsigned in
 
         if (SEAP_packet_send (ctx, sd, packet) != 0) {
                 protect_errno {
-                        dI("FAIL: errno=%u, %s.\n", errno, strerror (errno));
+                        dI("FAIL: errno=%u, %s.", errno, strerror (errno));
                         SEAP_packet_free (packet);
                 }
 
@@ -609,7 +609,7 @@ int SEAP_close (SEAP_CTX_t *ctx, int sd)
         protect_errno {
                 if (SEAP_desc_del (ctx->sd_table, sd) != 0) {
                         /* something very bad happened */
-                        dI("SEAP_desc_del failed\n");
+                        dI("SEAP_desc_del failed");
                         return(-1);
                 }
         }

--- a/src/OVAL/probes/SEAP/sexp-handler.c
+++ b/src/OVAL/probes/SEAP/sexp-handler.c
@@ -90,10 +90,10 @@ SEXP_handler_t *SEXP_gethandler (SEXP_handlertbl_t *htbl, const char *typestr, s
         key.handler.typelen = typelen;
 
         if ((nret = RB_SEARCH(handlers)(&(htbl->tree), &key)) != NULL) {
-                dI("Found handler for: %.*s\n", key.handler.typelen, key.handler.typestr);
+                dI("Found handler for: %.*s", key.handler.typelen, key.handler.typestr);
                 ret = &(nret->handler);
         } else {
-                dI("Handler for %.*s not found\n", key.handler.typelen, key.handler.typestr);
+                dI("Handler for %.*s not found", key.handler.typelen, key.handler.typestr);
                 ret = NULL;
         }
 
@@ -119,10 +119,10 @@ SEXP_handler_t *SEXP_reghandler (SEXP_handlertbl_t *htbl, SEXP_handler_t *handle
         memcpy (&(new->handler), handler, sizeof (SEXP_handler_t));
 
         if (RB_INSERT(handlers)(&(htbl->tree), new) == E_OK) {
-                dI("Registered handler for: %.*s\n", handler->typelen, handler->typestr);
+                dI("Registered handler for: %.*s", handler->typelen, handler->typestr);
                 ret = &(new->handler);
         } else {
-                dI("Failed to register handler for: %.*s\n", handler->typelen, handler->typestr);
+                dI("Failed to register handler for: %.*s", handler->typelen, handler->typestr);
                 sm_free (new);
                 ret = NULL;
         }

--- a/src/OVAL/probes/SEAP/sexp-manip.c
+++ b/src/OVAL/probes/SEAP/sexp-manip.c
@@ -1399,7 +1399,7 @@ SEXP_t *SEXP_list_sort(SEXP_t *list, int(*compare)(const SEXP_t *, const SEXP_t 
 
         list_it[0].block = SEXP_LCASTP(v_dsc.mem)->b_addr;
 
-        dI("Sorting blocks & building iterator array\n");
+        dI("Sorting blocks & building iterator array");
 
         while (list_it[list_it_count - 1].block != NULL) {
                 /* initialize the rest of the iterator */
@@ -1413,7 +1413,7 @@ SEXP_t *SEXP_list_sort(SEXP_t *list, int(*compare)(const SEXP_t *, const SEXP_t 
 
                 /* reallocate the iterator array if needed */
                 if (list_it_count == list_it_alloc) {
-                        dI("Reallocating iterator array: %z -> %z\n",
+                        dI("Reallocating iterator array: %z -> %z",
                            list_it_alloc, list_it_alloc + SEXP_LISTIT_ARRAY_INC);
 
                         list_it_alloc += SEXP_LISTIT_ARRAY_INC;
@@ -1426,7 +1426,7 @@ SEXP_t *SEXP_list_sort(SEXP_t *list, int(*compare)(const SEXP_t *, const SEXP_t 
         }
 
         --list_it_count;
-        dI("Iterator count = %zu\n", list_it_count);
+        dI("Iterator count = %zu", list_it_count);
 
         if (list_it_count > 0) {
                 /*
@@ -1463,7 +1463,7 @@ SEXP_t *SEXP_list_sort(SEXP_t *list, int(*compare)(const SEXP_t *, const SEXP_t 
 								    list_it[min_i].count - 1, sizeof(SEXP_t), (void *)&tmp_v,
 								    (int(*)(void *, void *))compare, &dst_i);
 
-						dI("dst_i = %zu\n", dst_i);
+						dI("dst_i = %zu", dst_i);
 
 						/* make place for the old value in the min. value source block */
 						memmove(list_it[min_i].block->memb, list_it[min_i].block->memb + 1,
@@ -2083,7 +2083,7 @@ void __SEXP_VALIDATE(const SEXP_t *s_exp, const char *file, uint32_t line, const
         SEXP_val_t v_dsc;
 
 #ifdef SEXP_VALIDATE_DEBUG
-        dI("VALIDATE: s_exp=%p (%s:%u:%s)\n", s_exp, file, line, func);
+        dI("VALIDATE: s_exp=%p (%s:%u:%s)", s_exp, file, line, func);
 #endif
 
         if (getenv ("SEXP_VALIDATE_DISABLE") != NULL)

--- a/src/OVAL/probes/SEAP/sexp-manip_r.c
+++ b/src/OVAL/probes/SEAP/sexp-manip_r.c
@@ -409,7 +409,7 @@ void __SEXP_free_r (SEXP_t *s_exp, const char *file, uint32_t line, const char *
 #endif
 {
 #if !defined(NDEBUG) && defined(SEAP_VERBOSE_DEBUG)
-        dI("s_exp=%p (%s:%u:%s)\n", s_exp, file, line, func);
+        dI("s_exp=%p (%s:%u:%s)", s_exp, file, line, func);
 #endif
         if (s_exp == NULL)
                 return;

--- a/src/OVAL/probes/SEAP/sexp-value.c
+++ b/src/OVAL/probes/SEAP/sexp-value.c
@@ -48,7 +48,7 @@ int SEXP_val_new (SEXP_val_t *dst, size_t vmemsize, SEXP_type_t type)
         dst->type      = type;
         dst->ptr       = SEXP_val_ptr (dst);
 #if defined(SEAP_VERBOSE_DEBUG)
-        dI("\n"
+        dI(""
            "new value: hdr->refs = %u\n"
            "           hdr->size = %zu\n"
            "                type = %hhu\n"

--- a/src/OVAL/probes/SEAP/sm_alloc.c
+++ b/src/OVAL/probes/SEAP/sm_alloc.c
@@ -128,12 +128,12 @@ void *__sm_alloc_dbg (size_t s, const char *func, size_t line)
         m = malloc (s);
 #if defined(SEAP_MALLOC_EXIT)
         if (m == NULL) {
-                dI("FAIL: size=%zu\n", s);
+                dI("FAIL: size=%zu", s);
                 exit (ENOMEM);
         }
 #endif
 #if defined(SEAP_VERBOSE_DEBUG)
-        dI("%s:%u, ptr=%p, size=%zu\n", func, line, m, s);
+        dI("%s:%u, ptr=%p, size=%zu", func, line, m, s);
 #endif
         return (m);
 }
@@ -148,13 +148,13 @@ void *__sm_calloc_dbg (size_t n, size_t s, const char *f, size_t l)
         m = calloc (n, s);
 #if defined(SEAP_MALLOC_EXIT)
         if (m == NULL) {
-                dI("FAIL: nmemb=%zu, size=%zu, total=%zu\n",
+                dI("FAIL: nmemb=%zu, size=%zu, total=%zu",
                    n, s, n * s);
                 exit (ENOMEM);
         }
 #endif
 #if defined(SEAP_VERBOSE_DEBUG)
-        dI("ptr=%p, nmemb=%zu, size=%zu, total=%zu\n",
+        dI("ptr=%p, nmemb=%zu, size=%zu, total=%zu",
            m, n, s, n * s);
 #endif
         return (m);
@@ -166,12 +166,12 @@ void *__sm_realloc_dbg (void *p, size_t s, const char *f, size_t l)
         m = realloc (p, s);
 #if defined(SEAP_MALLOC_EXIT)
         if (m == NULL && s > 0) {
-                dI("FAIL: old=%p, size=%zu\n", p, s);
+                dI("FAIL: old=%p, size=%zu", p, s);
                 exit (ENOMEM);
         }
 #endif
 #if defined(SEAP_VERBOSE_DEBUG)
-        dI("%s:%u, old=%p, new=%p, size=%zu\n", f, l, p, m, s);
+        dI("%s:%u, old=%p, new=%p, size=%zu", f, l, p, m, s);
 #endif
         return (m);
 }
@@ -181,14 +181,14 @@ void *__sm_reallocf_dbg (void *p, size_t s, const char *f, size_t l)
         void *m;
         m = realloc (p, s);
         if (m == NULL && s > 0) {
-                dI("FAIL: old=%p, size=%zu\n", p, s);
+                dI("FAIL: old=%p, size=%zu", p, s);
                 sm_free (p);
 #if defined(SEAP_MALLOC_EXIT)
                 exit (ENOMEM);
 #endif
         } else {
 #if defined(SEAP_VERBOSE_DEBUG)
-                dI("old=%p, new=%p, size=%zu\n", p, m, s);
+                dI("old=%p, new=%p, size=%zu", p, m, s);
 #endif
         }
         return (m);
@@ -204,7 +204,7 @@ int __sm_memalign_dbg (void **p, size_t a, size_t s, const char *f, size_t l)
 
 #if defined(SEAP_MALLOC_EXIT)
         if (ret != 0) {
-                dI("FAIL: p=%p, a=%zu, s=%zu\n", p, a, s);
+                dI("FAIL: p=%p, a=%zu, s=%zu", p, a, s);
                 exit (ret);
         }
 #endif
@@ -217,7 +217,7 @@ void __sm_free_dbg (void *p, const char *f, size_t l)
         _A(p != NULL);
 #endif
 #if defined(SEAP_VERBOSE_DEBUG)
-        dI("ptr=%p\n", p);
+        dI("ptr=%p", p);
 #endif
         if (p != NULL)
                 free (p);

--- a/src/OVAL/probes/independent/environmentvariable58.c
+++ b/src/OVAL/probes/independent/environmentvariable58.c
@@ -75,7 +75,7 @@ static int read_environment(SEXP_t *pid_ent, SEXP_t *name_ent, probe_ctx *ctx)
 
 	d = opendir("/proc");
 	if (d == NULL) {
-		dE("Can't read /proc: errno=%d, %s.\n", errno, strerror (errno));
+		dE("Can't read /proc: errno=%d, %s.", errno, strerror (errno));
 		return PROBE_EACCESS;
 	}
 
@@ -102,7 +102,7 @@ static int read_environment(SEXP_t *pid_ent, SEXP_t *name_ent, probe_ctx *ctx)
 		sprintf(env_file, "/proc/%d/environ", pid);
 
 		if ((fd = open(env_file, O_RDONLY)) == -1) {
-			dE("Can't open \"%s\": errno=%d, %s.\n", env_file, errno, strerror (errno));
+			dE("Can't open \"%s\": errno=%d, %s.", env_file, errno, strerror (errno));
 			item = probe_item_create(
 					OVAL_INDEPENDENT_ENVIRONMENT_VARIABLE58, NULL,
 					"pid", OVAL_DATATYPE_INTEGER, (int64_t)pid,

--- a/src/OVAL/probes/independent/filehash.c
+++ b/src/OVAL/probes/independent/filehash.c
@@ -193,7 +193,7 @@ void *probe_init (void)
         case 0:
                 return ((void *)&__filehash_probe_mutex);
         default:
-                dI("Can't initialize mutex: errno=%u, %s.\n", errno, strerror (errno));
+                dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
         }
 
         probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
@@ -251,7 +251,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
         case 0:
                 break;
         default:
-                dI("Can't lock mutex(%p): %u, %s.\n", &__filehash_probe_mutex, errno, strerror (errno));
+                dI("Can't lock mutex(%p): %u, %s.", &__filehash_probe_mutex, errno, strerror (errno));
 
 		SEXP_free (behaviors);
 		SEXP_free (path);
@@ -279,7 +279,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
         case 0:
                 break;
         default:
-                dI("Can't unlock mutex(%p): %u, %s.\n", &__filehash_probe_mutex, errno, strerror (errno));
+                dI("Can't unlock mutex(%p): %u, %s.", &__filehash_probe_mutex, errno, strerror (errno));
 
 		return (PROBE_EFATAL);
         }

--- a/src/OVAL/probes/independent/filehash58.c
+++ b/src/OVAL/probes/independent/filehash58.c
@@ -213,7 +213,7 @@ void *probe_init (void)
 	case 0:
 		return ((void *)&__filehash58_probe_mutex);
 	default:
-		dI("Can't initialize mutex: errno=%u, %s.\n", errno, strerror (errno));
+		dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
 	}
 
 	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
@@ -275,7 +275,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
 	case 0:
 		break;
 	default:
-		dI("Can't lock mutex(%p): %u, %s.\n", &__filehash58_probe_mutex, errno, strerror (errno));
+		dI("Can't lock mutex(%p): %u, %s.", &__filehash58_probe_mutex, errno, strerror (errno));
 
 		err = PROBE_EFATAL;
 		goto cleanup;
@@ -311,7 +311,7 @@ cleanup:
 	case 0:
 		break;
 	default:
-		dI("Can't unlock mutex(%p): %u, %s.\n", &__filehash58_probe_mutex, errno, strerror (errno));
+		dI("Can't unlock mutex(%p): %u, %s.", &__filehash58_probe_mutex, errno, strerror (errno));
 
 		err = PROBE_EFATAL;
 	}

--- a/src/OVAL/probes/independent/filemd5.c
+++ b/src/OVAL/probes/independent/filemd5.c
@@ -171,7 +171,7 @@ void *probe_init (void)
         case 0:
                 return ((void *)&__filemd5_probe_mutex);
         default:
-                dI("Can't initialize mutex: errno=%u, %s.\n", errno, strerror (errno));
+                dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
         }
 
         probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
@@ -230,7 +230,7 @@ int probe_main (SEXP_t *probe_in, SEXP_t *probe_out, void *mutex, SEXP_t *filter
         case 0:
                 break;
         default:
-                dI("Can't lock mutex(%p): %u, %s.\n", &__filemd5_probe_mutex, errno, strerror (errno));
+                dI("Can't lock mutex(%p): %u, %s.", &__filemd5_probe_mutex, errno, strerror (errno));
 
 		SEXP_free (behaviors);
 		SEXP_free (path);
@@ -258,7 +258,7 @@ int probe_main (SEXP_t *probe_in, SEXP_t *probe_out, void *mutex, SEXP_t *filter
         case 0:
                 break;
         default:
-                dI("Can't unlock mutex(%p): %u, %s.\n", &__filemd5_probe_mutex, errno, strerror (errno));
+                dI("Can't unlock mutex(%p): %u, %s.", &__filemd5_probe_mutex, errno, strerror (errno));
 
 		return (PROBE_EFATAL);
         }

--- a/src/OVAL/probes/independent/ldap57.c
+++ b/src/OVAL/probes/independent/ldap57.c
@@ -89,12 +89,12 @@ int probe_main(probe_ctx *ctx, void *mutex)
                 SEXP_free(se_ldap_behaviors);
 
                 if (sa_scope == NULL) {
-                        dE("Atrribute `scope' is missing!\n");
+                        dE("Atrribute `scope' is missing!");
                         return (PROBE_ENOATTR);
                 }
 
                 if (!SEXP_stringp(sa_scope)) {
-                        dE("Invalid value type of the `scope' attribute.\n");
+                        dE("Invalid value type of the `scope' attribute.");
                         SEXP_free(sa_scope);
                         return (PROBE_EINVAL);
                 }
@@ -106,7 +106,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
                 else if (SEXP_strcmp(sa_scope, "SUBTREE") == 0)
                         scope = LDAP_SCOPE_SUBTREE;
                 else {
-                        dE("Invalid value of the `scope' attribute.\n");
+                        dE("Invalid value of the `scope' attribute.");
                         SEXP_free(sa_scope);
                         return (PROBE_EINVAL);
                 }
@@ -192,7 +192,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
                 probe_item_setstatus(item, SYSCHAR_STATUS_ERROR);
                 probe_item_collect(ctx, item);
 
-                dE("ldap_get_option failed\n");
+                dE("ldap_get_option failed");
                 goto fail0;
         }
 
@@ -221,7 +221,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
                         probe_item_setstatus(item, SYSCHAR_STATUS_ERROR);
                         probe_item_collect(ctx, item);
 
-                        dE("ldap_search_ext_s failed\n");
+                        dE("ldap_search_ext_s failed");
                         goto fail0;
                 }
 
@@ -260,13 +260,13 @@ int probe_main(probe_ctx *ctx, void *mutex)
 
                                         switch(bertag & LBER_ENCODING_MASK) {
                                         case LBER_PRIMITIVE:
-                                                dI("Found primitive value, bertag = %u\n", bertag);
+                                                dI("Found primitive value, bertag = %u", bertag);
 						break;
                                         case LBER_CONSTRUCTED:
-                                                dW("Don't know how to handle LBER_CONSTRUCTED values\n");
+                                                dW("Don't know how to handle LBER_CONSTRUCTED values");
 						/* FALLTHROUGH */
                                         default:
-                                                dW("Skipping attribute value, bertag = %u\n", bertag);
+                                                dW("Skipping attribute value, bertag = %u", bertag);
                                                 continue;
                                         }
 
@@ -278,7 +278,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
                                                 ber_int_t val = -1;
 
                                                 if (ber_get_boolean(berelm, &val) == LBER_ERROR) {
-                                                        dW("ber_get_boolean: LBER_ERROR\n");
+                                                        dW("ber_get_boolean: LBER_ERROR");
                                                         /* XXX: set error status on field */
                                                         continue;
                                                 }
@@ -293,7 +293,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
                                                 ber_int_t val = -1;
 
                                                 if (ber_get_int(berelm, &val) == LBER_ERROR) {
-                                                        dW("ber_get_int: LBER_ERROR\n");
+                                                        dW("ber_get_int: LBER_ERROR");
                                                         /* XXX: set error status on field */
                                                         continue;
                                                 }
@@ -304,7 +304,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
                                         }       break;
                                         case LBER_BITSTRING:
                                                 /* LDAPTYPE_BIT_STRING */
-                                                dW("LBER_BITSTRING: not implemented\n");
+                                                dW("LBER_BITSTRING: not implemented");
                                                 continue;
                                         case LBER_OCTETSTRING:
                                         {       /*
@@ -316,7 +316,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
                                                 char *val = NULL;
 
                                                 if (ber_get_stringa(berelm, &val) == LBER_ERROR) {
-                                                        dW("ber_get_stringa: LBER_ERROR\n");
+                                                        dW("ber_get_stringa: LBER_ERROR");
                                                         /* XXX: set error status on field */
                                                         continue;
                                                 }
@@ -329,14 +329,14 @@ int probe_main(probe_ctx *ctx, void *mutex)
                                         }       break;
                                         case LBER_NULL:
                                                 /* XXX: no equivalent LDAPTYPE_? or empty */
-                                                dI("LBER_NULL: skipped\n");
+                                                dI("LBER_NULL: skipped");
                                                 continue;
                                         case LBER_ENUMERATED:
                                                 /* XXX: no equivalent LDAPTYPE_? */
-                                                dW("Don't know how to handle LBER_ENUMERATED type\n");
+                                                dW("Don't know how to handle LBER_ENUMERATED type");
                                                 continue;
                                         default:
-                                                dW("Unknown attribute value type, bertag = %u\n", bertag);
+                                                dW("Unknown attribute value type, bertag = %u", bertag);
                                                 continue;
                                         }
 

--- a/src/OVAL/probes/independent/sql.c
+++ b/src/OVAL/probes/independent/sql.c
@@ -214,7 +214,7 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 	tmp = NULL;
 
 	while ((tok = strsep (&copy, ";")) != NULL) {
-		dI("tok: '%s'.\n", tok);
+		dI("tok: '%s'.", tok);
 		switch (tolower(*tok)) {
 			matchitem1(tok, 's',
 				  "erver", info->host); break;
@@ -248,7 +248,7 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 	oscap_free(conn_copy);
 	return (0);
 __fail:
-	dE("Parsing failed.\n");
+	dE("Parsing failed.");
 	oscap_free(conn_copy);
 	return (-1);
 }
@@ -267,7 +267,7 @@ static int dbSQL_eval(const char *engine, const char *version,
 	 * parse the connection string
 	 */
 	if (dbURIInfo_parse(&uriInfo, conn) != 0) {
-		dE("Malformed connection string: %s\n", conn);
+		dE("Malformed connection string: %s", conn);
 		goto __exit;
 	} else {
 		int            sql_err = 0;
@@ -287,7 +287,7 @@ static int dbSQL_eval(const char *engine, const char *version,
 			SEXP_free(msg);
 			probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
 			err = 0;
-			dE("DB engine not found: %s\n", engine);
+			dE("DB engine not found: %s", engine);
 			goto __exit;
 		}
 
@@ -298,7 +298,7 @@ static int dbSQL_eval(const char *engine, const char *version,
 			SEXP_free(msg);
 			probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
 			err = 0;
-			dE("DB engine not supported: %s\n", engine);
+			dE("DB engine not supported: %s", engine);
 			goto __exit;
 		}
 
@@ -306,7 +306,7 @@ static int dbSQL_eval(const char *engine, const char *version,
 				uriInfo.host, uriInfo.port);
 		if (odbx_res != ODBX_ERR_SUCCESS) {
 			const char *error_msg = odbx_error(NULL, odbx_res);
-			dE("odbx_init failed: e=%s, h=%s:%s msg=%s\n",
+			dE("odbx_init failed: e=%s, h=%s:%s msg=%s",
 				sql_dbe->b_engine, uriInfo.host, uriInfo.port,
 				error_msg != NULL ? error_msg : "(none)");
 			if (odbx_res == -ODBX_ERR_NOTEXIST) {
@@ -335,14 +335,14 @@ static int dbSQL_eval(const char *engine, const char *version,
 			SEXP_free(msg);
 			probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
 			err = 0;
-			dE("odbx_bind failed: db=%s, u=%s, p=%s\n",
+			dE("odbx_bind failed: db=%s, u=%s, p=%s",
 			   uriInfo.db, uriInfo.user, uriInfo.pass);
 			odbx_finish(sql_dbh);
 			goto __exit;
 		}
 
 		if (odbx_query(sql_dbh, sql, strlen (sql)) != ODBX_ERR_SUCCESS) {
-			dE("odbx_query failed: q=%s\n", sql);
+			dE("odbx_query failed: q=%s", sql);
 			odbx_finish(sql_dbh);
 
 			goto __exit;
@@ -359,7 +359,7 @@ static int dbSQL_eval(const char *engine, const char *version,
 
 			while ((sql_err = odbx_result (sql_dbh, &sql_dbr, NULL, 0)) == ODBX_RES_ROWS) {
 				if (odbx_column_count(sql_dbr) != 1) {
-					dE("Don't how to handle result, column count != 1\n");
+					dE("Don't how to handle result, column count != 1");
 					odbx_result_finish(sql_dbr);
 					SEXP_free(item);
 					goto __exit;
@@ -380,7 +380,7 @@ static int dbSQL_eval(const char *engine, const char *version,
 		}
 
 		if (odbx_finish(sql_dbh) != ODBX_ERR_SUCCESS) {
-			dE("odbx_finish failed\n");
+			dE("odbx_finish failed");
 			goto __exit;
 		}
 	}
@@ -404,7 +404,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 		__sval = probe_obj_getentval (obj, ent_name, 1);	\
 									\
 		if (__sval == NULL) {					\
-			dE("Missing entity or value: obj=%p, ent=%s\n", obj, #ent_name); \
+			dE("Missing entity or value: obj=%p, ent=%s", obj, #ent_name); \
 			err = PROBE_ENOENT;				\
 			goto __exit;					\
 		}							\

--- a/src/OVAL/probes/independent/sql57.c
+++ b/src/OVAL/probes/independent/sql57.c
@@ -214,7 +214,7 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 	tmp = NULL;
 
 	while ((tok = strsep (&copy, ";")) != NULL) {
-		dI("tok: '%s'.\n", tok);
+		dI("tok: '%s'.", tok);
 		switch (tolower(*tok)) {
 			matchitem1(tok, 's',
 				  "erver", info->host); break;
@@ -248,7 +248,7 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 	oscap_free(conn_copy);
 	return (0);
 __fail:
-	dE("Parsing failed.\n");
+	dE("Parsing failed.");
 	oscap_free(conn_copy);
 	return (-1);
 }
@@ -267,7 +267,7 @@ static int dbSQL_eval(const char *engine, const char *version,
 	 * parse the connection string
 	 */
 	if (dbURIInfo_parse(&uriInfo, conn) != 0) {
-		dE("Malformed connection string: %s\n", conn);
+		dE("Malformed connection string: %s", conn);
 		goto __exit;
 	} else {
 		int            sql_err = 0;
@@ -286,7 +286,7 @@ static int dbSQL_eval(const char *engine, const char *version,
 			SEXP_free(msg);
 			probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
 			err = 0;
-			dE("DB engine not found: %s\n", engine);
+			dE("DB engine not found: %s", engine);
 			goto __exit;
 		}
 
@@ -297,7 +297,7 @@ static int dbSQL_eval(const char *engine, const char *version,
 			SEXP_free(msg);
 			probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
 			err = 0;
-			dE("DB engine not supported: %s\n", engine);
+			dE("DB engine not supported: %s", engine);
 			goto __exit;
 		}
 
@@ -305,7 +305,7 @@ static int dbSQL_eval(const char *engine, const char *version,
 				uriInfo.host, uriInfo.port);
 		if (odbx_res != ODBX_ERR_SUCCESS) {
 			const char *error_msg = odbx_error(NULL, odbx_res);
-			dE("odbx_init failed: e=%s, h=%s:%s msg=%s\n",
+			dE("odbx_init failed: e=%s, h=%s:%s msg=%s",
 				sql_dbe->b_engine, uriInfo.host, uriInfo.port,
 				error_msg != NULL ? error_msg : "(none)");
 			if (odbx_res == -ODBX_ERR_NOTEXIST) {
@@ -334,14 +334,14 @@ static int dbSQL_eval(const char *engine, const char *version,
 			SEXP_free(msg);
 			probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
 			err = 0;
-			dE("odbx_bind failed: db=%s, u=%s, p=%s\n",
+			dE("odbx_bind failed: db=%s, u=%s, p=%s",
 			   uriInfo.db, uriInfo.user, uriInfo.pass);
 			odbx_finish(sql_dbh);
 			goto __exit;
 		}
 
 		if (odbx_query(sql_dbh, sql, strlen (sql)) != ODBX_ERR_SUCCESS) {
-			dE("odbx_query failed: q=%s\n", sql);
+			dE("odbx_query failed: q=%s", sql);
 			odbx_finish(sql_dbh);
 
 			goto __exit;
@@ -370,7 +370,7 @@ static int dbSQL_eval(const char *engine, const char *version,
                                                 col_type = OVAL_DATATYPE_UNKNOWN;
                                                 field    = NULL;
 
-						dI("Column type: %d.\n", odbx_column_type(sql_dbr, ci));
+						dI("Column type: %d.", odbx_column_type(sql_dbr, ci));
                                                 switch(odbx_column_type(sql_dbr, ci)) {
                                                 case ODBX_TYPE_BOOLEAN:
                                                         break;
@@ -380,7 +380,7 @@ static int dbSQL_eval(const char *engine, const char *version,
                                                         int   val = strtol(col_val, &end, 10);
 
                                                         if (val == 0 && (end == col_val))
-                                                                dE("strtol(%s) failed\n", col_val);
+                                                                dE("strtol(%s) failed", col_val);
 
 							field    = probe_ent_creat1(col_name, NULL, SEXP_number_newi_r(&se_tmp_mem, val));
                                                         col_type = OVAL_DATATYPE_INTEGER;
@@ -394,7 +394,7 @@ static int dbSQL_eval(const char *engine, const char *version,
                                                         double val = strtod(col_val, &end);
 
                                                         if (val == 0 && (end == col_val))
-                                                                dE("strtod(%s) failed\n", col_val);
+                                                                dE("strtod(%s) failed", col_val);
 
 							field    = probe_ent_creat1(col_name, NULL, SEXP_number_newf_r(&se_tmp_mem, val));
                                                         col_type = OVAL_DATATYPE_FLOAT;
@@ -412,7 +412,7 @@ static int dbSQL_eval(const char *engine, const char *version,
                                                 case ODBX_TYPE_TIMESTAMP:
                                                         break;
 						default:
-							dW("Unsupported ODBX type: %d.\n", odbx_column_type(sql_dbr, ci));
+							dW("Unsupported ODBX type: %d.", odbx_column_type(sql_dbr, ci));
 							break;
                                                 }
 
@@ -435,7 +435,7 @@ static int dbSQL_eval(const char *engine, const char *version,
 		}
 
 		if (odbx_finish(sql_dbh) != ODBX_ERR_SUCCESS) {
-			dE("odbx_finish failed\n");
+			dE("odbx_finish failed");
 			goto __exit;
 		}
 	}
@@ -459,7 +459,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 		__sval = probe_obj_getentval (obj, ent_name, 1);	\
 									\
 		if (__sval == NULL) {					\
-			dE("Missing entity or value: obj=%p, ent=%s\n", obj, #ent_name); \
+			dE("Missing entity or value: obj=%p, ent=%s", obj, #ent_name); \
 			err = PROBE_ENOENT;				\
 			goto __exit;					\
 		}							\

--- a/src/OVAL/probes/independent/textfilecontent.c
+++ b/src/OVAL/probes/independent/textfilecontent.c
@@ -188,7 +188,7 @@ static SEXP_t *create_item(const char *path, const char *filename, char *pattern
 	char *text;
 
         if (strlen(path) + strlen(filename) + 1 > PATH_MAX) {
-                dE("path+filename too long\n");
+                dE("path+filename too long");
                 return (NULL);
         }
 

--- a/src/OVAL/probes/independent/textfilecontent54.c
+++ b/src/OVAL/probes/independent/textfilecontent54.c
@@ -168,7 +168,7 @@ static SEXP_t *create_item(const char *path, const char *filename, char *pattern
 	char *text;
 
         if (strlen(path) + strlen(filename) + 1 > PATH_MAX) {
-                dE("path+filename too long\n");
+                dE("path+filename too long");
                 return (NULL);
         }
 

--- a/src/OVAL/probes/independent/xmlfilecontent.c
+++ b/src/OVAL/probes/independent/xmlfilecontent.c
@@ -174,7 +174,7 @@ static int process_file(const char *path, const char *filename, void *arg)
                                  "xpath",    OVAL_DATATYPE_STRING, pfd->xpath,
                                  NULL);
 
-	dI("xpath obj type: %d.\n", xpath_obj->type);
+	dI("xpath obj type: %d.", xpath_obj->type);
 	switch(xpath_obj->type) {
 	case XPATH_BOOLEAN:
 	{
@@ -223,7 +223,7 @@ static int process_file(const char *path, const char *filename, void *arg)
 		}
 
 		node_cnt = nodes->nodeNr;
-		dI("node_cnt: %d.\n", node_cnt);
+		dI("node_cnt: %d.", node_cnt);
 		if (node_cnt == 0) {
 			probe_item_setstatus(item, SYSCHAR_STATUS_DOES_NOT_EXIST);
 			probe_item_ent_add(item, "value_of", NULL, NULL);
@@ -232,7 +232,7 @@ static int process_file(const char *path, const char *filename, void *arg)
 			node_tab = nodes->nodeTab;
 			for (i = 0; i < node_cnt; ++i) {
 				cur_node = node_tab[i];
-				dI("node[%d] line: %d, name: '%s', type: %d.\n",
+				dI("node[%d] line: %d, name: '%s', type: %d.",
 				   i, cur_node->line, cur_node->name, cur_node->type);
 				if (cur_node->type == XML_ATTRIBUTE_NODE
 				    || cur_node->type == XML_TEXT_NODE) {

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -114,7 +114,7 @@ static OVAL_FTSENT *OVAL_FTSENT_new(OVAL_FTS *ofts, FTSENT *fts_ent)
 	}
 
 #if defined(OSCAP_FTS_DEBUG)
-	dI("\n"
+	dI(""
 	   "New OVAL_FTSENT:\n"
 	   "\t    file: '%s'.\n"
 	   "\t    path: '%s'.\n", ofts_ent->file, ofts_ent->path);
@@ -479,7 +479,7 @@ static int process_pattern_match(const char *path, pcre **regex_out)
 	}
 
 	if (regex == NULL) {
-		dI("Disabling partial match optimization.\n");
+		dI("Disabling partial match optimization.");
 	} else {
 		dI("Enabling partial match optimization using "
 		   "pattern: '%s'.\n", pattern);
@@ -534,7 +534,7 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 		path_op = OVAL_OPERATION_EQUALS;
 	}
 #if defined(OSCAP_FTS_DEBUG)
-	dI("path_op: %u, '%s'.\n", path_op, oval_operation_get_text(path_op));
+	dI("path_op: %u, '%s'.", path_op, oval_operation_get_text(path_op));
 #endif
 	if (path) { /* filepath == NULL */
 		PROBE_ENT_STRVAL(path, cstr_path, sizeof cstr_path,
@@ -546,7 +546,7 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 					 return NULL;, /* noop */;);
 		}
 #if defined(OSCAP_FTS_DEBUG)
-		dI("\n"
+		dI(""
 		   "        path: '%s'.\n"
 		   "    filename: '%s'.\n"
 		   "nil filename: %d.\n", cstr_path, nilfilename ? "" : cstr_file, nilfilename);
@@ -560,12 +560,12 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 	SEXP_string_cstr_r(r0, cstr_buff, sizeof cstr_buff - 1);
 	max_depth = strtol(cstr_buff, NULL, 10);
 	if (errno == EINVAL || errno == ERANGE) {
-		dE("Invalid value of the `%s' attribute: %s\n", "recurse_direction", cstr_buff);
+		dE("Invalid value of the `%s' attribute: %s", "recurse_direction", cstr_buff);
 		SEXP_free(r0);
 		return (NULL);
 	}
 #if defined(OSCAP_FTS_DEBUG)
-	dI("bh.max_depth: %s => max_depth: %d\n", cstr_buff, max_depth);
+	dI("bh.max_depth: %s => max_depth: %d", cstr_buff, max_depth);
 #endif
 	SEXP_free(r0);
 
@@ -580,12 +580,12 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 	} else if (strcmp(cstr_buff, "up") == 0) {
 		direction = OVAL_RECURSE_DIRECTION_UP;
 	} else {
-		dE("Invalid direction: %s\n", cstr_buff);
+		dE("Invalid direction: %s", cstr_buff);
 		SEXP_free(r0);
 		return (NULL);
 	}
 #if defined(OSCAP_FTS_DEBUG)
-	dI("bh.direction: %s => direction: %d\n", cstr_buff, direction);
+	dI("bh.direction: %s => direction: %d", cstr_buff, direction);
 #endif
 	SEXP_free(r0);
 
@@ -603,7 +603,7 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 		} else if (strcmp(cstr_buff, "directories") == 0) {
 			recurse = OVAL_RECURSE_DIRS;
 		} else {
-			dE("Invalid recurse: %s\n", cstr_buff);
+			dE("Invalid recurse: %s", cstr_buff);
 			SEXP_free(r0);
 			return (NULL);
 		}
@@ -611,7 +611,7 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 		recurse = OVAL_RECURSE_SYMLINKS_AND_DIRS;
 	}
 #if defined(OSCAP_FTS_DEBUG)
-	dI("bh.recurse: %s => recurse: %d\n", cstr_buff, recurse);
+	dI("bh.recurse: %s => recurse: %d", cstr_buff, recurse);
 #endif
 	SEXP_free(r0);
 
@@ -629,7 +629,7 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 			filesystem = OVAL_RECURSE_FS_DEFINED;
 			rec_fts_options |= FTS_XDEV;
 		} else {
-			dE("Invalid recurse filesystem: %s\n", cstr_buff);
+			dE("Invalid recurse filesystem: %s", cstr_buff);
 			SEXP_free(r0);
 			return (NULL);
 		}
@@ -637,7 +637,7 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 		filesystem = OVAL_RECURSE_FS_ALL;
 	}
 #if defined(OSCAP_FTS_DEBUG)
-	dI("bh.filesystem: %s => filesystem: %d\n", cstr_buff, filesystem);
+	dI("bh.filesystem: %s => filesystem: %d", cstr_buff, filesystem);
 #endif
 	SEXP_free(r0);
 
@@ -654,7 +654,7 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 		if (process_pattern_match(cstr_path, &regex) != 0)
 			return NULL;
 		paths[0] = extract_fixed_path_prefix(cstr_path);
-		dI("Extracted fixed path: '%s'.\n", paths[0]);
+		dI("Extracted fixed path: '%s'.", paths[0]);
 	} else {
 		paths[0] = strdup("/");
 	}
@@ -663,14 +663,14 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 	   without targets are accepted. */
 	if (lstat(paths[0], &st) == -1) {
 		if (errno) {
-			dE("lstat() failed: errno: %d, '%s'.\n",
+			dE("lstat() failed: errno: %d, '%s'.",
 			   errno, strerror(errno));
 		}
 		free((void *) paths[0]);
 		return NULL;
 	}
 
-	dI("fts_open args: path: \"%s\", options: %d.\n", paths[0], mtc_fts_options);
+	dI("fts_open args: path: \"%s\", options: %d.", paths[0], mtc_fts_options);
 
 	ofts = OVAL_FTS_new();
 	/* reset errno as fts_open() doesn't do it itself. */
@@ -680,7 +680,7 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 	/* fts_open() doesn't return NULL for all errors (e.g. nonexistent paths),
 	   so check errno to detect it. Far from being perfect. */
 	if (ofts->ofts_match_path_fts == NULL || errno != 0) {
-		dE("fts_open() failed, errno: %d \"%s\".\n", errno, strerror(errno));
+		dE("fts_open() failed, errno: %d \"%s\".", errno, strerror(errno));
 		OVAL_FTS_free(ofts);
 		return (NULL);
 	}
@@ -697,7 +697,7 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 	if (filesystem == OVAL_RECURSE_FS_LOCAL) {
 		ofts->localdevs = fsdev_init(NULL, 0);
 		if (ofts->localdevs == NULL) {
-			dE("fsdev_init() failed.\n");
+			dE("fsdev_init() failed.");
 			/* One dummy read to get rid of an uninitialized
 			 * value in the FTS data before calling
 			 * fts_close() on it. */
@@ -750,13 +750,13 @@ static FTSENT *oval_fts_read_match_path(OVAL_FTS *ofts)
 		case FTS_DP:
 			continue;
 		case FTS_DC:
-			dW("Filesystem tree cycle detected at '%s'.\n", fts_ent->fts_path);
+			dW("Filesystem tree cycle detected at '%s'.", fts_ent->fts_path);
 			fts_set(ofts->ofts_match_path_fts, fts_ent, FTS_SKIP);
 			continue;
 		}
 
 #if defined(OSCAP_FTS_DEBUG)
-		dI("fts_path: '%s' (l=%d).\n"
+		dI("fts_path: '%s' (l=%d)."
 		   "fts_name: '%s' (l=%d).\n"
 		   "fts_info: %u.\n", fts_ent->fts_path, fts_ent->fts_pathlen,
 		   fts_ent->fts_name, fts_ent->fts_namelen, fts_ent->fts_info);
@@ -764,7 +764,7 @@ static FTSENT *oval_fts_read_match_path(OVAL_FTS *ofts)
 
 		if (fts_ent->fts_info == FTS_SL) {
 #if defined(OSCAP_FTS_DEBUG)
-			dI("Only the target of a symlink gets reported, skipping '%s'.\n", fts_ent->fts_path, fts_ent->fts_name);
+			dI("Only the target of a symlink gets reported, skipping '%s'.", fts_ent->fts_path, fts_ent->fts_name);
 #endif
 			fts_set(ofts->ofts_match_path_fts, fts_ent, FTS_FOLLOW);
 			continue;
@@ -776,7 +776,7 @@ static FTSENT *oval_fts_read_match_path(OVAL_FTS *ofts)
 		    && (!OVAL_FTS_localp(ofts, fts_ent->fts_path,
 					 (fts_ent->fts_statp != NULL) ?
 					 &fts_ent->fts_statp->st_dev : NULL))) {
-			dI("Don't recurse into non-local filesystems, skipping '%s'.\n", fts_ent->fts_path);
+			dI("Don't recurse into non-local filesystems, skipping '%s'.", fts_ent->fts_path);
 			fts_set(ofts->ofts_recurse_path_fts, fts_ent, FTS_SKIP);
 			continue;
 		}
@@ -798,14 +798,14 @@ static FTSENT *oval_fts_read_match_path(OVAL_FTS *ofts)
 			if (ret < 0) {
 				switch (ret) {
 				case PCRE_ERROR_NOMATCH:
-					dI("Partial match optimization: PCRE_ERROR_NOMATCH, skipping.\n");
+					dI("Partial match optimization: PCRE_ERROR_NOMATCH, skipping.");
 					fts_set(ofts->ofts_match_path_fts, fts_ent, FTS_SKIP);
 					continue;
 				case PCRE_ERROR_PARTIAL:
-					dI("Partial match optimization: PCRE_ERROR_PARTIAL, continuing.\n");
+					dI("Partial match optimization: PCRE_ERROR_PARTIAL, continuing.");
 					continue;
 				default:
-					dE("pcre_exec() error: %d.\n", ret);
+					dE("pcre_exec() error: %d.", ret);
 					return NULL;
 				}
 			}
@@ -868,7 +868,7 @@ static FTSENT *oval_fts_read_recurse_path(OVAL_FTS *ofts)
 			char * const paths[2] = { ofts->ofts_match_path_fts_ent->fts_path, NULL };
 
 #if defined(OSCAP_FTS_DEBUG)
-			dI("fts_open args: path: \"%s\", options: %d.\n",
+			dI("fts_open args: path: \"%s\", options: %d.",
 				paths[0], ofts->ofts_recurse_path_fts_opts);
 #endif
 			/* reset errno as fts_open() doesn't do it itself. */
@@ -879,10 +879,10 @@ static FTSENT *oval_fts_read_recurse_path(OVAL_FTS *ofts)
 			   (e.g. nonexistent paths), so check errno to detect it.
 			   Far from being perfect. */
 			if (ofts->ofts_recurse_path_fts == NULL || errno != 0) {
-				dE("fts_open() failed, errno: %d \"%s\".\n",
+				dE("fts_open() failed, errno: %d \"%s\".",
 					errno, strerror(errno));
 #if !defined(OSCAP_FTS_DEBUG)
-				dE("fts_open args: path: \"%s\", options: %d.\n",
+				dE("fts_open args: path: \"%s\", options: %d.",
 					paths[0], ofts->ofts_recurse_path_fts_opts);
 #endif
 				if (ofts->ofts_recurse_path_fts != NULL) {
@@ -909,13 +909,13 @@ static FTSENT *oval_fts_read_recurse_path(OVAL_FTS *ofts)
 			case FTS_DP:
 				continue;
 			case FTS_DC:
-				dW("Filesystem tree cycle detected at '%s'.\n", fts_ent->fts_path);
+				dW("Filesystem tree cycle detected at '%s'.", fts_ent->fts_path);
 				fts_set(ofts->ofts_recurse_path_fts, fts_ent, FTS_SKIP);
 				continue;
 			}
 
 #if defined(OSCAP_FTS_DEBUG)
-			dI("fts_path: '%s' (l=%d).\n"
+			dI("fts_path: '%s' (l=%d)."
 			   "fts_name: '%s' (l=%d).\n"
 			   "fts_info: %u.\n", fts_ent->fts_path, fts_ent->fts_pathlen,
 			   fts_ent->fts_name, fts_ent->fts_namelen, fts_ent->fts_info);
@@ -997,7 +997,7 @@ static FTSENT *oval_fts_read_recurse_path(OVAL_FTS *ofts)
 				char * const paths[2] = { ofts->ofts_recurse_path_curpth, NULL };
 
 #if defined(OSCAP_FTS_DEBUG)
-				dI("fts_open args: path: \"%s\", options: %d.\n",
+				dI("fts_open args: path: \"%s\", options: %d.",
 					paths[0], ofts->ofts_recurse_path_fts_opts);
 #endif
 				/* reset errno as fts_open() doesn't do it itself. */
@@ -1008,10 +1008,10 @@ static FTSENT *oval_fts_read_recurse_path(OVAL_FTS *ofts)
 				ofts->ofts_recurse_path_fts = fts_open(paths,
 					ofts->ofts_recurse_path_fts_opts, NULL);
 				if (ofts->ofts_recurse_path_fts == NULL || errno != 0) {
-					dE("fts_open() failed, errno: %d \"%s\".\n",
+					dE("fts_open() failed, errno: %d \"%s\".",
 						errno, strerror(errno));
 #if !defined(OSCAP_FTS_DEBUG)
-					dE("fts_open args: path: \"%s\", options: %d.\n",
+					dE("fts_open args: path: \"%s\", options: %d.",
 						paths[0], ofts->ofts_recurse_path_fts_opts);
 #endif
 					if (ofts->ofts_recurse_path_fts != NULL) {
@@ -1104,7 +1104,7 @@ OVAL_FTSENT *oval_fts_read(OVAL_FTS *ofts)
 	FTSENT *fts_ent;
 
 #if defined(OSCAP_FTS_DEBUG)
-	dI("ofts: %p.\n", ofts);
+	dI("ofts: %p.", ofts);
 #endif
 
 	if (ofts == NULL)

--- a/src/OVAL/probes/oval_fts.h
+++ b/src/OVAL/probes/oval_fts.h
@@ -46,7 +46,7 @@
 		SEXP_t *___r;					\
 								\
 		if ((___r = probe_ent_getval(ent)) == NULL) {	\
-			dW("entity has no value!\n");		\
+			dW("entity has no value!");		\
 			return (NULL);				\
 		} else {					\
 			if (!SEXP_stringp(___r)) {		\

--- a/src/OVAL/probes/probe-api.c
+++ b/src/OVAL/probes/probe-api.c
@@ -427,7 +427,7 @@ SEXP_t *probe_obj_getent(const SEXP_t * obj, const char *name, uint32_t n)
 #if !defined(NDEBUG) && defined(SEAP_VERBOSE_DEBUG)
 			char buf[128];
 			SEXP_string_cstr_r(ent_name, buf, sizeof buf);
-			dI("1=\"%s\", 2=\"%s\", n=%u\n", buf, name, n);
+			dI("1=\"%s\", 2=\"%s\", n=%u", buf, name, n);
 #endif
 
 			if (SEXP_strcmp(ent_name, name) == 0 && (--n == 0)) {
@@ -672,7 +672,7 @@ void probe_cobj_set_flag(SEXP_t *cobj, oval_syschar_collection_flag_t flag)
 	of = SEXP_number_getu(old_sflag);
 	SEXP_free(old_sflag);
 	SEXP_free(sflag);
-	dI("old flag: %d, new flag: %d.\n", of, flag);
+	dI("old flag: %d, new flag: %d.", of, flag);
 }
 
 oval_syschar_collection_flag_t probe_cobj_get_flag(const SEXP_t *cobj)
@@ -682,7 +682,7 @@ oval_syschar_collection_flag_t probe_cobj_get_flag(const SEXP_t *cobj)
 
 	sflag = SEXP_list_first(cobj);
 	if (sflag == NULL) {
-		dE("sflag == NULL.\n");
+		dE("sflag == NULL.");
 		return SYSCHAR_FLAG_UNKNOWN;
 	}
 
@@ -908,7 +908,7 @@ SEXP_t *probe_msg_creat(oval_message_level_t level, char *message)
 {
 	SEXP_t *lvl, *str, *msg;
 
-	dI("%s\n", message);
+	dI("%s", message);
 	lvl = SEXP_number_newu(level);
 	str = SEXP_string_newf("%s", message);
 	msg = SEXP_list_new(lvl, str, NULL);
@@ -930,7 +930,7 @@ SEXP_t *probe_msg_creatf(oval_message_level_t level, const char *fmt, ...)
 	if (len < 0)
 		return NULL;
 
-	dI("%s\n", cstr);
+	dI("%s", cstr);
 	str = SEXP_string_new(cstr, len);
 	oscap_free(cstr);
 	lvl = SEXP_number_newu(level);
@@ -1135,7 +1135,7 @@ static oval_datatype_t _sexp_val_getdatatype(const SEXP_t *val)
 			return OVAL_DATATYPE_INTEGER;
 		}
 	default:
-		dE("Unexpected SEXP datatype: %d, '%s'.\n", sdt, SEXP_strtype(val));
+		dE("Unexpected SEXP datatype: %d, '%s'.", sdt, SEXP_strtype(val));
 		return OVAL_DATATYPE_UNKNOWN;
 	}
 }
@@ -1397,7 +1397,7 @@ SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attr
         subtype_name = oval_subtype_to_str(item_subtype);
 
         if (subtype_name == NULL) {
-                dE("Invalid/Unknown subtype: %d\n", (int)item_subtype);
+                dE("Invalid/Unknown subtype: %d", (int)item_subtype);
                 return (NULL);
         }
 
@@ -1406,7 +1406,7 @@ SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attr
                 strcat(item_name, "_item");
                 item_name[sizeof item_name - 1] = '\0';
         } else {
-                dE("item name too long: no buffer space available\n");
+                dE("item name too long: no buffer space available");
                 return (NULL);
         }
 
@@ -1488,7 +1488,7 @@ SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attr
                         /* TODO */
                 case OVAL_DATATYPE_BINARY:
                 case OVAL_DATATYPE_UNKNOWN:
-			dE("Unknown or unsupported OVAL datatype: %d, '%s', name: '%s'.\n",
+			dE("Unknown or unsupported OVAL datatype: %d, '%s', name: '%s'.",
 			   value_type, oval_datatype_get_text(value_type), value_name);
                         SEXP_free(item);
 
@@ -1548,19 +1548,19 @@ oval_operation_t probe_ent_getoperation(SEXP_t *entity, oval_operation_t default
         SEXP_t *aval;
 
         if (entity == NULL) {
-                dW("entity == NULL\n");
+                dW("entity == NULL");
                 return (OVAL_OPERATION_UNKNOWN);
         }
 
         aval = probe_ent_getattrval(entity, "operation");
 
         if (aval == NULL) {
-                dW("Attribute \"operation\" not found. Using default.\n");
+                dW("Attribute \"operation\" not found. Using default.");
                 return (default_op);
         }
 
         if (!SEXP_numberp(aval)) {
-                dW("Invalid type\n");
+                dW("Invalid type");
                 SEXP_free(aval);
                 return (OVAL_OPERATION_UNKNOWN);
         }
@@ -1584,13 +1584,13 @@ int probe_item_add_msg(SEXP_t *item, oval_message_level_t msglvl, char *msgfmt, 
     msg_length = vsnprintf(msg_buffer, sizeof msg_buffer, msgfmt, ap);
 
     if (msg_length < 0) {
-	dE("vsnprintf failed! errno=%u, %s.\n", errno, strerror(errno));
+	dE("vsnprintf failed! errno=%u, %s.", errno, strerror(errno));
 	va_end(ap);
 	return (-1);
     }
 
     if ((size_t)msg_length >= sizeof msg_buffer) {
-	dE("message too long!\n");
+	dE("message too long!");
 	va_end(ap);
 	return (-1);
     }

--- a/src/OVAL/probes/probe/entcmp.c
+++ b/src/OVAL/probes/probe/entcmp.c
@@ -200,7 +200,7 @@ static inline oval_result_t probe_ent_cmp_single(SEXP_t *state_ent, oval_datatyp
 	case OVAL_DATATYPE_IPV6ADDR:
 		return probe_ent_cmp_ipaddr(AF_INET6, state_ent, sysent, op);
 	default:
-		dI("Unexpected data type: %d\n", state_data_type);
+		dI("Unexpected data type: %d", state_data_type);
 		break;
 	}
 
@@ -243,7 +243,7 @@ static oval_result_t probe_ent_cmp(SEXP_t * ent, SEXP_t * val2)
 
 	SEXP_list_foreach(val1, vals) {
 		if (SEXP_typeof(val1) != SEXP_typeof(val2)) {
-			dI("Types of values to compare don't match: val1: %d, val2: %d\n",
+			dI("Types of values to compare don't match: val1: %d, val2: %d",
 			   SEXP_typeof(val1), SEXP_typeof(val2));
 
                         SEXP_free(vals);
@@ -427,13 +427,13 @@ oval_result_t probe_entobj_cmp(SEXP_t * ent_obj, SEXP_t * val)
 	valcnt = probe_ent_getvals(ent_obj, &r0);
 	SEXP_free(r0);
 	if (valcnt == 0) {
-		dI("valcnt == 0.\n");
+		dI("valcnt == 0.");
 		return OVAL_RESULT_FALSE;
 	}
 
 	ores = probe_ent_cmp(ent_obj, val);
 #if defined(OSCAP_VERBOSE_DEBUG)
-	dI("ores: %d, '%s'.\n", ores, oval_result_get_text(ores));
+	dI("ores: %d, '%s'.", ores, oval_result_get_text(ores));
 #endif
 	if (ores == OVAL_RESULT_NOT_EVALUATED)
 		return OVAL_RESULT_FALSE;

--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -75,7 +75,7 @@ void *probe_input_handler(void *arg)
         case PTHREAD_BARRIER_SERIAL_THREAD:
 	        break;
         default:
-	        dE("pthread_barrier_wait: %d, %s.\n",
+	        dE("pthread_barrier_wait: %d, %s.",
 	           errno, strerror(errno));
 	        return (NULL);
         }
@@ -84,7 +84,7 @@ void *probe_input_handler(void *arg)
                 TH_CANCEL_ON;
 
 		if (SEAP_recvmsg(probe->SEAP_ctx, probe->sd, &seap_request) == -1) {
-			dE("An error ocured while receiving SEAP message. errno=%u, %s.\n", errno, strerror(errno));
+			dE("An error ocured while receiving SEAP message. errno=%u, %s.", errno, strerror(errno));
 
                         /*
                          * TODO: check for abort request
@@ -111,12 +111,12 @@ void *probe_input_handler(void *arg)
 		if (oid != NULL) {
 			SEXP_VALIDATE(oid);
 
-			dI("offline_mode=%08x\n", OSCAP_GSYM(offline_mode));
-			dI("offline_supp=%08x\n", OSCAP_GSYM(offline_mode_supported));
+			dI("offline_mode=%08x", OSCAP_GSYM(offline_mode));
+			dI("offline_supp=%08x", OSCAP_GSYM(offline_mode_supported));
 
 			if ((OSCAP_GSYM(offline_mode) != PROBE_OFFLINE_NONE) &&
 			    !(OSCAP_GSYM(offline_mode) & OSCAP_GSYM(offline_mode_supported))) {
-				dW("Requested offline mode is not supported by %s.\n", probe->name);
+				dW("Requested offline mode is not supported by %s.", probe->name);
 				/* Return a dummy. */
 				probe_out = probe_cobj_new(OSCAP_GSYM(offline_mode_cobjflag), NULL, NULL, NULL);
 				probe_ret = 0;
@@ -183,10 +183,10 @@ void *probe_input_handler(void *arg)
 
 							if (pthread_create(&pair->pth->tid, &pth_attr, &probe_worker_runfn, pair))
 							{
-								dE("Cannot start a new worker thread: %d, %s.\n", errno, strerror(errno));
+								dE("Cannot start a new worker thread: %d, %s.", errno, strerror(errno));
 
 								if (rbt_i32_del(probe->workers, pair->pth->sid, NULL) != 0)
-									dE("rbt_i32_del: failed to remove worker thread (ID=%u)\n", pair->pth->sid);
+									dE("rbt_i32_del: failed to remove worker thread (ID=%u)", pair->pth->sid);
 
 								SEAP_msg_free(pair->pth->msg);
 								oscap_free(pair->pth);
@@ -211,7 +211,7 @@ void *probe_input_handler(void *arg)
 			}
 		} else {
                         /* the `id' was not found in the input object */
-                        dE("No `id' attribute\n");
+                        dE("No `id' attribute");
                         probe_ret = PROBE_ENOATTR;
 			probe_out = NULL;
                 }
@@ -220,7 +220,7 @@ void *probe_input_handler(void *arg)
 		__error_reply:
 			if (SEAP_replyerr(probe->SEAP_ctx, probe->sd, seap_request, probe_ret) == -1)
                         {
-				dE("An error ocured while sending error status. errno=%u, %s.\n",
+				dE("An error ocured while sending error status. errno=%u, %s.",
 				   errno, strerror(errno));
 
 				SEAP_msg_free(seap_request);
@@ -236,7 +236,7 @@ void *probe_input_handler(void *arg)
                         SEXP_free(probe_out);
 
 			if (SEAP_reply(probe->SEAP_ctx, probe->sd, seap_reply, seap_request) == -1) {
-				dE("An error ocured while sending SEAP message. errno=%u, %s.\n",
+				dE("An error ocured while sending SEAP message. errno=%u, %s.",
 				   errno, strerror(errno));
 
                                 /* TODO: check for abort request */

--- a/src/OVAL/probes/probe/signal_handler.c
+++ b/src/OVAL/probes/probe/signal_handler.c
@@ -77,23 +77,23 @@ void *probe_signal_handler(void *arg)
 
 #if defined(__linux__)
         if (prctl(PR_SET_PDEATHSIG, SIGTERM) != 0)
-                dW("prctl(PR_SET_PDEATHSIG, SIGTERM) failed\n");
+                dW("prctl(PR_SET_PDEATHSIG, SIGTERM) failed");
 #endif
        
-	dI("Signal handler ready\n");
+	dI("Signal handler ready");
 	switch (errno = pthread_barrier_wait(&OSCAP_GSYM(th_barrier)))
 	{
 	case 0:
 	case PTHREAD_BARRIER_SERIAL_THREAD:
 		break;
 	default:
-		dE("pthread_barrier_wait: %d, %s.\n", errno, strerror(errno));
+		dE("pthread_barrier_wait: %d, %s.", errno, strerror(errno));
 		return (NULL);
 	}
 
 	while (sigwaitinfo(&siset, &siinf) != -1) {
 
-		dI("Received signal %d from %u (%s)\n",
+		dI("Received signal %d from %u (%s)",
 		   siinf.si_signo, (unsigned int)siinf.si_pid,
 		   getppid() == siinf.si_pid ? "parent" : "not my parent");
 
@@ -132,14 +132,14 @@ void *probe_signal_handler(void *arg)
 				probe_worker_t *thr = coll.thr[coll.cnt - 1];
 
 				if (clock_gettime(CLOCK_REALTIME, &j_tm) == -1) {
-					dE("clock_gettime(CLOCK_REALTIME): %d, %s.\n", errno, strerror(errno));
+					dE("clock_gettime(CLOCK_REALTIME): %d, %s.", errno, strerror(errno));
 					continue;
 				}
 
 				j_tm.tv_sec += 60;
 
 				if ((errno = pthread_timedjoin_np(thr->tid, NULL, &j_tm)) != 0) {
-					dE("[%llu] pthread_timedjoin_np: %d, %s.\n", (uint64_t)thr->sid, errno, strerror(errno));
+					dE("[%llu] pthread_timedjoin_np: %d, %s.", (uint64_t)thr->sid, errno, strerror(errno));
 					/*
 					 * Memory will be leaked here by continuing to the next thread. However, we are in the
 					 * process of shutting down the whole probe. We're just nice and gave the probe_main()
@@ -149,7 +149,7 @@ void *probe_signal_handler(void *arg)
 				}
 #else
 				if ((errno = pthread_join(thr->tid, NULL)) != 0) {
-					dE("pthread_join: %d, %s.\n", errno, strerror(errno));
+					dE("pthread_join: %d, %s.", errno, strerror(errno));
 					continue;
 				}
 #endif

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -48,16 +48,16 @@ void *probe_worker_runfn(void *arg)
 	int     probe_ret;
 
 	pthread_setname_np(pthread_self(), "probe_worker");
-	dI("handling SEAP message ID %u\n", pair->pth->sid);
+	dI("handling SEAP message ID %u", pair->pth->sid);
 	//
 	probe_ret = -1;
 	probe_res = pair->pth->msg_handler(pair->probe, pair->pth->msg, &probe_ret);
 	//
-	dI("handler result = %p, return code = %d\n", probe_res, probe_ret);
+	dI("handler result = %p, return code = %d", probe_res, probe_ret);
 
 	/* Assuming that the red-black tree API is doing locking for us... */
 	if (rbt_i32_del(pair->probe->workers, pair->pth->sid, NULL) != 0) {
-		dW("thread not found in the probe thread tree, probably canceled by an external signal\n");
+		dW("thread not found in the probe thread tree, probably canceled by an external signal");
 		/*
 		 * XXX: this is a possible deadlock; we can't send anything from
 		 * here because the signal handler replied to the message
@@ -72,7 +72,7 @@ void *probe_worker_runfn(void *arg)
 	} else {
                 SEXP_t *items;
 
-		dI("probe thread deleted\n");
+		dI("probe thread deleted");
 
 		obj = SEAP_msg_get(pair->pth->msg);
 		oid = probe_obj_getattrval(obj, "id");
@@ -99,7 +99,7 @@ void *probe_worker_runfn(void *arg)
 		if (SEAP_replyerr(pair->probe->SEAP_ctx, pair->probe->sd, pair->pth->msg, probe_ret) == -1) {
 			int ret = errno;
 
-			dE("An error ocured while sending error status. errno=%u, %s.\n", errno, strerror(errno));
+			dE("An error ocured while sending error status. errno=%u, %s.", errno, strerror(errno));
 			SEXP_free(probe_res);
 
 			/* FIXME */
@@ -521,7 +521,7 @@ static SEXP_t *probe_set_combine(SEXP_t *cobj0, SEXP_t *cobj1, oval_setobject_op
 
                 break;
         default:
-                dE("Unknown set operation: %d\n", op);
+                dE("Unknown set operation: %d", op);
                 abort();
         }
 
@@ -706,7 +706,7 @@ static SEXP_t *probe_set_eval(probe_t *probe, SEXP_t *set, size_t depth)
 			SEXP_t *objres; /**< Result of the evaluation */
 			char    OID_cstr[128];
 
-			dI("Handling object_reference\n");
+			dI("Handling object_reference");
 
 			if ((OID = probe_ent_getval(member)) == NULL) {
 				Omsg = probe_msg_creatf(OVAL_MESSAGE_LEVEL_ERROR,
@@ -715,14 +715,14 @@ static SEXP_t *probe_set_eval(probe_t *probe, SEXP_t *set, size_t depth)
 			}
 #ifndef NDEBUG
 			SEXP_string_cstr_r(OID, OID_cstr, sizeof OID_cstr);
-			dI("Looking for the result in cache: OID=%s\n", OID_cstr);
+			dI("Looking for the result in cache: OID=%s", OID_cstr);
 #endif
 			if ((objres = probe_rcache_sexp_get(probe->rcache, OID)) == NULL) {
-				dI("MISS => requesting object evaluation from the library\n");
+				dI("MISS => requesting object evaluation from the library");
 
 				objres = probe_obj_eval(probe, OID);
 
-				dI("EVAL: result=%p\n", objres);
+				dI("EVAL: result=%p", objres);
 				if (objres != NULL) {
 					dO(OSCAP_DEBUGOBJ_SEXP, objres);
 				} else {
@@ -838,22 +838,22 @@ static SEXP_t *probe_set_eval(probe_t *probe, SEXP_t *set, size_t depth)
 
                 for (i = 0; i < s_subset_i; ++i) {
                         if (s_subset[i] != NULL) {
-                                dI("=== s_subset[%d] ===\n", i);
+                                dI("=== s_subset[%d] ===", i);
                                 dO(OSCAP_DEBUGOBJ_SEXP, s_subset[i]);
-                                dI("\n");
+                                dI("");
                         }
                 }
 
                 for (i = 0; i < o_subset_i; ++i) {
                         if (o_subset[i] != NULL) {
-                                dI("=== o_subset[%d] ===\n", i);
+                                dI("=== o_subset[%d] ===", i);
                                 dO(OSCAP_DEBUGOBJ_SEXP, o_subset[i]);
-                                dI("\n");
+                                dI("");
                         }
                 }
         }
 
-        dI("OP= %d\n", op_num);
+        dI("OP= %d", op_num);
 #endif
 
 	SEXP_free(filters_a);
@@ -864,9 +864,9 @@ static SEXP_t *probe_set_eval(probe_t *probe, SEXP_t *set, size_t depth)
 	SEXP_free(s_subset[0]);
 	SEXP_free(s_subset[1]);
 
-        dI("=== RESULT ===\n");
+        dI("=== RESULT ===");
         dO(OSCAP_DEBUGOBJ_SEXP, result);
-        dI("\n");
+        dI("");
 
 	return (result);
  eval_fail:
@@ -966,7 +966,7 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 			 */
 			struct probe_varref_ctx *ctx;
 
-			dI("handling varrefs in object\n");
+			dI("handling varrefs in object");
 
 			if (probe_varref_create_ctx(probe_in, varrefs, &ctx) != 0) {
 				SEXP_vfree(varrefs, pctx.filters, probe_in, mask, NULL);

--- a/src/OVAL/probes/public/probe-api.h
+++ b/src/OVAL/probes/public/probe-api.h
@@ -513,7 +513,7 @@ SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attr
 #define PROBE_ENT_AREF(ent, dst, attr_name, invalid_exp)		\
 	do {								\
 		if (((dst) = probe_ent_getattrval(ent, attr_name)) == NULL) { \
-			dE("Attribute `%s' is missing!\n", attr_name);	\
+			dE("Attribute `%s' is missing!", attr_name);	\
 			invalid_exp					\
 		}               					\
 	} while(0)
@@ -523,11 +523,11 @@ SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attr
 		SEXP_t *___r;					\
 								\
 		if ((___r = probe_ent_getval(ent)) == NULL) {	\
-			dW("Entity has no value!\n");		\
+			dW("Entity has no value!");		\
 			invalid_exp				\
 		} else {					\
 			if (!SEXP_stringp(___r)) {		\
-				dE("Invalid type\n");		\
+				dE("Invalid type");		\
 				SEXP_free(___r);		\
 				invalid_exp			\
 			}					\
@@ -546,11 +546,11 @@ SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attr
 		SEXP_t *___r;					\
 								\
 		if ((___r = probe_ent_getval(ent)) == NULL) {	\
-			dW("Entity has no value!\n");		\
+			dW("Entity has no value!");		\
 			nil_exp;				\
 		} else {					\
 			if (!SEXP_numberp(___r)) {		\
-				dE("Invalid type\n");		\
+				dE("Invalid type");		\
 				SEXP_free(___r);		\
 				invalid_exp;			\
 			} else {				\

--- a/src/OVAL/probes/unix/file.c
+++ b/src/OVAL/probes/unix/file.c
@@ -256,7 +256,7 @@ static int file_cb (const char *p, const char *f, void *ptr)
 	}
 
         if (lstat (st_path, &st) == -1) {
-                dI("lstat failed when processing %s: errno=%u, %s.\n", st_path, errno, strerror (errno));
+                dI("lstat failed when processing %s: errno=%u, %s.", st_path, errno, strerror (errno));
 		return strncmp(st_path, "/proc", 4) == 0 ? 0 : -1;
         } else {
                 SEXP_t *se_usr_id, *se_grp_id;
@@ -380,7 +380,7 @@ void *probe_init (void)
         case 0:
                 return ((void *)&__file_probe_mutex);
         default:
-                dI("Can't initialize mutex: errno=%u, %s.\n", errno, strerror (errno));
+                dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
         }
 #if 0
 	probe_setoption(PROBEOPT_VARREF_HANDLING, false, "path");
@@ -456,7 +456,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
         case 0:
                 break;
         default:
-                dI("Can't lock mutex(%p): %u, %s.\n", &__file_probe_mutex, errno, strerror (errno));
+                dI("Can't lock mutex(%p): %u, %s.", &__file_probe_mutex, errno, strerror (errno));
 
 		SEXP_free(path);
 		SEXP_free(filename);
@@ -491,7 +491,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
         case 0:
                 break;
         default:
-                dI("Can't unlock mutex(%p): %u, %s.\n", &__file_probe_mutex, errno, strerror (errno));
+                dI("Can't unlock mutex(%p): %u, %s.", &__file_probe_mutex, errno, strerror (errno));
 
                 return PROBE_EFATAL;
         }

--- a/src/OVAL/probes/unix/fileextendedattribute.c
+++ b/src/OVAL/probes/unix/fileextendedattribute.c
@@ -110,7 +110,7 @@ retry_list:
                 return (0);
 
         if (xattr_count < 0) {
-                dI("FAIL: llistxattr(%s, %p, %zu): errno=%u, %s.\n", errno, strerror(errno));
+                dI("FAIL: llistxattr(%s, %p, %zu): errno=%u, %s.", errno, strerror(errno));
                 return 0;
         }
 
@@ -126,7 +126,7 @@ retry_list:
                 goto retry_list;
 
         if (xattr_count < 0) {
-                dI("FAIL: llistxattr(%s, %p, %zu): errno=%u, %s.\n", errno, strerror(errno));
+                dI("FAIL: llistxattr(%s, %p, %zu): errno=%u, %s.", errno, strerror(errno));
                 oscap_free(xattr_buf);
         }
 
@@ -167,7 +167,7 @@ retry_list:
 
                                 oscap_free(xattr_val);
                         } else {
-                                dI("FAIL: lgetxattr(%s, %s, NULL, 0): errno=%u, %s.\n", errno, strerror(errno));
+                                dI("FAIL: lgetxattr(%s, %s, NULL, 0): errno=%u, %s.", errno, strerror(errno));
 
                                 item = probe_item_create(OVAL_UNIX_FILEEXTENDEDATTRIBUTE, NULL, NULL);
                                 probe_item_setstatus(item, SYSCHAR_STATUS_ERROR);
@@ -204,7 +204,7 @@ void *probe_init (void)
         case 0:
                 return ((void *)&__file_probe_mutex);
         default:
-                dI("Can't initialize mutex: errno=%u, %s.\n", errno, strerror (errno));
+                dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
         }
 #if 0
 	probe_setoption(PROBEOPT_VARREF_HANDLING, false, "path");
@@ -270,7 +270,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
         case 0:
                 break;
         default:
-                dI("Can't lock mutex(%p): %u, %s.\n", &__file_probe_mutex, errno, strerror (errno));
+                dI("Can't lock mutex(%p): %u, %s.", &__file_probe_mutex, errno, strerror (errno));
 
 		SEXP_free(path);
 		SEXP_free(filename);
@@ -305,7 +305,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
         case 0:
                 break;
         default:
-                dI("Can't unlock mutex(%p): %u, %s.\n", &__file_probe_mutex, errno, strerror (errno));
+                dI("Can't unlock mutex(%p): %u, %s.", &__file_probe_mutex, errno, strerror (errno));
 
                 return PROBE_EFATAL;
         }

--- a/src/OVAL/probes/unix/gconf.c
+++ b/src/OVAL/probes/unix/gconf.c
@@ -78,7 +78,7 @@ static int collect_item(probe_ctx *ctx, const char *source, GConfEntry *entry)
                 case GCONF_VALUE_LIST:
                 case GCONF_VALUE_PAIR:
                 default:
-                        dE("Unsupported GConfValue type: %d\n", gconf_value->type);
+                        dE("Unsupported GConfValue type: %d", gconf_value->type);
                         gconf_type = "GCONF_VALUE_INVALID";
                         sexp_value = NULL;
                 }
@@ -184,7 +184,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
                 gconf_engine = gconf_engine_get_default();
 
 		if (gconf_engine == NULL) {
-			dE("Unable to get the default GConf engine!\n");
+			dE("Unable to get the default GConf engine!");
 			SEXP_free(gconf_src);
 			SEXP_free(gconf_key);
 			/* XXX: construct an error item */
@@ -210,7 +210,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
                                 gconf_addr[ofts_ent->path_len] = '/';
                                 strcpy(gconf_addr + ofts_ent->path_len + 1, ofts_ent->file);
 
-                                dI("GConf source: %s\n", gconf_addr);
+                                dI("GConf source: %s", gconf_addr);
 
                                 gconf_engine = gconf_engine_get_for_address(gconf_addr, &gconf_err);
 
@@ -230,7 +230,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 
 					gconf_engine_unref(gconf_engine);
 				} else {
-					dW("Invalid GConf source, skipping!\n");
+					dW("Invalid GConf source, skipping!");
 				}
 
 				oval_ftsent_free(ofts_ent);
@@ -240,7 +240,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 
 		SEXP_free(behaviors);
         } else {
-                dI("GConf source: gconfd\n");
+                dI("GConf source: gconfd");
 
 		switch(key_op) {
 		case OVAL_OPERATION_EQUALS:

--- a/src/OVAL/probes/unix/linux/dpkginfo.c
+++ b/src/OVAL/probes/unix/linux/dpkginfo.c
@@ -100,7 +100,7 @@ int probe_main (probe_ctx *ctx, void *arg)
         val = probe_ent_getval (ent);
 
         if (val == NULL) {
-                dI("%s: no value\n", "name");
+                dI("%s: no value", "name");
                 SEXP_free (ent);
                 return (PROBE_ENOVAL);
         }
@@ -111,11 +111,11 @@ int probe_main (probe_ctx *ctx, void *arg)
         if (request_st == NULL) {
                 switch (errno) {
                 case EINVAL:
-                        dI("%s: invalid value type\n", "name");
+                        dI("%s: invalid value type", "name");
 			return PROBE_EINVAL;
                         break;
                 case EFAULT:
-                        dI("%s: element not found\n", "name");
+                        dI("%s: element not found", "name");
 			return PROBE_ENOELM;
                         break;
 		default:
@@ -132,12 +132,12 @@ int probe_main (probe_ctx *ctx, void *arg)
                 switch (errflag) {
 		case 0: /* Not found */
 		{
-			dI("Package \"%s\" not found.\n", request_st);
+			dI("Package \"%s\" not found.", request_st);
 			break;
 		}
 		case -1: /* Error */
 		{
-			dI("dpkginfo_get_by_name failed.\n");
+			dI("dpkginfo_get_by_name failed.");
 			item = probe_item_create(OVAL_LINUX_DPKG_INFO, NULL,
 					"name", OVAL_DATATYPE_STRING, request_st,
 					NULL);
@@ -151,7 +151,7 @@ int probe_main (probe_ctx *ctx, void *arg)
                 int num_items = 1; /* FIXME */
 
                 for (i = 0; i < num_items; ++i) {
-                        dI("%s: element found version %s\n", dpkginfo_reply->name, dpkginfo_reply->evr);
+                        dI("%s: element found version %s", dpkginfo_reply->name, dpkginfo_reply->evr);
                         item = probe_item_create (OVAL_LINUX_DPKG_INFO, NULL,
                                         "name", OVAL_DATATYPE_STRING, dpkginfo_reply->name,
                                         "arch", OVAL_DATATYPE_STRING, dpkginfo_reply->arch,

--- a/src/OVAL/probes/unix/linux/iflisteners.c
+++ b/src/OVAL/probes/unix/linux/iflisteners.c
@@ -404,7 +404,7 @@ static int read_packet(llist *l, probe_ctx *ctx, oval_version_t over)
 		if (list_find_inode(l, inode) && get_interface(ifindex, &interface)) {
 			struct result_info r;
 			SEXP_t *r0;
-			dI("Have interface_name: %s, hw_address: %s\n",
+			dI("Have interface_name: %s, hw_address: %s",
 					interface.interface_name, interface.hw_address);
 
 			r0 = SEXP_string_newf("%s", interface.interface_name);

--- a/src/OVAL/probes/unix/linux/inetlisteningservers.c
+++ b/src/OVAL/probes/unix/linux/inetlisteningservers.c
@@ -424,7 +424,7 @@ static int read_tcp(const char *proc, const char *type, llist *l, probe_ctx *ctx
 		char src[NI_MAXHOST], dest[NI_MAXHOST];
 		addr_convert(local_addr, src, NI_MAXHOST);
 		addr_convert(rem_addr, dest, NI_MAXHOST);
-		dI("Have tcp port: %s:%u\n", src, local_port);
+		dI("Have tcp port: %s:%u", src, local_port);
 		if (eval_data(type, src, local_port)) {
 			struct result_info r;
 			r.proto = type;
@@ -475,7 +475,7 @@ static int read_udp(const char *proc, const char *type, llist *l, probe_ctx *ctx
 		char src[NI_MAXHOST], dest[NI_MAXHOST];
 		addr_convert(local_addr, src, NI_MAXHOST);
 		addr_convert(rem_addr, dest, NI_MAXHOST);
-		dI("Have udp port: %s:%u\n", src, local_port);
+		dI("Have udp port: %s:%u", src, local_port);
 		if (eval_data(type, src, local_port)) {
 			struct result_info r;
 			r.proto = type;
@@ -526,7 +526,7 @@ static int read_raw(const char *proc, const char *type, llist *l, probe_ctx *ctx
 		char src[NI_MAXHOST], dest[NI_MAXHOST];
 		addr_convert(local_addr, src, NI_MAXHOST);
 		addr_convert(rem_addr, dest, NI_MAXHOST);
-		dI("Have raw port: %s:%u\n", src, local_port);
+		dI("Have raw port: %s:%u", src, local_port);
 		if (eval_data(type, src, local_port)) {
 			struct result_info r;
 			r.proto = type;

--- a/src/OVAL/probes/unix/linux/partition.c
+++ b/src/OVAL/probes/unix/linux/partition.c
@@ -175,7 +175,7 @@ static int collect_item(probe_ctx *ctx, oval_version_t over, struct mntent *mnt_
                 mnt_opts[mnt_ocnt] = NULL;
         } while ((tok = strtok_r(NULL, ",", &save)) != NULL);
 
-        dI("mnt_ocnt = %d, mnt_opts[mnt_ocnt]=%p\n", mnt_ocnt, mnt_opts[mnt_ocnt]);
+        dI("mnt_ocnt = %d, mnt_opts[mnt_ocnt]=%p", mnt_ocnt, mnt_opts[mnt_ocnt]);
 
 	/*
 	 * "Correct" the type (this won't be (hopefully) needed in a later version

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -116,7 +116,7 @@ struct rpminfo_global {
 	do { \
 		int prev_cancel_state = -1; \
 		if (pthread_mutex_lock(&g_rpm.mutex) != 0) { \
-			dE("Can't lock mutex\n"); \
+			dE("Can't lock mutex"); \
 			return (-1); \
 		} \
 		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &prev_cancel_state); \
@@ -126,7 +126,7 @@ struct rpminfo_global {
 	do { \
 		int prev_cancel_state = -1; \
 		if (pthread_mutex_unlock(&g_rpm.mutex) != 0) { \
-			dE("Can't unlock mutex. Aborting...\n"); \
+			dE("Can't unlock mutex. Aborting..."); \
 			abort(); \
 		} \
 		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &prev_cancel_state); \
@@ -182,7 +182,7 @@ static void pkgh2rep (Header h, struct rpminfo_rep *r)
 
 	if (regexec(&g_keyid_regex, str, 1, keyid_match, 0) != 0) {
 		sid = NULL;
-		dW("Failed to extract the Key ID value: regex=\"%s\", string=\"%s\"\n",
+		dW("Failed to extract the Key ID value: regex=\"%s\", string=\"%s\"",
 		   g_keyid_regex_string, str);
 	} else {
 		size_t keyid_start, keyid_length;
@@ -306,7 +306,7 @@ void *probe_init (void)
 	probe_offline_flags offline_mode = PROBE_OFFLINE_NONE;
 
         if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
-                dI("rpmReadConfigFiles failed: %u, %s.\n", errno, strerror (errno));
+                dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
                 return (NULL);
         }
 
@@ -319,7 +319,7 @@ void *probe_init (void)
         pthread_mutex_init (&(g_rpm.mutex), NULL);
 
 	if (regcomp(&g_keyid_regex, g_keyid_regex_string, REG_EXTENDED) != 0) {
-		dE("regcomp(%s) failed.\n");
+		dE("regcomp(%s) failed.");
 		return NULL;
 	}
 
@@ -430,7 +430,7 @@ int probe_main (probe_ctx *ctx, void *arg)
         val = probe_ent_getval (ent);
 
         if (val == NULL) {
-                dI("%s: no value\n", "name");
+                dI("%s: no value", "name");
                 SEXP_free (ent);
                 return (PROBE_ENOVAL);
         }
@@ -464,11 +464,11 @@ int probe_main (probe_ctx *ctx, void *arg)
 		SEXP_free (ent);
                 switch (errno) {
                 case EINVAL:
-                        dI("%s: invalid value type\n", "name");
+                        dI("%s: invalid value type", "name");
 			return PROBE_EINVAL;
                         break;
                 case EFAULT:
-                        dI("%s: element not found\n", "name");
+                        dI("%s: element not found", "name");
 			return PROBE_ENOELM;
                         break;
 		default:
@@ -481,10 +481,10 @@ int probe_main (probe_ctx *ctx, void *arg)
         /* get info from RPM db */
         switch (rpmret = get_rpminfo (&request_st, &reply_st)) {
         case 0: /* Not found */
-                dI("Package \"%s\" not found.\n", request_st.name);
+                dI("Package \"%s\" not found.", request_st.name);
                 break;
         case -1: /* Error */
-                dI("get_rpminfo failed\n");
+                dI("get_rpminfo failed");
 
                 item = probe_item_create(OVAL_LINUX_RPM_INFO, NULL,
                                          "name", OVAL_DATATYPE_STRING, request_st.name,

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -94,7 +94,7 @@ static struct rpmverify_global g_rpm;
 	do { \
 		int prev_cancel_state = -1; \
 		if (pthread_mutex_lock(&g_rpm.mutex) != 0) { \
-			dE("Can't lock mutex\n"); \
+			dE("Can't lock mutex"); \
 			return (-1); \
 		} \
 		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &prev_cancel_state); \
@@ -104,7 +104,7 @@ static struct rpmverify_global g_rpm;
 	do { \
 		int prev_cancel_state = -1; \
 		if (pthread_mutex_unlock(&g_rpm.mutex) != 0) { \
-			dE("Can't unlock mutex. Aborting...\n"); \
+			dE("Can't unlock mutex. Aborting..."); \
 			abort(); \
 		} \
 		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &prev_cancel_state); \
@@ -183,7 +183,7 @@ static int rpmverify_collect(probe_ctx *ctx,
                 break;
         default:
                 /* not supported */
-                dE("package name: operation not supported\n");
+                dE("package name: operation not supported");
                 ret = -1;
                 goto ret;
         }
@@ -258,7 +258,7 @@ ret:
 void *probe_init (void)
 {
         if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
-                dI("rpmReadConfigFiles failed: %u, %s.\n", errno, strerror (errno));
+                dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
                 return (NULL);
         }
 
@@ -356,7 +356,7 @@ int probe_main (probe_ctx *ctx, void *arg)
         file_ent = probe_obj_getent(probe_in, "filepath", 1);
 
         if (name_ent == NULL || file_ent == NULL) {
-                dE("Missing \"name\" (%p) or \"filepath\" (%p) entity\n", name_ent, file_ent);
+                dE("Missing \"name\" (%p) or \"filepath\" (%p) entity", name_ent, file_ent);
 
                 SEXP_free(name_ent);
                 SEXP_free(file_ent);
@@ -398,7 +398,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 
                         if (aval != NULL) {
                                 if (SEXP_strcmp(aval, "true") == 0) {
-                                        dI("omit verify attr: %s\n", rpmverify_bhmap[i].a_name);
+                                        dI("omit verify attr: %s", rpmverify_bhmap[i].a_name);
                                         collect_flags |= rpmverify_bhmap[i].a_flag;
                                 }
 
@@ -409,7 +409,7 @@ int probe_main (probe_ctx *ctx, void *arg)
                 SEXP_free(bh_ent);
         }
 
-        dI("Collecting rpmverify data, query: n=\"%s\" (%d), f=\"%s\" (%d)\n",
+        dI("Collecting rpmverify data, query: n=\"%s\" (%d), f=\"%s\" (%d)",
            name, name_op, file, file_op);
 
         if (rpmverify_collect(ctx,
@@ -419,7 +419,7 @@ int probe_main (probe_ctx *ctx, void *arg)
                               collect_flags,
                               rpmverify_additem) != 0)
         {
-                dE("An error ocured while collecting rpmverify data\n");
+                dE("An error ocured while collecting rpmverify data");
                 probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
         }
 

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -101,7 +101,7 @@ static struct rpmverify_global g_rpm;
 	do { \
 		int prev_cancel_state = -1; \
 		if (pthread_mutex_lock(&g_rpm.mutex) != 0) { \
-			dE("Can't lock mutex\n"); \
+			dE("Can't lock mutex"); \
 			return (-1); \
 		} \
 		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &prev_cancel_state); \
@@ -111,7 +111,7 @@ static struct rpmverify_global g_rpm;
 	do { \
 		int prev_cancel_state = -1; \
 		if (pthread_mutex_unlock(&g_rpm.mutex) != 0) { \
-			dE("Can't unlock mutex. Aborting...\n"); \
+			dE("Can't unlock mutex. Aborting..."); \
 			abort(); \
 		} \
 		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &prev_cancel_state); \
@@ -285,7 +285,7 @@ static int rpmverify_collect(probe_ctx *ctx,
 			oscap_free(res.file);
 			continue;
 		      default:
-			dE("pcre_exec() failed!\n");
+			dE("pcre_exec() failed!");
 			ret = -1;
 			oscap_free(res.file);
 			goto ret;
@@ -293,7 +293,7 @@ static int rpmverify_collect(probe_ctx *ctx,
 		      break;
 		    default:
 		      /* unsupported operation */
-		      dE("Operation \"%d\" on `filepath' not supported\n", file_op);
+		      dE("Operation \"%d\" on `filepath' not supported", file_op);
 		      ret = -1;
 					oscap_free(res.file);
 		      goto ret;
@@ -327,7 +327,7 @@ ret:
 void *probe_init (void)
 {
 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
-		dI("rpmReadConfigFiles failed: %u, %s.\n", errno, strerror (errno));
+		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
 		return (NULL);
 	}
 
@@ -423,7 +423,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 	file_ent = probe_obj_getent(probe_in, "filepath", 1);
 
 	if (file_ent == NULL) {
-		dE("Missing \"filepath\" (%p) entity\n", file_ent);
+		dE("Missing \"filepath\" (%p) entity", file_ent);
 
 		SEXP_free(file_ent);
 
@@ -465,7 +465,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 
 			if (aval != NULL) {
 				if (SEXP_strcmp(aval, "true") == 0) {
-					dI("omit verify attr: %s\n", rpmverifyfile_bhmap[i].a_name);
+					dI("omit verify attr: %s", rpmverifyfile_bhmap[i].a_name);
 					collect_flags |= rpmverifyfile_bhmap[i].a_flag;
 				}
 
@@ -476,7 +476,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 		SEXP_free(bh_ent);
 	}
 
-	dI("Collecting rpmverifyfile data, query: f=\"%s\" (%d)\n",
+	dI("Collecting rpmverifyfile data, query: f=\"%s\" (%d)",
 	   file, file_op);
 
 	if (rpmverify_collect(ctx,
@@ -485,7 +485,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 			      collect_flags,
 			      rpmverify_additem) != 0)
 	{
-		dE("An error ocured while collecting rpmverifyfile data\n");
+		dE("An error ocured while collecting rpmverifyfile data");
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
 	}
 

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -123,7 +123,7 @@ static struct poptOption optionsTable[] = {
 	do { \
 		int prev_cancel_state = -1; \
 		if (pthread_mutex_lock(&g_rpm.mutex) != 0) { \
-			dE("Can't lock mutex\n"); \
+			dE("Can't lock mutex"); \
 			return (-1); \
 		} \
 		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &prev_cancel_state); \
@@ -133,7 +133,7 @@ static struct poptOption optionsTable[] = {
 	do { \
 		int prev_cancel_state = -1; \
 		if (pthread_mutex_unlock(&g_rpm.mutex) != 0) { \
-			dE("Can't unlock mutex. Aborting...\n"); \
+			dE("Can't unlock mutex. Aborting..."); \
 			abort(); \
 		} \
 		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &prev_cancel_state); \
@@ -313,7 +313,7 @@ ret:
 void *probe_init (void)
 {
 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
-		dI("rpmReadConfigFiles failed: %u, %s.\n", errno, strerror (errno));
+		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
 		return (NULL);
 	}
 
@@ -352,25 +352,25 @@ static int rpmverifypackage_additem(probe_ctx *ctx, struct rpmverify_res *res)
 				 NULL);
 
 	if (res->vflags & VERIFY_DEPS) {
-		dI("VERIFY_DEPS %d\n", res->vresults & VERIFY_DEPS);
+		dI("VERIFY_DEPS %d", res->vresults & VERIFY_DEPS);
 		value = probe_entval_from_cstr(OVAL_DATATYPE_BOOLEAN, (res->vresults & VERIFY_DEPS ? "1" : "0"), 1);
 		probe_item_ent_add(item, "dependency_check_passed", NULL, value);
 		SEXP_free(value);
 	}
 	if (res->vflags & VERIFY_DIGEST) {
-		dI("VERIFY_DIGEST %d\n", res->vresults & VERIFY_DIGEST);
+		dI("VERIFY_DIGEST %d", res->vresults & VERIFY_DIGEST);
 		value = probe_entval_from_cstr(OVAL_DATATYPE_BOOLEAN, (res->vresults & VERIFY_DIGEST ? "1" : "0"), 1);
 		probe_item_ent_add(item, "digest_check_passed", NULL, value);
 		SEXP_free(value);
 	}
 	if (res->vflags & VERIFY_SCRIPT) {
-		dI("VERIFY_SCRIPT %d\n", res->vresults & VERIFY_SCRIPT);
+		dI("VERIFY_SCRIPT %d", res->vresults & VERIFY_SCRIPT);
 		value = probe_entval_from_cstr(OVAL_DATATYPE_BOOLEAN, (res->vresults & VERIFY_SCRIPT ? "1" : "0"), 1);
 		probe_item_ent_add(item, "verification_script_successful", NULL, value);
 		SEXP_free(value);
 	}
 	if (res->vflags & VERIFY_SIGNATURE) {
-		dI("VERIFY_SIGNATURE %d\n", res->vresults & VERIFY_SIGNATURE);
+		dI("VERIFY_SIGNATURE %d", res->vresults & VERIFY_SIGNATURE);
 		value = probe_entval_from_cstr(OVAL_DATATYPE_BOOLEAN, (res->vresults & VERIFY_SIGNATURE ? "1" : "0"), 1);
 		probe_item_ent_add(item, "signature_check_passed", NULL, value);
 		SEXP_free(value);
@@ -409,7 +409,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 
 			if (aval != NULL) {
 				if (SEXP_strcmp(aval, "true") == 0) {
-					dI("omit verify attr: %s\n", rpmverifypackage_bhmap[i].a_name);
+					dI("omit verify attr: %s", rpmverifypackage_bhmap[i].a_name);
 					collect_flags |= rpmverifypackage_bhmap[i].a_flag;
 				}
 
@@ -425,7 +425,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 			      collect_flags,
 			      rpmverifypackage_additem) != 0)
 	{
-		dE("An error ocured while collecting rpmverifypackage data\n");
+		dE("An error ocured while collecting rpmverifypackage data");
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
 	}
 

--- a/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
+++ b/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
@@ -78,7 +78,7 @@ static void split_range(const char *range, char **l_s, char **l_c, char **h_s, c
 	const char *range_split;
 
 	if (range == NULL) {
-		dW("%s: range is NULL\n", __func__);
+		dW("%s: range is NULL", __func__);
 		*l_s = *l_c = *h_s = *h_c = NULL;
 		return;
 	}
@@ -114,7 +114,7 @@ static int selinuxsecuritycontext_process_cb (SEXP_t *pid_ent, probe_ctx *ctx) {
 	char *l_sensitivity, *l_category, *h_sensitivity, *h_category;
 
 	if ((proc = opendir("/proc")) == NULL) {
-		dE("Can't open /proc dir: %s\n", strerror(errno));
+		dE("Can't open /proc dir: %s", strerror(errno));
 
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
 		return errno;
@@ -130,7 +130,7 @@ static int selinuxsecuritycontext_process_cb (SEXP_t *pid_ent, probe_ctx *ctx) {
 
 			if (getpidcon(pid_number, &pid_context) == -1) {
 				/* error getting pid selinux context */
-				dW("Can't get selinux context for process %d\n", pid_number);
+				dW("Can't get selinux context for process %d", pid_number);
 				SEXP_free(pid_sexp);
 				continue;
 			}
@@ -218,7 +218,7 @@ static int selinuxsecuritycontext_file_cb (const char *p, const char *f, probe_c
 
 	file_context_size = getfilecon(pbuf, &file_context);
 	if (file_context_size == -1) {
-		dE("Can't get context for %s: %s\n", pbuf, strerror(errno));
+		dE("Can't get context for %s: %s", pbuf, strerror(errno));
 
 		item = probe_item_create(OVAL_LINUX_SELINUXSECURITYCONTEXT, NULL,
 						"filepath", OVAL_DATATYPE_STRING, pbuf,

--- a/src/OVAL/probes/unix/password.c
+++ b/src/OVAL/probes/unix/password.c
@@ -102,7 +102,7 @@ static int read_password(SEXP_t *un_ent, probe_ctx *ctx, oval_version_t over)
         while ((pw = getpwent())) {
                 SEXP_t *un;
 
-                dI("Have user: %s\n", pw->pw_name);
+                dI("Have user: %s", pw->pw_name);
                 un = SEXP_string_newf("%s", pw->pw_name);
                 if (probe_entobj_cmp(un_ent, un) == OVAL_RESULT_TRUE) {
                         struct result_info r;

--- a/src/OVAL/probes/unix/process.c
+++ b/src/OVAL/probes/unix/process.c
@@ -245,7 +245,7 @@ static int read_process(SEXP_t *cmd_ent, probe_ctx *ctx)
 			continue;
 
 		err = 0; // If we get this far, no permission problems
-		dI("Have command: %s\n", cmd);
+		dI("Have command: %s", cmd);
 		cmd_sexp = SEXP_string_newf("%s", cmd);
 		if (probe_entobj_cmp(cmd_ent, cmd_sexp) == OVAL_RESULT_TRUE) {
 			struct result_info r;
@@ -407,7 +407,7 @@ static int read_process(SEXP_t *cmd_ent, probe_ctx *ctx)
 
 
 		err = 0; // If we get this far, no permission problems
-		dI("Have command: %s\n", psinfo->pr_fname);
+		dI("Have command: %s", psinfo->pr_fname);
 		cmd_sexp = SEXP_string_newf("%s", psinfo->pr_fname);
 		if (probe_entobj_cmp(cmd_ent, cmd_sexp) == OVAL_RESULT_TRUE) {
 			struct result_info r;

--- a/src/OVAL/probes/unix/process58.c
+++ b/src/OVAL/probes/unix/process58.c
@@ -210,7 +210,7 @@ static int get_uids(int pid, struct result_info *r)
 	sf = fopen(buf, "rt");
 	if (sf) {
 		if (fscanf(sf, "%u", &r->loginuid) < 1) {
-			dW("fscanf failed from %s\n", buf);
+			dW("fscanf failed from %s", buf);
 		}
 		fclose(sf);
 	}
@@ -244,7 +244,7 @@ static char *get_selinux_label(int pid) {
 
 	if (getpidcon(pid, &pid_context) == -1) {
 		/* error getting pid selinux context */
-		dW("Can't get selinux context for process %d\n", pid);
+		dW("Can't get selinux context for process %d", pid);
 		return NULL;
 	}
 	context = context_new(pid_context);
@@ -268,19 +268,19 @@ static char **get_posix_capability(int pid) {
 #if LIBCAP_VERSION == 1
 	pid_caps = cap_init();
 	if (capgetp(pid, pid_caps) == -1) {
-		dW("Can't get capabilities for process %d\n", pid);
+		dW("Can't get capabilities for process %d", pid);
 		cap_free(pid_caps);
 		return NULL;
 	}
 #elif LIBCAP_VERSION == 2
 	pid_caps = cap_get_pid(pid);
 #else
-	dW("Can't detect libcap version\n");
+	dW("Can't detect libcap version");
 	return NULL;
 #endif
 
 	if (pid_caps == NULL) {
-		dW("Can't get capabilities for process %d\n", pid);
+		dW("Can't get capabilities for process %d", pid);
 		return NULL;
 	}
 
@@ -515,7 +515,7 @@ static int read_process(SEXP_t *cmd_ent, SEXP_t *pid_ent, probe_ctx *ctx)
 
 
 		err = 0; // If we get this far, no permission problems
-		dI("Have command: %s\n", cmd);
+		dI("Have command: %s", cmd);
 		cmd_sexp = SEXP_string_newf("%s", cmd);
 		pid_sexp = SEXP_number_newu_32(pid);
 		if ((cmd_sexp == NULL || probe_entobj_cmp(cmd_ent, cmd_sexp) == OVAL_RESULT_TRUE) &&
@@ -704,7 +704,7 @@ static int read_process(SEXP_t *cmd_ent, probe_ctx *ctx)
 
 
 		err = 0; // If we get this far, no permission problems
-		dI("Have command: %s\n", psinfo->pr_fname);
+		dI("Have command: %s", psinfo->pr_fname);
 		cmd_sexp = SEXP_string_newf("%s", psinfo->pr_fname);
 		if (probe_entobj_cmp(cmd_ent, cmd_sexp) == OVAL_RESULT_TRUE) {
 			struct result_info r;

--- a/src/OVAL/probes/unix/routingtable.c
+++ b/src/OVAL/probes/unix/routingtable.c
@@ -183,7 +183,7 @@ static int process_line_ip4(char *line, struct route_info *rt)
 #define TOK_flags  token[3]
 #define TOK_ifname token[0]
 
-    dI("name=%s, dst=%s, gw=%s, flags=%s\n", TOK_ifname, TOK_dst, TOK_gw, TOK_flags);
+    dI("name=%s, dst=%s, gw=%s, flags=%s", TOK_ifname, TOK_dst, TOK_gw, TOK_flags);
 
     if (proc_ip4_to_string(TOK_dst, strlen(TOK_dst), rt->ip_dst, sizeof rt->ip_dst) != 0 ||
         proc_ip4_to_string(TOK_gw, strlen(TOK_gw), rt->ip_gw, sizeof rt->ip_gw) != 0)
@@ -245,7 +245,7 @@ static int process_line_ip6(char *line, struct route_info *rt)
 #define TOK_flags  token[8]
 #define TOK_ifname token[9]
 
-    dI("name=%s, dst=%s, gw=%s, flags=%s\n", TOK_ifname, TOK_dst, TOK_gw, TOK_flags);
+    dI("name=%s, dst=%s, gw=%s, flags=%s", TOK_ifname, TOK_dst, TOK_gw, TOK_flags);
 
     if (proc_ip6_to_string(TOK_dst, strlen(TOK_dst), rt->ip_dst, sizeof rt->ip_dst) != 0 ||
         proc_ip6_to_string(TOK_gw, strlen(TOK_gw), rt->ip_gw, sizeof rt->ip_gw) != 0)
@@ -311,7 +311,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 
 	    if (!feof(fp)) {
 	      /* error */
-              dE("An error ocured while reading /proc/net/route: %s\n", strerror(errno));
+              dE("An error ocured while reading /proc/net/route: %s", strerror(errno));
 	    }
 	    break;
 	  case OVAL_DATATYPE_IPV6ADDR:
@@ -326,7 +326,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 
 	    if (!feof(fp)) {
 	      /* error */
-              dE("An error ocured while reading /proc/net/ipv6_route: %s\n", strerror(errno));
+              dE("An error ocured while reading /proc/net/ipv6_route: %s", strerror(errno));
             }
 	    break;
           default:

--- a/src/OVAL/probes/unix/runlevel.c
+++ b/src/OVAL/probes/unix/runlevel.c
@@ -105,7 +105,7 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 
 	init_dir = opendir(init_path);
 	if (init_dir == NULL) {
-		dI("Can't open directory \"%s\": errno=%d, %s.\n",
+		dI("Can't open directory \"%s\": errno=%d, %s.",
 		   init_path, errno, strerror (errno));
 		return (-1);
 	}
@@ -118,14 +118,14 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 		// Ensure that we are in the expected directory before
 		// touching relative paths
 		if (fchdir(dirfd(init_dir)) != 0) {
-			dI("Can't fchdir to \"%s\": errno=%d, %s.\n",
+			dI("Can't fchdir to \"%s\": errno=%d, %s.",
 			   init_path, errno, strerror (errno));
 			closedir(init_dir);
 			return -1;
 		}
 
 		if (stat(init_dp->d_name, &init_st) != 0) {
-			dI("Can't stat file %s/%s: errno=%d, %s.\n",
+			dI("Can't stat file %s/%s: errno=%d, %s.",
 			   init_path, init_dp->d_name, errno, strerror(errno));
 			continue;
 		}
@@ -153,12 +153,12 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 			snprintf(pathbuf, sizeof (pathbuf), rc_path, runlevel_list[i]);
 			rc_dir = opendir(pathbuf);
 			if (rc_dir == NULL) {
-				dI("Can't open directory \"%s\": errno=%d, %s.\n",
+				dI("Can't open directory \"%s\": errno=%d, %s.",
 				   rc_path, errno, strerror (errno));
 				continue;
 			}
 			if (chdir(pathbuf) != 0) {
-				dI("Can't fchdir to \"%s\": errno=%d, %s.\n",
+				dI("Can't fchdir to \"%s\": errno=%d, %s.",
 				   rc_path, errno, strerror (errno));
 				closedir(rc_dir);
 				continue;
@@ -168,7 +168,7 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 
 			while ((rc_dp = readdir(rc_dir)) != NULL) {
 				if (stat(rc_dp->d_name, &rc_st) != 0) {
-					dI("Can't stat file %s/%s: errno=%d, %s.\n",
+					dI("Can't stat file %s/%s: errno=%d, %s.",
 					   rc_path, rc_dp->d_name, errno, strerror(errno));
 					continue;
 				}
@@ -181,7 +181,7 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 						kill = true;
 						break;
 					} else {
-						dI("Unexpected character in filename: %c, %s/%s.\n",
+						dI("Unexpected character in filename: %c, %s/%s.",
 						   rc_dp->d_name[0], pathbuf, rc_dp->d_name);
 					}
 				}
@@ -373,7 +373,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 
 	request_st.service_name_ent = probe_obj_getent(object, "service_name", 1);
 	if (request_st.service_name_ent == NULL) {
-		dI("%s: element not found\n", "service_name");
+		dI("%s: element not found", "service_name");
 
 		return PROBE_ENOELM;
 	}
@@ -381,7 +381,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 	request_st.runlevel_ent = probe_obj_getent(object, "runlevel", 1);
 	if (request_st.runlevel_ent == NULL) {
 		SEXP_free(request_st.service_name_ent);
-		dI("%s: element not found\n", "runlevel");
+		dI("%s: element not found", "runlevel");
 
 		return PROBE_ENOELM;
 	}
@@ -398,7 +398,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 		SEXP_t *item;
 
 		while (reply_st != NULL) {
-			dI("get_runlevel: [0]=\"%s\", [1]=\"%s\", [2]=\"%d\", [3]=\"%d\"\n",
+			dI("get_runlevel: [0]=\"%s\", [1]=\"%s\", [2]=\"%d\", [3]=\"%d\"",
 			   reply_st->service_name, reply_st->runlevel, reply_st->start, reply_st->kill);
 
                         item = probe_item_create(OVAL_UNIX_RUNLEVEL, NULL,

--- a/src/OVAL/probes/unix/shadow.c
+++ b/src/OVAL/probes/unix/shadow.c
@@ -183,7 +183,7 @@ static int read_shadow(SEXP_t *un_ent, probe_ctx *ctx)
 	while ((pw = getspent())) {
 		SEXP_t *un;
 
-		dI("Have user: %s\n", pw->sp_namp);
+		dI("Have user: %s", pw->sp_namp);
 		err = 0;
 		un = SEXP_string_newf("%s", pw->sp_namp);
 		if (probe_entobj_cmp(un_ent, un) == OVAL_RESULT_TRUE) {

--- a/src/OVAL/probes/unix/sysctl.c
+++ b/src/OVAL/probes/unix/sysctl.c
@@ -67,7 +67,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
         over_cmp    = oval_version_cmp(over, OVAL_VERSION(5.10));
 
         if (name_entity == NULL) {
-                dE("Missing \"name\" entity in the input object\n");
+                dE("Missing \"name\" entity in the input object");
                 return (PROBE_ENOENT);
         }
 
@@ -102,7 +102,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
         ofts = oval_fts_open(path_entity, filename_entity, NULL, bh_entity);
 
         if (ofts == NULL) {
-                dE("oval_ftp_open(%s, %s) failed\n", PROC_SYS_DIR, ".\\+");
+                dE("oval_ftp_open(%s, %s) failed", PROC_SYS_DIR, ".\\+");
                 SEXP_vfree(path_entity, filename_entity, bh_entity, name_entity, NULL);
 
                 return (PROBE_EFATAL);
@@ -118,13 +118,13 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 
 		/* Skip write-only files, eg. /proc/sys/net/ipv4/route/flush */
 		if (stat(mibpath, &file_stat) == -1) {
-			dE("Stat failed on %s: %u, %s\n", mibpath, errno, strerror(errno));
+			dE("Stat failed on %s: %u, %s", mibpath, errno, strerror(errno));
 			oval_ftsent_free(ofts_ent);
 			continue;
 		}
 		/* the sysctl utility uses same condition in sysctl.c in ReadSetting() */
 		if ((file_stat.st_mode & S_IRUSR) == 0) {
-			dI("Skipping write-only file %s\n", mibpath);
+			dI("Skipping write-only file %s", mibpath);
 			oval_ftsent_free(ofts_ent);
 			continue;
 		}
@@ -138,7 +138,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
                         --miblen;
                 }
 
-                dI("MIB: %s\n", mib);
+                dI("MIB: %s", mib);
                 se_mib = SEXP_string_new(mib, strlen(mib));
                 oscap_free(mib);
 
@@ -150,7 +150,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
                         long i, l;
                         size_t s;
 
-                        dI("MIB match\n");
+                        dI("MIB match");
 
                         /*
                          * read sysctl value
@@ -158,7 +158,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
                         fp = fopen(mibpath, "r");
 
                         if (fp == NULL) {
-                                dE("Can't read sysctl value from \"%s\": %u, %s\n",
+                                dE("Can't read sysctl value from \"%s\": %u, %s",
                                    mibpath, errno, strerror(errno));
                                 goto fail_item;
                         }
@@ -172,13 +172,13 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 				 */
 				if (strncmp(ofts_ent->path, ipv6_conf_path, ipv6_conf_path_len) == 0 &&
 						strcmp(ofts_ent->file, "stable_secret") == 0) {
-					dI("Skippping file %s\n", mibpath);
+					dI("Skippping file %s", mibpath);
 					oval_ftsent_free(ofts_ent);
 					SEXP_free(se_mib);
 					fclose(fp);
 					continue;
 				} else {
-					dE("An error ocured when reading from \"%s\" (fp=%p): l=%ld, %u, %s\n",
+					dE("An error ocured when reading from \"%s\" (fp=%p): l=%ld, %u, %s",
 						mibpath, fp, l, errno, strerror(errno));
 					goto fail_item;
 				}

--- a/src/OVAL/probes/unix/xinetd.c
+++ b/src/OVAL/probes/unix/xinetd.c
@@ -492,7 +492,7 @@ static xiconf_file_t *xiconf_read(const char *path, int flags)
 	}
 
 	if ((st.st_mode & S_IFMT) != S_IFREG) {
-		dE("Not a regular file: %s\n", path);
+		dE("Not a regular file: %s", path);
 		close (fd);
 		return (NULL);
 	}
@@ -554,15 +554,15 @@ static int xiconf_add_cfile(xiconf_t *xiconf, const char *path, int depth)
 	xiconf_file_t *xifile;
 
 	if (xiconf->count + 1 > XICFG_PARSER_MAXFILECOUNT) {
-		dE("include count limit reached: %u\n", XICFG_PARSER_MAXFILECOUNT);
+		dE("include count limit reached: %u", XICFG_PARSER_MAXFILECOUNT);
 		return (-1);
 	}
 
-	dI("Reading included file: %s\n", path);
+	dI("Reading included file: %s", path);
 	xifile = xiconf_read (path, 0);
 
 	if (xifile == NULL) {
-		dW("Failed to read file: %s\n", path);
+		dW("Failed to read file: %s", path);
 		return (-1);
 	}
 
@@ -570,7 +570,7 @@ static int xiconf_add_cfile(xiconf_t *xiconf, const char *path, int depth)
 	xiconf->cfile = oscap_realloc(xiconf->cfile, sizeof(xiconf_file_t *) * ++xiconf->count);
 	xiconf->cfile[xiconf->count - 1] = xifile;
 
-	dI("Added new file to the cfile queue: %s; fi=%zu\n", path, xiconf->count - 1);
+	dI("Added new file to the cfile queue: %s; fi=%zu", path, xiconf->count - 1);
 
 	return (0);
 }
@@ -724,18 +724,18 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 				buffer[l_size] = '\0';
 
 				if (*inclarg == '\0') {
-					dW("Found includedir directive without an argument!\n");
+					dW("Found includedir directive without an argument!");
 					break;
 				}
 
 				if (xifile->depth + 1 > max_depth) {
-					dE("include depth limit reached: %u\n", max_depth);
+					dE("include depth limit reached: %u", max_depth);
 					break;
 				}
 
 				switch (inctype) {
 				case XICONF_INCTYPE_FILE:
-					dI("includefile: %s\n", pathbuf);
+					dI("includefile: %s", pathbuf);
 
 					if (xiconf_add_cfile (xiconf, pathbuf, xifile->depth + 1) != 0)
 						continue;
@@ -746,11 +746,11 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 					DIR           *dirfp;
 					struct dirent  dent, *dentp = NULL;
 
-					dI("includedir open: %s\n", inclarg);
+					dI("includedir open: %s", inclarg);
 					dirfp = opendir (inclarg);
 
 					if (dirfp == NULL) {
-						dW("Can't open includedir: %s; %d, %s.\n", inclarg, errno, strerror (errno));
+						dW("Can't open includedir: %s; %d, %s.", inclarg, errno, strerror (errno));
 						break;
 					}
 
@@ -762,7 +762,7 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 							pathbuf[incllen++] =  '/';
 							pathbuf[incllen  ] = '\0';
 						} else {
-							dE("Length of the includedir argument is out of range: len=%zu, max=%zu\n",
+							dE("Length of the includedir argument is out of range: len=%zu, max=%zu",
 							   incllen, PATH_MAX);
 							closedir(dirfp);
 							break;
@@ -771,7 +771,7 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 
 					for (;;) {
 						if (readdir_r (dirfp, &dent, &dentp) != 0) {
-							dW("Can't read directory: %s; %d, %s.\n", inclarg, errno, strerror (errno));
+							dW("Can't read directory: %s; %d, %s.", inclarg, errno, strerror (errno));
 							break;
 						}
 
@@ -781,7 +781,7 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 						if (fnmatch ("*~",  dent.d_name, FNM_PATHNAME) == 0 ||
 						    fnmatch ("*.*", dent.d_name, FNM_PATHNAME) == 0)
 						{
-							dI("Skipping: %s\n", dent.d_name);
+							dI("Skipping: %s", dent.d_name);
 							continue;
 						}
 
@@ -791,14 +791,14 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 							continue;
 					}
 
-					dI("includedir close: %s\n", inclarg);
+					dI("includedir close: %s", inclarg);
 					closedir(dirfp);
 					break;
 				}}
 				break;
 			}
 			default:
-				dE("Don't know how to parse the line: %s\n", buffer);
+				dE("Don't know how to parse the line: %s", buffer);
 				tmpbuf_free(buffer);
 
 				return (NULL);
@@ -813,7 +813,7 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 
 int xiconf_update(xiconf_t *xiconf)
 {
-	dI("Not implemented yet.\n");
+	dI("Not implemented yet.");
 	return (0);
 }
 
@@ -829,7 +829,7 @@ static int xiconf_service_merge_defaults(xiconf_service_t *dst, xiconf_service_t
 			if (xiattr_table[i].op_merge (xiattr_ptr(dst, xiattr_table[i].offset),
 						      xiattr_ptr(def, xiattr_table[i].offset), XIATTR_MERGE_DEFAULTS) != 0)
 			{
-				dE("Merge failed. Merge operation returned a non-zero value.\n");
+				dE("Merge failed. Merge operation returned a non-zero value.");
 				    return (-1);
 			}
 		}
@@ -853,10 +853,10 @@ int xiconf_parse_section(xiconf_t *xiconf, xiconf_file_t *xifile, int type, char
 	tmpbuf_def(128);
 
 	if (type == XICONF_SECTION_DEFAULTS && xiconf->defaults != NULL) {
-		dE("defaults section was already parsed!\n");
+		dE("defaults section was already parsed!");
 		return (-1);
 	} else if (type == XICONF_SECTION_SERVICE && name == NULL) {
-		dE("Don't know how to handle anonymous service sections!\n");
+		dE("Don't know how to handle anonymous service sections!");
 		return (-1);
 	}
 
@@ -953,7 +953,7 @@ int xiconf_parse_section(xiconf_t *xiconf, xiconf_file_t *xifile, int type, char
 			xiattr = oscap_bfind(xiattr_table, XIATTR_TABLE_COUNT, sizeof(struct xiconf_attr), key, &xiattr_cmp);
 
 			if (xiattr == NULL) {
-				dW("Unknown keyword: %s\n", key);
+				dW("Unknown keyword: %s", key);
 #if XICFG_PARSER_IGNORE_UNKNOWN != 1
 				goto fail;
 #else
@@ -962,7 +962,7 @@ int xiconf_parse_section(xiconf_t *xiconf, xiconf_file_t *xifile, int type, char
 			}
 
 			if (!(type & xiattr->sections)) {
-				dW("Don't know how to handle attribute %s in this sections type (%d)\n",
+				dW("Don't know how to handle attribute %s in this sections type (%d)",
 				   key, type);
 #if XICFG_PARSER_IGNORE_INVSECT != 1
 				goto fail;
@@ -974,11 +974,11 @@ int xiconf_parse_section(xiconf_t *xiconf, xiconf_file_t *xifile, int type, char
 			switch (xiattr->pass_arg) {
 			case XIATTR_OPARG_LOCAL:
 				opvar = (void *)xiattr_ptr(snew, xiattr->offset);
-				dI("local opvar\n");
+				dI("local opvar");
 				break;
 			case XIATTR_OPARG_GLOBAL:
 				opvar = (void *)xiconf;
-				dI("global opvar\n");
+				dI("global opvar");
 				break;
 			default:
 				abort ();
@@ -988,21 +988,21 @@ int xiconf_parse_section(xiconf_t *xiconf, xiconf_file_t *xifile, int type, char
 				opfun = xiattr->op_assign;
 				opval = op + 1;
 
-				dI("assign(%p): var=%s (at %p+%zu = %p), val=%s\n",
+				dI("assign(%p): var=%s (at %p+%zu = %p), val=%s",
 				   opfun, xiattr->name, snew, xiattr->offset, opvar, opval);
 
 			} else if (*op == '+' && *(op+1) == '=') {
 				opfun = xiattr->op_insert;
 				opval = op + 2;
 
-				dI("insert(%p): var=%s (at %p+%zu = %p), val=%s\n",
+				dI("insert(%p): var=%s (at %p+%zu = %p), val=%s",
 				   opfun, xiattr->name, snew, xiattr->offset, opvar, opval);
 
 			} else if (*op == '-' && *(op+1) == '=') {
 				opfun = xiattr->op_remove;
 				opval = op + 2;
 
-				dI("remove(%p): var=%s (at %p+%zu = %p), val=%s\n",
+				dI("remove(%p): var=%s (at %p+%zu = %p), val=%s",
 				   opfun, xiattr->name, snew, xiattr->offset, opvar, opval);
 			} else
 				goto fail;
@@ -1021,12 +1021,12 @@ int xiconf_parse_section(xiconf_t *xiconf, xiconf_file_t *xifile, int type, char
 
 finish_section:
 	if (buffer != NULL) {
-		dW("Line buffer not freed; freeing now...\n");
+		dW("Line buffer not freed; freeing now...");
 		tmpbuf_free(buffer);
 	}
 
 	if (key != NULL) {
-		dW("key not freed; freeing now...\n");
+		dW("key not freed; freeing now...");
 		free(key);
 	}
 
@@ -1050,7 +1050,7 @@ finish_section:
 
 		if (scur == NULL) {
 			if (rbt_str_add (xiconf->stree, snew->id, snew) != 0) {
-				dE("Can't add service (%s) into the service tree (%p)\n",
+				dE("Can't add service (%s) into the service tree (%p)",
 				   snew->id, xiconf->stree);
 
 				xiconf_service_free(snew);
@@ -1080,21 +1080,21 @@ finish_section:
 			// If we still don't know the protocol, then get the default from /etc/services
 			if (scur->protocol == NULL) {
 				struct servent *service = getservbyname(scur->name, NULL);
-				dI("protocol is empty, trying to guess from /etc/services for %s\n", scur->name);
+				dI("protocol is empty, trying to guess from /etc/services for %s", scur->name);
 				if (service != NULL) {
 					scur->protocol = strdup(service->s_proto);
-					dI("service %s has default protocol=%s\n", scur->name, scur->protocol);
+					dI("service %s has default protocol=%s", scur->name, scur->protocol);
 				}
 				endservent();
 			}
 		}
 		if (scur->port == 0) {
 			struct servent *service = getservbyname(scur->name, scur->protocol);
-			dI("port not set, trying to guess from /etc/services for %s\n", scur->name);
+			dI("port not set, trying to guess from /etc/services for %s", scur->name);
 			if (service != NULL) {
 				if (service->s_port > 0 && service->s_port < 65536) {
 					scur->port = ntohs((uint16_t)service->s_port);
-					dI("service %s has default port=%hu/%s\n",
+					dI("service %s has default port=%hu/%s",
 					   scur->name, scur->port, scur->protocol);
 				}
 			}
@@ -1130,7 +1130,7 @@ finish_section:
 		rbt_str_get(xiconf->ttree, st_key, (void *)&st);
 
 		if (st == NULL) {
-			dI("new strans record: k=%s\n", st_key);
+			dI("new strans record: k=%s", st_key);
 
 			st = oscap_talloc (xiconf_strans_t);
 			st->cnt = 1;
@@ -1138,12 +1138,12 @@ finish_section:
 			st->srv[0] = scur;
 
 			if (rbt_str_add (xiconf->ttree, strdup(st_key), st) != 0) {
-				dE("Can't add strans record (k=%s) into the strans tree (%p)\n",
+				dE("Can't add strans record (k=%s) into the strans tree (%p)",
 				   st_key, xiconf->ttree);
 				return (-1);
 			}
 		} else {
-			dI("adding new strans record to an exiting one: k=%s, cnt=%u+1\n",
+			dI("adding new strans record to an exiting one: k=%s, cnt=%u+1",
 			   st_key, st->cnt);
 
 			st->srv = oscap_realloc(st->srv, sizeof (xiconf_service_t *) * ++(st->cnt));
@@ -1155,7 +1155,7 @@ finish_section:
 		 * that happen to have a default value defined.
 		 */
 		if (xiconf_service_merge_defaults(scur, xiconf->defaults) != 0) {
-			dE("Failed to merge service (%p, id=%s) with defaults (%p)\n",
+			dE("Failed to merge service (%p, id=%s) with defaults (%p)",
 			   scur, scur->id, xiconf->defaults);
 			return (-1);
 		}
@@ -1172,12 +1172,12 @@ finish_section:
 fail:
 	tmpbuf_free(buffer);
 	if (key) {
-		dW("fail: key not freed; freeing now...\n");
+		dW("fail: key not freed; freeing now...");
 		free(key);
 	}
 
 	if (snew->name) {
-		dW("fail: snew->name not freed; freeing now...\n");
+		dW("fail: snew->name not freed; freeing now...");
 		free(snew->name);
 	}
 	free(snew);
@@ -1313,7 +1313,7 @@ int op_merge_str(void *dst, void *src, int type)
 	char **b = (char **)src;
 
 	if (*a != NULL) {
-		dE("Cannot merge str value: dst=%p (%s), src=%p (%s)\n", dst, *a, src, *b);
+		dE("Cannot merge str value: dst=%p (%s), src=%p (%s)", dst, *a, src, *b);
 		return (-1);
 	} else
 		*a = *b;
@@ -1346,7 +1346,7 @@ int op_assign_strl(void *var, char *val)
 		if (*tok == '\0') {
 			continue;
 		}
-		dI("Adding new member to string array: %s\n", tok);
+		dI("Adding new member to string array: %s", tok);
 		string_array = oscap_realloc(string_array, sizeof(char *) * (++string_array_size + 1));
 		string_array[string_array_size-1] = strdup(tok);
 		string_array[string_array_size] = NULL;
@@ -1367,7 +1367,7 @@ int op_insert_strl(void *var, char *val)
 		while(string_array[string_array_size]) {
 			++string_array_size;
 		}
-		dI("String array has %zu members\n", string_array_size);
+		dI("String array has %zu members", string_array_size);
 	}
 	str = val;
 	while ((tok = strsep(&str, " ")) != NULL) {
@@ -1377,7 +1377,7 @@ int op_insert_strl(void *var, char *val)
 		if (*tok == '\0') {
 			continue;
 		}
-		dI("Adding new member to string array: %s\n", tok);
+		dI("Adding new member to string array: %s", tok);
 		string_array = oscap_realloc(string_array, sizeof(char *) * (++string_array_size + 1));
 		string_array[string_array_size-1] = strdup(tok);
 		string_array[string_array_size] = NULL;
@@ -1401,7 +1401,7 @@ int op_remove_strl(void *var, char *val)
 		while(string_array[string_array_size]) {
 			++string_array_size;
 		}
-		dI("String array has %zu members\n", string_array_size);
+		dI("String array has %zu members", string_array_size);
 	}
 
 	if (string_array_size < 1) {
@@ -1423,7 +1423,7 @@ int op_remove_strl(void *var, char *val)
 		if (*tok == '\0') {
 			continue;
 		}
-		dI("Adding new member to string array: %s\n", tok);
+		dI("Adding new member to string array: %s", tok);
 		valstr_array = oscap_realloc(valstr_array, sizeof(char *) * (++valstr_array_size + 1));
 		valstr_array[valstr_array_size-1] = tok;
 		valstr_array[valstr_array_size] = NULL;
@@ -1436,10 +1436,10 @@ int op_remove_strl(void *var, char *val)
 
 		for (valstr_array_pos = 0; valstr_array[valstr_array_pos]; ++valstr_array_pos) {
 			char *delete_val = valstr_array[valstr_array_pos];
-			dI("Removing: %s\n", delete_val);
+			dI("Removing: %s", delete_val);
 			// Destroy the string if it matches a string from the value string array
 			// Otherwise move it to the new string array
-			dI("cmp: %s ?= %s\n", string_array_val, delete_val);
+			dI("cmp: %s ?= %s", string_array_val, delete_val);
 			if (strcmp(string_array_val, delete_val) == 0) {
 				oscap_free(string_array_val);
 				string_array_val = NULL;
@@ -1485,17 +1485,17 @@ int op_assign_disabled(void *var, char *val)
 			srv->id = strdup (tok);
 			srv->def_disabled = 1;
 
-			dI("new: def_disabled: = 1: %s\n", srv->id);
+			dI("new: def_disabled: = 1: %s", srv->id);
 
 			if (rbt_str_add (xiconf->stree, srv->id, srv) != 0) {
-				dE("Can't add service (%s) into the service tree (%p)\n",
+				dE("Can't add service (%s) into the service tree (%p)",
 				   srv->id, xiconf->stree);
 
 				xiconf_service_free(srv);
 				return (-1);
 			}
 		} else {
-			dI("mod: def_disabled: %u -> 1: %s\n", srv->def_disabled, srv->id);
+			dI("mod: def_disabled: %u -> 1: %s", srv->def_disabled, srv->id);
 			srv->def_disabled = 1;
 		}
 	}
@@ -1526,17 +1526,17 @@ int op_assign_enabled(void *var, char *val)
 			srv->id = strdup (tok);
 			srv->def_enabled = 1;
 
-			dI("new: def_enabled: = 1: %s\n", srv->id);
+			dI("new: def_enabled: = 1: %s", srv->id);
 
 			if (rbt_str_add (xiconf->stree, srv->id, srv) != 0) {
-				dE("Can't add service (%s) into the service tree (%p)\n",
+				dE("Can't add service (%s) into the service tree (%p)",
 				   srv->id, xiconf->stree);
 
 				xiconf_service_free(srv);
 				return (-1);
 			}
 		} else {
-			dI("mod: def_enabled: %u -> 1: %s\n", srv->def_disabled, srv->id);
+			dI("mod: def_enabled: %u -> 1: %s", srv->def_disabled, srv->id);
 			srv->def_enabled = 1;
 		}
 	}

--- a/src/OVAL/results/oval_cmp.c
+++ b/src/OVAL/results/oval_cmp.c
@@ -146,7 +146,7 @@ oval_result_t oval_str_cmp_str(char *state_data, oval_datatype_t state_data_type
 		return oval_ipaddr_cmp(AF_INET6, state_data, sys_data, operation);
 	} else if (state_data_type == OVAL_DATATYPE_FILESET_REVISION
 			|| state_data_type == OVAL_DATATYPE_IOS_VERSION) {
-		dW("Unsupported data type: %s.\n", oval_datatype_get_text(state_data_type));
+		dW("Unsupported data type: %s.", oval_datatype_get_text(state_data_type));
 		return OVAL_RESULT_NOT_EVALUATED;
 	}
 

--- a/src/OVAL/results/oval_cmp_basic.c
+++ b/src/OVAL/results/oval_cmp_basic.c
@@ -135,7 +135,7 @@ static oval_result_t strregcomp(const char *pattern, const char *test_str)
 
 	re = pcre_compile(pattern, PCRE_UTF8, &err, &errofs, NULL);
 	if (re == NULL) {
-		oscap_dlprintf(DBG_E, "Unable to compile regex pattern, "
+		dE("Unable to compile regex pattern, "
 			       "pcre_compile() returned error (offset: %d): '%s'.\n", errofs, err);
 		return OVAL_RESULT_ERROR;
 	}
@@ -146,7 +146,7 @@ static oval_result_t strregcomp(const char *pattern, const char *test_str)
 	} else if (ret == -1) {
 		result = OVAL_RESULT_FALSE;
 	} else {
-		oscap_dlprintf(DBG_E, "Unable to match regex pattern, "
+		dE("Unable to match regex pattern, "
 			       "pcre_exec() returned error: %d.\n", ret);
 		result = OVAL_RESULT_ERROR;
 	}
@@ -157,7 +157,7 @@ static oval_result_t strregcomp(const char *pattern, const char *test_str)
 
 	ret = regcomp(&re, pattern, REG_EXTENDED);
 	if (ret != 0) {
-		oscap_dlprintf(DBG_E, "Unable to compile regex pattern, "
+		dE("Unable to compile regex pattern, "
 			       "regcomp() returned error: %d.\n", ret);
 		return OVAL_RESULT_ERROR;
 	}
@@ -168,7 +168,7 @@ static oval_result_t strregcomp(const char *pattern, const char *test_str)
 	} else if (ret == REG_NOMATCH) {
 		result = OVAL_RESULT_FALSE;
 	} else {
-		oscap_dlprintf(DBG_E, "Unable to match regex pattern: %d.\n", ret);
+		dE("Unable to match regex pattern: %d.", ret);
 		result = OVAL_RESULT_ERROR;
 	}
 

--- a/src/OVAL/results/oval_cmp_ip_address.c
+++ b/src/OVAL/results/oval_cmp_ip_address.c
@@ -174,7 +174,7 @@ oval_result_t oval_ipaddr_cmp(int af, const char *s1, const char *s2, oval_opera
 			result = OVAL_RESULT_FALSE;
 		break;
 	default:
-		dE("Unexpected compare operation: %d.\n", op);
+		dE("Unexpected compare operation: %d.", op);
 		assert(false);
 	}
 
@@ -204,7 +204,7 @@ static inline int ipv4addr_parse(const char *oval_ipv4_string, uint32_t *netmask
 	}
 
 	if (inet_pton(AF_INET, s, ip_out) <= 0)
-		dW("inet_pton() failed.\n");
+		dW("inet_pton() failed.");
 	else
 		result = 0;
 
@@ -232,7 +232,7 @@ static inline int ipv6addr_parse(const char *oval_ipv6_string, uint32_t *len_out
 	}
 
 	if (inet_pton(AF_INET6, s, ip_out) <= 0)
-		dW("inet_pton() failed.\n");
+		dW("inet_pton() failed.");
 	else
 		result = 0;
 

--- a/src/OVAL/results/oval_resModel.c
+++ b/src/OVAL/results/oval_resModel.c
@@ -317,7 +317,7 @@ int oval_results_model_parse(xmlTextReaderPtr reader, struct oval_parser_context
                         } else if (is_ovalres && (strcmp(tagname, "results") == 0)) {
                                 ret = oval_parser_parse_tag(reader, context, &oval_result_system_parse_tag , NULL);
                         } else {
-                                dW("Unprocessed tag: <%s:%s>.\n", namespace, tagname);
+                                dW("Unprocessed tag: <%s:%s>.", namespace, tagname);
                                 oval_parser_skip_tag(reader, context);
                         }
 

--- a/src/OVAL/results/oval_resultCriteriaNode.c
+++ b/src/OVAL/results/oval_resultCriteriaNode.c
@@ -137,7 +137,7 @@ struct oval_result_criteria_node *oval_result_criteria_node_new(struct oval_resu
 		} break;
 	default:
 		va_end(ap);
-		dE("Unsupported criteria node type: %d.\n", type);
+		dE("Unsupported criteria node type: %d.", type);
 		return NULL;
 	}
 	node->sys = sys;
@@ -562,12 +562,12 @@ int oval_result_criteria_node_parse(xmlTextReaderPtr reader,
 						     variable_instance);
 		oscap_free(definition_ref);
 	} else {
-		dW("unhandled criteria node: <%s>.\n",(char *)localName);
+		dW("unhandled criteria node: <%s>.",(char *)localName);
 		oval_parser_skip_tag(reader, context);
 	}
 
 	if (node==NULL || rc==-1) {
-		dE("Can't parse result criteria node.\n");
+		dE("Can't parse result criteria node.");
 		return 1;
 	}
 

--- a/src/OVAL/results/oval_resultDefinition.c
+++ b/src/OVAL/results/oval_resultDefinition.c
@@ -257,7 +257,7 @@ int oval_result_definition_parse_tag(xmlTextReaderPtr reader, struct oval_parser
 
 	int defvsn = oval_definition_get_version(definition->definition);
 	if (defvsn && resvsn != defvsn) {
-		dW("Definition versions don't match: definition id: %s, ovaldef vsn: %d, resdef vsn: %d.\n", definition_id, defvsn, resvsn);
+		dW("Definition versions don't match: definition id: %s, ovaldef vsn: %d, resdef vsn: %d.", definition_id, defvsn, resvsn);
 	}
 	oval_definition_set_version(definition->definition, resvsn);
 	// The following _set_instance() might be overabundant, since it should be already set
@@ -269,7 +269,7 @@ int oval_result_definition_parse_tag(xmlTextReaderPtr reader, struct oval_parser
 	if ((int)result != OVAL_ENUMERATION_INVALID) {
 		oval_result_definition_set_result(definition, result);
 	} else {
-		dW("Can't resolve result attribute, definition id: %s.\n", definition_id);
+		dW("Can't resolve result attribute, definition id: %s.", definition_id);
 		oval_result_definition_set_result(definition, OVAL_RESULT_UNKNOWN);
 	}
 

--- a/src/OVAL/results/oval_resultSystem.c
+++ b/src/OVAL/results/oval_resultSystem.c
@@ -211,7 +211,7 @@ struct oval_result_definition *oval_result_system_get_new_definition
 		}
 		else if (oval_result_definition_get_variable_instance_hint(rslt_definition) != oval_result_definition_get_instance(rslt_definition)) {
 			int hint = oval_result_definition_get_variable_instance_hint(rslt_definition);
-			dI("Creating another result-definition for id=%s based on variable_instance: %d\n", id, hint);
+			dI("Creating another result-definition for id=%s based on variable_instance: %d", id, hint);
 			rslt_definition = make_result_definition_from_oval_definition(sys, oval_definition, hint);
 			oval_result_system_add_definition(sys, rslt_definition);
 		}
@@ -228,7 +228,7 @@ struct oval_result_test *oval_result_system_get_new_test(struct oval_result_syst
 		oval_result_system_add_test(sys, rslt_testtest);
 	}
 	else if (variable_instance != 0 && oval_result_test_get_instance(rslt_testtest) != variable_instance) {
-		dI("Creating another result-test for id=%s based on variable_instance: %d\n", id, variable_instance);
+		dI("Creating another result-test for id=%s based on variable_instance: %d", id, variable_instance);
 		rslt_testtest = make_result_test_from_oval_test(sys, oval_test, variable_instance);
 		oval_result_system_add_test(sys, rslt_testtest);
 	}
@@ -285,12 +285,12 @@ static int oval_result_system_parse(xmlTextReaderPtr reader, struct oval_parser_
 	} else if (strcmp((const char *)localName, OVAL_ROOT_ELM_SYSCHARS) == 0) {
 		return_code = oval_syschar_model_parse(reader, context);
 	} else {
-                dW("Skipping tag: %s\n", localName);
+                dW("Skipping tag: %s", localName);
                 oval_parser_skip_tag(reader, context);
 	}
 
         if (return_code != 0) {
-                dW("Parsing of <%s> terminated by an error at line %d.\n", localName, xmlTextReaderGetParserLineNumber(reader));
+                dW("Parsing of <%s> terminated by an error at line %d.", localName, xmlTextReaderGetParserLineNumber(reader));
         }
 
 	oscap_free(localName);
@@ -314,12 +314,12 @@ int oval_result_system_parse_tag(xmlTextReaderPtr reader, struct oval_parser_con
 		/* populate results system  */
 		return_code = oval_parser_parse_tag(reader, context, oval_result_system_parse, sys);
         } else {
-                dW("Skipping tag: %s\n", tagname);
+                dW("Skipping tag: %s", tagname);
                 oval_parser_skip_tag(reader, context);
         }
 
         if (return_code != 0) {
-                dW("Parsing of <%s> terminated by an error at line %d.\n", tagname, xmlTextReaderGetParserLineNumber(reader));
+                dW("Parsing of <%s> terminated by an error at line %d.", tagname, xmlTextReaderGetParserLineNumber(reader));
         }
 
         oscap_free(tagname);
@@ -373,7 +373,7 @@ int oval_result_system_eval_definition(struct oval_result_system *sys, const cha
         }
 	else if (oval_result_definition_get_variable_instance_hint(rslt_definition) != oval_result_definition_get_instance(rslt_definition)) {
 		int hint = oval_result_definition_get_variable_instance_hint(rslt_definition);
-		dI("Creating another result-definition for id=%s based on variable_instance: %d\n", id, hint);
+		dI("Creating another result-definition for id=%s based on variable_instance: %d", id, hint);
 		rslt_definition = make_result_definition_from_oval_definition(sys, oval_definition, hint);
 		oval_result_system_add_definition(sys, rslt_definition);
 	}

--- a/src/OVAL/results/oval_resultTest.c
+++ b/src/OVAL/results/oval_resultTest.c
@@ -410,7 +410,7 @@ static inline oval_result_t _evaluate_sysent_with_variable(struct oval_syschar_m
 			var_val = oval_value_iterator_next(val_itr);
 			state_entity_val_text = oval_value_get_text(var_val);
 			if (state_entity_val_text == NULL) {
-				dE("Found NULL variable value text.\n");
+				dE("Found NULL variable value text.");
 				ores_add_res(&var_ores, OVAL_RESULT_ERROR);
 				break;
 			}
@@ -555,7 +555,7 @@ static oval_result_t eval_item(struct oval_syschar_model *syschar_model, struct 
 		oval_sysent_iterator_free(item_entities_itr);
 
 		if (!found_matching_item)
-			dW("Entity name '%s' from state (id: '%s') not found in item (id: '%s').\n",
+			dW("Entity name '%s' from state (id: '%s') not found in item (id: '%s').",
 			   state_entity_name, oval_state_get_id(state), oval_sysitem_get_id(cur_sysitem));
 
 		ste_ent_res = ores_get_result_bychk(&ent_ores, entity_check);
@@ -851,7 +851,7 @@ static oval_result_t _oval_result_test_result(struct oval_result_test *rtest, vo
 
 	/* is the test already evaluated? */
 	if (rtest->result != OVAL_RESULT_NOT_EVALUATED) {
-		dI("Found result from previous evaluation: %d, returning without further processing.\n", rtest->result);
+		dI("Found result from previous evaluation: %d, returning without further processing.", rtest->result);
 		return (rtest->result);
 	}
 
@@ -865,7 +865,7 @@ static oval_result_t _oval_result_test_result(struct oval_result_test *rtest, vo
 
 	struct oval_syschar * syschar = oval_syschar_model_get_syschar(syschar_model, object_id);
 	if (syschar == NULL) {
-		dW("No syschar for object: %s\n", object_id);
+		dW("No syschar for object: %s", object_id);
 		return OVAL_RESULT_UNKNOWN;
 	}
 
@@ -977,7 +977,7 @@ oval_result_t oval_result_test_eval(struct oval_result_test *rtest)
 			rtest->result = OVAL_RESULT_UNKNOWN;
 	}
 
-        dI("\t%s => %s\n", oval_result_test_get_id(rtest), oval_result_get_text(rtest->result));
+        dI("\t%s => %s", oval_result_test_get_id(rtest), oval_result_get_text(rtest->result));
 
 	return rtest->result;
 }
@@ -1088,7 +1088,7 @@ static int _oval_result_test_parse(xmlTextReaderPtr reader, struct oval_parser_c
 	} else if (strcmp((const char *)localName, "tested_variable") == 0) {
 		return_code = _oval_result_test_binding_parse(reader, context, args);
 	} else {
-		dW( "Unhandled tag: <%s>.\n", localName);
+		dW("Unhandled tag: <%s>.", localName);
 		oval_parser_skip_tag(reader, context);
 	}
 
@@ -1124,7 +1124,7 @@ int oval_result_test_parse_tag(xmlTextReaderPtr reader, struct oval_parser_conte
 	if (tst_check_existence == OVAL_EXISTENCE_UNKNOWN) {
 		oval_test_set_existence(ovaltst, check_existence);
 	} else if (tst_check_existence != check_existence) {
-		oscap_dlprintf(DBG_W, "@check_existence does not match, test_id: %s.\n", test_id);
+		dW("@check_existence does not match, test_id: %s.", test_id);
 	}
 
 	oval_check_t check = oval_check_parse(reader, "check", OVAL_CHECK_UNKNOWN);
@@ -1132,7 +1132,7 @@ int oval_result_test_parse_tag(xmlTextReaderPtr reader, struct oval_parser_conte
 	if (tst_check == OVAL_CHECK_UNKNOWN) {
 		oval_test_set_check(ovaltst, check);
 	} else if (tst_check != check) {
-		oscap_dlprintf(DBG_W, "@check does not match, test_id: %s.\n", test_id);
+		dW("@check does not match, test_id: %s.", test_id);
 	}
 
 	int version = oval_parser_int_attribute(reader, "version", 0);
@@ -1140,7 +1140,7 @@ int oval_result_test_parse_tag(xmlTextReaderPtr reader, struct oval_parser_conte
 	if (tst_version == 0) {
 		oval_test_set_version(ovaltst, version);
 	} else if (tst_version != version) {
-		oscap_dlprintf(DBG_W, "@version does not match, test_id: %s.\n", test_id);
+		dW("@version does not match, test_id: %s.", test_id);
 	}
 
 	struct oval_string_map *itemmap = oval_string_map_new();

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -126,7 +126,7 @@ static bool xccdf_policy_filter_selected(void *item, void *policy)
 
         struct xccdf_item * titem = xccdf_benchmark_get_item(benchmark, xccdf_select_get_item((struct xccdf_select *) item));
         if (titem == NULL) {
-            oscap_dlprintf(DBG_E, "Item \"%s\" does not exist. Remove it from Profile !\n", xccdf_select_get_item((struct xccdf_select *) item));
+            dE("Item \"%s\" does not exist. Remove it from Profile !", xccdf_select_get_item((struct xccdf_select *) item));
             return false;
         }
 	return ((xccdf_item_get_type(titem) == XCCDF_RULE) &&
@@ -305,7 +305,7 @@ static xccdf_test_result_type_t _resolve_operation(int A, int B, xccdf_bool_oper
      */
     if ((A == 0) || (B == 0)
 	|| A > XCCDF_RESULT_INFORMATIONAL || B > XCCDF_RESULT_INFORMATIONAL) {
-	oscap_dlprintf(DBG_E, "Bad test results %d, %d.\n", A, B);
+	dE("Bad test results %d, %d.", A, B);
 	return 0;
     }
 
@@ -318,7 +318,7 @@ static xccdf_test_result_type_t _resolve_operation(int A, int B, xccdf_bool_oper
             value = (xccdf_test_result_type_t) RESULT_TABLE_OR[A][B];
             break;
 	default:
-	    oscap_dlprintf(DBG_E, "Operation not supported.\n");
+	    dE("Operation not supported.");
             return 0;
             break;
     }
@@ -2280,7 +2280,7 @@ struct xccdf_score * xccdf_policy_get_score(struct xccdf_policy * policy, struct
         oscap_free(item_score);
     } else {
         xccdf_score_free(score);
-        oscap_dlprintf(DBG_E, "Scoring system \"%s\" is not supported.\n", scsystem);
+        dE("Scoring system \"%s\" is not supported.", scsystem);
         return NULL;
     }
 

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -235,7 +235,7 @@ static inline int _xccdf_fix_decode_xml(struct xccdf_fix *fix, char **result)
 		xccdf_fix_get_content(fix));
         xmlDoc *doc = xmlReadMemory(str, strlen(str), NULL, NULL, XML_PARSE_RECOVER |
 		XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET | XML_PARSE_NSCLEAN);
-	dI("Following script will be executed: '''%s'''\n", str);
+	dI("Following script will be executed: '''%s'''", str);
 	oscap_free(str);
 
         xmlBuffer *buff = xmlBufferCreate();
@@ -467,21 +467,21 @@ static inline int _xccdf_policy_rule_generate_fix(struct xccdf_policy *policy, s
 	// Ensure that given Rule is selected and applicable (CPE).
 	const bool is_selected = xccdf_policy_is_item_selected(policy, xccdf_rule_get_id(rule));
 	if (!is_selected) {
-		dI("Skipping unselected Rule/@id=\"%s\"\n", xccdf_rule_get_id(rule));
+		dI("Skipping unselected Rule/@id=\"%s\"", xccdf_rule_get_id(rule));
 		return 0;
 	}
 	const bool is_applicable = xccdf_policy_model_item_is_applicable(xccdf_policy_get_model(policy), (struct xccdf_item*)rule);
 	if (!is_applicable) {
-		dI("Skipping notapplicable Rule/@id\"%s\"\n", xccdf_rule_get_id(rule));
+		dI("Skipping notapplicable Rule/@id\"%s\"", xccdf_rule_get_id(rule));
 		return 0;
 	}
 	// Find the most suitable fix.
 	const struct xccdf_fix *fix = _find_fix_for_template(policy, rule, template);
 	if (fix == NULL) {
-		dI("No fix element was found for Rule/@id=\"%s\"\n", xccdf_rule_get_id(rule));
+		dI("No fix element was found for Rule/@id=\"%s\"", xccdf_rule_get_id(rule));
 		return 0;
 	}
-	dI("Processing a fix for Rule/@id=\"%s\"\n", xccdf_rule_get_id(rule));
+	dI("Processing a fix for Rule/@id=\"%s\"", xccdf_rule_get_id(rule));
 
 	// Process Text Substitute within the fix
 	struct xccdf_fix *cfix = xccdf_fix_clone(fix);
@@ -540,7 +540,7 @@ int xccdf_policy_generate_fix(struct xccdf_policy *policy, struct xccdf_result *
 
 	if (result == NULL) {
 		// No TestResult is available. Generate fix from the stock profile.
-		dI("Generating fixes for policy(profile/@id=%s)\n", xccdf_policy_get_id(policy));
+		dI("Generating fixes for policy(profile/@id=%s)", xccdf_policy_get_id(policy));
 		int ret = 0;
 		struct xccdf_benchmark *benchmark = xccdf_policy_get_benchmark(policy);
 		if (benchmark == NULL) {

--- a/src/XCCDF_POLICY/xccdf_policy_substitute.c
+++ b/src/XCCDF_POLICY/xccdf_policy_substitute.c
@@ -59,7 +59,7 @@ static int _xccdf_text_substitution_cb(xmlNode **node, void *user_data)
 
 	if (oscap_streq((const char *) (*node)->name, "sub") && xccdf_is_supported_namespace((*node)->ns)) {
 		if ((*node)->children != NULL)
-			dW("The xccdf:sub element SHALL NOT have any content.\n");
+			dW("The xccdf:sub element SHALL NOT have any content.");
 		char *sub_idref = (char *) xmlGetProp(*node, BAD_CAST "idref");
 		if (oscap_streq(sub_idref, NULL)) {
 			oscap_seterr(OSCAP_EFAMILY_XCCDF, "The xccdf:sub MUST have a single @idref attribute.");
@@ -94,7 +94,7 @@ static int _xccdf_text_substitution_cb(xmlNode **node, void *user_data)
 				oscap_text_iterator_free(title_it);
 			} else {
 				if (!oscap_streq(sub_use, "value"))
-					dW("xccdf:sub/@idref='%s' has incorrect @use='%s'! Using @use='value' instead.\n", sub_idref, sub_use);
+					dW("xccdf:sub/@idref='%s' has incorrect @use='%s'! Using @use='value' instead.", sub_idref, sub_use);
 				result = xccdf_policy_get_value_of_item(data->policy, value);
 			}
 			oscap_free(sub_use);
@@ -135,7 +135,7 @@ static int _xccdf_text_substitution_cb(xmlNode **node, void *user_data)
 			} else {
 				result = xccdf_benchmark_get_plain_text(benchmark, value_id);
 				if (result == NULL) {
-					dW("Text substitution for xccdf:fact is not supported!\n"); // TODO.
+					dW("Text substitution for xccdf:fact is not supported!"); // TODO.
 				}
 			}
 		}
@@ -154,7 +154,7 @@ static int _xccdf_text_substitution_cb(xmlNode **node, void *user_data)
 		else {
 			// Let's not consider this as an error. Since in similar cases NISTIR-7275r4
 			// suggests to retain the <object> element.
-			dW("Unsupported XCCDF uri: xhtml:object/@data='%s'\n", object_data);
+			dW("Unsupported XCCDF uri: xhtml:object/@data='%s'", object_data);
 			free(object_data);
 			return 0;
 		}
@@ -168,7 +168,7 @@ static int _xccdf_text_substitution_cb(xmlNode **node, void *user_data)
 		const char *result;
 		// <instance> elements
 		if ((*node)->children != NULL)
-			dW("The xccdf:instance element SHALL NOT have any content.\n");
+			dW("The xccdf:instance element SHALL NOT have any content.");
 		if (data->rule_result == NULL)
 			return 1;
 		struct xccdf_instance_iterator *instances = xccdf_rule_result_get_instances(data->rule_result);
@@ -179,7 +179,7 @@ static int _xccdf_text_substitution_cb(xmlNode **node, void *user_data)
 		}
 		else {
 			xccdf_instance_iterator_free(instances);
-			dW("The xccdf:rule-result/xccdf:instance element was not found.\n");
+			dW("The xccdf:rule-result/xccdf:instance element was not found.");
 			return 1;
 		}
 		xmlNode *new_node = xmlNewText(BAD_CAST result);

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -183,6 +183,7 @@ static void __oscap_vdlprintf(int level, const char *file, const char *fn, size_
 		l, f, line, fn);
 #endif
 	vfprintf(__debuglog_fp, fmt, ap);
+	fputc('\n', __debuglog_fp);
 
 	if (flock(fileno(__debuglog_fp), LOCK_UN) == -1) {
 		/* __UNLOCK_FP; */

--- a/src/common/elements.c
+++ b/src/common/elements.c
@@ -185,7 +185,7 @@ oscap_xml_save_filename(const char *filename, xmlDocPtr doc)
 		if (buff == NULL) {
 			close(fd);
 			oscap_setxmlerr(xmlGetLastError());
-			oscap_dlprintf(DBG_W, "xmlOutputBufferCreateFile() failed.\n");
+			dW("xmlOutputBufferCreateFile() failed.");
 			xmlFreeDoc(doc);
 			return -1;
 		}
@@ -195,7 +195,7 @@ oscap_xml_save_filename(const char *filename, xmlDocPtr doc)
 	}
 	if (xmlCode <= 0) {
 		oscap_setxmlerr(xmlGetLastError());
-		oscap_dlprintf(DBG_W, "No bytes exported: xmlCode: %d.\n", xmlCode);
+		dW("No bytes exported: xmlCode: %d.", xmlCode);
 	}
 
 	xmlFreeDoc(doc);

--- a/src/common/error.c
+++ b/src/common/error.c
@@ -54,7 +54,7 @@ static struct oscap_err_t *oscap_err_new(oscap_errfamily_t family, const char *d
 	err->line = line;
 	err->file = file;
 
-	dE("\(%s:%d:%s\()) %s\n", file, line, func, desc);
+	dE("\(%s:%d:%s\()) %s", file, line, func, desc);
 
 	return (err);
 }

--- a/src/common/memusage.c
+++ b/src/common/memusage.c
@@ -83,7 +83,7 @@ static int read_status(const char *source, void *base, struct stat_parser *spt, 
 
 		for (i = 0; i < spt_size - 1; ++i) {
 			if (cmpkey(spt[i].keyword, spt + i+1) > 0) {
-				dE("spt not sorted! %s > %s\n",
+				dE("spt not sorted! %s > %s",
 				   spt[i].keyword, spt[i+1].keyword);
 				abort();
 			}
@@ -117,7 +117,7 @@ static int read_status(const char *source, void *base, struct stat_parser *spt, 
 			sp = oscap_bfind(spt, spt_size, sizeof(struct stat_parser),
 			                 linebuf, (int(*)(void *, void *))&cmpkey);
 
-			dI("spt: %s\n", linebuf);
+			dI("spt: %s", linebuf);
 
 			if (sp == NULL) {
 				/* drop end of unread line */

--- a/src/common/oscapxml.c
+++ b/src/common/oscapxml.c
@@ -632,7 +632,7 @@ int oscap_determine_document_type(const char *document, oscap_document_type_t *d
                 return -1;
         }
 
-        dI("Identified document type: %s\n", elm_name);
+        dI("Identified document type: %s", elm_name);
 
         xmlFreeTextReader(reader);
         return 0;

--- a/src/common/reference.c
+++ b/src/common/reference.c
@@ -173,7 +173,7 @@ struct oscap_reference *oscap_reference_new_parse(xmlTextReaderPtr reader)
     }
 
     if (!oscap_to_start_element(reader, depth))
-	    dW("oscap_to_start_element returned `false'\n");
+	    dW("oscap_to_start_element returned `false'");
 
     return ref;
 }

--- a/src/common/xml_iterate.c
+++ b/src/common/xml_iterate.c
@@ -55,12 +55,12 @@ int xml_iterate_dfs(const char *input_text, char **output_text, xml_iterate_call
 
 	input_document = oscap_sprintf("<x xmlns='http://www.w3.org/1999/xhtml'>%s</x>", input_text);
 	if ((doc = xmlParseMemory(input_document, strlen(input_document))) == NULL) {
-		dW("Could not xmlParseMemory: '%s'\n", input_document);
+		dW("Could not xmlParseMemory: '%s'", input_document);
 		free(input_document);
 		return 1;
 	}
 	if ((root = xmlDocGetRootElement(doc)) == NULL) {
-		dW("Could not xmlDocGetRootElement: '%s'\n", input_document);
+		dW("Could not xmlDocGetRootElement: '%s'", input_document);
 		xmlFreeDoc(doc);
 		free(input_document);
 		return 1;
@@ -71,7 +71,7 @@ int xml_iterate_dfs(const char *input_text, char **output_text, xml_iterate_call
 	if (output_text != NULL) {
 		// We cannot simply xmlDumpMemory, because we need to skip the upper <x/> element.
 		if ((root = xmlDocGetRootElement(doc)) == NULL) {
-			dW("Could not get xmlDocGetRootElement of result document.\n");
+			dW("Could not get xmlDocGetRootElement of result document.");
 			xmlFreeDoc(doc);
 			return 1;
 		}
@@ -80,7 +80,7 @@ int xml_iterate_dfs(const char *input_text, char **output_text, xml_iterate_call
 		while (child != NULL) {
 			int size = xmlNodeDump(buff, doc, child, 0, 0);
 			if (size == 0) {
-				dW("xmlBufNodeDump returns zero.\n");
+				dW("xmlBufNodeDump returns zero.");
 			}
 			child = child->next;
 		}


### PR DESCRIPTION
To allow to change or redesign the format of verbose log we have to remove
line breaks at the end of some messages. Then it will be possible to move
the message to the begining or middle of a line without any hacks.
The commit also enforces usage of dI, dE, dW macros instead of
ocassionaly appearing oscap_dlprintf macro. This change makes
codebase more consistent regarding the debugging.
To avoid possible wrong usage of debugging macros or wrong formating
by developers in future, first part of this change has to be done
in the maint-1.0 branch.
