### PR TITLE
Query test and evaluate its results in one step

### DIFF
--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -172,9 +172,6 @@ int oval_agent_eval_definition(oval_agent_session_t *ag_sess, const char *id)
 	dI("Evaluating definition '%s': %s.", id, title);
 
 	/* probe */
-	ret = oval_probe_query_definition(ag_sess->psess, id);
-	if (ret == -1)
-		return ret;
 
 	rsystem = _oval_agent_get_first_result_system(ag_sess);
 	/* eval */

--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -118,7 +118,8 @@ oval_agent_session_t * oval_agent_new_session(struct oval_definition_model *mode
 	/* one system only */
 	ag_sess->sys_models[0] = ag_sess->sys_model;
 	ag_sess->sys_models[1] = NULL;
-	ag_sess->res_model = oval_results_model_new(model, ag_sess->sys_models);
+	ag_sess->res_model = oval_results_model_new_with_probe_session(
+			model, ag_sess->sys_models, ag_sess->psess);
 	generator = oval_results_model_get_generator(ag_sess->res_model);
 	oval_generator_set_product_version(generator, oscap_get_version());
 

--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -392,18 +392,13 @@ static int oval_probe_query_var_ref(oval_probe_session_t *sess, struct oval_stat
 	return 1;
 }
 
-static int oval_probe_query_criterion(oval_probe_session_t *sess, struct oval_criteria_node *cnode)
+static int oval_probe_query_test(oval_probe_session_t *sess, struct oval_test *test)
 {
-	/* There should be a test .. */
-	struct oval_test *test;
 	struct oval_object *object;
 	struct oval_state_iterator *ste_itr;
 	const char *type, *test_id, *comment;
 	int ret;
 
-	test = oval_criteria_node_get_test(cnode);
-	if (test == NULL)
-		return 0;
 	type = oval_subtype_get_text(oval_test_get_subtype(test));
 	test_id = oval_test_get_id(test);
 	comment = oval_test_get_comment(test);
@@ -447,7 +442,12 @@ static int oval_probe_query_criteria(oval_probe_session_t *sess, struct oval_cri
 	switch (oval_criteria_node_get_type(cnode)) {
 	/* Criterion node is the final node that has a reference to a test */
 	case OVAL_NODETYPE_CRITERION:{
-		ret = oval_probe_query_criterion(sess, cnode);
+		/* There should be a test .. */
+		struct oval_test *test = oval_criteria_node_get_test(cnode);
+		if (test == NULL) {
+			return 0;
+		}
+		ret = oval_probe_query_test(sess, test);
 		return ret;
 		}
 		break;

--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -392,7 +392,7 @@ static int oval_probe_query_var_ref(oval_probe_session_t *sess, struct oval_stat
 	return 1;
 }
 
-static int oval_probe_query_test(oval_probe_session_t *sess, struct oval_test *test)
+int oval_probe_query_test(oval_probe_session_t *sess, struct oval_test *test)
 {
 	struct oval_object *object;
 	struct oval_state_iterator *ste_itr;

--- a/src/OVAL/oval_probe_impl.h
+++ b/src/OVAL/oval_probe_impl.h
@@ -55,6 +55,8 @@ OSCAP_HIDDEN_START;
 
 #define OVAL_PROBE_MAXRETRY 0
 
+int oval_probe_query_test(oval_probe_session_t *sess, struct oval_test *test);
+
 OSCAP_HIDDEN_END;
 
 extern probe_ncache_t *OSCAP_GSYM(ncache);

--- a/src/OVAL/results/oval_resModel.c
+++ b/src/OVAL/results/oval_resModel.c
@@ -56,10 +56,18 @@ struct oval_results_model {
 	struct oval_directives_model *directives_model;
 	struct oval_definition_model *definition_model;
 	struct oval_collection *systems;
+	struct oval_probe_session *probe_session;
 };
 
 struct oval_results_model *oval_results_model_new(struct oval_definition_model *definition_model,
 						  struct oval_syschar_model **syschar_models)
+{
+	return oval_results_model_new_with_probe_session(definition_model, syschar_models, NULL);
+}
+
+struct oval_results_model *oval_results_model_new_with_probe_session(struct oval_definition_model *definition_model,
+						  struct oval_syschar_model **syschar_models,
+						  struct oval_probe_session *probe_session)
 {
 	struct oval_results_model *model = (struct oval_results_model *) oscap_alloc(sizeof(struct oval_results_model));
 	if (model == NULL)
@@ -78,6 +86,7 @@ struct oval_results_model *oval_results_model_new(struct oval_definition_model *
 		}
 	}
 	model->directives_model = oval_directives_model_new();
+	model->probe_session = probe_session;
 	return model;
 }
 

--- a/src/OVAL/results/oval_resModel.c
+++ b/src/OVAL/results/oval_resModel.c
@@ -148,6 +148,12 @@ struct oval_result_system_iterator *oval_results_model_get_systems(struct oval_r
 	    oval_collection_iterator(model->systems);
 }
 
+struct oval_probe_session *oval_results_model_get_probe_session(struct oval_results_model *model)
+{
+	__attribute__nonnull__(model);
+	return model->probe_session;
+}
+
 void oval_results_model_add_system(struct oval_results_model *model, struct oval_result_system *sys)
 {
 	__attribute__nonnull__(model);

--- a/src/OVAL/results/oval_resultDefinition.c
+++ b/src/OVAL/results/oval_resultDefinition.c
@@ -150,9 +150,9 @@ oval_result_t oval_result_definition_eval(struct oval_result_definition * defini
 
 	if (definition->result == OVAL_RESULT_NOT_EVALUATED) {
 		struct oval_result_criteria_node *criteria = oval_result_definition_get_criteria(definition);
-
-		definition->result = (criteria == NULL)
-		    ? OVAL_RESULT_ERROR : oval_result_criteria_node_eval(criteria);
+		if (criteria != NULL) {
+			definition->result = oval_result_criteria_node_eval(criteria);
+		}
 	}
 	dI("Definition '%s' evaluated as %s.", oval_result_definition_get_id(definition), oval_result_get_text(definition->result));
 	return definition->result;

--- a/src/OVAL/results/oval_resultTest.c
+++ b/src/OVAL/results/oval_resultTest.c
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "oval_agent_api_impl.h"
+#include "oval_probe_impl.h"
 #include "results/oval_results_impl.h"
 #include "results/oval_status_counter.h"
 #include "oval_cmp_impl.h"
@@ -929,6 +930,16 @@ static oval_result_t _oval_result_test_result(struct oval_result_test *rtest, vo
 	char * object_id = oval_object_get_id(object);
 
 	struct oval_result_system *sys = oval_result_test_get_system(rtest);
+	struct oval_results_model *results_model = oval_result_system_get_results_model(sys);
+	struct oval_probe_session *probe_session = oval_results_model_get_probe_session(results_model);
+	if (probe_session != NULL) {
+		/* probe test */
+		int ret = oval_probe_query_test(probe_session, test);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
 	struct oval_syschar_model *syschar_model = oval_result_system_get_syschar_model(sys);
 
 	struct oval_syschar * syschar = oval_syschar_model_get_syschar(syschar_model, object_id);

--- a/src/OVAL/results/oval_results_impl.h
+++ b/src/OVAL/results/oval_results_impl.h
@@ -92,6 +92,7 @@ oval_result_t ores_get_result_bychk(struct oresults *ores, oval_check_t check);
 oval_result_t ores_get_result_byopr(struct oresults *ores, oval_operator_t op);
 
 struct oval_results_model *oval_results_model_new_with_probe_session(struct oval_definition_model *definition_model, struct oval_syschar_model **syschar_models, struct oval_probe_session *probe_session);
+struct oval_probe_session *oval_results_model_get_probe_session(struct oval_results_model *model);
 void oval_results_model_add_system(struct oval_results_model *, struct oval_result_system *);
 
 struct oval_result_definition_iterator *oval_result_definition_iterator_new(struct oval_smc *mapping);

--- a/src/OVAL/results/oval_results_impl.h
+++ b/src/OVAL/results/oval_results_impl.h
@@ -91,6 +91,7 @@ void ores_clear(struct oresults *ores);
 oval_result_t ores_get_result_bychk(struct oresults *ores, oval_check_t check);
 oval_result_t ores_get_result_byopr(struct oresults *ores, oval_operator_t op);
 
+struct oval_results_model *oval_results_model_new_with_probe_session(struct oval_definition_model *definition_model, struct oval_syschar_model **syschar_models, struct oval_probe_session *probe_session);
 void oval_results_model_add_system(struct oval_results_model *, struct oval_result_system *);
 
 struct oval_result_definition_iterator *oval_result_definition_iterator_new(struct oval_smc *mapping);


### PR DESCRIPTION
Currently, we do two steps to get the results of a definition:
1) Querying probes for objects for all the definitions
2) After all items are collected, we compute results separately.
It causes some confusion in the verbose log in cases one definition contains multiple criteria,
the messages are not in logical order here.
I think that messages describing computing results of a test should be displayed just after messages describing evaluation of the same test, it should not be mixed as is now.
We can fix this by merging aforementioned steps into single step.
It would basically mean that each test is evaluated separately, no other querying starts before a result of single test is done.
Therefore we would have messages in verbose mode in expected order.

This pull request is a rework of #333. It tries to call probing from the results model.