### PR TITLE
Added the oscap-chroot tool - scan filesystems on arbitrary paths

### DIFF
--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -490,6 +490,14 @@ AC_ARG_ENABLE([util-oscap-vm],
        *) AC_MSG_ERROR([bad value ${enableval} for --enable-util-oscap-vm]) ;;
      esac],[util_oscap_vm=yes])
 
+AC_ARG_ENABLE([util-oscap-chroot],
+     [AC_HELP_STRING([--enable-util-oscap-chroot], [enable compilation of the oscap-chroot utility (default=yes)])],
+     [case "${enableval}" in
+       yes) util_oscap_chroot=yes ;;
+       no)  util_oscap_chroot=no  ;;
+       *) AC_MSG_ERROR([bad value ${enableval} for --enable-util-oscap-chroot]) ;;
+     esac],[util_oscap_chroot=yes])
+
 if test "$vgdebug" = "yes"; then
  if test "$HAVE_VALGRIND" = "yes"; then
    vgcheck="yes"
@@ -568,6 +576,7 @@ AM_CONDITIONAL([WANT_UTIL_SCAP_AS_RPM], test "$util_scap_as_rpm" = yes)
 AM_CONDITIONAL([WANT_UTIL_OSCAP_SSH], test "$util_oscap_ssh" = yes)
 AM_CONDITIONAL([WANT_UTIL_OSCAP_DOCKER], test "$util_oscap_docker" = yes)
 AM_CONDITIONAL([WANT_UTIL_OSCAP_VM], test "$util_oscap_vm" = yes)
+AM_CONDITIONAL([WANT_UTIL_OSCAP_CHROOT], test "$util_oscap_chroot" = yes)
 AM_CONDITIONAL([WANT_PYTHON], test "$python_bind" = yes)
 AM_CONDITIONAL([WANT_PYTHON3], test "$python3_bind" = yes)
 AM_CONDITIONAL([WANT_PERL], test "$perl_bind" = yes)
@@ -712,6 +721,7 @@ echo "scap-as-rpm tool:              $util_scap_as_rpm"
 echo "oscap-ssh tool:                $util_oscap_ssh"
 echo "oscap-docker tool:             $util_oscap_docker"
 echo "oscap-vm tool:                 $util_oscap_vm"
+echo "oscap-chroot tool:             $util_oscap_chroot"
 echo "python2 bindings enabled:      $python_bind"
 echo "python3 bindings enabled:      $python3_bind"
 echo "perl bindings enabled:         $perl_bind"

--- a/configure.ac
+++ b/configure.ac
@@ -1215,6 +1215,14 @@ AC_ARG_ENABLE([util-oscap-vm],
        *) AC_MSG_ERROR([bad value ${enableval} for --enable-util-oscap-vm]) ;;
      esac],[util_oscap_vm=yes])
 
+AC_ARG_ENABLE([util-oscap-chroot],
+     [AC_HELP_STRING([--enable-util-oscap-chroot], [enable compilation of the oscap-chroot utility (default=yes)])],
+     [case "${enableval}" in
+       yes) util_oscap_chroot=yes ;;
+       no)  util_oscap_chroot=no  ;;
+       *) AC_MSG_ERROR([bad value ${enableval} for --enable-util-oscap-chroot]) ;;
+     esac],[util_oscap_chroot=yes])
+
 if test "$vgdebug" = "yes"; then
  if test "$HAVE_VALGRIND" = "yes"; then
    vgcheck="yes"
@@ -1381,6 +1389,7 @@ AM_CONDITIONAL([WANT_UTIL_SCAP_AS_RPM], test "$util_scap_as_rpm" = yes)
 AM_CONDITIONAL([WANT_UTIL_OSCAP_SSH], test "$util_oscap_ssh" = yes)
 AM_CONDITIONAL([WANT_UTIL_OSCAP_DOCKER], test "$util_oscap_docker" = yes)
 AM_CONDITIONAL([WANT_UTIL_OSCAP_VM], test "$util_oscap_vm" = yes)
+AM_CONDITIONAL([WANT_UTIL_OSCAP_CHROOT], test "$util_oscap_chroot" = yes)
 AM_CONDITIONAL([WANT_PYTHON], test "$python_bind" = yes)
 AM_CONDITIONAL([WANT_PYTHON3], test "$python3_bind" = yes)
 AM_CONDITIONAL([WANT_PERL], test "$perl_bind" = yes)
@@ -1525,6 +1534,7 @@ echo "scap-as-rpm tool:              $util_scap_as_rpm"
 echo "oscap-ssh tool:                $util_oscap_ssh"
 echo "oscap-docker tool:             $util_oscap_docker"
 echo "oscap-vm tool:                 $util_oscap_vm"
+echo "oscap-chroot tool:             $util_oscap_chroot"
 echo "python2 bindings enabled:      $python_bind"
 echo "python3 bindings enabled:      $python3_bind"
 echo "perl bindings enabled:         $perl_bind"

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -57,6 +57,10 @@ if WANT_UTIL_OSCAP_VM
 bin_SCRIPTS += oscap-vm
 man_MANS += oscap-vm.8
 endif
+if WANT_UTIL_OSCAP_CHROOT
+bin_SCRIPTS += oscap-chroot
+man_MANS += oscap-chroot.8
+endif
 
 CONFIG_CLEAN_FILES = oscap-docker
 

--- a/utils/oscap-chroot
+++ b/utils/oscap-chroot
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Copyright 2016 Red Hat Inc., Durham, North Carolina.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:
+#      Martin Preisler <mpreisle@redhat.com>
+
+function die()
+{
+    echo "$*" >&2
+    exit 1
+}
+
+function usage()
+{
+    echo "oscap-chroot -- Tool for offline SCAP evaluation of filesystems mounted in arbitrary paths."
+    echo
+    echo "Usage:"
+    echo
+    echo "$ oscap-chroot CHROOT_PATH xccdf eval [options] INPUT_CONTENT"
+    echo
+    echo "supported oscap xccdf eval options are:"
+    echo "  --profile"
+    echo "  --tailoring-file"
+    echo "  --tailoring-id"
+    echo "  --cpe (external OVAL dependencies are not supported yet!)"
+    echo "  --oval-results"
+    echo "  --sce-results"
+    echo "  --check-engine-results"
+    echo "  --results"
+    echo "  --results-arf"
+    echo "  --report"
+    echo "  --skip-valid"
+    echo "  --fetch-remote-resources"
+    echo "  --progress"
+    echo "  --datastream-id"
+    echo "  --xccdf-id"
+    echo "  --benchmark-id"
+    echo
+    echo "$ oscap-chroot CHROOT_PATH oval eval [options] INPUT_CONTENT"
+    echo
+    echo "supported oscap oval eval options are:"
+    echo "  --id"
+    echo "  --variables"
+    echo "  --directives"
+    echo "  --results"
+    echo "  --report"
+    echo "  --skip-valid"
+    echo "  --datastream-id"
+    echo "  --oval-id"
+    echo "  --probe-root"
+    echo
+    echo "$ oscap-chroot CHROOT_PATH oval collect [options] INPUT_CONTENT"
+    echo
+    echo "supported oscap oval collect options are:"
+    echo "  --id"
+    echo "  --syschar"
+    echo "  --variables"
+    echo "  --skip-valid"
+    echo
+    echo "See \`man oscap\` to learn more about semantics of these options."
+}
+
+if [ $# -lt 1 ]; then
+    echo "No arguments provided."
+    usage
+    die
+elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+    usage
+    die
+elif [ "$#" -gt 1 ]; then
+    true
+else
+    echo "Invalid arguments provided."
+    usage
+    die
+fi
+
+# Learn more at https://www.redhat.com/archives/open-scap-list/2013-July/msg00000.html
+export OSCAP_PROBE_ROOT
+OSCAP_PROBE_ROOT="$(cd "$1"; pwd)"
+export OSCAP_PROBE_OS_NAME="Linux" # TODO: This may be wrong!
+export OSCAP_PROBE_OS_VERSION
+OSCAP_PROBE_OS_VERSION="$(uname --kernel-release)" # TODO
+export OSCAP_PROBE_ARCHITECTURE
+OSCAP_PROBE_ARCHITECTURE="$(uname --hardware-platform)" # TODO
+export OSCAP_PROBE_PRIMARY_HOST_NAME="oscap-chroot of $1"
+shift 1
+
+oscap "$@"
+EXIT_CODE=$?
+exit $EXIT_CODE

--- a/utils/oscap-chroot.8
+++ b/utils/oscap-chroot.8
@@ -1,0 +1,62 @@
+.TH oscap-chroot "8" "February 2016" "Red Hat, Inc." "System Administration Utilities"
+.SH NAME
+oscap-chroot \- Tool for offline SCAP evaluation of filesystems mounted at arbitrary paths.
+.SH DESCRIPTION
+oscap-chroot runs oscap tool on it in a filesystem mounted at given path.
+
+Usage of the tool mimics usage and options of oscap(8) tool.
+
+.SH USAGE
+.SS Evaluation of XCCDF content
+$ oscap-chroot CHROOT_PATH xccdf eval [options] INPUT_CONTENT
+
+supported oscap xccdf eval options are:
+  --profile
+  --tailoring-file
+  --tailoring-id
+  --cpe (external OVAL dependencies are not supported yet!)
+  --oval-results
+  --sce-results
+  --check-engine-results
+  --results
+  --results-arf
+  --report
+  --skip-valid
+  --fetch-remote-resources
+  --progress
+  --datastream-id
+  --xccdf-id
+  --benchmark-id
+
+.SS Evaluation of OVAL content
+$ oscap-vm image CHROOT_PATH oval eval [options] INPUT_CONTENT
+
+supported oscap oval eval options are:
+  --id
+  --variables
+  --directives
+  --results
+  --report
+  --skip-valid
+  --datastream-id
+  --oval-id
+  --probe-root
+
+.SS Collection of OVAL System Characteristic
+$ oscap-vm CHROOT_PATH oval collect [options] INPUT_CONTENT
+
+supported oscap oval collect options are:
+  --id
+  --syschar
+  --variables
+  --skip-valid
+
+
+.SH REPORTING BUGS
+.nf
+Please report bugs using https://github.com/OpenSCAP/openscap/issues
+
+.SH AUTHORS
+.nf
+Martin Preisler <mpreisle@redhat.com>
+.fi

--- a/utils/oscap-chroot.8
+++ b/utils/oscap-chroot.8
@@ -29,7 +29,7 @@ supported oscap xccdf eval options are:
   --benchmark-id
 
 .SS Evaluation of OVAL content
-$ oscap-vm image CHROOT_PATH oval eval [options] INPUT_CONTENT
+$ oscap-chroot image CHROOT_PATH oval eval [options] INPUT_CONTENT
 
 supported oscap oval eval options are:
   --id
@@ -43,7 +43,7 @@ supported oscap oval eval options are:
   --probe-root
 
 .SS Collection of OVAL System Characteristic
-$ oscap-vm CHROOT_PATH oval collect [options] INPUT_CONTENT
+$ oscap-chroot CHROOT_PATH oval collect [options] INPUT_CONTENT
 
 supported oscap oval collect options are:
   --id


### PR DESCRIPTION
A very very small command-line tool with no dependencies outside `oscap`. The only thing it does is setup environment variables correctly for `oscap` for running it for a chroot.

I could do all of this inside the daemon but I'd prefer to have the logic neat and simple so I created it as a separate script. We could also decide we don't want this in OpenSCAP and just ship it with the daemon but I think that would be a shame. This makes a few use-cases simpler.

Let me know what you think!