### PR TITLE
oscap-vm cosmetic changes

### DIFF
--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -22,9 +22,6 @@ function die()
     exit 1
 }
 
-which guestmount > /dev/null || die "Cannot find guestmount, please install libguestfs utilities."
-which guestunmount > /dev/null || die "Cannot find guestunmount, please install libguestfs utilities."
-which mktemp > /dev/null || die "Cannot find mktemp, please install coreutils."
 
 function usage()
 {
@@ -95,6 +92,10 @@ else
     usage
     die
 fi
+
+which guestmount > /dev/null || die "Cannot find guestmount, please install libguestfs utilities."
+which guestunmount > /dev/null || die "Cannot find guestunmount, please install libguestfs utilities."
+which mktemp > /dev/null || die "Cannot find mktemp, please install coreutils."
 
 MOUNTPOINT=$(mktemp -d)
 

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -94,7 +94,7 @@ else
 fi
 
 which guestmount > /dev/null || die "Cannot find guestmount, please install libguestfs utilities."
-which guestunmount > /dev/null || die "Cannot find guestunmount, please install libguestfs utilities."
+which fusermount > /dev/null || die "Cannot find fusermount, please install fuse."
 which mktemp > /dev/null || die "Cannot find mktemp, please install coreutils."
 
 MOUNTPOINT=$(mktemp -d)
@@ -121,6 +121,6 @@ shift 2
 oscap "$@"
 EXIT_CODE=$?
 echo "Unmounting '$MOUNTPOINT'..."
-guestunmount "$MOUNTPOINT"
+fusermount -u "$MOUNTPOINT"
 rmdir "$MOUNTPOINT"
 exit $EXIT_CODE

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -22,7 +22,6 @@ function die()
     exit 1
 }
 
-
 function usage()
 {
     echo "oscap-vm -- Tool for offline SCAP evaluation of virtual machines."
@@ -94,7 +93,16 @@ else
 fi
 
 which guestmount > /dev/null || die "Cannot find guestmount, please install libguestfs utilities."
-which fusermount > /dev/null || die "Cannot find fusermount, please install fuse."
+
+if [ `which guestunmount` > /dev/null ]; then
+    UNMOUNT_COMMAND="guestunmount"
+elif [ `which fusermount` > /dev/null ]; then
+    echo "guestunmount command not present on the system, using simpler fusermount instead"
+    UNMOUNT_COMMAND="fusermount -u"
+else
+    die "Cannot find guestunmount or fusermount, please install libguestfs utilities, or fuse."
+fi
+
 which mktemp > /dev/null || die "Cannot find mktemp, please install coreutils."
 
 MOUNTPOINT=$(mktemp -d)
@@ -121,6 +129,6 @@ shift 2
 oscap "$@"
 EXIT_CODE=$?
 echo "Unmounting '$MOUNTPOINT'..."
-fusermount -u "$MOUNTPOINT"
+$UNMOUNT_COMMAND "$MOUNTPOINT"
 rmdir "$MOUNTPOINT"
 exit $EXIT_CODE


### PR DESCRIPTION
Hello,
these are more of cosmetic changes, self-explanatory I guess, except for the introduction of `fusermount -u`. Originally used `guestunmount` is wrapper of `fusermount -u`, which provides option to wait for unmounting. But usecase in `oscap-vm` does not necessitate this, thus both commands should be interchangeable.

And reasoning is, that some distributions, for example RHEL6, does not have `libguestfs` up-to-date enough to provide `guestunmount` command :)