### PR TITLE
Remove information about spec files from user manual

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1169,13 +1169,6 @@ installed on your system:
 
 . Run the installation procedure by executing the following command: # make install
 
-If you want to create a package for Fedora or Red Hat Enterprise Linux
-distribution, you will need the respective spec files. These spec files are
-available under the following directories:
-
-* dist/fedora
-* dist/rhel5
-* dist/rhel6
 
 === Debugging
 Developers and users who intend to help find and fix possible bugs in OpenSCAP


### PR DESCRIPTION
The spec files are not present in maint-1.2 anymore.
They were removed in commits
3fe208f3caf1f3a46cd2ee2ea7baa88154600674
41fe1106a680885cd684313d306c12eb54d4353d