### PR TITLE
probes/sysctl: Enable scan 'files' through different devices

### DIFF
--- a/src/OVAL/probes/unix/sysctl.c
+++ b/src/OVAL/probes/unix/sysctl.c
@@ -76,7 +76,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
          */
         ent_attrs = probe_attr_creat("max_depth",           r0 = SEXP_string_newf("%d", PROC_SYS_MAXDEPTH),
                                      "recurse_direction",   r1 = SEXP_string_new("down", 4),
-                                     "recurse_file_system", r2 = SEXP_string_new("defined", 7),
+                                     "recurse_file_system", r2 = SEXP_string_new("local", 7),
                                      "recurse", r3 = SEXP_string_new("symlinks and directories", 24),
                                      NULL);
         bh_entity = probe_ent_creat1("behaviors", ent_attrs, NULL);


### PR DESCRIPTION
/proc/sys/fs/binfmt_misc is on different device than rest of /proc/sys
(stat /proc/sys/fs/binfmt_misc). This commit enable to scan it too

More info https://github.com/OpenSCAP/openscap/issues/258