### PR TITLE
Provide basic information about evaluating test results in verbose log

### DIFF
--- a/src/OVAL/oval_definitions_impl.h
+++ b/src/OVAL/oval_definitions_impl.h
@@ -48,6 +48,7 @@ oval_operation_t oval_operation_parse(xmlTextReaderPtr, char *, oval_operation_t
 oval_definition_class_t oval_definition_class_parse(xmlTextReaderPtr);
 oval_existence_t oval_existence_parse(xmlTextReaderPtr, char *, oval_existence_t);
 oval_check_t oval_check_parse(xmlTextReaderPtr, char *, oval_check_t);
+const char *oval_check_get_description(oval_check_t);
 oval_entity_type_t oval_entity_type_parse(xmlTextReaderPtr);
 oval_datatype_t oval_datatype_parse(xmlTextReaderPtr, char *, oval_datatype_t);
 oval_entity_varref_type_t oval_entity_varref_type_parse(xmlTextReaderPtr);

--- a/src/OVAL/oval_definitions_impl.h
+++ b/src/OVAL/oval_definitions_impl.h
@@ -69,6 +69,7 @@ const char *oval_definition_class_text(oval_definition_class_t);
 typedef void (*oval_affected_consumer) (struct oval_affected *, void *);
 int oval_affected_parse_tag(xmlTextReaderPtr reader, struct oval_parser_context *context, oval_affected_consumer, void *);
 
+char *oval_test_get_state_names(struct oval_test *test);
 int oval_test_parse_tag(xmlTextReaderPtr reader, struct oval_parser_context *context, void *);
 xmlNode *oval_test_to_dom(struct oval_test *, xmlDoc *, xmlNode *);
 

--- a/src/OVAL/oval_enumerations.c
+++ b/src/OVAL/oval_enumerations.c
@@ -233,6 +233,15 @@ static const struct oscap_string_map OVAL_CHECK_MAP[] = {
 	{OVAL_ENUMERATION_INVALID, NULL}
 };
 
+static const struct oscap_string_map OVAL_CHECK_DESCRIPTION_MAP[] = {
+	{OVAL_CHECK_ALL, "all"},
+	{OVAL_CHECK_AT_LEAST_ONE, "at least one"},
+	{OVAL_CHECK_NONE_EXIST, "none"},
+	{OVAL_CHECK_NONE_SATISFY, "none"},
+	{OVAL_CHECK_ONLY_ONE, "only one"},
+	{OVAL_ENUMERATION_INVALID, NULL}
+};
+
 oval_check_t oval_check_parse(xmlTextReaderPtr reader, char *attname, oval_check_t defval)
 {
 	return oval_enumeration_attr(reader, attname, OVAL_CHECK_MAP, defval);
@@ -241,6 +250,11 @@ oval_check_t oval_check_parse(xmlTextReaderPtr reader, char *attname, oval_check
 const char *oval_check_get_text(oval_check_t check)
 {
 	return oval_enumeration_get_text(OVAL_CHECK_MAP, check);
+}
+
+const char *oval_check_get_description(oval_check_t check)
+{
+	return oval_enumeration_get_text(OVAL_CHECK_DESCRIPTION_MAP, check);
 }
 
 static const struct oscap_string_map OVAL_DATATYPE_MAP[] = {

--- a/src/OVAL/oval_enumerations.c
+++ b/src/OVAL/oval_enumerations.c
@@ -236,7 +236,7 @@ static const struct oscap_string_map OVAL_CHECK_MAP[] = {
 static const struct oscap_string_map OVAL_CHECK_DESCRIPTION_MAP[] = {
 	{OVAL_CHECK_ALL, "all"},
 	{OVAL_CHECK_AT_LEAST_ONE, "at least one"},
-	{OVAL_CHECK_NONE_EXIST, "none"},
+	{OVAL_CHECK_NONE_EXIST, "none"}, // deprecated since OVAL 5.3
 	{OVAL_CHECK_NONE_SATISFY, "none"},
 	{OVAL_CHECK_ONLY_ONE, "only one"},
 	{OVAL_ENUMERATION_INVALID, NULL}

--- a/src/OVAL/oval_test.c
+++ b/src/OVAL/oval_test.c
@@ -168,7 +168,7 @@ char *oval_test_get_state_names(struct oval_test *test)
 	struct oval_state_iterator *ste_itr = oval_test_get_states(test);
 	if (!oval_state_iterator_has_more(ste_itr)) {
 		oval_state_iterator_free(ste_itr);
-		return oscap_strdup("");
+		return NULL;
 	}
 	struct oscap_string *state_list = oscap_string_new();
 	oscap_string_append_char(state_list, '\'');

--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -253,6 +253,7 @@ const char *oval_operator_get_text(oval_operator_t);
 const char *oval_subtype_get_text(oval_subtype_t);
 const char *oval_family_get_text(oval_family_t);
 const char *oval_check_get_text(oval_check_t);
+const char *oval_check_get_description(oval_check_t);
 const char *oval_existence_get_text(oval_existence_t);
 const char *oval_affected_family_get_text(oval_affected_family_t);
 const char *oval_datatype_get_text(oval_datatype_t);

--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -1184,12 +1184,6 @@ struct oval_object *oval_test_get_object(struct oval_test *);
  * @memberof oval_test
  */
 struct oval_state_iterator *oval_test_get_states(struct oval_test *);
-/**
- * Get a nicely formated list of states referenced by test.
- * @return String containing state names delimited by a comma.
- * @memberof oval_test
- */
-char *oval_test_get_state_names(struct oval_test *test);
 
 /** @} */
 

--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -253,7 +253,6 @@ const char *oval_operator_get_text(oval_operator_t);
 const char *oval_subtype_get_text(oval_subtype_t);
 const char *oval_family_get_text(oval_family_t);
 const char *oval_check_get_text(oval_check_t);
-const char *oval_check_get_description(oval_check_t);
 const char *oval_existence_get_text(oval_existence_t);
 const char *oval_affected_family_get_text(oval_affected_family_t);
 const char *oval_datatype_get_text(oval_datatype_t);

--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -1183,6 +1183,12 @@ struct oval_object *oval_test_get_object(struct oval_test *);
  * @memberof oval_test
  */
 struct oval_state_iterator *oval_test_get_states(struct oval_test *);
+/**
+ * Get a nicely formated list of states referenced by test.
+ * @return String containing state names delimited by a comma.
+ * @memberof oval_test
+ */
+char *oval_test_get_state_names(struct oval_test *test);
 
 /** @} */
 

--- a/src/OVAL/results/oval_resultTest.c
+++ b/src/OVAL/results/oval_resultTest.c
@@ -1019,7 +1019,7 @@ oval_result_t oval_result_test_eval(struct oval_result_test *rtest)
 			rtest->result = OVAL_RESULT_UNKNOWN;
 	}
 
-        dI("\t%s => %s", oval_result_test_get_id(rtest), oval_result_get_text(rtest->result));
+	dI("Test '%s' evaluated as %s.", oval_result_test_get_id(rtest), oval_result_get_text(rtest->result));
 
 	return rtest->result;
 }

--- a/src/OVAL/results/oval_resultTest.c
+++ b/src/OVAL/results/oval_resultTest.c
@@ -628,11 +628,11 @@ static oval_result_t eval_check_state(struct oval_test *test, void **args)
 	ores_clear(&item_ores);
 
 	char *state_names = oval_test_get_state_names(test);
-	dI("To get result of '%s', collected items will be compared with these oval states: %s.",
-		oval_test_get_id(test), state_names);
-	dI("In test '%s' %s of the collected items must satisfy these states: %s.",
-		oval_test_get_id(test), oval_check_get_description(ste_check), state_names);
-	oscap_free(state_names);
+	if (state_names) {
+		dI("In test '%s' %s of the collected items must satisfy these states: %s.",
+			oval_test_get_id(test), oval_check_get_description(ste_check), state_names);
+		oscap_free(state_names);
+	}
 
 	ritems_itr = oval_result_test_get_items(TEST);
 	while (oval_result_item_iterator_has_more(ritems_itr)) {

--- a/src/OVAL/results/oval_resultTest.c
+++ b/src/OVAL/results/oval_resultTest.c
@@ -624,6 +624,13 @@ static oval_result_t eval_check_state(struct oval_test *test, void **args)
 	syschar_model = oval_result_system_get_syschar_model(SYSTEM);
 	ores_clear(&item_ores);
 
+	char *state_names = oval_test_get_state_names(test);
+	dI("To get result of '%s', collected items will be compared with these oval states: %s.",
+		oval_test_get_id(test), state_names);
+	dI("In test '%s' %s of the collected items must satisfy these states: %s.",
+		oval_test_get_id(test), oval_check_get_description(ste_check), state_names);
+	oscap_free(state_names);
+
 	ritems_itr = oval_result_test_get_items(TEST);
 	while (oval_result_item_iterator_has_more(ritems_itr)) {
 		struct oval_result_item *ritem;

--- a/src/OVAL/results/oval_resultTest.c
+++ b/src/OVAL/results/oval_resultTest.c
@@ -585,6 +585,9 @@ static oval_result_t eval_item(struct oval_syschar_model *syschar_model, struct 
 
 	operator = oval_state_get_operator(state);
 	result = ores_get_result_byopr(&ste_ores, operator);
+	dI("Item '%s' compared to state '%s' with result %s.",
+			   oval_sysitem_get_id(cur_sysitem), oval_state_get_id(state),
+			   oval_result_get_text(result));
 
 	return result;
 


### PR DESCRIPTION
In this pull request I would like to introduce some very basic informational messages that can help user of the verbose mode to figure out the reasons of OVAL test results.

(More will follow, but I think it will be in another pull request.)