### PR TITLE
Fix offline mode in file probe

### DIFF
--- a/src/OVAL/probes/unix/file.c
+++ b/src/OVAL/probes/unix/file.c
@@ -339,6 +339,7 @@ static pthread_mutex_t __file_probe_mutex;
 
 void *probe_init (void)
 {
+	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
         /*
          * Initialize true/false global reference.
          */
@@ -386,7 +387,6 @@ void *probe_init (void)
 	probe_setoption(PROBEOPT_VARREF_HANDLING, false, "path");
 	probe_setoption(PROBEOPT_VARREF_HANDLING, false, "filename");
 #endif
-		probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
         return (NULL);
 }
 


### PR DESCRIPTION
I have found a logical error in file probe.
The offline mode in file probe is enabled on only when a mutex cannot be initialized,
which is not very likely and also it is definitely not what we want.
This commit enables the offline mode in file probe.