### PR TITLE
Add message about extend definition

### DIFF
--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -449,10 +449,12 @@ static int oval_probe_query_criteria(oval_probe_session_t *sess, struct oval_cri
                  * definition to be evaluated completely */
         case OVAL_NODETYPE_EXTENDDEF:{
                         struct oval_definition *oval_def = oval_criteria_node_get_definition(cnode);
+			const char *def_id = oval_definition_get_id(oval_def);
+			dI("Criteria are extended by definition '%s'.", def_id);
 			struct oval_criteria_node *node =  oval_definition_get_criteria(oval_def);
 			if (node == NULL) {
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not find extended definition: %s.",
-					oval_definition_get_id(oval_def));
+					def_id);
 				return -1;
 			}
                         return oval_probe_query_criteria(sess, node);


### PR DESCRIPTION
In OVAL the definitions usually contain one or more tests,
but they can also be extended by referencing to other definitions.
The refrenced definitions are required to be evaluated to get
final result of the definition under the evaluation.
This construct is sometimes used in SSG.
Currently we don't show the information about extending definition
in verbose log. The log is very confusing for a reader if a
extended definition is evaluated.
This commit adds an info message when extend_definition is used.