### PR TITLE
Change messages category to DEVEL

### DIFF
--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -490,7 +490,7 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 			}
 		}
 
-		dI("Sending message.");
+		dD("Sending message.");
 
 		ret = SEAP_sendmsg(ctx, pd->sd, s_omsg);
 		if (ret != 0) {
@@ -549,7 +549,7 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 			}
 		}
 
-		dI("Waiting for reply.");
+		dD("Waiting for reply.");
 
 		/* recv_retry: */
 		s_imsg = NULL;
@@ -583,7 +583,7 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 			}
 		}
 
-		dI("Message received.");
+		dD("Message received.");
 		break;
 	}
 

--- a/src/OVAL/probes/SEAP/seap-message.c
+++ b/src/OVAL/probes/SEAP/seap-message.c
@@ -135,11 +135,11 @@ bool SEAP_msgattr_exists (SEAP_msg_t *msg, const char *name)
         _A(msg  != NULL);
         _A(name != NULL);
 
-        dI("cnt = %u", msg->attrs_cnt);
+        dD("cnt = %u", msg->attrs_cnt);
 
         /* FIXME: this is stupid */
         for (i = 0; i < msg->attrs_cnt; ++i) {
-                dI("%s ?= %s", name, msg->attrs[i].name);
+                dD("%s ?= %s", name, msg->attrs[i].name);
                 if (strcmp (name, msg->attrs[i].name) == 0)
                         return (true);
         }

--- a/src/OVAL/probes/SEAP/seap-packet.c
+++ b/src/OVAL/probes/SEAP/seap-packet.c
@@ -437,9 +437,9 @@ static SEXP_t *SEAP_packet_cmd2sexp (SEAP_cmd_t *cmd)
         if (cmd->args != NULL)
                 SEXP_list_add (sexp, cmd->args);
 
-	dI("CMD -> SEXP");
+	dD("CMD -> SEXP");
 	dO(OSCAP_DEBUGOBJ_SEXP, sexp);
-	dI("packet size: %zu", SEXP_sizeof(sexp));
+	dD("packet size: %zu", SEXP_sizeof(sexp));
 
         SEXP_VALIDATE(sexp);
         return (sexp);
@@ -900,9 +900,9 @@ eloop_exit:
 		}
 
 
-		dI("Received packet");
+		dD("Received packet");
 		dO(OSCAP_DEBUGOBJ_SEXP, sexp_packet);
-		dI("packet size: %zu", SEXP_sizeof(sexp_packet));
+		dD("packet size: %zu", SEXP_sizeof(sexp_packet));
 
 		SEXP_free(sexp_packet);
 

--- a/src/OVAL/probes/SEAP/sexp-manip.c
+++ b/src/OVAL/probes/SEAP/sexp-manip.c
@@ -1399,7 +1399,7 @@ SEXP_t *SEXP_list_sort(SEXP_t *list, int(*compare)(const SEXP_t *, const SEXP_t 
 
         list_it[0].block = SEXP_LCASTP(v_dsc.mem)->b_addr;
 
-        dI("Sorting blocks & building iterator array");
+        dD("Sorting blocks & building iterator array");
 
         while (list_it[list_it_count - 1].block != NULL) {
                 /* initialize the rest of the iterator */
@@ -1413,7 +1413,7 @@ SEXP_t *SEXP_list_sort(SEXP_t *list, int(*compare)(const SEXP_t *, const SEXP_t 
 
                 /* reallocate the iterator array if needed */
                 if (list_it_count == list_it_alloc) {
-                        dI("Reallocating iterator array: %z -> %z",
+                        dD("Reallocating iterator array: %z -> %z",
                            list_it_alloc, list_it_alloc + SEXP_LISTIT_ARRAY_INC);
 
                         list_it_alloc += SEXP_LISTIT_ARRAY_INC;
@@ -1426,7 +1426,7 @@ SEXP_t *SEXP_list_sort(SEXP_t *list, int(*compare)(const SEXP_t *, const SEXP_t 
         }
 
         --list_it_count;
-        dI("Iterator count = %zu", list_it_count);
+        dD("Iterator count = %zu", list_it_count);
 
         if (list_it_count > 0) {
                 /*

--- a/src/OVAL/probes/probe-api.c
+++ b/src/OVAL/probes/probe-api.c
@@ -683,7 +683,7 @@ void probe_cobj_set_flag(SEXP_t *cobj, oval_syschar_collection_flag_t flag)
 	of = SEXP_number_getu(old_sflag);
 	SEXP_free(old_sflag);
 	SEXP_free(sflag);
-	dI("old flag: %d, new flag: %d.", of, flag);
+	dD("old flag: %d, new flag: %d.", of, flag);
 }
 
 oval_syschar_collection_flag_t probe_cobj_get_flag(const SEXP_t *cobj)

--- a/src/OVAL/probes/probe/signal_handler.c
+++ b/src/OVAL/probes/probe/signal_handler.c
@@ -80,7 +80,7 @@ void *probe_signal_handler(void *arg)
                 dW("prctl(PR_SET_PDEATHSIG, SIGTERM) failed");
 #endif
        
-	dI("Signal handler ready");
+	dD("Signal handler ready");
 	switch (errno = pthread_barrier_wait(&OSCAP_GSYM(th_barrier)))
 	{
 	case 0:
@@ -93,7 +93,7 @@ void *probe_signal_handler(void *arg)
 
 	while (sigwaitinfo(&siset, &siinf) != -1) {
 
-		dI("Received signal %d from %u (%s)",
+		dD("Received signal %d from %u (%s)",
 		   siinf.si_signo, (unsigned int)siinf.si_pid,
 		   getppid() == siinf.si_pid ? "parent" : "not my parent");
 

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -48,12 +48,12 @@ void *probe_worker_runfn(void *arg)
 	int     probe_ret;
 
 	pthread_setname_np(pthread_self(), "probe_worker");
-	dI("handling SEAP message ID %u", pair->pth->sid);
+	dD("handling SEAP message ID %u", pair->pth->sid);
 	//
 	probe_ret = -1;
 	probe_res = pair->pth->msg_handler(pair->probe, pair->pth->msg, &probe_ret);
 	//
-	dI("handler result = %p, return code = %d", probe_res, probe_ret);
+	dD("handler result = %p, return code = %d", probe_res, probe_ret);
 
 	/* Assuming that the red-black tree API is doing locking for us... */
 	if (rbt_i32_del(pair->probe->workers, pair->pth->sid, NULL) != 0) {
@@ -72,7 +72,7 @@ void *probe_worker_runfn(void *arg)
 	} else {
                 SEXP_t *items;
 
-		dI("probe thread deleted");
+		dD("probe thread deleted");
 
 		obj = SEAP_msg_get(pair->pth->msg);
 		oid = probe_obj_getattrval(obj, "id");
@@ -632,7 +632,7 @@ static SEXP_t *probe_set_eval(probe_t *probe, SEXP_t *set, size_t depth)
 	if (depth > MAX_EVAL_DEPTH) {
 		char *fmt = "probe_set_eval: Too many levels: max=%zu.";
 #ifndef NDEBUG
-                dI(fmt, (size_t) MAX_EVAL_DEPTH);
+                dD(fmt, (size_t) MAX_EVAL_DEPTH);
 		abort();
 #endif
 		r0 = probe_msg_creatf(OVAL_MESSAGE_LEVEL_ERROR, fmt, (size_t) MAX_EVAL_DEPTH);
@@ -706,7 +706,7 @@ static SEXP_t *probe_set_eval(probe_t *probe, SEXP_t *set, size_t depth)
 			SEXP_t *objres; /**< Result of the evaluation */
 			char    OID_cstr[128];
 
-			dI("Handling object_reference");
+			dD("Handling object_reference");
 
 			if ((OID = probe_ent_getval(member)) == NULL) {
 				Omsg = probe_msg_creatf(OVAL_MESSAGE_LEVEL_ERROR,
@@ -715,14 +715,14 @@ static SEXP_t *probe_set_eval(probe_t *probe, SEXP_t *set, size_t depth)
 			}
 #ifndef NDEBUG
 			SEXP_string_cstr_r(OID, OID_cstr, sizeof OID_cstr);
-			dI("Looking for the result in cache: OID=%s", OID_cstr);
+			dD("Looking for the result in cache: OID=%s", OID_cstr);
 #endif
 			if ((objres = probe_rcache_sexp_get(probe->rcache, OID)) == NULL) {
-				dI("MISS => requesting object evaluation from the library");
+				dD("MISS => requesting object evaluation from the library");
 
 				objres = probe_obj_eval(probe, OID);
 
-				dI("EVAL: result=%p", objres);
+				dD("EVAL: result=%p", objres);
 				if (objres != NULL) {
 					dO(OSCAP_DEBUGOBJ_SEXP, objres);
 				} else {
@@ -838,22 +838,20 @@ static SEXP_t *probe_set_eval(probe_t *probe, SEXP_t *set, size_t depth)
 
                 for (i = 0; i < s_subset_i; ++i) {
                         if (s_subset[i] != NULL) {
-                                dI("=== s_subset[%d] ===", i);
+                                dD("=== s_subset[%d] ===", i);
                                 dO(OSCAP_DEBUGOBJ_SEXP, s_subset[i]);
-                                dI("");
                         }
                 }
 
                 for (i = 0; i < o_subset_i; ++i) {
                         if (o_subset[i] != NULL) {
-                                dI("=== o_subset[%d] ===", i);
+                                dD("=== o_subset[%d] ===", i);
                                 dO(OSCAP_DEBUGOBJ_SEXP, o_subset[i]);
-                                dI("");
                         }
                 }
         }
 
-        dI("OP= %d", op_num);
+        dD("OP= %d", op_num);
 #endif
 
 	SEXP_free(filters_a);
@@ -864,9 +862,8 @@ static SEXP_t *probe_set_eval(probe_t *probe, SEXP_t *set, size_t depth)
 	SEXP_free(s_subset[0]);
 	SEXP_free(s_subset[1]);
 
-        dI("=== RESULT ===");
+        dD("=== RESULT ===");
         dO(OSCAP_DEBUGOBJ_SEXP, result);
-        dI("");
 
 	return (result);
  eval_fail:
@@ -966,7 +963,7 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 			 */
 			struct probe_varref_ctx *ctx;
 
-			dI("handling varrefs in object");
+			dD("handling varrefs in object");
 
 			if (probe_varref_create_ctx(probe_in, varrefs, &ctx) != 0) {
 				SEXP_vfree(varrefs, pctx.filters, probe_in, mask, NULL);


### PR DESCRIPTION
These messages has not value from the OVAL evaluation point of view.
They may be interesting for OpenSCAP developers, so they should
have DEVEL category.