### PR TITLE
Issue #317: Fix oscap-docker traceback

### DIFF
--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -27,6 +27,7 @@ import sys
 
 try:
     from Atomic.mount import DockerMount
+    from Atomic.mount import MountError
     import inspect
 
     if "mnt_mkdir" not in inspect.getargspec(DockerMount.__init__).args:
@@ -190,7 +191,11 @@ class OscapScan(object):
         '''
         # Mount the temporary image/container to the dir
         DM = DockerMount(self.mnt_dir, mnt_mkdir=True)
-        _tmp_mnt_dir = DM.mount(image)
+        try:
+            _tmp_mnt_dir = DM.mount(image)
+        except MountError as e:
+            sys.stderr.write(str(e) + "\n")
+            return None
 
         # Remeber actual mounted fs in 'rootfs'
         chroot = os.path.join(_tmp_mnt_dir, 'rootfs')
@@ -218,7 +223,11 @@ class OscapScan(object):
         '''
         # Mount the temporary image/container to the dir
         DM = DockerMount(self.mnt_dir, mnt_mkdir=True)
-        _tmp_mnt_dir = DM.mount(image)
+        try:
+            _tmp_mnt_dir = DM.mount(image)
+        except MountError as e:
+            sys.stderr.write(str(e) + "\n")
+            return None
 
         # Remeber actual mounted fs in 'rootfs'
         chroot = os.path.join(_tmp_mnt_dir, 'rootfs')


### PR DESCRIPTION
Oscap-docker gave a traceback when providing a wrong image ID
or wrong container ID.
This commit fixes the traceback by catching the exception
and writes an error message on stderr.