### PR TITLE
Deprecate function oval_probe_query_definition

### DIFF
--- a/src/OVAL/public/oval_probe.h
+++ b/src/OVAL/public/oval_probe.h
@@ -69,7 +69,7 @@ int oval_probe_query_object(oval_probe_session_t *psess, struct oval_object *obj
  * @param id definition id
  * @return 0 on success; -1 on error; 1 warning
  */
-int oval_probe_query_definition(oval_probe_session_t *sess, const char *id) __attribute__ ((nonnull(1, 2)));
+OSCAP_DEPRECATED(int oval_probe_query_definition(oval_probe_session_t *sess, const char *id)) __attribute__ ((nonnull(1, 2)));
 
 /**
  * Query the specified variable and all its dependencies in order to compute the vector of its values


### PR DESCRIPTION
We have moved querying definitions into results model and
removed call of oval_probe_query_definition in
b8e8860fa362b37201f3f46cb6f3dc1da6863246 .
The only case where this function is called now (oval_probe.c:433)
is a recursive call.
We can deprecate the function and remove it in next major release,
because it is a dead code.