### PR TITLE
Evaluate results while collecting objects

### DIFF
--- a/src/OVAL/_oval_probe_session.h
+++ b/src/OVAL/_oval_probe_session.h
@@ -45,6 +45,7 @@ struct oval_probe_session {
         struct oval_syschar_model *sys_model; /**< system characteristics model */
         char         *dir;  /**< probe session directory */
         uint32_t      flg;  /**< probe session flags */
+        struct oval_result_system *result_system; /**< results system model */
 };
 
 #endif /* _OVAL_PROBE_SESSION */

--- a/src/OVAL/_oval_probe_session.h
+++ b/src/OVAL/_oval_probe_session.h
@@ -48,6 +48,8 @@ struct oval_probe_session {
         struct oval_result_system *result_system; /**< results system model */
 };
 
+struct oval_result_system *oval_probe_session_get_result_system(oval_probe_session_t *sess);
+
 #endif /* _OVAL_PROBE_SESSION */
 
 /// @}

--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -86,10 +86,13 @@ static const struct oval_result_to_xccdf_spec XCCDF_OVAL_RESULTS_MAP[] = {
 	{0, 0, 0}
 };
 
+static struct oval_result_system *_oval_agent_get_first_result_system(oval_agent_session_t *ag_sess);
+
 oval_agent_session_t * oval_agent_new_session(struct oval_definition_model *model, const char * name) {
 	oval_agent_session_t *ag_sess;
 	struct oval_sysinfo *sysinfo;
 	struct oval_generator *generator;
+	struct oval_result_system *result_system;
 	int ret;
 
 	dI("Started new OVAL agent.", name);
@@ -102,7 +105,16 @@ oval_agent_session_t * oval_agent_new_session(struct oval_definition_model *mode
 	ag_sess->def_model = model;
 	ag_sess->cur_var_model = NULL;
 	ag_sess->sys_model = oval_syschar_model_new(model);
-	ag_sess->psess     = oval_probe_session_new(ag_sess->sys_model);
+
+	/* one system only */
+	ag_sess->sys_models[0] = ag_sess->sys_model;
+	ag_sess->sys_models[1] = NULL;
+	ag_sess->res_model = oval_results_model_new(model, ag_sess->sys_models);
+	generator = oval_results_model_get_generator(ag_sess->res_model);
+	oval_generator_set_product_version(generator, oscap_get_version());
+
+	result_system = _oval_agent_get_first_result_system(ag_sess);
+	ag_sess->psess = oval_probe_session_with_result_system_new(ag_sess->sys_model, result_system);
 
 	/* probe sysinfo */
 	ret = oval_probe_query_sysinfo(ag_sess->psess, &sysinfo);
@@ -114,14 +126,6 @@ oval_agent_session_t * oval_agent_new_session(struct oval_definition_model *mode
 	}
 	oval_syschar_model_set_sysinfo(ag_sess->sys_model, sysinfo);
 	oval_sysinfo_free(sysinfo);
-
-	/* one system only */
-	ag_sess->sys_models[0] = ag_sess->sys_model;
-	ag_sess->sys_models[1] = NULL;
-	ag_sess->res_model = oval_results_model_new(model, ag_sess->sys_models);
-	generator = oval_results_model_get_generator(ag_sess->res_model);
-	oval_generator_set_product_version(generator, oscap_get_version());
-
 
 	ag_sess->product_name = NULL;
 

--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -245,7 +245,7 @@ int oval_agent_reset_session(oval_agent_session_t * ag_sess) {
 	}
 
 	oval_probe_session_destroy(ag_sess->psess);
-	ag_sess->psess = oval_probe_session_new(ag_sess->sys_model);
+	ag_sess->psess = oval_probe_session_with_result_system_new(ag_sess->sys_model, _oval_agent_get_first_result_system(ag_sess));
 
 	return 0;
 }

--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -165,7 +165,6 @@ int oval_agent_eval_definition(oval_agent_session_t *ag_sess, const char *id)
 {
 	int ret;
 	const char *title = NULL;
-	struct oval_result_system *rsystem;
 	struct oval_definition *oval_def;
 
 	oval_def = oval_definition_model_get_definition(ag_sess->def_model, id);
@@ -176,13 +175,6 @@ int oval_agent_eval_definition(oval_agent_session_t *ag_sess, const char *id)
 
 	/* probe */
 	ret = oval_probe_query_definition(ag_sess->psess, id);
-	if (ret == -1)
-		return ret;
-
-	rsystem = _oval_agent_get_first_result_system(ag_sess);
-	/* eval */
-	ret = oval_result_system_eval_definition(rsystem, id);
-
 	return ret;
 }
 

--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -433,12 +433,17 @@ static oval_result_t oval_probe_query_criterion(oval_probe_session_t *sess, stru
 	return oval_result_test_eval(result_test);
 }
 
-static int oval_probe_query_extend_definition(oval_probe_session_t *sess, struct oval_criteria_node *cnode)
+static oval_result_t oval_probe_query_extend_definition(oval_probe_session_t *sess, struct oval_criteria_node *cnode, struct oval_result_criteria_node *result_cnode)
 {
 	struct oval_definition *oval_def = oval_criteria_node_get_definition(cnode);
 	const char *def_id = oval_definition_get_id(oval_def);
 	dI("Criteria are extended by definition '%s'.", def_id);
-	return oval_probe_query_definition(sess, def_id);
+	int ret = oval_probe_query_definition(sess, def_id);
+	if (ret != 0) {
+		return OVAL_RESULT_ERROR;
+	}
+	struct oval_result_definition *extends = oval_result_criteria_node_get_extends(result_cnode);
+	return oval_result_definition_get_result(extends);
 }
 
 static oval_result_t oval_probe_query_criteria(oval_probe_session_t *sess, struct oval_criteria_node *cnode, struct oval_result_criteria_node *result_cnode)

--- a/src/OVAL/oval_probe_session.c
+++ b/src/OVAL/oval_probe_session.c
@@ -216,4 +216,9 @@ struct oval_syschar_model *oval_probe_session_getmodel(oval_probe_session_t *ses
 	return (sess->sys_model);
 }
 
+struct oval_result_system *oval_probe_session_get_result_system(oval_probe_session_t *sess)
+{
+	return sess->result_system;
+}
+
 /// @}

--- a/src/OVAL/oval_probe_session.c
+++ b/src/OVAL/oval_probe_session.c
@@ -118,7 +118,7 @@ static void __init_once(void)
         return;
 }
 
-oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model)
+oval_probe_session_t *oval_probe_session_with_result_system_new(struct oval_syschar_model *model, struct oval_result_system *result_system)
 {
         oval_probe_session_t *sess;
         void *handler_arg;
@@ -131,7 +131,7 @@ oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model)
         sess->pext = oval_pext_new();
         sess->pext->model    = &sess->sys_model;
         sess->pext->sess_ptr = sess;
-        sess->result_system = NULL;
+        sess->result_system = result_system;
 
         __init_once();
 
@@ -150,6 +150,11 @@ oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model)
 
         oval_probe_handler_set(sess->ph, OVAL_SUBTYPE_ALL, oval_probe_ext_handler, sess->pext); /* special case for reset */
         return(sess);
+}
+
+oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model)
+{
+	return oval_probe_session_with_result_system_new(model, NULL);
 }
 
 void oval_probe_session_destroy(oval_probe_session_t *sess)

--- a/src/OVAL/oval_probe_session.c
+++ b/src/OVAL/oval_probe_session.c
@@ -131,6 +131,7 @@ oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model)
         sess->pext = oval_pext_new();
         sess->pext->model    = &sess->sys_model;
         sess->pext->sess_ptr = sess;
+        sess->result_system = NULL;
 
         __init_once();
 

--- a/src/OVAL/public/oval_probe_session.h
+++ b/src/OVAL/public/oval_probe_session.h
@@ -39,8 +39,10 @@ typedef struct oval_probe_session oval_probe_session_t;
 /**
  * Create and initialize a new probe session
  * @param model system characteristics model
+ * @deprecated This function has been deprecated. Make a use of oval_probe_session_with_result_system_new
+ * instead. This function may be dropped from later versions of the library.
  */
-oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model);
+OSCAP_DEPRECATED(oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model));
 
 /**
  * Create and initialize a new probe session

--- a/src/OVAL/public/oval_probe_session.h
+++ b/src/OVAL/public/oval_probe_session.h
@@ -34,12 +34,20 @@ typedef struct oval_probe_session oval_probe_session_t;
 
 #include "oval_probe_handler.h"
 #include "oval_system_characteristics.h"
+#include "oval_results.h"
 
 /**
  * Create and initialize a new probe session
  * @param model system characteristics model
  */
 oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model);
+
+/**
+ * Create and initialize a new probe session
+ * @param model system characteristics model
+ * @param result_system OVAL results system
+ */
+oval_probe_session_t *oval_probe_session_with_result_system_new(struct oval_syschar_model *model, struct oval_result_system *result_system);
 
 /**
  * Destroy probe session. All state information created during the lifetime

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -269,7 +269,7 @@ int app_collect_oval(const struct oscap_action *action)
 	oval_generator_set_product_name(generator, OSCAP_PRODUCTNAME);
 
 	/* create probe session */
-	pb_sess = oval_probe_session_new(sys_model);
+	pb_sess = oval_probe_session_with_result_system_new(sys_model, NULL);
 
 	/* query sysinfo */
 	ret = oval_probe_query_sysinfo(pb_sess, &sysinfo);


### PR DESCRIPTION
This pull request proposes a small change to process of evaluation of OVAL definition.
Currently, we do two steps to get the results of a definition:
1) Querying probes for objects for all the definitions
2) After all items are collected, we compute results separately.
It causes some confusion in the verbose log in cases one definition contains multiple criteria,
the messages are not in logical order here.
I think that messages describing computing results of a test should be displayed just after messages  describing evaluation of the same test, it should not be mixed as is now.
We can fix this by merging aforementioned steps into single step, which is done in this PR by some refactoring.
It would basically mean that each test is evaluated separately, no other querying starts before a result of single test is done.
Therefore we would have messages in verbose mode in expected order.

Since this is not trivial change, I have done some testing. I have compared OVAL results produced by evaluating RHEL6, RHEL7, and Fedora OVAL from SSG with and without these patches and reviewed the result files using meld. Results from both were same (except item IDs and time stamps, of course).