### PR TITLE
Adjust the valgrind suppression file

### DIFF
--- a/tests/suppressions.supp
+++ b/tests/suppressions.supp
@@ -24,6 +24,6 @@
    Memcheck:Leak
    match-leak-kinds: reachable
    ...
-   fun:curl_easy_init
+   fun:curl_global_init
    ...
 }


### PR DESCRIPTION
After merging c97417a328687ebf49f4da0ac54d6104d15297c7, we must suppress
the memory leak in curl_global_init directly, not via curl_easy_init.