### PR TITLE
RHBZ#1250072: Fix regression in loading DS session

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -324,6 +324,10 @@ int xccdf_session_load(struct xccdf_session *session)
 {
 	int ret = 0;
 
+	if (session->ds.session) {
+		ds_sds_session_reset(session->ds.session);
+	}
+
 	if ((ret = xccdf_session_load_xccdf(session)) != 0)
 		return ret;
 	if ((ret = xccdf_session_load_cpe(session)) != 0)


### PR DESCRIPTION
Loading session for a DS file multiple times with different XCCDF IDs
didn't work. When a session for a data stream is created using Python API
and then it is loaded twice with different XCCDF IDs being set,
the session doesn't reflect the change of the XCCDF ID.
This commit fixes the regression by resetting the DS session
when a new XCCDF session is loaded. Therefore the IDs are resetted.