### PR TITLE
Issue #303: Fix oscap-docker traceback

### DIFF
--- a/utils/oscap-docker.in
+++ b/utils/oscap-docker.in
@@ -65,6 +65,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='oscap docker',
                                      epilog='See `man oscap` to learn \
                                      more about OSCAP-ARGUMENTS')
+    parser.set_defaults(func=parser.print_help)
     subparser = parser.add_subparsers(help="commands")
 
     # Scan CVEs in image


### PR DESCRIPTION
The oscap-docker utility failed with a traceback with Python 3
whe invoked with no argument.
It will print the help instead.