### PR TITLE
Change messages category to DEVEL

### DIFF
--- a/src/OVAL/probes/SEAP/seap-command.c
+++ b/src/OVAL/probes/SEAP/seap-command.c
@@ -430,7 +430,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                                 }
                         }
 
-                        dI("cond return: h.args=%p", h.args);
+                        dD("cond return: h.args=%p", h.args);
 
                         if (h.args == NULL)
                                 res = NULL;

--- a/src/OVAL/probes/SEAP/sexp-manip.c
+++ b/src/OVAL/probes/SEAP/sexp-manip.c
@@ -1463,7 +1463,7 @@ SEXP_t *SEXP_list_sort(SEXP_t *list, int(*compare)(const SEXP_t *, const SEXP_t 
 								    list_it[min_i].count - 1, sizeof(SEXP_t), (void *)&tmp_v,
 								    (int(*)(void *, void *))compare, &dst_i);
 
-						dI("dst_i = %zu", dst_i);
+						dD("dst_i = %zu", dst_i);
 
 						/* make place for the old value in the min. value source block */
 						memmove(list_it[min_i].block->memb, list_it[min_i].block->memb + 1,

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -966,11 +966,11 @@ static FTSENT *oval_fts_read_match_path(OVAL_FTS *ofts)
 			if (ret < 0) {
 				switch (ret) {
 				case PCRE_ERROR_NOMATCH:
-					dI("Partial match optimization: PCRE_ERROR_NOMATCH, skipping.");
+					dD("Partial match optimization: PCRE_ERROR_NOMATCH, skipping.");
 					fts_set(ofts->ofts_match_path_fts, fts_ent, FTS_SKIP);
 					continue;
 				case PCRE_ERROR_PARTIAL:
-					dI("Partial match optimization: PCRE_ERROR_PARTIAL, continuing.");
+					dD("Partial match optimization: PCRE_ERROR_PARTIAL, continuing.");
 					continue;
 				default:
 					dE("pcre_exec() error: %d.", ret);

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -499,7 +499,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 
 			if (aval != NULL) {
 				if (SEXP_strcmp(aval, "true") == 0) {
-					dI("omit verify attr: %s", rpmverifyfile_bhmap[i].a_name);
+					dD("omit verify attr: %s", rpmverifyfile_bhmap[i].a_name);
 					collect_flags |= rpmverifyfile_bhmap[i].a_flag;
 				}
 


### PR DESCRIPTION
While browsing verbose log produced on Fedora SSG,
I have discovered several messages which disturb in INFO level.
They should be in DEVEL category instead.