### PR TITLE
Inform user in verbose log that a test will be evaluated

### DIFF
--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -372,6 +372,7 @@ static int oval_probe_query_criteria(oval_probe_session_t *sess, struct oval_cri
 		test = oval_criteria_node_get_test(cnode);
 		if (test == NULL)
 			return 0;
+		dI("Evaluating test '%s'.", oval_test_get_id(test));
 		object = oval_test_get_object(test);
 		if (object == NULL)
 			return 0;


### PR DESCRIPTION
We currently inform user that a definition will be evaluated,
but definition contains one or more tests, and we currently
don't show it in log, which complicates the understanding
of whole story.