### PR TITLE
Move messages to results model

### DIFF
--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -161,17 +161,7 @@ static struct oval_result_system *_oval_agent_get_first_result_system(oval_agent
 int oval_agent_eval_definition(oval_agent_session_t *ag_sess, const char *id)
 {
 	int ret;
-	const char *title = NULL;
 	struct oval_result_system *rsystem;
-	struct oval_definition *oval_def;
-
-	oval_def = oval_definition_model_get_definition(ag_sess->def_model, id);
-	if (oval_def != NULL) {
-		title = oval_definition_get_title(oval_def);
-	}
-	dI("Evaluating definition '%s': %s.", id, title);
-
-	/* probe */
 
 	rsystem = _oval_agent_get_first_result_system(ag_sess);
 	/* eval */

--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -396,13 +396,8 @@ int oval_probe_query_test(oval_probe_session_t *sess, struct oval_test *test)
 {
 	struct oval_object *object;
 	struct oval_state_iterator *ste_itr;
-	const char *type, *test_id, *comment;
 	int ret;
 
-	type = oval_subtype_get_text(oval_test_get_subtype(test));
-	test_id = oval_test_get_id(test);
-	comment = oval_test_get_comment(test);
-	dI("Evaluating %s test '%s': %s.", type, test_id, comment);
 	object = oval_test_get_object(test);
 	if (object == NULL)
 		return 0;

--- a/src/OVAL/results/oval_resultDefinition.c
+++ b/src/OVAL/results/oval_resultDefinition.c
@@ -147,6 +147,9 @@ int oval_result_definition_get_instance(const struct oval_result_definition *def
 oval_result_t oval_result_definition_eval(struct oval_result_definition * definition)
 {
 	__attribute__nonnull__(definition);
+	const char *id = oval_result_definition_get_id(definition);
+	const char *title = oval_definition_get_title(oval_result_definition_get_definition(definition));
+	dI("Evaluating definition '%s': %s.", id, title);
 
 	if (definition->result == OVAL_RESULT_NOT_EVALUATED) {
 		struct oval_result_criteria_node *criteria = oval_result_definition_get_criteria(definition);
@@ -154,7 +157,8 @@ oval_result_t oval_result_definition_eval(struct oval_result_definition * defini
 			definition->result = oval_result_criteria_node_eval(criteria);
 		}
 	}
-	dI("Definition '%s' evaluated as %s.", oval_result_definition_get_id(definition), oval_result_get_text(definition->result));
+
+	dI("Definition '%s' evaluated as %s.", id, oval_result_get_text(definition->result));
 	return definition->result;
 }
 

--- a/src/OVAL/results/oval_resultTest.c
+++ b/src/OVAL/results/oval_resultTest.c
@@ -1041,6 +1041,12 @@ oval_result_t oval_result_test_eval(struct oval_result_test *rtest)
 {
 	__attribute__nonnull__(rtest);
 
+	struct oval_test *test = oval_result_test_get_test(rtest);
+	const char *type = oval_subtype_get_text(oval_test_get_subtype(test));
+	const char *test_id = oval_test_get_id(test);
+	const char *comment = oval_test_get_comment(test);
+	dI("Evaluating %s test '%s': %s.", type, test_id, comment);
+
 	if (rtest->result == OVAL_RESULT_NOT_EVALUATED) {
 		if ((oval_independent_subtype_t)oval_test_get_subtype(oval_result_test_get_test(rtest)) != OVAL_INDEPENDENT_UNKNOWN ) {
 			struct oval_string_map *tmp_map = oval_string_map_new();
@@ -1056,7 +1062,7 @@ oval_result_t oval_result_test_eval(struct oval_result_test *rtest)
 			rtest->result = OVAL_RESULT_UNKNOWN;
 	}
 
-	dI("Test '%s' evaluated as %s.", oval_result_test_get_id(rtest), oval_result_get_text(rtest->result));
+	dI("Test '%s' evaluated as %s.", test_id, oval_result_get_text(rtest->result));
 
 	return rtest->result;
 }


### PR DESCRIPTION
After we have involved probing for  definitions into results evaluation, we can move some of info messages to their proper place.

This pull request contains two very similar commits. First of them is related to OVAL definitions, second is related to OVAL tests. The commits just move messages "Evaluating .." nearer to  actual evaluation in source code.