### PR TITLE
Issue #364: Fix OCIL in data streams

### DIFF
--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -874,7 +874,7 @@ int ds_sds_compose_add_component_with_ref(xmlDocPtr doc, xmlNodePtr datastream, 
 			return -1;
 		}
 	}
-	else if (doc_type == OSCAP_DOCUMENT_OVAL_DEFINITIONS)
+	else if (doc_type == OSCAP_DOCUMENT_OVAL_DEFINITIONS || doc_type == OSCAP_DOCUMENT_OCIL)
 	{
 		cref_parent = node_get_child_element(datastream, "checks");
 	}

--- a/src/common/public/oscap.h
+++ b/src/common/public/oscap.h
@@ -95,7 +95,8 @@ typedef enum oscap_document_type {
 	OSCAP_DOCUMENT_SCE_RESULT,            ///< SCE result file
 	OSCAP_DOCUMENT_SDS,                   ///< Source Data Stream file
 	OSCAP_DOCUMENT_ARF,                   ///< Result Data Stream file
-	OSCAP_DOCUMENT_XCCDF_TAILORING        ///< XCCDF tailoring file
+	OSCAP_DOCUMENT_XCCDF_TAILORING,       ///< XCCDF tailoring file
+	OSCAP_DOCUMENT_OCIL                   ///< OCIL Definitions file
 	// If you are adding a new enum here, make sure you add support for it
 	// to utils/oscap-info.c!
 } oscap_document_type_t;

--- a/src/source/doc_type.c
+++ b/src/source/doc_type.c
@@ -84,8 +84,9 @@ int oscap_determine_document_type_reader(xmlTextReader *reader, oscap_document_t
 	}
 	else if (!strcmp("sce_results", elm_name)) {
                 *doc_type = OSCAP_DOCUMENT_SCE_RESULT;
-        }
-	else {
+	} else if (!strcmp("ocil", elm_name)) {
+		*doc_type = OSCAP_DOCUMENT_OCIL;
+	} else {
                 return -1;
         }
 

--- a/utils/oscap-info.c
+++ b/utils/oscap-info.c
@@ -373,6 +373,10 @@ static int app_info(const struct oscap_action *action)
 		printf("Document type: SCE Result File\n");
 		// Currently, we do not have any SCE result file parsing capabilities.
 	break;
+	case OSCAP_DOCUMENT_OCIL:
+		printf("Document type: OCIL Definitions file\n");
+		// we don't support OCIL yet
+	break;
 	default:
 		printf("Could not determine document type\n");
 		goto cleanup;


### PR DESCRIPTION
Oscap ds sds-compose does not recognize OCIL file as SCAP-1.2
check system and places it into <ds:extended-components>
element (intended for non-SCAP content) rather into
<ds:checks> element (intended for SCAP-1.2 check systems)
That caused build problems in SSG - error message displayed
and invalid datastream created.
This commit adds basic support for including OCILs in data streams.