### PR TITLE
Reviewed linebreaks in multiline calls of debugging macros

### DIFF
--- a/src/OVAL/oval_test.c
+++ b/src/OVAL/oval_test.c
@@ -382,7 +382,7 @@ int oval_test_parse_tag(xmlTextReaderPtr reader, struct oval_parser_context *con
 	oval_check_t check = oval_check_parse(reader, "check", OVAL_CHECK_UNKNOWN);
 	if (check == OVAL_CHECK_NONE_EXIST) {
 		dW("The 'none exist' CheckEnumeration value has been deprecated. "
-		   "Converted to check='none satisfy' and check_existence='none exist'.\n");
+		   "Converted to check='none satisfy' and check_existence='none exist'.");
 		oval_test_set_check(test, OVAL_CHECK_NONE_SATISFY);
 		oval_test_set_existence(test, OVAL_NONE_EXIST);
 	} else {

--- a/src/OVAL/probes/SEAP/sexp-value.c
+++ b/src/OVAL/probes/SEAP/sexp-value.c
@@ -48,12 +48,8 @@ int SEXP_val_new (SEXP_val_t *dst, size_t vmemsize, SEXP_type_t type)
         dst->type      = type;
         dst->ptr       = SEXP_val_ptr (dst);
 #if defined(SEAP_VERBOSE_DEBUG)
-        dI(""
-           "new value: hdr->refs = %u\n"
-           "           hdr->size = %zu\n"
-           "                type = %hhu\n"
-           "                 ptr = %p\n",
-           dst->hdr->refs, dst->hdr->size, dst->type, (void *)dst->ptr);
+	dD("new value: hdr->refs = %u, hdr->size = %zu, type = %hhu, ptr = %p",
+		dst->hdr->refs, dst->hdr->size, dst->type, (void *)dst->ptr);
 #endif
         return (0);
 }

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -114,10 +114,7 @@ static OVAL_FTSENT *OVAL_FTSENT_new(OVAL_FTS *ofts, FTSENT *fts_ent)
 	}
 
 #if defined(OSCAP_FTS_DEBUG)
-	dI(""
-	   "New OVAL_FTSENT:\n"
-	   "\t    file: '%s'.\n"
-	   "\t    path: '%s'.\n", ofts_ent->file, ofts_ent->path);
+	dD("New OVAL_FTSENT: file: '%s', path: '%s'.", ofts_ent->file, ofts_ent->path);
 #endif
 	return (ofts_ent);
 }
@@ -315,7 +312,7 @@ static int badpartial_transform_pattern(char *pattern, pcre **regex_out)
 	if (s == NULL) {
 		dW("Nonfatal failure: can't transform the pattern for partial "
 		   "match optimization: none of the suspected culprits found, "
-		   "pattern: '%s'.\n", pattern);
+		   "pattern: '%s'.", pattern);
 		return -1;
 	}
 
@@ -328,7 +325,7 @@ static int badpartial_transform_pattern(char *pattern, pcre **regex_out)
 	if (regex == NULL) {
 		dW("Nonfatal failure: can't transform the pattern for partial "
 		   "match optimization, error: '%s', error offset: %d, "
-		   "pattern: '%s'.\n", errptr, errofs, pattern);
+		   "pattern: '%s'.", errptr, errofs, pattern);
 		return -1;
 	}
 
@@ -338,7 +335,7 @@ static int badpartial_transform_pattern(char *pattern, pcre **regex_out)
 		pcre_free(regex);
 		dW("Nonfatal failure: can't transform the pattern for partial "
 		   "match optimization, pcre_exec() return code: %d, pattern: "
-		   "'%s'.\n", ret, pattern);
+		   "'%s'.", ret, pattern);
 		return -1;
 	}
 
@@ -371,7 +368,7 @@ static int process_pattern_match(const char *path, pcre **regex_out)
 		memcpy(pattern + 1, path, plen);
 		dW("The pattern doesn't contain a leading caret - added. "
 		   "All paths with the 'pattern match' operation must begin "
-		   "with a caret.\n");
+		   "with a caret.");
 	} else {
 		pattern = strdup(path);
 	}
@@ -482,7 +479,7 @@ static int process_pattern_match(const char *path, pcre **regex_out)
 		dI("Disabling partial match optimization.");
 	} else {
 		dI("Enabling partial match optimization using "
-		   "pattern: '%s'.\n", pattern);
+		   "pattern: '%s'.", pattern);
 		if (regex_out != NULL)
 			*regex_out = regex;
 	}
@@ -546,10 +543,7 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 					 return NULL;, /* noop */;);
 		}
 #if defined(OSCAP_FTS_DEBUG)
-		dI(""
-		   "        path: '%s'.\n"
-		   "    filename: '%s'.\n"
-		   "nil filename: %d.\n", cstr_path, nilfilename ? "" : cstr_file, nilfilename);
+		dD("path: '%s', filename: '%s', filename: %d.", cstr_path, nilfilename ? "" : cstr_file, nilfilename);
 #endif
 	} else { /* filepath != NULL */
 		PROBE_ENT_STRVAL(filepath, cstr_path, sizeof cstr_path, return NULL;, return NULL;);

--- a/src/OVAL/probes/probe/entcmp.c
+++ b/src/OVAL/probes/probe/entcmp.c
@@ -530,7 +530,7 @@ oval_result_t probe_ent_result_bychk(SEXP_t * res_lst, oval_check_t check)
 		break;
 	case OVAL_CHECK_NONE_EXIST:
 		dW("The 'none exist' CheckEnumeration value has been deprecated. "
-		   "Converted to check='none satisfy'.\n");
+		   "Converted to check='none satisfy'.");
 		/* FALLTHROUGH */
 	case OVAL_CHECK_NONE_SATISFY:
 		if (ores.true_cnt > 0) {

--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -173,7 +173,7 @@ void *probe_input_handler(void *arg)
 							 */
 							dW("Attempt to evaluate an object "
 							   "(ID=%u) " // TODO: 64b IDs
-							   "which is already being evaluated by an other thread.\n", pair->pth->sid);
+							   "which is already being evaluated by an other thread.", pair->pth->sid);
 
 							oscap_free(pair->pth);
 							oscap_free(pair);

--- a/src/OVAL/probes/unix/xinetd.c
+++ b/src/OVAL/probes/unix/xinetd.c
@@ -1115,7 +1115,7 @@ finish_section:
 			}
 			if (!type_enum_match) {
 				dE("The value of the type setting does not match"
-				   " any of the allowed values by OVAL: %s\n", scur->type);
+				   " any of the allowed values by OVAL: %s", scur->type);
 				scur->type = "";
 			}
 		}

--- a/src/OVAL/results/oval_resultTest.c
+++ b/src/OVAL/results/oval_resultTest.c
@@ -235,7 +235,7 @@ oval_result_t ores_get_result_bychk(struct oresults *ores, oval_check_t check)
 		break;
 	case OVAL_CHECK_NONE_EXIST:
 		dW("The 'none exist' CheckEnumeration value has been deprecated. "
-		   "Converted to check='none satisfy'.\n");
+		   "Converted to check='none satisfy'.");
 		/* FALLTHROUGH */
 	case OVAL_CHECK_NONE_SATISFY:
 		if (ores->true_cnt > 0) {


### PR DESCRIPTION
All messages should not finish with '\n'.