### PR TITLE
Show type of test and test comment in verbose log

### DIFF
--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -368,11 +368,15 @@ static int oval_probe_query_criteria(oval_probe_session_t *sess, struct oval_cri
 		struct oval_test *test;
 		struct oval_object *object;
 		struct oval_state_iterator *ste_itr;
+		const char *type, *test_id, *comment;
 
 		test = oval_criteria_node_get_test(cnode);
 		if (test == NULL)
 			return 0;
-		dI("Evaluating test '%s'.", oval_test_get_id(test));
+		type = oval_subtype_get_text(oval_test_get_subtype(test));
+		test_id = oval_test_get_id(test);
+		comment = oval_test_get_comment(test);
+		dI("Evaluating %s test '%s': %s.", type, test_id, comment);
 		object = oval_test_get_object(test);
 		if (object == NULL)
 			return 0;


### PR DESCRIPTION
Currently we show only test id in log message.
However, if we show only id, user will need look
to the OVAL file to figure out which test is which.
We can easily improve it by adding object type and its comment
into the message.