### PR TITLE
Use canonical PATH when executing remediations

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -331,7 +331,8 @@ static inline int _xccdf_fix_execute(struct xccdf_rule_result *rr, struct xccdf_
 				NULL
 			};
 
-			char *const envp[1] = {
+			char *const envp[2] = {
+				"PATH=/bin:/sbin:/usr/bin:/usr/sbin",
 				NULL
 			};
 


### PR DESCRIPTION
This makes content author's life a little bit easier. The change doesn't
break any existing remediations but new remediations relying on these
PATHs won't work with old openscap!