### PR TITLE
rpm error handler

### DIFF
--- a/src/OVAL/probes/unix/linux/rpm-helper.c
+++ b/src/OVAL/probes/unix/linux/rpm-helper.c
@@ -23,3 +23,9 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+
+int rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data)
+{
+	dE("RPM: %s", rpmlogRecMessage(rec));
+	return RPMLOG_EXIT; // don't perform default logging
+}

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -75,3 +75,5 @@ struct rpm_probe_global {
 	} while(0)
 
 #endif
+
+int rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data);

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -266,6 +266,7 @@ void *probe_init (void)
 {
 	probe_offline_flags offline_mode = PROBE_OFFLINE_NONE;
 
+	rpmlogSetCallback(rpmErrorCb, NULL);
         if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
                 dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
                 return (NULL);

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -218,6 +218,7 @@ ret:
 
 void *probe_init (void)
 {
+	rpmlogSetCallback(rpmErrorCb, NULL);
         if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
                 dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
                 return (NULL);

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -288,6 +288,7 @@ ret:
 
 void *probe_init (void)
 {
+	rpmlogSetCallback(rpmErrorCb, NULL);
 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
 		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
 		return (NULL);

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -274,6 +274,7 @@ ret:
 
 void *probe_init (void)
 {
+	rpmlogSetCallback(rpmErrorCb, NULL);
 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
 		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
 		return (NULL);


### PR DESCRIPTION
Handle RPM error.

```dE()``` seems not to be very good solution for this, but when somebody tries to scan debian - it is valid to get error.

maint-1.2 result
```
E: probe_rpminfo: RPM: Failed to initialize NSS library
 [probe_rpminfo(27732):probe_rpminfo(7f0108644800):rpm-helper.c:29:rpmErrorCb]
```