### PR TITLE
Improve format of verbose log

### DIFF
--- a/src/OVAL/probes/SEAP/seap-packet.c
+++ b/src/OVAL/probes/SEAP/seap-packet.c
@@ -258,9 +258,9 @@ static SEXP_t *SEAP_packet_msg2sexp (SEAP_msg_t *msg)
                 SEXP_free(r0);
         }
 
-	dI("MSG -> SEXP");
+	dD("MSG -> SEXP");
 	dO(OSCAP_DEBUGOBJ_SEXP, sexp);
-	dI("packet size: %zu", SEXP_sizeof(sexp));
+	dD("packet size: %zu", SEXP_sizeof(sexp));
 
         return (sexp);
 }


### PR DESCRIPTION
From my observations, I think that the current format of verbose log is difficult to read and important information are lost in metadata.
Here are the major drawbacks of the current approach:
1) The message is at the end of the line, preceded by a lot of metadata.  User has to read the metadata before he can read information that interests him.
2) Moreover, if an user has a narrow terminal window, he has to scroll left and right, which is horribly annoying.
3) Information about verbosity level (in other words importance of the message) is shown in the middle of the line, which makes difficult to distinguish warnings from informational messagess etc.
4) Some metadata , eg. PID, thread id, line number, source file, are interesting only for a OpenSCAP developer. Content developer or final user will net be interested on which line in source code is a particular feature implemented. PIDs can be easily obtained by standard tools.
5) The log shows SEXP dumps as message of INFO level, but they are hardly understandable. Users perhaps don't want to see details of underlying internal protocols.

In this pull request, I propose that the information on a line will be displayed in following order:
1) Verbosity level
2) name of process that produced this message
3) The message
4) additional metadata - displayed only when DEVEL level selected

I also change the category of SEXP dump to devel level.