### PR TITLE
Fix compiler warning: unused variable

### DIFF
--- a/src/OVAL/probes/unix/runlevel.c
+++ b/src/OVAL/probes/unix/runlevel.c
@@ -224,7 +224,6 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 
 static int get_runlevel_redhat (struct runlevel_req *req, struct runlevel_rep **rep)
 {
-	const char runlevel_list[] = {'0', '1', '2', '3', '4', '5', '6'};
 #if defined(__linux__) || defined(__GLIBC__)
 	const char *init_path = "/etc/rc.d/init.d";
 #elif defined(__SVR4) && defined(__sun)


### PR DESCRIPTION
Addressing:
unix/runlevel.c: In function ‘get_runlevel_redhat’:
unix/runlevel.c:227:13: warning: unused variable ‘runlevel_list’ [-Wunused-variable]
  const char runlevel_list[] = {'0', '1', '2', '3', '4', '5', '6'};