### PR TITLE
Maint 1.2 offline scan tested probes

### DIFF
--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -71,6 +71,9 @@
 #include "debug_priv.h"
 #include "probe/entcmp.h"
 
+#include <probe/probe.h>
+#include <probe/option.h>
+
 struct rpmverify_res {
         char *name;  /**< package name */
         char *file;  /**< filepath */
@@ -265,6 +268,8 @@ void *probe_init (void)
         g_rpm.rpmts = rpmtsCreate();
 
         pthread_mutex_init(&(g_rpm.mutex), NULL);
+
+	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
 
         return ((void *)&g_rpm);
 }

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -73,6 +73,9 @@
 #include "debug_priv.h"
 #include "probe/entcmp.h"
 
+#include <probe/probe.h>
+#include <probe/option.h>
+
 struct rpmverify_res {
 	char *name;  /**< package name */
 	const char *epoch;
@@ -334,7 +337,7 @@ void *probe_init (void)
 	g_rpm.rpmts = rpmtsCreate();
 
 	pthread_mutex_init(&(g_rpm.mutex), NULL);
-
+	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
 	return ((void *)&g_rpm);
 }
 

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -74,6 +74,9 @@
 #include "debug_priv.h"
 #include "probe/entcmp.h"
 
+#include <probe/probe.h>
+#include <probe/option.h>
+
 typedef struct {
 	const char *a_name;
 	uint64_t    a_flag;
@@ -320,7 +323,7 @@ void *probe_init (void)
 	g_rpm.rpmts = rpmtsCreate();
 
 	pthread_mutex_init(&(g_rpm.mutex), NULL);
-
+	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
 	return ((void *)&g_rpm);
 }
 

--- a/src/OVAL/probes/unix/symlink.c
+++ b/src/OVAL/probes/unix/symlink.c
@@ -40,6 +40,9 @@
 #include <limits.h>
 #include <stdlib.h>
 
+#include <probe/probe.h>
+#include <probe/option.h>
+
 static int collect_symlink(SEXP_t *ent, probe_ctx *ctx)
 {
 	SEXP_t *ent_val, *item_sexp, *msg;
@@ -110,6 +113,12 @@ static int collect_symlink(SEXP_t *ent, probe_ctx *ctx)
 	oscap_free(linkname);
 	oscap_free(pathname);
 	return 0;
+}
+
+void *probe_init (void)
+{
+	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
+	return NULL;
 }
 
 int probe_main(probe_ctx *ctx, void *probe_arg)


### PR DESCRIPTION
I have done simple beaker test using oscap-docker for these probes, so these probes should really work.