### PR TITLE
Move a message from unused code

### DIFF
--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -429,7 +429,6 @@ static int oval_probe_query_extend_definition(oval_probe_session_t *sess, struct
 {
 	struct oval_definition *oval_def = oval_criteria_node_get_definition(cnode);
 	const char *def_id = oval_definition_get_id(oval_def);
-	dI("Criteria are extended by definition '%s'.", def_id);
 	return oval_probe_query_definition(sess, def_id);
 }
 

--- a/src/OVAL/results/oval_resultCriteriaNode.c
+++ b/src/OVAL/results/oval_resultCriteriaNode.c
@@ -359,6 +359,8 @@ static oval_result_t _oval_result_criteria_node_result(struct oval_result_criter
 		} break;
 	case OVAL_NODETYPE_EXTENDDEF:{
 			struct oval_result_definition *extends = oval_result_criteria_node_get_extends(node);
+			const char *def_id = oval_result_definition_get_id(extends);
+			dI("Criteria are extended by definition '%s'.", def_id);
 			result = oval_result_definition_eval(extends);
 		} break;
 	default:


### PR DESCRIPTION
Since we have merged PR #360, we miss a message reporting extended
definition in our verbose mode. This commit moves a message from
function which is not used now to the right place.