### PR TITLE
Seap: Fix double free

### DIFF
--- a/src/OVAL/probes/SEAP/seap-packet.c
+++ b/src/OVAL/probes/SEAP/seap-packet.c
@@ -730,7 +730,6 @@ eloop_exit:
                         } else {
                                 SEXP_list_free (sexp_buffer);
                                 SEXP_psetup_free (psetup);
-				SEXP_free(sexp_buffer);
                                 dI("eloop_restart");
                                 goto eloop_start;
                         }


### PR DESCRIPTION
The free caused "double free or corruption (fasttop)" when I was using
probe from commandline.

Free is already in **SEXP_list_free** https://github.com/OpenSCAP/openscap/blob/maint-1.2/src/OVAL/probes/SEAP/sexp-manip.c#L941