### PR TITLE
Use { NULL } instead of NULL as envp when executing remediations

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -330,7 +330,11 @@ static inline int _xccdf_fix_execute(struct xccdf_rule_result *rr, struct xccdf_
 				NULL
 			};
 
-			execve(interpret, argvp, NULL);
+			char *const envp[1] = {
+				NULL
+			};
+
+			execve(interpret, argvp, envp);
 			/* Wow, execve returned. In this special case, we failed to execute the fix
 			 * and we return 0 from function. At least the following error message will
 			 * indicate the problem in xccdf:message. */


### PR DESCRIPTION
Using just NULL is discouraged and nonportable, see `man 2 execve`.
This commit doesn't change behavior, just improves portability.