### PR TITLE
Desperate grave digger

### DIFF
--- a/tests/probes/process58/command_line.sh
+++ b/tests/probes/process58/command_line.sh
@@ -42,6 +42,10 @@ function get_zombie_pid_from_ppid() {
 			[ "${ZOMBIE_PID}" != "" ] && break;
 			sleep 0.1s
 		done
+	if [ "x${ZOMBIE_PID}" == "x" ]; then
+		echo "Debug: The ZOMBIE_PID was not found!" >&2
+		ps -ostate,pid --ppid ${PARENT_PID} >&2
+	fi
 	echo ${ZOMBIE_PID}
 }
 


### PR DESCRIPTION
Voodoo: Tell us where is zombie

We think she left dead, but the priest (ps) conceals where it is.

This is not a black magic really. We think the zombie process should be
listed in cemetery, but sometimes it is missing. Good thing is to put
more details into the log. Next time we need to record the moon phase.

See github issue #315 for more details.