### PR TITLE
Fix compiler errors on older systems

### DIFF
--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -149,7 +149,7 @@ fi
 SAVE_CFLAGS=$CFLAGS
 CFLAGS="$CFLAGS -D_GNU_SOURCE"
 LIBS="$pthread_LIBS"
-AC_CHECK_FUNCS([pthread_timedjoin_np clock_gettime])
+AC_CHECK_FUNCS([pthread_timedjoin_np pthread_setname_np pthread_getname_np clock_gettime])
 CFLAGS=$SAVE_CFLAGS
 
 LIBS=$SAVE_LIBS

--- a/configure.ac
+++ b/configure.ac
@@ -313,7 +313,7 @@ fi
 SAVE_CFLAGS=$CFLAGS
 CFLAGS="$CFLAGS -D_GNU_SOURCE"
 LIBS="$pthread_LIBS"
-AC_CHECK_FUNCS([pthread_timedjoin_np clock_gettime])
+AC_CHECK_FUNCS([pthread_timedjoin_np pthread_setname_np pthread_getname_np clock_gettime])
 CFLAGS=$SAVE_CFLAGS
 
 LIBS=$SAVE_LIBS

--- a/src/OVAL/probes/SEAP/seap.c
+++ b/src/OVAL/probes/SEAP/seap.c
@@ -239,7 +239,9 @@ static void *__SEAP_cmdexec_worker (void *arg)
 
         _A(job != NULL);
         _A(job->cmd != NULL);
+#if defined(HAVE_PTHREAD_SETNAME_NP)
 	pthread_setname_np(pthread_self(), "command_worker");
+#endif
 
         if (job->cmd->flags & SEAP_CMDFLAG_REPLY) {
                 (void) SEAP_cmd_exec (job->ctx, job->sd, SEAP_EXEC_WQUEUE,

--- a/src/OVAL/probes/probe/icache.c
+++ b/src/OVAL/probes/probe/icache.c
@@ -92,7 +92,9 @@ static void *probe_icache_worker(void *arg)
 
         assume_d(cache != NULL, NULL);
 
+#if defined(HAVE_PTHREAD_SETNAME_NP)
 	pthread_setname_np(pthread_self(), "icache_worker");
+#endif
 
         if (pthread_mutex_lock(&cache->queue_mutex) != 0) {
                 dE("An error ocured while locking the queue mutex: %u, %s",

--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -52,7 +52,9 @@ void *probe_input_handler(void *arg)
         SEAP_msg_t *seap_request, *seap_reply;
         SEXP_t *probe_in, *probe_out, *oid;
 
+#if defined(HAVE_PTHREAD_SETNAME_NP)
 	pthread_setname_np(pthread_self(), "input_handler");
+#endif
 
 #define TH_CANCEL_ON  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &cstate)
 #define TH_CANCEL_OFF pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cstate)

--- a/src/OVAL/probes/probe/signal_handler.c
+++ b/src/OVAL/probes/probe/signal_handler.c
@@ -64,7 +64,9 @@ void *probe_signal_handler(void *arg)
 	siginfo_t siinf;
 	sigset_t  siset;
 
+#if defined(HAVE_PTHREAD_SETNAME_NP)
 	pthread_setname_np(pthread_self(), "signal_handler");
+#endif
 
 	sigemptyset(&siset);
 	sigaddset(&siset, SIGHUP);

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -47,7 +47,9 @@ void *probe_worker_runfn(void *arg)
 	SEXP_t *probe_res, *obj, *oid;
 	int     probe_ret;
 
+#if defined(HAVE_PTHREAD_SETNAME_NP)
 	pthread_setname_np(pthread_self(), "probe_worker");
+#endif
 	dI("handling SEAP message ID %u", pair->pth->sid);
 	//
 	probe_ret = -1;

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -283,7 +283,7 @@ static int rpmverify_collect(probe_ctx *ctx,
 
 			rpmReadConfigFiles ((const char *)NULL, (const char *)NULL);
 			rpmts ts = rpmtsCreate();
-			ret = rpmcliVerify(ts, qva, (ARGV_const_t) poptGetArgs(rpmcli_context));
+			ret = rpmcliVerify(ts, qva, (char * const *) poptGetArgs(rpmcli_context));
 			ts = rpmtsFree(ts);
 			rpmcli_context = rpmcliFini(rpmcli_context);
 

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -173,7 +173,11 @@ static void __oscap_vdlprintf(int level, const char *file, const char *fn, size_
 #if defined(OSCAP_THREAD_SAFE)
 	char thread_name[THREAD_NAME_LEN];
 	pthread_t thread = pthread_self();
+#if defined(HAVE_PTHREAD_GETNAME_NP)
 	pthread_getname_np(thread, thread_name, THREAD_NAME_LEN);
+#else
+	snprintf(thread_name, THREAD_NAME_LEN, "unknown");
+#endif
 	/* XXX: non-portable usage of pthread_t */
 	fprintf(__debuglog_fp, "(%s(%ld):%s(%llx)) [%c:%s:%zu:%s] ",
 		program_invocation_short_name, (long) getpid(), thread_name,


### PR DESCRIPTION
Functions pthread_getname_np and pthread_setname_np were introduced
in glibc 2.12. With older versions of glibc used on RHEL5 or SLES11
OpenSCAP failed to compile. This commit adds an autoconf rule
to detect the presence of these functions.

See mail thread on our mailing list https://www.redhat.com/archives/open-scap-list/2016-March/msg00000.html