### PR TITLE
If verbose log file is not specified, write messages on stderr

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1190,12 +1190,10 @@ and ```oval analyse``` modules.
 There is no need to special compilation, the feature is available for all
 OpenSCAP users.
 
-To turn the verbose mode on, run ```oscap``` with both those two options:
+To turn the verbose mode on, run ```oscap``` with this option:
 
 * ```--verbose VERBOSITY_LEVEL``` - Turn on verbose mode at specified
 verbosity level.
-* ```--verbose-log-file FILE``` - Provide name of a log file that the log
-will be written into.
 
 The ```VERBOSITY_LEVEL``` can be one of:
 
@@ -1204,8 +1202,9 @@ The ```VERBOSITY_LEVEL``` can be one of:
 3. *WARNING* - possible failures which OpenSCAP can recover from
 4. *ERROR* - shows only serious errors
 
-If you omit one of those two options, verbose mode can't be turned on
-and you will get an error message.
+The verbose messages will be written on standard error output (stderr).
+Optionally, you can write the log into a file using
+ ```--verbose-log-file FILE```.
 
 This is an example describing how to run OpenSCAP in verbose mode:
 
@@ -1218,10 +1217,6 @@ Then see the log using eg.:
 ----
 $ less log.txt
 ----
-
-Each message contains identifier and name of the process and thread which produced
-the message, then its verbosity level, and also source file, line and function
-describing specific place of its origin.
 
 ==== Debug mode
 Debug mode is useful for programmers. You need to build OpenSCAP from source code

--- a/src/OVAL/probes/SEAP/sch_pipe.c
+++ b/src/OVAL/probes/SEAP/sch_pipe.c
@@ -219,21 +219,12 @@ int sch_pipe_connect (SEAP_desc_t *desc, const char *uri, uint32_t flags)
                 close (pfd[0]);
 
                 /*
-                 * setup input, output and error streams
+                 * setup input and output streams
                  */
                 if (dup2 (pfd[1], STDIN_FILENO) != STDIN_FILENO)
                         _exit (errno);
                 if (dup2 (pfd[1], STDOUT_FILENO) != STDOUT_FILENO)
                         _exit (errno);
-#ifdef NDEBUG
-                pfd[0] = open ("/dev/null", O_WRONLY);
-
-                if (pfd[0] < 0)
-                        _exit (errno);
-
-                if (dup2 (pfd[0], STDERR_FILENO) != STDERR_FILENO)
-                        _exit (errno);
-#endif
                 execl (data->execpath, data->execpath, NULL);
                 _exit (errno);
         default: /* parent */

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -84,18 +84,24 @@ oscap_verbosity_levels oscap_verbosity_level_from_cstr(const char *level_name)
 
 bool oscap_set_verbose(const char *verbosity_level, const char *filename, bool is_probe)
 {
-	if (verbosity_level == NULL || filename == NULL) {
+	if (verbosity_level == NULL) {
 		return true;
 	}
 	__debuglog_level = oscap_verbosity_level_from_cstr(verbosity_level);
 	if (__debuglog_level == DBG_UNKNOWN) {
 		return false;
 	}
+	if (!is_probe) {
+		setenv("OSCAP_PROBE_VERBOSITY_LEVEL", verbosity_level, 1);
+	}
+	if (filename == NULL) {
+		__debuglog_fp = stderr;
+		return true;
+	}
 	int fd;
 	if (is_probe) {
 		fd = open(filename, O_APPEND | O_WRONLY);
 	} else {
-		setenv("OSCAP_PROBE_VERBOSITY_LEVEL", verbosity_level, 1);
 		setenv("OSCAP_PROBE_VERBOSE_LOG_FILE", filename, 1);
 		/* Open a file. If the file doesn't exist, create it.
 		 * If the file exists, erase its content.

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -384,11 +384,6 @@ bool check_verbose_options(struct oscap_action *action)
 			"Verbosity level is not specified! Please provide --verbose VERBOSITY_LEVEL option together with --verbose-log-file.");
 		return false;
 	}
-	if (action->verbosity_level != NULL && action->f_verbose_log == NULL) {
-		oscap_module_usage(action->module, stderr,
-			"Log file is not specified! Please provide --verbose-log-file FILE option together with --verbose.");
-		return false;
-	}
 	if (action->verbosity_level != NULL && oscap_verbosity_level_from_cstr(action->verbosity_level) == -1) {
 		oscap_module_usage(action->module, stderr,
 			"Invalid verbosity level! Verbosity level must be one of: DEVEL, INFO, WARNING, ERROR.");

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -323,7 +323,6 @@ static int callback_scr_rule(struct xccdf_rule *rule, void *arg)
 	}
 	xccdf_ident_iterator_free(idents);
 
-	printf("Result\r\t");
 	fflush(stdout);
 
 	return 0;
@@ -338,6 +337,7 @@ static int callback_scr_result(struct xccdf_rule_result *rule_result, void *arg)
 		return 0;
 
 	/* print result */
+	printf("Result\r\t");
 	const char * result_str = xccdf_test_result_type_get_text(result);
 	if (isatty(1))
 		printf("\033[%sm%s\033[0m\n\n", RESULT_COLORS[result], result_str);


### PR DESCRIPTION
This pull request proposes a small enhancement in OpenSCAP verbose mode, based on feedback from developers team.

The `--verbose-log-file` will no longer be obligatory with verbose mode. When this option won't be specified, the messages will be written on stderr.

I hope this will make our developer's life a little easier.

Also edited the user manual to reflect this change.