### PR TITLE
test: XCCDF/test_platform_element fix var

### DIFF
--- a/tests/API/XCCDF/applicability/test_platform_element.sh
+++ b/tests/API/XCCDF/applicability/test_platform_element.sh
@@ -12,7 +12,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $stderr"
 
 $OSCAP xccdf eval --cpe $cpe --results $result $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
-[ $ret -eq 2 ]
+[ "$ret" -eq 2 ]
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 assert_exists 1 '//TestResult'
 assert_exists 1 '//TestResult/platform'


### PR DESCRIPTION
When oscap finish successfully, $ret is not set and
we will get 'line 15: [: -eq: unary operator expected'