### PR TITLE
Remove linebreaks from debug messages in maint-1.2

### DIFF
--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -92,7 +92,7 @@ oval_agent_session_t * oval_agent_new_session(struct oval_definition_model *mode
 	struct oval_generator *generator;
 	int ret;
 
-	dI("Started new OVAL agent.\n", name);
+	dI("Started new OVAL agent.", name);
 
         /* Optimalization */
         oval_definition_model_optimize_by_filter_propagation(model);
@@ -168,7 +168,7 @@ int oval_agent_eval_definition(oval_agent_session_t *ag_sess, const char *id)
 	if (oval_def != NULL) {
 		title = oval_definition_get_title(oval_def);
 	}
-	dI("Evaluating definition '%s': %s.\n", id, title);
+	dI("Evaluating definition '%s': %s.", id, title);
 
 	/* probe */
 	ret = oval_probe_query_definition(ag_sess->psess, id);
@@ -260,7 +260,7 @@ int oval_agent_eval_system(oval_agent_session_t * ag_sess, agent_reporter cb, vo
 	char   *id;
 	int ret = 0;
 
-	dI("OVAL agent started to evaluate OVAL definitions on your system.\n");
+	dI("OVAL agent started to evaluate OVAL definitions on your system.");
 	oval_def_it = oval_definition_model_get_definitions(ag_sess->def_model);
 	while (oval_definition_iterator_has_more(oval_def_it)) {
 		oval_def = oval_definition_iterator_next(oval_def_it);
@@ -290,7 +290,7 @@ int oval_agent_eval_system(oval_agent_session_t * ag_sess, agent_reporter cb, vo
 
 cleanup:
 	oval_definition_iterator_free(oval_def_it);
-	dI("OVAL agent finished evaluation.\n");
+	dI("OVAL agent finished evaluation.");
 	return ret;
 }
 

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1338,7 +1338,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_OBJECTREF(oval_ar
 		return flag;
 
 	const char *obj_id = oval_object_get_id(object);
-	dI("Variable component references to object '%s'.\n", obj_id);
+	dI("Variable component references to object '%s'.", obj_id);
 
 	if (argu->mode == OVAL_MODE_QUERY) {
 		if (oval_probe_query_object(argu->u.sess, object, 0, &syschar) != 0)

--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -266,7 +266,7 @@ int oval_probe_query_object(oval_probe_session_t *psess, struct oval_object *obj
 			}
 		}
 	} else {
-		dI("Creating new syschar for %s_object '%s'.\n", type_name, oid);
+		dI("Creating new syschar for %s_object '%s'.", type_name, oid);
 		sysc = oval_syschar_new(model, object);
 	}
 
@@ -305,7 +305,7 @@ int oval_probe_query_sysinfo(oval_probe_session_t *sess, struct oval_sysinfo **o
         oval_ph_t *ph;
 	int ret;
 
-	dI("Querying system information.\n");
+	dI("Querying system information.");
 
         ph = oval_probe_handler_get(sess->ph, OVAL_SUBTYPE_SYSINFO);
 
@@ -394,7 +394,7 @@ static int oval_probe_query_criteria(oval_probe_session_t *sess, struct oval_cri
 					oval_variable_type_t var_type = oval_variable_get_type(var);
 					const char *var_type_text = oval_variable_type_get_text(var_type);
 					const char *var_id = oval_variable_get_id(var);
-					dI("State '%s' references %s '%s'.\n", state_id,
+					dI("State '%s' references %s '%s'.", state_id,
 						var_type_text, var_id);
 
 					ret = oval_probe_query_variable(sess, var);

--- a/src/OVAL/oval_schema_version.c
+++ b/src/OVAL/oval_schema_version.c
@@ -60,7 +60,7 @@ oval_schema_version_t oval_schema_version_from_cstr(const char *ver_str)
 	int erroffset;
 	pcre *re = pcre_compile(pattern, 0, &error, &erroffset, NULL);
 	if (re == NULL) {
-		dE("Regular expression compilation failed with %s\n", pattern);
+		dE("Regular expression compilation failed with %s", pattern);
 		return version;
 	}
 	const int ovector_size = 30; // must be a multiple of 30
@@ -68,7 +68,7 @@ oval_schema_version_t oval_schema_version_from_cstr(const char *ver_str)
 	int rc = pcre_exec(re, NULL, ver_str, strlen(ver_str), 0, 0, ovector, ovector_size);
 	pcre_free(re);
 	if (rc < 0) {
-		dE("Regular expression %s did not match string %s\n", pattern, ver_str);
+		dE("Regular expression %s did not match string %s", pattern, ver_str);
 		return version;
 	}
 	for (int i = 1; i < rc; i++) {
@@ -81,7 +81,7 @@ oval_schema_version_t oval_schema_version_from_cstr(const char *ver_str)
 	int groups[OVAL_SCHEMA_VERSION_COMPONENTS_COUNT] = {1, 2, 4, 6, 7, 9};
 	regex_t re;
 	if (regcomp(&re, pattern, REG_EXTENDED) != 0) {
-		dE("Regular expression compilation failed with %s\n", pattern);
+		dE("Regular expression compilation failed with %s", pattern);
 		return version;
 	}
 	size_t max_matches = 10;
@@ -89,7 +89,7 @@ oval_schema_version_t oval_schema_version_from_cstr(const char *ver_str)
 	int match = regexec(&re, ver_str, max_matches, matches, 0);
 	regfree(&re);
 	if (match != 0) {
-		dE("Regular expression %s did not match string %s\n", pattern, ver_str);
+		dE("Regular expression %s did not match string %s", pattern, ver_str);
 		return version;
 	}
 	for (int i = 0; i < OVAL_SCHEMA_VERSION_COMPONENTS_COUNT; i++) {

--- a/src/OVAL/oval_session.c
+++ b/src/OVAL/oval_session.c
@@ -96,7 +96,7 @@ struct oval_session *oval_session_new(const char *filename)
 		return NULL;
 	}
 
-	dI("Created a new OVAL session from input file '%s'.\n", filename);
+	dI("Created a new OVAL session from input file '%s'.", filename);
 	return session;
 }
 
@@ -270,9 +270,9 @@ static int oval_session_load_variables(struct oval_session *session)
 				return 1;
 			}
 		}
-		dI("Loaded OVAL variables.\n");
+		dI("Loaded OVAL variables.");
 	} else {
-		dI("No external OVAL variables provided.\n");
+		dI("No external OVAL variables provided.");
 	}
 
 	return 0;
@@ -362,7 +362,7 @@ int oval_session_evaluate(struct oval_session *session, char *probe_root, agent_
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Failed to set the OSCAP_PROBE_ROOT environment variable.");
 			return 1;
 		}
-		dI("OSCAP_PROBE_ROOT environment variable set to '%s'.\n", probe_root);
+		dI("OSCAP_PROBE_ROOT environment variable set to '%s'.", probe_root);
 	}
 
 	if (oval_session_setup_agent(session) != 0) {
@@ -376,7 +376,7 @@ int oval_session_evaluate(struct oval_session *session, char *probe_root, agent_
 
 	session->res_model = oval_agent_get_results_model(session->sess);
 
-	dI("OVAL evaluation successfully finished.\n");
+	dI("OVAL evaluation successfully finished.");
 	return 0;
 }
 

--- a/src/OVAL/oval_sexp.c
+++ b/src/OVAL/oval_sexp.c
@@ -481,7 +481,7 @@ int oval_object_to_sexp(void *sess, const char *typestr, struct oval_syschar *sy
 			if (vr_type == OVAL_ENTITY_VARREF_ATTRIBUTE) {
 				const char *var_id = oval_variable_get_id(oval_entity_get_variable(entity));
 				const char *field_name = oval_object_content_get_field_name(content);
-				dI("Object '%s' references variable '%s' in '%s' field.\n", obj_id, var_id, field_name);
+				dI("Object '%s' references variable '%s' in '%s' field.", obj_id, var_id, field_name);
 				ret = oval_varref_attr_to_sexp(sess, entity, syschar, &stmp);
 
 				if (ret == 0) {

--- a/src/OVAL/oval_variable.c
+++ b/src/OVAL/oval_variable.c
@@ -370,7 +370,7 @@ int oval_probe_query_variable(oval_probe_session_t *sess, struct oval_variable *
 	if (var->flag != SYSCHAR_FLAG_UNKNOWN)
 		return 0;
 
-	dI("Querying variable '%s'.\n", var->id);
+	dI("Querying variable '%s'.", var->id);
 	component = var->component;
         if (component) {
 		if (!var->values)
@@ -386,7 +386,7 @@ int oval_probe_query_variable(oval_probe_session_t *sess, struct oval_variable *
 	case SYSCHAR_FLAG_INCOMPLETE:
 		break;
 	default:
-		dI("Variable '%s' has no values.\n", var->id);
+		dI("Variable '%s' has no values.", var->id);
 		return 0;
 	}
 
@@ -416,7 +416,7 @@ int oval_probe_query_variable(oval_probe_session_t *sess, struct oval_variable *
 		oscap_string_append_string(val_dump, "\", \"");
 	}
 	oscap_string_append_char(val_dump, '\"');
-	dI("Variable '%s' has values %s.\n", var->id, oscap_string_get_cstr(val_dump));
+	dI("Variable '%s' has values %s.", var->id, oscap_string_get_cstr(val_dump));
 	oscap_string_free(val_dump);
 	oval_value_iterator_free(val_itr);
 
@@ -951,7 +951,7 @@ static int _oval_variable_parse_external_tag(xmlTextReaderPtr reader, struct ova
 		return_code = 1;
 	}
 	if (return_code != 0) {
-		dW("Parsing of %s terminated by an error at <%s>, line %d.\n", variable->id, tagname, xmlTextReaderGetParserLineNumber(reader));
+		dW("Parsing of %s terminated by an error at <%s>, line %d.", variable->id, tagname, xmlTextReaderGetParserLineNumber(reader));
 	}
 	oscap_free(tagname);
 	oscap_free(namespace);

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -200,17 +200,17 @@ int load_zones_path_list()
 		if (strcmp(name, "global") == 0)
 			continue;
 		if (zone_get_state(name, &state_num) != Z_OK) {
-			dE("Could not get zone state for %s\n", name);
+			dE("Could not get zone state for %s", name);
 			continue;
 		} else if (state_num > ZONE_STATE_CONFIGURED) {
 			temp = malloc(sizeof(zone_path_t));
 			if (temp == NULL) {
-				dE("Memory alloc failed\n");
+				dE("Memory alloc failed");
 				return(1);
 			}
 			if (zone_get_zonepath(name, rpath,
 			    sizeof(rpath)) != Z_OK) {
-				dE("Could not get zone path for %s\n",
+				dE("Could not get zone path for %s",
 				    name);
 				continue;
 			}

--- a/src/OVAL/probes/probe/entcmp.c
+++ b/src/OVAL/probes/probe/entcmp.c
@@ -93,7 +93,7 @@ oval_result_t probe_ent_cmp_debian_evr(SEXP_t * val1, SEXP_t * val2, oval_operat
 {
 	//TODO: implement Debian's epoch-version-release comparing algorithm
 	// it is different algorithm than RPM algorithm
-	dW("Using RPM algorithm to compare epoch, version and release.\n");
+	dW("Using RPM algorithm to compare epoch, version and release.");
 	return probe_ent_cmp_evr(val1, val2, op);
 }
 

--- a/src/OVAL/probes/unix/file.c
+++ b/src/OVAL/probes/unix/file.c
@@ -256,7 +256,7 @@ static SEXP_t *has_extended_acl(const char *path)
 #if defined(HAVE_ACL_EXTENDED_FILE)
 	int has_acl = acl_extended_file(path);
 	if (has_acl == -1) {
-		dW("Getting extended ACL for file '%s' has failed, %s\n", path, strerror(errno));
+		dW("Getting extended ACL for file '%s' has failed, %s", path, strerror(errno));
 		return NULL;
 	}
 	return (has_acl == 1) ? gr_true : gr_false;

--- a/src/OVAL/probes/unix/gconf.c
+++ b/src/OVAL/probes/unix/gconf.c
@@ -223,7 +223,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 						collect_item_regexp(ctx, gconf_addr, gconf_engine, gconf_key);
 						break;
 					default:
-						dE("Unsupported operation on the `key' entity: %d\n.", key_op);
+						dE("Unsupported operation on the `key' entity: %d.", key_op);
 						probe_ret = PROBE_EOPNOTSUPP;
 						abort(); /* XXX */
 					}
@@ -250,7 +250,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 			collect_item_regexp(ctx, NULL, gconf_engine, gconf_key);
 			break;
 		default:
-			dE("Unsupported operation on the `key' entity: %d\n.", key_op);
+			dE("Unsupported operation on the `key' entity: %d.", key_op);
 			probe_ret = PROBE_EOPNOTSUPP;
 		}
 

--- a/src/OVAL/probes/unix/linux/systemdshared.h
+++ b/src/OVAL/probes/unix/linux/systemdshared.h
@@ -78,7 +78,7 @@ static char *get_path_by_unit(DBusConnection *conn, const char *unit)
 		"LoadUnit"
 	);
 	if (msg == NULL) {
-		dI("Failed to create dbus_message via dbus_message_new_method_call!\n");
+		dI("Failed to create dbus_message via dbus_message_new_method_call!");
 		goto cleanup;
 	}
 
@@ -86,16 +86,16 @@ static char *get_path_by_unit(DBusConnection *conn, const char *unit)
 
 	dbus_message_iter_init_append(msg, &args);
 	if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &unit)) {
-		dI("Failed to append unit '%s' string parameter to dbus message!\n", unit);
+		dI("Failed to append unit '%s' string parameter to dbus message!", unit);
 		goto cleanup;
 	}
 
 	if (!dbus_connection_send_with_reply(conn, msg, &pending, -1)) {
-		dI("Failed to send message via dbus!\n");
+		dI("Failed to send message via dbus!");
 		goto cleanup;
 	}
 	if (pending == NULL) {
-		dI("Invalid dbus pending call!\n");
+		dI("Invalid dbus pending call!");
 		goto cleanup;
 	}
 
@@ -105,18 +105,18 @@ static char *get_path_by_unit(DBusConnection *conn, const char *unit)
 	dbus_pending_call_block(pending);
 	msg = dbus_pending_call_steal_reply(pending);
 	if (msg == NULL) {
-		dI("Failed to steal dbus pending call reply.\n");
+		dI("Failed to steal dbus pending call reply.");
 		goto cleanup;
 	}
 	dbus_pending_call_unref(pending); pending = NULL;
 
 	if (!dbus_message_iter_init(msg, &args)) {
-		dI("Failed to initialize iterator over received dbus message.\n");
+		dI("Failed to initialize iterator over received dbus message.");
 		goto cleanup;
 	}
 
 	if (dbus_message_iter_get_arg_type(&args) != DBUS_TYPE_OBJECT_PATH) {
-		dI("Expected string argument in reply. Instead received: %s.\n", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
+		dI("Expected string argument in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
 		goto cleanup;
 	}
 
@@ -147,7 +147,7 @@ static int get_all_systemd_units(DBusConnection* conn, int(*callback)(const char
 		"ListUnits"
 	);
 	if (msg == NULL) {
-		dI("Failed to create dbus_message via dbus_message_new_method_call!\n");
+		dI("Failed to create dbus_message via dbus_message_new_method_call!");
 		goto cleanup;
 	}
 
@@ -157,11 +157,11 @@ static int get_all_systemd_units(DBusConnection* conn, int(*callback)(const char
 	dbus_message_iter_init_append(msg, &args);
 
 	if (!dbus_connection_send_with_reply(conn, msg, &pending, -1)) {
-		dI("Failed to send message via dbus!\n");
+		dI("Failed to send message via dbus!");
 		goto cleanup;
 	}
 	if (pending == NULL) {
-		dI("Invalid dbus pending call!\n");
+		dI("Invalid dbus pending call!");
 		goto cleanup;
 	}
 
@@ -171,25 +171,25 @@ static int get_all_systemd_units(DBusConnection* conn, int(*callback)(const char
 	dbus_pending_call_block(pending);
 	msg = dbus_pending_call_steal_reply(pending);
 	if (msg == NULL) {
-		dI("Failed to steal dbus pending call reply.\n");
+		dI("Failed to steal dbus pending call reply.");
 		goto cleanup;
 	}
 	dbus_pending_call_unref(pending); pending = NULL;
 
 	if (!dbus_message_iter_init(msg, &args)) {
-		dI("Failed to initialize iterator over received dbus message.\n");
+		dI("Failed to initialize iterator over received dbus message.");
 		goto cleanup;
 	}
 
 	if (dbus_message_iter_get_arg_type(&args) != DBUS_TYPE_ARRAY) {
-		dI("Expected array of structs in reply. Instead received: %s.\n", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
+		dI("Expected array of structs in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
 		goto cleanup;
 	}
 
 	dbus_message_iter_recurse(&args, &unit_iter);
 	do {
 		if (dbus_message_iter_get_arg_type(&unit_iter) != DBUS_TYPE_STRUCT) {
-			dI("Expected unit struct as elements in returned array. Instead received: %s.\n", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&unit_iter)));
+			dI("Expected unit struct as elements in returned array. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&unit_iter)));
 			goto cleanup;
 		}
 
@@ -197,7 +197,7 @@ static int get_all_systemd_units(DBusConnection* conn, int(*callback)(const char
 		dbus_message_iter_recurse(&unit_iter, &unit_name);
 
 		if (dbus_message_iter_get_arg_type(&unit_name) != DBUS_TYPE_STRING) {
-			dI("Expected string as the first element in the unit struct. Instead received: %s.\n", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&unit_name)));
+			dI("Expected string as the first element in the unit struct. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&unit_name)));
 			goto cleanup;
 		}
 
@@ -279,7 +279,7 @@ static char *dbus_value_to_string(DBusMessageIter *iter)
 			//	return oscap_sprintf("%i", value.fd);
 
 			default:
-				dI("Encountered unknown dbus basic type!\n");
+				dI("Encountered unknown dbus basic type!");
 				return oscap_strdup("error, unknown basic type!");
 		}
 	}
@@ -325,17 +325,17 @@ static DBusConnection *connect_dbus()
 
 	conn = dbus_bus_get(DBUS_BUS_SYSTEM, &err);
 	if (dbus_error_is_set(&err)) {
-		dI("Failed to get DBUS_BUS_SYSTEM connection - %s\n", err.message);
+		dI("Failed to get DBUS_BUS_SYSTEM connection - %s", err.message);
 		goto cleanup;
 	}
 	if (conn == NULL) {
-		dI("DBusConnection == NULL!\n");
+		dI("DBusConnection == NULL!");
 		goto cleanup;
 	}
 
 	dbus_bus_register(conn, &err);
 	if (dbus_error_is_set(&err)) {
-		dI("Failed to register on dbus - %s\n", err.message);
+		dI("Failed to register on dbus - %s", err.message);
 		goto cleanup;
 	}
 

--- a/src/OVAL/probes/unix/linux/systemdunitdependency.c
+++ b/src/OVAL/probes/unix/linux/systemdunitdependency.c
@@ -49,7 +49,7 @@ static char *get_property_by_unit_path(DBusConnection *conn, const char *unit_pa
 		"Get"
 	);
 	if (msg == NULL) {
-		dI("Failed to create dbus_message via dbus_message_new_method_call!\n");
+		dI("Failed to create dbus_message via dbus_message_new_method_call!");
 		goto cleanup;
 	}
 
@@ -59,20 +59,20 @@ static char *get_property_by_unit_path(DBusConnection *conn, const char *unit_pa
 
 	dbus_message_iter_init_append(msg, &args);
 	if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &interface)) {
-		dI("Failed to append interface '%s' string parameter to dbus message!\n", interface);
+		dI("Failed to append interface '%s' string parameter to dbus message!", interface);
 		goto cleanup;
 	}
 	if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &property)) {
-		dI("Failed to append property '%s' string parameter to dbus message!\n", property);
+		dI("Failed to append property '%s' string parameter to dbus message!", property);
 		goto cleanup;
 	}
 
 	if (!dbus_connection_send_with_reply(conn, msg, &pending, -1)) {
-		dI("Failed to send message via dbus!\n");
+		dI("Failed to send message via dbus!");
 		goto cleanup;
 	}
 	if (pending == NULL) {
-		dI("Invalid dbus pending call!\n");
+		dI("Invalid dbus pending call!");
 		goto cleanup;
 	}
 
@@ -82,19 +82,19 @@ static char *get_property_by_unit_path(DBusConnection *conn, const char *unit_pa
 	dbus_pending_call_block(pending);
 	msg = dbus_pending_call_steal_reply(pending);
 	if (msg == NULL) {
-		dI("Failed to steal dbus pending call reply.\n");
+		dI("Failed to steal dbus pending call reply.");
 		goto cleanup;
 	}
 	dbus_pending_call_unref(pending); pending = NULL;
 
 	if (!dbus_message_iter_init(msg, &args)) {
-		dI("Failed to initialize iterator over received dbus message.\n");
+		dI("Failed to initialize iterator over received dbus message.");
 		goto cleanup;
 	}
 
 	if (dbus_message_iter_get_arg_type(&args) != DBUS_TYPE_VARIANT)
 	{
-		dI("Expected variant argument in reply. Instead received: %s.\n", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
+		dI("Expected variant argument in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
 		goto cleanup;
 	}
 

--- a/src/OVAL/probes/unix/linux/systemdunitproperty.c
+++ b/src/OVAL/probes/unix/linux/systemdunitproperty.c
@@ -48,7 +48,7 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 		"GetAll"
 	);
 	if (msg == NULL) {
-		dI("Failed to create dbus_message via dbus_message_new_method_call!\n");
+		dI("Failed to create dbus_message via dbus_message_new_method_call!");
 		goto cleanup;
 	}
 
@@ -58,16 +58,16 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 
 	dbus_message_iter_init_append(msg, &args);
 	if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &interface)) {
-		dI("Failed to append interface '%s' string parameter to dbus message!\n", interface);
+		dI("Failed to append interface '%s' string parameter to dbus message!", interface);
 		goto cleanup;
 	}
 
 	if (!dbus_connection_send_with_reply(conn, msg, &pending, -1)) {
-		dI("Failed to send message via dbus!\n");
+		dI("Failed to send message via dbus!");
 		goto cleanup;
 	}
 	if (pending == NULL) {
-		dI("Invalid dbus pending call!\n");
+		dI("Invalid dbus pending call!");
 		goto cleanup;
 	}
 
@@ -77,18 +77,18 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 	dbus_pending_call_block(pending);
 	msg = dbus_pending_call_steal_reply(pending);
 	if (msg == NULL) {
-		dI("Failed to steal dbus pending call reply.\n");
+		dI("Failed to steal dbus pending call reply.");
 		goto cleanup;
 	}
 	dbus_pending_call_unref(pending); pending = NULL;
 
 	if (!dbus_message_iter_init(msg, &args)) {
-		dI("Failed to initialize iterator over received dbus message.\n");
+		dI("Failed to initialize iterator over received dbus message.");
 		goto cleanup;
 	}
 
 	if (dbus_message_iter_get_arg_type(&args) != DBUS_TYPE_ARRAY && dbus_message_iter_get_element_type(&args) != DBUS_TYPE_DICT_ENTRY) {
-		dI("Expected array of dict_entry argument in reply. Instead received: %s.\n", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
+		dI("Expected array of dict_entry argument in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
 		goto cleanup;
 	}
 
@@ -98,7 +98,7 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 		dbus_message_iter_recurse(&property_iter, &dict_entry);
 
 		if (dbus_message_iter_get_arg_type(&dict_entry) != DBUS_TYPE_STRING) {
-			dI("Expected string as key in dict_entry. Instead received: %s.\n", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&dict_entry)));
+			dI("Expected string as key in dict_entry. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&dict_entry)));
 			goto cleanup;
 		}
 
@@ -113,7 +113,7 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 		}
 
 		if (dbus_message_iter_get_arg_type(&dict_entry) != DBUS_TYPE_VARIANT) {
-			dI("Expected variant as value in dict_entry. Instead received: %s.\n", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&dict_entry)));
+			dI("Expected variant as value in dict_entry. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&dict_entry)));
 			oscap_free(property_name);
 			goto cleanup;
 		}

--- a/src/XCCDF/result_scoring.c
+++ b/src/XCCDF/result_scoring.c
@@ -269,7 +269,7 @@ struct xccdf_score *xccdf_result_calculate_score(struct xccdf_result *test_resul
 		oscap_free(item_score);
 	} else {
 		xccdf_score_free(score);
-		oscap_dlprintf(DBG_E, "Scoring system \"%s\" is not supported.\n", score_system);
+		dE("Scoring system \"%s\" is not supported.", score_system);
 		return NULL;
 	}
 	return score;

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -149,7 +149,7 @@ struct xccdf_session *xccdf_session_new(const char *filename)
 		}
 	}
 
-	dI("Created a new XCCDF session from a %s '%s'.\n",
+	dI("Created a new XCCDF session from a %s '%s'.",
 		oscap_document_type_to_string(document_type), filename);
 	return session;
 }

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -965,7 +965,7 @@ _xccdf_policy_rule_evaluate(struct xccdf_policy * policy, const struct xccdf_rul
 
 	xccdf_role_t role = xccdf_get_final_role(rule, r_rule);
 	if (!is_selected) {
-		dI("Rule '%s' is not selected.\n", rule_id);
+		dI("Rule '%s' is not selected.", rule_id);
 		return _xccdf_policy_report_rule_result(policy, result, rule, NULL, XCCDF_RESULT_NOT_SELECTED, NULL);
 	}
 
@@ -974,7 +974,7 @@ _xccdf_policy_rule_evaluate(struct xccdf_policy * policy, const struct xccdf_rul
 
 	const bool is_applicable = xccdf_policy_model_item_is_applicable(policy->model, (struct xccdf_item*)rule);
 	if (!is_applicable) {
-		dI("Rule '%s' is not applicable.\n", rule_id);
+		dI("Rule '%s' is not applicable.", rule_id);
 		return _xccdf_policy_report_rule_result(policy, result, rule, NULL, XCCDF_RESULT_NOT_APPLICABLE, NULL);
 	}
 
@@ -1092,13 +1092,13 @@ static int xccdf_policy_item_evaluate(struct xccdf_policy * policy, struct xccdf
     switch (itype) {
         case XCCDF_RULE:{
 			const char *rule_id = xccdf_rule_get_id((const struct xccdf_rule *)item);
-			dI("Evaluating XCCDF rule '%s'.\n", rule_id);
+			dI("Evaluating XCCDF rule '%s'.", rule_id);
 			return _xccdf_policy_rule_evaluate(policy, (struct xccdf_rule *) item, result);
         } break;
 
         case XCCDF_GROUP:{
 			const char *group_id = xccdf_group_get_id((const struct xccdf_group *)item);
-			dI("Evaluating XCCDF group '%s'.\n", group_id);
+			dI("Evaluating XCCDF group '%s'.", group_id);
 			child_it = xccdf_group_get_content((const struct xccdf_group *)item);
 			while (xccdf_item_iterator_has_more(child_it)) {
 				child = xccdf_item_iterator_next(child_it);
@@ -2031,7 +2031,7 @@ struct xccdf_result * xccdf_policy_evaluate(struct xccdf_policy * policy)
     else
         id = oscap_strdup("default-profile");
 
-	dI("Evaluating a XCCDF policy with selected '%s' profile.\n", id);
+	dI("Evaluating a XCCDF policy with selected '%s' profile.", id);
 
     /* Get all constant information */
     benchmark = xccdf_policy_model_get_benchmark(xccdf_policy_get_model(policy));

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -183,6 +183,7 @@ static void debug_message_start(int level, const char *file, const char *fn, siz
 
 static void debug_message_end()
 {
+	fputc('\n', __debuglog_fp);
 #if defined(__SVR4) && defined (__sun)
 	if (lockf(fileno(__debuglog_fp), F_ULOCK, 0L) == -1) {
 #else
@@ -225,7 +226,6 @@ void __oscap_debuglog_object (const char *file, const char *fn, size_t line, int
 	switch (objtype) {
 	case OSCAP_DEBUGOBJ_SEXP:
 		SEXP_fprintfa(__debuglog_fp, (SEXP_t *)obj);
-		fputc('\n', __debuglog_fp);
 		break;
 	default:
 		fprintf(__debuglog_fp, "Attempt to dump a not supported object.\n");

--- a/src/source/doc_type.c
+++ b/src/source/doc_type.c
@@ -89,7 +89,7 @@ int oscap_determine_document_type_reader(xmlTextReader *reader, oscap_document_t
                 return -1;
         }
 
-        dI("Identified document type: %s\n", elm_name);
+        dI("Identified document type: %s", elm_name);
 
         return 0;
 }

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -262,7 +262,7 @@ int oscap_source_validate(struct oscap_source *source, xml_reporter reporter, vo
 		const char *schema_version = oscap_source_get_schema_version(source);
 		const char *type_name = oscap_document_type_to_string(scap_type);
 		const char *origin = oscap_source_readable_origin(source);
-		dD("Validating %s (%s) document from %s.\n", type_name, schema_version, origin);
+		dD("Validating %s (%s) document from %s.", type_name, schema_version, origin);
 		ret = oscap_source_validate_priv(source, scap_type, schema_version, reporter, user);
 		if (ret != 0) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Invalid %s (%s) content in %s.", type_name, schema_version, origin);


### PR DESCRIPTION
To allow to change or redesign the format of verbose log we have to remove
    line breaks at the end of some messages. Then it will be possible to move
    the message to the begining or middle of a line without any hacks.
    The commit also enforces usage of dI, dE, dW macros instead of
    ocassionaly appearing oscap_dlprintf macro. This change makes
    codebase more consistent regarding the debugging.
    This is a continuing of work done in PR#282, which has already removed
    the line breaks from maint-1.0 branch.
