### PR TITLE
RPM probes - refactoring only

### DIFF
--- a/src/OVAL/probes/Makefile.am
+++ b/src/OVAL/probes/Makefile.am
@@ -241,28 +241,40 @@ endif
 
 if probe_rpminfo_enabled
 pkglibexec_PROGRAMS += probe_rpminfo
-probe_rpminfo_SOURCES= unix/linux/rpminfo.c
+probe_rpminfo_SOURCES= \
+    unix/linux/rpminfo.c \
+    unix/linux/rpm-helper.h \
+    unix/linux/rpm-helper.c
 probe_rpminfo_CFLAGS= @rpm_CFLAGS@
 probe_rpminfo_LDFLAGS= @rpm_LIBS@
 endif
 
 if probe_rpmverify_enabled
 pkglibexec_PROGRAMS += probe_rpmverify
-probe_rpmverify_SOURCES= unix/linux/rpmverify.c
+probe_rpmverify_SOURCES= \
+    unix/linux/rpmverify.c \
+    unix/linux/rpm-helper.h \
+    unix/linux/rpm-helper.c
 probe_rpmverify_CFLAGS= @rpm_CFLAGS@
 probe_rpmverify_LDFLAGS= @rpm_LIBS@
 endif
 
 if probe_rpmverifyfile_enabled
 pkglibexec_PROGRAMS += probe_rpmverifyfile
-probe_rpmverifyfile_SOURCES= unix/linux/rpmverifyfile.c
+probe_rpmverifyfile_SOURCES= \
+    unix/linux/rpmverifyfile.c \
+    unix/linux/rpm-helper.h \
+    unix/linux/rpm-helper.c
 probe_rpmverifyfile_CFLAGS= @rpm_CFLAGS@
 probe_rpmverifyfile_LDFLAGS= @rpm_LIBS@
 endif
 
 if probe_rpmverifypackage_enabled
 pkglibexec_PROGRAMS += probe_rpmverifypackage
-probe_rpmverifypackage_SOURCES= unix/linux/rpmverifypackage.c
+probe_rpmverifypackage_SOURCES= \
+    unix/linux/rpmverifypackage.c \
+    unix/linux/rpm-helper.h \
+    unix/linux/rpm-helper.c
 probe_rpmverifypackage_CFLAGS= @rpm_CFLAGS@
 probe_rpmverifypackage_LDFLAGS= @rpm_LIBS@ -lpopt
 endif

--- a/src/OVAL/probes/unix/linux/rpm-helper.c
+++ b/src/OVAL/probes/unix/linux/rpm-helper.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include "rpm-helper.h"
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -36,6 +36,10 @@
 #include "common/debug_priv.h"
 #include "pthread.h"
 
+struct rpm_probe_global {
+	rpmts rpmts;
+	pthread_mutex_t mutex;
+};
 
 #ifndef HAVE_HEADERFORMAT
 # define HAVE_LIBRPM44 1 /* hack */

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -20,4 +20,23 @@
 #ifndef __RPM_HELPER__
 #define __RPM_HELPER__
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#ifndef HAVE_HEADERFORMAT
+# define HAVE_LIBRPM44 1 /* hack */
+# define headerFormat(_h, _fmt, _emsg) headerSprintf((_h),( _fmt), rpmTagTable, rpmHeaderFormats, (_emsg))
+#endif
+
+#ifndef HAVE_RPMFREECRYPTO
+# define rpmFreeCrypto() while(0)
+#endif
+
+#ifndef HAVE_RPMFREEFILESYSTEMS
+# define rpmFreeFilesystems() while(0)
+#endif
+
+
+
 #endif

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+#ifndef __RPM_HELPER__
+#define __RPM_HELPER__
+
+#endif

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -24,6 +24,13 @@
 #include <config.h>
 #endif
 
+#include <rpm/rpmdb.h>
+#include <rpm/rpmlib.h>
+#include <rpm/rpmts.h>
+#include <rpm/rpmmacro.h>
+#include <rpm/rpmlog.h>
+#include <rpm/header.h>
+
 #ifndef HAVE_HEADERFORMAT
 # define HAVE_LIBRPM44 1 /* hack */
 # define headerFormat(_h, _fmt, _emsg) headerSprintf((_h),( _fmt), rpmTagTable, rpmHeaderFormats, (_emsg))

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -68,18 +68,6 @@
 #include <rpm/header.h>
 
 #include "rpm-helper.h"
-#ifndef HAVE_HEADERFORMAT
-# define HAVE_LIBRPM44 1 /* hack */
-# define headerFormat(_h, _fmt, _emsg) headerSprintf((_h),( _fmt), rpmTagTable, rpmHeaderFormats, (_emsg))
-#endif
-
-#ifndef HAVE_RPMFREECRYPTO
-# define rpmFreeCrypto() while(0)
-#endif
-
-#ifndef HAVE_RPMFREEFILESYSTEMS
-# define rpmFreeFilesystems() while(0)
-#endif
 
 /* SEAP */
 #include <seap.h>

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -94,25 +94,9 @@ struct rpminfo_global {
         pthread_mutex_t mutex;
 };
 
-#define RPMINFO_LOCK	  \
-	do { \
-		int prev_cancel_state = -1; \
-		if (pthread_mutex_lock(&g_rpm.mutex) != 0) { \
-			dE("Can't lock mutex"); \
-			return (-1); \
-		} \
-		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &prev_cancel_state); \
-	} while(0)
+#define RPMINFO_LOCK	RPM_MUTEX_LOCK(&g_rpm.mutex)
 
-#define RPMINFO_UNLOCK	  \
-	do { \
-		int prev_cancel_state = -1; \
-		if (pthread_mutex_unlock(&g_rpm.mutex) != 0) { \
-			dE("Can't unlock mutex. Aborting..."); \
-			abort(); \
-		} \
-		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &prev_cancel_state); \
-	} while(0)
+#define RPMINFO_UNLOCK	RPM_MUTEX_UNLOCK(&g_rpm.mutex)
 
 static struct rpminfo_global g_rpm;
 static const char g_keyid_regex_string[] = "Key ID [a-fA-F0-9]{16}";

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -60,13 +60,6 @@
 #include <regex.h>
 
 /* RPM headers */
-#include <rpm/rpmdb.h>
-#include <rpm/rpmlib.h>
-#include <rpm/rpmts.h>
-#include <rpm/rpmmacro.h>
-#include <rpm/rpmlog.h>
-#include <rpm/header.h>
-
 #include "rpm-helper.h"
 
 /* SEAP */

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -89,16 +89,11 @@ struct rpminfo_rep {
 	char extended_name[1024];
 };
 
-struct rpminfo_global {
-        rpmts           rpmts;
-        pthread_mutex_t mutex;
-};
-
 #define RPMINFO_LOCK	RPM_MUTEX_LOCK(&g_rpm.mutex)
 
 #define RPMINFO_UNLOCK	RPM_MUTEX_UNLOCK(&g_rpm.mutex)
 
-static struct rpminfo_global g_rpm;
+static struct rpm_probe_global g_rpm;
 static const char g_keyid_regex_string[] = "Key ID [a-fA-F0-9]{16}";
 static regex_t g_keyid_regex;
 
@@ -296,7 +291,7 @@ void *probe_init (void)
 
 void probe_fini (void *ptr)
 {
-        struct rpminfo_global *r = (struct rpminfo_global *)ptr;
+        struct rpm_probe_global *r = (struct rpm_probe_global *)ptr;
 
         rpmtsFree(r->rpmts);
 	rpmFreeCrypto();

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -67,6 +67,7 @@
 #include <rpm/rpmlog.h>
 #include <rpm/header.h>
 
+#include "rpm-helper.h"
 #ifndef HAVE_HEADERFORMAT
 # define HAVE_LIBRPM44 1 /* hack */
 # define headerFormat(_h, _fmt, _emsg) headerSprintf((_h),( _fmt), rpmTagTable, rpmHeaderFormats, (_emsg))

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -42,13 +42,7 @@
 #include <pcre.h>
 
 /* RPM headers */
-#include <rpm/rpmdb.h>
-#include <rpm/rpmlib.h>
-#include <rpm/rpmts.h>
-#include <rpm/rpmmacro.h>
-#include <rpm/rpmlog.h>
 #include <rpm/rpmfi.h>
-#include <rpm/header.h>
 #include <rpm/rpmcli.h>
 
 #include "rpm-helper.h"

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -73,25 +73,8 @@ struct rpmverify_global {
 
 static struct rpmverify_global g_rpm;
 
-#define RPMVERIFY_LOCK	  \
-	do { \
-		int prev_cancel_state = -1; \
-		if (pthread_mutex_lock(&g_rpm.mutex) != 0) { \
-			dE("Can't lock mutex"); \
-			return (-1); \
-		} \
-		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &prev_cancel_state); \
-	} while(0)
-
-#define RPMVERIFY_UNLOCK	  \
-	do { \
-		int prev_cancel_state = -1; \
-		if (pthread_mutex_unlock(&g_rpm.mutex) != 0) { \
-			dE("Can't unlock mutex. Aborting..."); \
-			abort(); \
-		} \
-		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &prev_cancel_state); \
-	} while(0)
+#define RPMVERIFY_LOCK   RPM_MUTEX_LOCK(&g_rpm.mutex)
+#define RPMVERIFY_UNLOCK RPM_MUTEX_UNLOCK(&g_rpm.mutex)
 
 static int rpmverify_collect(probe_ctx *ctx,
                              const char *name, oval_operation_t name_op,

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -41,11 +41,11 @@
 #include <fcntl.h>
 #include <pcre.h>
 
-/* RPM headers */
+#include "rpm-helper.h"
+
+/* Individual RPM headers */
 #include <rpm/rpmfi.h>
 #include <rpm/rpmcli.h>
-
-#include "rpm-helper.h"
 
 /* SEAP */
 #include <probe-api.h>

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -51,6 +51,7 @@
 #include <rpm/header.h>
 #include <rpm/rpmcli.h>
 
+#include "rpm-helper.h"
 #ifndef HAVE_HEADERFORMAT
 # define HAVE_LIBRPM44 1 /* hack */
 # define headerFormat(_h, _fmt, _emsg) headerSprintf((_h),( _fmt), rpmTagTable, rpmHeaderFormats, (_emsg))

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -66,12 +66,7 @@ struct rpmverify_res {
 #define RPMVERIFY_SKIP_GHOST  0x2000000000000000
 #define RPMVERIFY_RPMATTRMASK 0x00000000ffffffff
 
-struct rpmverify_global {
-        rpmts           rpmts;
-        pthread_mutex_t mutex;
-};
-
-static struct rpmverify_global g_rpm;
+static struct rpm_probe_global g_rpm;
 
 #define RPMVERIFY_LOCK   RPM_MUTEX_LOCK(&g_rpm.mutex)
 #define RPMVERIFY_UNLOCK RPM_MUTEX_UNLOCK(&g_rpm.mutex)
@@ -237,7 +232,7 @@ void *probe_init (void)
 
 void probe_fini (void *ptr)
 {
-        struct rpmverify_global *r = (struct rpmverify_global *)ptr;
+        struct rpm_probe_global *r = (struct rpm_probe_global *)ptr;
 
         rpmtsFree(r->rpmts);
 	rpmFreeCrypto();

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -52,18 +52,6 @@
 #include <rpm/rpmcli.h>
 
 #include "rpm-helper.h"
-#ifndef HAVE_HEADERFORMAT
-# define HAVE_LIBRPM44 1 /* hack */
-# define headerFormat(_h, _fmt, _emsg) headerSprintf((_h),( _fmt), rpmTagTable, rpmHeaderFormats, (_emsg))
-#endif
-
-#ifndef HAVE_RPMFREECRYPTO
-# define rpmFreeCrypto() while(0)
-#endif
-
-#ifndef HAVE_RPMFREEFILESYSTEMS
-# define rpmFreeFilesystems() while(0)
-#endif
 
 /* SEAP */
 #include <probe-api.h>

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -44,13 +44,7 @@
 #include <pcre.h>
 
 /* RPM headers */
-#include <rpm/rpmdb.h>
-#include <rpm/rpmlib.h>
-#include <rpm/rpmts.h>
-#include <rpm/rpmmacro.h>
-#include <rpm/rpmlog.h>
 #include <rpm/rpmfi.h>
-#include <rpm/header.h>
 #include <rpm/rpmcli.h>
 
 #include "rpm-helper.h"

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -80,25 +80,9 @@ struct rpmverify_global {
 
 static struct rpmverify_global g_rpm;
 
-#define RPMVERIFY_LOCK	  \
-	do { \
-		int prev_cancel_state = -1; \
-		if (pthread_mutex_lock(&g_rpm.mutex) != 0) { \
-			dE("Can't lock mutex"); \
-			return (-1); \
-		} \
-		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &prev_cancel_state); \
-	} while(0)
+#define RPMVERIFY_LOCK   RPM_MUTEX_LOCK(&g_rpm.mutex)
 
-#define RPMVERIFY_UNLOCK	  \
-	do { \
-		int prev_cancel_state = -1; \
-		if (pthread_mutex_unlock(&g_rpm.mutex) != 0) { \
-			dE("Can't unlock mutex. Aborting..."); \
-			abort(); \
-		} \
-		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &prev_cancel_state); \
-	} while(0)
+#define RPMVERIFY_UNLOCK RPM_MUTEX_UNLOCK(&g_rpm.mutex)
 
 /* modify passed-in iterator to test also given entity */
 static int adjust_filter(rpmdbMatchIterator iterator, SEXP_t *ent, rpmTag rpm_tag) {

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -73,12 +73,7 @@ struct rpmverify_res {
 #define RPMVERIFY_SKIP_GHOST  0x2000000000000000
 #define RPMVERIFY_RPMATTRMASK 0x00000000ffffffff
 
-struct rpmverify_global {
-	rpmts	   rpmts;
-	pthread_mutex_t mutex;
-};
-
-static struct rpmverify_global g_rpm;
+static struct rpm_probe_global g_rpm;
 
 #define RPMVERIFY_LOCK   RPM_MUTEX_LOCK(&g_rpm.mutex)
 
@@ -307,7 +302,7 @@ void *probe_init (void)
 
 void probe_fini (void *ptr)
 {
-	struct rpmverify_global *r = (struct rpmverify_global *)ptr;
+	struct rpm_probe_global *r = (struct rpm_probe_global *)ptr;
 
 	rpmtsFree(r->rpmts);
 	rpmFreeCrypto();

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -54,18 +54,6 @@
 #include <rpm/rpmcli.h>
 
 #include "rpm-helper.h"
-#ifndef HAVE_HEADERFORMAT
-# define HAVE_LIBRPM44 1 /* hack */
-# define headerFormat(_h, _fmt, _emsg) headerSprintf((_h),( _fmt), rpmTagTable, rpmHeaderFormats, (_emsg))
-#endif
-
-#ifndef HAVE_RPMFREECRYPTO
-# define rpmFreeCrypto() while(0)
-#endif
-
-#ifndef HAVE_RPMFREEFILESYSTEMS
-# define rpmFreeFilesystems() while(0)
-#endif
 
 /* SEAP */
 #include <probe-api.h>

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -43,11 +43,11 @@
 #include <fcntl.h>
 #include <pcre.h>
 
-/* RPM headers */
+#include "rpm-helper.h"
+
+/* Individual RPM headers */
 #include <rpm/rpmfi.h>
 #include <rpm/rpmcli.h>
-
-#include "rpm-helper.h"
 
 /* SEAP */
 #include <probe-api.h>

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -53,6 +53,7 @@
 #include <rpm/header.h>
 #include <rpm/rpmcli.h>
 
+#include "rpm-helper.h"
 #ifndef HAVE_HEADERFORMAT
 # define HAVE_LIBRPM44 1 /* hack */
 # define headerFormat(_h, _fmt, _emsg) headerSprintf((_h),( _fmt), rpmTagTable, rpmHeaderFormats, (_emsg))

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -44,13 +44,7 @@
 #include <pcre.h>
 
 /* RPM headers */
-#include <rpm/rpmdb.h>
-#include <rpm/rpmlib.h>
-#include <rpm/rpmts.h>
-#include <rpm/rpmmacro.h>
-#include <rpm/rpmlog.h>
 #include <rpm/rpmfi.h>
-#include <rpm/header.h>
 #include <rpm/rpmcli.h>
 #include <popt.h>
 

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -54,6 +54,7 @@
 #include <rpm/rpmcli.h>
 #include <popt.h>
 
+#include "rpm-helper.h"
 #ifndef HAVE_HEADERFORMAT
 # define HAVE_LIBRPM44 1 /* hack */
 # define headerFormat(_h, _fmt, _emsg) headerSprintf((_h),( _fmt), rpmTagTable, rpmHeaderFormats, (_emsg))

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -102,25 +102,9 @@ static struct poptOption optionsTable[] = {
 	POPT_TABLEEND
 };
 
-#define RPMVERIFY_LOCK	  \
-	do { \
-		int prev_cancel_state = -1; \
-		if (pthread_mutex_lock(&g_rpm.mutex) != 0) { \
-			dE("Can't lock mutex"); \
-			return (-1); \
-		} \
-		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &prev_cancel_state); \
-	} while(0)
+#define RPMVERIFY_LOCK   RPM_MUTEX_LOCK(&g_rpm.mutex)
 
-#define RPMVERIFY_UNLOCK	  \
-	do { \
-		int prev_cancel_state = -1; \
-		if (pthread_mutex_unlock(&g_rpm.mutex) != 0) { \
-			dE("Can't unlock mutex. Aborting..."); \
-			abort(); \
-		} \
-		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &prev_cancel_state); \
-	} while(0)
+#define RPMVERIFY_UNLOCK RPM_MUTEX_UNLOCK(&g_rpm.mutex)
 
 /* modify passed-in iterator to test also given entity */
 static int adjust_filter(rpmdbMatchIterator iterator, SEXP_t *ent, rpmTag rpm_tag) {

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -55,18 +55,6 @@
 #include <popt.h>
 
 #include "rpm-helper.h"
-#ifndef HAVE_HEADERFORMAT
-# define HAVE_LIBRPM44 1 /* hack */
-# define headerFormat(_h, _fmt, _emsg) headerSprintf((_h),( _fmt), rpmTagTable, rpmHeaderFormats, (_emsg))
-#endif
-
-#ifndef HAVE_RPMFREECRYPTO
-# define rpmFreeCrypto() while(0)
-#endif
-
-#ifndef HAVE_RPMFREEFILESYSTEMS
-# define rpmFreeFilesystems() while(0)
-#endif
 
 /* SEAP */
 #include <probe-api.h>

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -85,12 +85,7 @@ struct rpmverify_res {
 #define RPMVERIFY_SKIP_GHOST  0x2000000000000000
 #define RPMVERIFY_RPMATTRMASK 0x00000000ffffffff
 
-struct rpmverify_global {
-	rpmts	   rpmts;
-	pthread_mutex_t mutex;
-};
-
-static struct rpmverify_global g_rpm;
+static struct rpm_probe_global g_rpm;
 
 static struct poptOption optionsTable[] = {
 	{ NULL, '\0', POPT_ARG_INCLUDE_TABLE, rpmcliAllPoptTable, 0,
@@ -293,7 +288,7 @@ void *probe_init (void)
 
 void probe_fini (void *ptr)
 {
-	struct rpmverify_global *r = (struct rpmverify_global *)ptr;
+	struct rpm_probe_global *r = (struct rpm_probe_global *)ptr;
 
 	rpmtsFree(r->rpmts);
 	rpmFreeCrypto();

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -43,12 +43,12 @@
 #include <fcntl.h>
 #include <pcre.h>
 
-/* RPM headers */
+#include "rpm-helper.h"
+
+/* Individual RPM headers */
 #include <rpm/rpmfi.h>
 #include <rpm/rpmcli.h>
 #include <popt.h>
-
-#include "rpm-helper.h"
 
 /* SEAP */
 #include <probe-api.h>


### PR DESCRIPTION
It is part of https://github.com/OpenSCAP/openscap/issues/379

Main reason to this pull request is - https://github.com/OpenSCAP/openscap/issues/368.
To add error handler to rpm functions I had to copy same function to all four probes - in rpm-helper.c file will be the callback function.
