### PR TITLE
Always strip the source file path

### DIFF
--- a/src/common/debug_priv.h
+++ b/src/common/debug_priv.h
@@ -38,19 +38,6 @@
 
 OSCAP_HIDDEN_START;
 
-/**
- * Name of the environment variable that can be used to enable
- * striping of __FILE__ paths. It's numeric value specifies how
- * many path tokens from the end should remain after striping.
- * Value 1 is equal to basename(__FILE__)
- * If this environment variable isn't defined or is set to 0
- * then no striping is done.
- */
-#ifndef OSCAP_DEBUG_PATHSTRIP_ENV
-# define OSCAP_DEBUG_PATHSTRIP_ENV "OSCAP_DEBUG_PSTRIP"
-#endif
-
-
 #define OSCAP_DEBUGOBJ_SEXP 1
 
 #ifndef _A


### PR DESCRIPTION
Do not depend on an environment variable.
Now we will use behavior which used to be default.
Showing the full filepath is not as helpful to slow down the program
by reading an environment variable.