### PR TITLE
Reuse existing function during the check

### DIFF
--- a/tests/API/XCCDF/applicability/all.sh
+++ b/tests/API/XCCDF/applicability/all.sh
@@ -18,7 +18,8 @@ function test_api_xccdf_cpe_eval {
         return 1
     fi
 
-    assert_exists $3 '//result[text()="notapplicable"]'
+    assert_exists $EXPECTED_NA '//result[text()="notapplicable"]'
+    rm -f $result
 }
 
 function test_api_xccdf_cpe2_eval {
@@ -32,7 +33,8 @@ function test_api_xccdf_cpe2_eval {
         return 1
     fi
 
-    assert_exists $3 '//result[text()="notapplicable"]'
+    assert_exists $EXPECTED_NA '//result[text()="notapplicable"]'
+    rm -f $result
 }
 
 function test_api_xccdf_embedded_cpe_eval {
@@ -45,7 +47,8 @@ function test_api_xccdf_embedded_cpe_eval {
         return 1
     fi
 
-    assert_exists $2 '//result[text()="notapplicable"]'
+    assert_exists $EXPECTED_NA '//result[text()="notapplicable"]'
+    rm -f $result
 }
 # Testing.
 

--- a/tests/API/XCCDF/applicability/all.sh
+++ b/tests/API/XCCDF/applicability/all.sh
@@ -12,20 +12,13 @@ function test_api_xccdf_cpe_eval {
     local CPE_DICT=$srcdir/$2
     local EXPECTED_NA=$3
 
-    local TMP_RESULTS=`mktemp`
-    $OSCAP xccdf eval --cpe $CPE_DICT --results $TMP_RESULTS $INPUT
+    result=`mktemp`
+    $OSCAP xccdf eval --cpe $CPE_DICT --results $result $INPUT
     if [ "$?" != "0" ]; then
         return 1
     fi
 
-    local NOTAPPLICABLE_COUNT=$($XPATH $TMP_RESULTS 'count(//result[text()="notapplicable"])')
-    rm -f $TMP_RESULTS
-
-    if [ "$NOTAPPLICABLE_COUNT" == "$EXPECTED_NA" ]; then
-        return 0
-    fi
-
-    return 1
+    assert_exists $3 '//result[text()="notapplicable"]'
 }
 
 function test_api_xccdf_cpe2_eval {
@@ -33,40 +26,26 @@ function test_api_xccdf_cpe2_eval {
     local CPE_DICT=$srcdir/$2
     local EXPECTED_NA=$3
 
-    local TMP_RESULTS=`mktemp`
-    $OSCAP xccdf eval --cpe $CPE_DICT --results $TMP_RESULTS $INPUT
+    result=`mktemp`
+    $OSCAP xccdf eval --cpe $CPE_DICT --results $result $INPUT
     if [ "$?" != "0" ]; then
         return 1
     fi
 
-    local NOTAPPLICABLE_COUNT=$($XPATH $TMP_RESULTS 'count(//result[text()="notapplicable"])')
-    rm -f $TMP_RESULTS
-
-    if [ "$NOTAPPLICABLE_COUNT" == "$EXPECTED_NA" ]; then
-        return 0
-    fi
-
-    return 1
+    assert_exists $3 '//result[text()="notapplicable"]'
 }
 
 function test_api_xccdf_embedded_cpe_eval {
     local INPUT=$srcdir/$1
     local EXPECTED_NA=$2
 
-    local TMP_RESULTS=`mktemp`
-    $OSCAP xccdf eval --results $TMP_RESULTS $INPUT
+    result=`mktemp`
+    $OSCAP xccdf eval --results $result $INPUT
     if [ "$?" != "0" ]; then
         return 1
     fi
 
-    local NOTAPPLICABLE_COUNT=$($XPATH $TMP_RESULTS 'count(//result[text()="notapplicable"])')
-    rm -f $TMP_RESULTS
-
-    if [ "$NOTAPPLICABLE_COUNT" == "$EXPECTED_NA" ]; then
-        return 0
-    fi
-
-    return 1
+    assert_exists $2 '//result[text()="notapplicable"]'
 }
 # Testing.
 

--- a/tests/API/XCCDF/tailoring/all.sh
+++ b/tests/API/XCCDF/tailoring/all.sh
@@ -19,7 +19,7 @@ function test_api_xccdf_tailoring {
         return 1
     fi
 
-    assert_exists $4 '//result[text()="pass"]'
+    assert_exists $EXPECTED_PASS '//result[text()="pass"]'
     rm -f $result
 }
 
@@ -35,7 +35,7 @@ function test_api_xccdf_tailoring_ds {
         return 1
     fi
 
-    assert_exists $4 '//result[text()="pass"]'
+    assert_exists $EXPECTED_PASS '//result[text()="pass"]'
     rm -f $result
 }
 
@@ -51,7 +51,7 @@ function test_api_xccdf_tailoring_ds_hybrid {
         return 1
     fi
 
-    assert_exists $4 '//result[text()="pass"]'
+    assert_exists $EXPECTED_PASS '//result[text()="pass"]'
     rm -f $result
 }
 
@@ -80,7 +80,8 @@ function test_api_xccdf_tailoring_autonegotiation {
         return 1
     fi
 
-    assert_exists $3 '//result[text()="pass"]'
+    assert_exists $EXPECTED_PASS '//result[text()="pass"]'
+    rm -f $result
 }
 
 # Testing.

--- a/tests/API/XCCDF/tailoring/all.sh
+++ b/tests/API/XCCDF/tailoring/all.sh
@@ -13,20 +13,14 @@ function test_api_xccdf_tailoring {
     local PROFILE=$3
     local EXPECTED_PASS=$4
 
-    local TMP_RESULTS=`mktemp`
-    $OSCAP xccdf eval --tailoring-file $TAILORING --profile $PROFILE --results $TMP_RESULTS $INPUT
+    result=`mktemp`
+    $OSCAP xccdf eval --tailoring-file $TAILORING --profile $PROFILE --results $result $INPUT
     if [ "$?" != "0" ]; then
         return 1
     fi
 
-    local PASS_COUNT=$($XPATH $TMP_RESULTS 'count(//result[text()="pass"])')
-    rm -f $TMP_RESULTS
-
-    if [ "$PASS_COUNT" == "$EXPECTED_PASS" ]; then
-        return 0
-    fi
-
-    return 1
+    assert_exists $4 '//result[text()="pass"]'
+    rm -f $result
 }
 
 function test_api_xccdf_tailoring_ds {
@@ -35,20 +29,14 @@ function test_api_xccdf_tailoring_ds {
     local PROFILE=$3
     local EXPECTED_PASS=$4
 
-    local TMP_RESULTS=`mktemp`
-    $OSCAP xccdf eval --tailoring-id $TAILORING_ID --profile $PROFILE --results $TMP_RESULTS $INPUT
+    result=`mktemp`
+    $OSCAP xccdf eval --tailoring-id $TAILORING_ID --profile $PROFILE --results $result $INPUT
     if [ "$?" != "0" ]; then
         return 1
     fi
 
-    local PASS_COUNT=$($XPATH $TMP_RESULTS 'count(//result[text()="pass"])')
-    rm -f $TMP_RESULTS
-
-    if [ "$PASS_COUNT" == "$EXPECTED_PASS" ]; then
-        return 0
-    fi
-
-    return 1
+    assert_exists $4 '//result[text()="pass"]'
+    rm -f $result
 }
 
 function test_api_xccdf_tailoring_ds_hybrid {
@@ -57,20 +45,14 @@ function test_api_xccdf_tailoring_ds_hybrid {
     local PROFILE=$3
     local EXPECTED_PASS=$4
 
-    local TMP_RESULTS=`mktemp`
-    $OSCAP xccdf eval --tailoring-file $TAILORING --profile $PROFILE --results $TMP_RESULTS $INPUT
+    result=`mktemp`
+    $OSCAP xccdf eval --tailoring-file $TAILORING --profile $PROFILE --results $result $INPUT
     if [ "$?" != "0" ]; then
         return 1
     fi
 
-    local PASS_COUNT=$($XPATH $TMP_RESULTS 'count(//result[text()="pass"])')
-    rm -f $TMP_RESULTS
-
-    if [ "$PASS_COUNT" == "$EXPECTED_PASS" ]; then
-        return 0
-    fi
-
-    return 1
+    assert_exists $4 '//result[text()="pass"]'
+    rm -f $result
 }
 
 function test_api_xccdf_tailoring_oscap_info {
@@ -92,20 +74,13 @@ function test_api_xccdf_tailoring_autonegotiation {
     local PROFILE=$2
     local EXPECTED_PASS=$3
 
-    local TMP_RESULTS=`mktemp`
-    $OSCAP xccdf eval --profile $PROFILE --results $TMP_RESULTS $TAILORING
+    result=`mktemp`
+    $OSCAP xccdf eval --profile $PROFILE --results $result $TAILORING
     if [ "$?" != "0" ]; then
         return 1
     fi
 
-    local PASS_COUNT=$($XPATH $TMP_RESULTS 'count(//result[text()="pass"])')
-    rm -f $TMP_RESULTS
-
-    if [ "$PASS_COUNT" == "$EXPECTED_PASS" ]; then
-        return 0
-    fi
-
-    return 1
+    assert_exists $3 '//result[text()="pass"]'
 }
 
 # Testing.


### PR DESCRIPTION
The two modified script files explicitly parse the formatted file
by xpath command, which act the same as the assert_exists function
in tests/test_common.sh.