### PR TITLE
RPM probes: return "Not applicable" without valid db

### DIFF
--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -415,6 +415,11 @@ int probe_main (probe_ctx *ctx, void *arg)
         struct rpminfo_req request_st;
         struct rpminfo_rep *reply_st;
 
+	if ( g_rpm.rpmts == NULL ) {
+		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
+		return 0;
+	}
+
 	probe_in = probe_ctx_getobject(ctx);
 	if (probe_in == NULL)
 		return PROBE_ENOOBJ;

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -415,7 +415,7 @@ int probe_main (probe_ctx *ctx, void *arg)
         struct rpminfo_req request_st;
         struct rpminfo_rep *reply_st;
 
-	if ( g_rpm.rpmts == NULL ) {
+	if (g_rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;
 	}

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -348,7 +348,7 @@ int probe_main (probe_ctx *ctx, void *arg)
         uint64_t collect_flags = 0;
         unsigned int i;
 
-	if ( g_rpm.rpmts == NULL ) {
+	if (g_rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;
 	}

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -348,6 +348,11 @@ int probe_main (probe_ctx *ctx, void *arg)
         uint64_t collect_flags = 0;
         unsigned int i;
 
+	if ( g_rpm.rpmts == NULL ) {
+		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
+		return 0;
+	}
+
         /*
          * Get refs to object entities
          */

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -416,7 +416,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 	uint64_t collect_flags = 0;
 	unsigned int i;
 
-	if ( g_rpm.rpmts == NULL ) {
+	if (g_rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;
 	}

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -416,6 +416,11 @@ int probe_main (probe_ctx *ctx, void *arg)
 	uint64_t collect_flags = 0;
 	unsigned int i;
 
+	if ( g_rpm.rpmts == NULL ) {
+		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
+		return 0;
+	}
+
 	/*
 	 * Get refs to object entities
 	 */

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -385,7 +385,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 	uint64_t collect_flags = 0;
 	unsigned int i;
 
-	if ( g_rpm.rpmts == NULL ) {
+	if (g_rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;
 	}

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -385,6 +385,11 @@ int probe_main (probe_ctx *ctx, void *arg)
 	uint64_t collect_flags = 0;
 	unsigned int i;
 
+	if ( g_rpm.rpmts == NULL ) {
+		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
+		return 0;
+	}
+
 	/*
 	 * Get refs to object entities
 	 */


### PR DESCRIPTION
https://github.com/OpenSCAP/openscap/issues/348


Currently this fix breaks CPE results (problem should be in OVAL, not in this PR) -> Merge after https://github.com/OpenSCAP/openscap/pull/362