### PR TITLE
Adding implementation for runlevel probe on SUSE

### DIFF
--- a/src/OVAL/oval_session.c
+++ b/src/OVAL/oval_session.c
@@ -27,6 +27,7 @@
 #include <libgen.h>
 #include <unistd.h>
 #include <string.h>
+#include <linux/limits.h>
 
 #include "common/alloc.h"
 #include "common/debug_priv.h"


### PR DESCRIPTION
This check-in implements the run-level probe for SUSE as was discussed on the mailing list.

If have implemented the function separate from get_runlevel_sysv because the file paths to init.d and the rc directories are different on SUSE and there was no GCC macros to distinguish between RHEL and SUSE.

Also included the linux/limits.h header file in oval_session.c to resolve PATH_MAX.