### PR TITLE
probes dynamic library preloading

### DIFF
--- a/src/OVAL/probes/probe/Makefile.am
+++ b/src/OVAL/probes/probe/Makefile.am
@@ -12,7 +12,9 @@ libprobe_la_CFLAGS=	@pthread_CFLAGS@				\
 			-DTHREAD_SAFE					\
 			-DSEAP_THREAD_SAFE
 
-libprobe_la_SOURCES=	fini.c			\
+libprobe_la_SOURCES=	\
+			fini.c		\
+			preload.c		\
 			init.c			\
 			main.c			\
 			input_handler.c		\

--- a/src/OVAL/probes/probe/main.c
+++ b/src/OVAL/probes/probe/main.c
@@ -275,6 +275,7 @@ int main(int argc, char *argv[])
 			}
 
 			preload_libraries_before_chroot();
+			probe_preload();
 			if (chroot(rootdir) != 0) {
 				fail(errno, "chroot", __LINE__ - 1);
 			}

--- a/src/OVAL/probes/probe/preload.c
+++ b/src/OVAL/probes/probe/preload.c
@@ -1,12 +1,10 @@
 /**
- * @file   probe-skeleton.c
- * @brief  probe skeleton
- * @author "Daniel Kopecek" <dkopecek@redhat.com>
- *
+ * @file   preload.c
+ * @brief  file containg the dummy probe_preload function
  */
 
 /*
- * Copyright 2011 Red Hat Inc., Durham, North Carolina.
+ * Copyright 2016 Red Hat Inc., Durham, North Carolina.
  * All Rights Reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -23,8 +21,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- * Authors:
- *      "Daniel Kopecek" <dkopecek@redhat.com>
  */
 
 #ifdef HAVE_CONFIG_H
@@ -33,25 +29,13 @@
 
 #include <probe-api.h>
 
-void probe_preload()
+/**
+ * Dummy probe_preload function.
+ * This function is called right before chroot.
+ * It should load all dynamic libraries what can by used by probe
+ * after chroot.
+ */
+void probe_preload(void)
 {
-	/* preload dynamic libraries */
 	return;
-}
-
-void *probe_init(void)
-{
-        /* initialize stuff */
-        return (NULL);
-}
-
-void probe_fini(void *probe_arg)
-{
-        /* cleanup stuff */
-        return;
-}
-
-int probe_main(SEXP_t *probe_in, SEXP_t *probe_out, void *probe_arg, SEXP_t *filters)
-{
-        return (PROBE_EUNKNOWN);
 }

--- a/src/OVAL/probes/public/probe-api.h
+++ b/src/OVAL/probes/public/probe-api.h
@@ -468,6 +468,7 @@ void probe_tfc54behaviors_canonicalize(SEXP_t **behaviors);
 #define PROBECMD_OBJ_EVAL  2 /**< Object eval command code */
 #define PROBECMD_RESET     3 /**< Reset command code */
 
+void probe_preload(void);
 void *probe_init(void) __attribute__ ((unused));
 void probe_fini(void *) __attribute__ ((unused));
 

--- a/src/OVAL/probes/unix/linux/rpm-helper.c
+++ b/src/OVAL/probes/unix/linux/rpm-helper.c
@@ -27,7 +27,8 @@
 int rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data)
 {
 	dE("RPM: %s", rpmlogRecMessage(rec));
-	return RPMLOG_EXIT; // don't perform default logging
+	return RPMLOG_DEFAULT;
+}
 
 void rpmLibsPreload()
 {

--- a/src/OVAL/probes/unix/linux/rpm-helper.c
+++ b/src/OVAL/probes/unix/linux/rpm-helper.c
@@ -28,4 +28,8 @@ int rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data)
 {
 	dE("RPM: %s", rpmlogRecMessage(rec));
 	return RPMLOG_EXIT; // don't perform default logging
+
+void rpmLibsPreload()
+{
+	rpmReadConfigFiles(NULL, NULL);
 }

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -80,6 +80,6 @@ int rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data);
  * Preload libraries required by rpm
  * It destroy error callback!
  */
-void rpmLibsPreload();
+void rpmLibsPreload(void);
 
 #endif

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -76,4 +76,10 @@ struct rpm_probe_global {
 
 int rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data);
 
+/**
+ * Preload libraries required by rpm
+ * It destroy error callback!
+ */
+void rpmLibsPreload();
+
 #endif

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -74,6 +74,6 @@ struct rpm_probe_global {
 		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &prev_cancel_state); \
 	} while(0)
 
-#endif
-
 int rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data);
+
+#endif

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -262,6 +262,11 @@ ret:
         return (ret);
 }
 
+void probe_preload ()
+{
+	rpmLibsPreload();
+}
+
 void *probe_init (void)
 {
 	probe_offline_flags offline_mode = PROBE_OFFLINE_NONE;

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -216,6 +216,11 @@ ret:
         return (ret);
 }
 
+void probe_preload ()
+{
+	rpmLibsPreload();
+}
+
 void *probe_init (void)
 {
 	rpmlogSetCallback(rpmErrorCb, NULL);

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -286,6 +286,11 @@ ret:
 	return (ret);
 }
 
+void probe_preload ()
+{
+	rpmLibsPreload();
+}
+
 void *probe_init (void)
 {
 	rpmlogSetCallback(rpmErrorCb, NULL);

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -272,6 +272,11 @@ ret:
 	return (ret);
 }
 
+void probe_preload ()
+{
+	rpmLibsPreload();
+}
+
 void *probe_init (void)
 {
 	rpmlogSetCallback(rpmErrorCb, NULL);


### PR DESCRIPTION
Replaces https://github.com/OpenSCAP/openscap/pull/386
(It could be possible to divide it to more pull request, but it would delay merging.)

- I have deleted callback log function of rpm, because I didn't understand well function interface.
- libgcc_s is loaded before chroot due to call of pthread_cancel()
- rpm dynamic libraries are loaded from host, not from container as before
- ```disable_library_loading()``` I wasn't able so far to find right way how to implement it.
I've asked in mailing list and hope I will get some answer.