### PR TITLE
Windows build fixes

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1385,6 +1385,8 @@ OpenSCAP for Windows:
 
 1) Install the cross-compiler & dependencies
 
+NOTE: mingw32-pthreads needs to be version 5.0 or greater.
+
 -------------------------------------------------------------
  # yum install mingw32-gcc mingw32-binutils mingw32-libxml2 \
  mingw32-libgcrypt mingw32-pthreads mingw32-libxslt \
@@ -1419,23 +1421,11 @@ OpenSCAP for Windows:
 -----------------------------------------------
 
 -----------------------------------------------------------------------------
-debug.c:98:3: warning: implicit declaration of function 'setenv'
-debug.c:155:2: warning: implicit declaration of function 'flock'
-debug.c:155:35: error: 'LOCK_EX' undeclared (first use in this function)
-debug.c:180:2: warning: implicit declaration of function 'pthread_getname_np'
-debug.c:183:3: error: 'program_invocation_short_name' undeclared
-debug.c:196:35: error: 'LOCK_UN' undeclared (first use in this function)
+oval_resModel.c:70:28: error: conflicting types for 'oval_results_model_new_with_probe_session'
 -----------------------------------------------------------------------------
 
-We need to solve the following problems:
-
-1.  No implementation of ```setenv``` for Windows
-2.  No implementation of ```flock``` for Windows
-3.  No implementation of ```program_invocation_short_name``` for Windows
-4.  No implementation of ```pthread_getname_np``` for Windows
-
-If you would like to send us a patch solving one of these problems,
-please consult the page about
+If you would like to send us a patch fixing any Windows
+compiling issues, please consult the page about
 http://open-scap.org/page/Contribute[contributing to the OpenSCAP
 project].
 

--- a/lib/flock.c
+++ b/lib/flock.c
@@ -1,0 +1,157 @@
+/* Emulate flock on platforms that lack it, primarily Windows and MinGW.
+
+   This is derived from sqlite3 sources.
+   http://www.sqlite.org/cvstrac/rlog?f=sqlite/src/os_win.c
+   http://www.sqlite.org/copyright.html
+
+   Written by Richard W.M. Jones <rjones.at.redhat.com>
+
+   Copyright (C) 2008-2012 Free Software Foundation, Inc.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <config.h>
+#include <sys/file.h>
+
+#if (defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__
+
+/* LockFileEx */
+# define WIN32_LEAN_AND_MEAN
+# include <windows.h>
+# include <flock.h>
+# include <errno.h>
+
+/* _get_osfhandle */
+# include "msvc-nothrow.h"
+
+/* Determine the current size of a file.  Because the other braindead
+ * APIs we'll call need lower/upper 32 bit pairs, keep the file size
+ * like that too.
+ */
+static BOOL file_size (HANDLE h, DWORD * lower, DWORD * upper)
+{
+  *lower = GetFileSize (h, upper);
+  return 1;
+}
+
+/* LOCKFILE_FAIL_IMMEDIATELY is undefined on some Windows systems. */
+# ifndef LOCKFILE_FAIL_IMMEDIATELY
+#  define LOCKFILE_FAIL_IMMEDIATELY 1
+# endif
+
+/* Acquire a lock. */
+static BOOL do_lock (HANDLE h, int non_blocking, int exclusive)
+{
+  BOOL res;
+  DWORD size_lower, size_upper;
+  OVERLAPPED ovlp;
+  int flags = 0;
+
+  /* We're going to lock the whole file, so get the file size. */
+  res = file_size (h, &size_lower, &size_upper);
+  if (!res)
+    return 0;
+
+  /* Start offset is 0, and also zero the remaining members of this struct. */
+  memset (&ovlp, 0, sizeof ovlp);
+
+  if (non_blocking)
+    flags |= LOCKFILE_FAIL_IMMEDIATELY;
+  if (exclusive)
+    flags |= LOCKFILE_EXCLUSIVE_LOCK;
+
+  return LockFileEx (h, flags, 0, size_lower, size_upper, &ovlp);
+}
+
+/* Unlock reader or exclusive lock. */
+static BOOL do_unlock (HANDLE h)
+{
+  int res;
+  DWORD size_lower, size_upper;
+
+  res = file_size (h, &size_lower, &size_upper);
+  if (!res)
+    return 0;
+
+  return UnlockFile (h, 0, 0, size_lower, size_upper);
+}
+
+/* Now our BSD-like flock operation. */
+int flock (int fd, int operation)
+{
+  HANDLE h = (HANDLE) _get_osfhandle (fd);
+  DWORD res;
+  int non_blocking;
+
+  if (h == INVALID_HANDLE_VALUE)
+    {
+      errno = EBADF;
+      return -1;
+    }
+
+  non_blocking = operation & LOCK_NB;
+  operation &= ~LOCK_NB;
+
+  switch (operation)
+    {
+    case LOCK_SH:
+      res = do_lock (h, non_blocking, 0);
+      break;
+    case LOCK_EX:
+      res = do_lock (h, non_blocking, 1);
+      break;
+    case LOCK_UN:
+      res = do_unlock (h);
+      break;
+    default:
+      errno = EINVAL;
+      return -1;
+    }
+
+  /* Map Windows errors into Unix errnos.  As usual MSDN fails to
+   * document the permissible error codes.
+   */
+  if (!res)
+    {
+      DWORD err = GetLastError ();
+      switch (err)
+        {
+          /* This means someone else is holding a lock. */
+        case ERROR_LOCK_VIOLATION:
+          errno = EAGAIN;
+          break;
+
+          /* Out of memory. */
+        case ERROR_NOT_ENOUGH_MEMORY:
+          errno = ENOMEM;
+          break;
+
+        case ERROR_BAD_COMMAND:
+          errno = EINVAL;
+          break;
+
+          /* Unlikely to be other errors, but at least don't lose the
+           * error code.
+           */
+        default:
+          errno = err;
+        }
+
+      return -1;
+    }
+
+  return 0;
+}
+
+#endif /* Windows */

--- a/lib/flock.h
+++ b/lib/flock.h
@@ -1,0 +1,34 @@
+/* Emulate flock on platforms that lack it, primarily Windows and MinGW.
+
+   This is derived from sqlite3 sources.
+   http://www.sqlite.org/cvstrac/rlog?f=sqlite/src/os_win.c
+   http://www.sqlite.org/copyright.html
+
+   Written by Richard W.M. Jones <rjones.at.redhat.com>
+
+   Copyright (C) 2008-2012 Free Software Foundation, Inc.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+
+#ifndef FLOCK_
+#define FLOCK_
+#endif
+
+# define LOCK_SH 1
+# define LOCK_EX 2
+# define LOCK_NB 4
+# define LOCK_UN 8
+
+extern int flock(int fd, int operation);

--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -129,8 +129,10 @@ oval_agent_session_t * oval_agent_new_session(struct oval_definition_model *mode
 	/* one system only */
 	ag_sess->sys_models[0] = ag_sess->sys_model;
 	ag_sess->sys_models[1] = NULL;
+#if defined(OVAL_PROBES_ENABLED)
 	ag_sess->res_model = oval_results_model_new_with_probe_session(
 			model, ag_sess->sys_models, ag_sess->psess);
+#endif
 	generator = oval_results_model_get_generator(ag_sess->res_model);
 	oval_generator_set_product_version(generator, oscap_get_version());
 

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -61,6 +61,10 @@
 #include <regex.h>
 #endif
 
+#if !defined(OVAL_PROBES_ENABLED)
+const char *oval_subtype_to_str(oval_subtype_t subtype);
+#endif
+
 /***************************************************************************/
 /* Variable definitions
  * */

--- a/src/OVAL/oval_session.c
+++ b/src/OVAL/oval_session.c
@@ -28,7 +28,6 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
-#include <linux/limits.h>
 
 #include "common/alloc.h"
 #include "common/debug_priv.h"
@@ -40,6 +39,14 @@
 #include "public/oval_session.h"
 #include "../DS/public/ds_sds_session.h"
 #include "oscap_source.h"
+
+#if !defined(_WIN32)
+#include <linux/limits.h>
+#endif
+
+#if !defined(OVAL_PROBES_ENABLED)
+const char *oval_subtype_to_str(oval_subtype_t subtype);
+#endif
 
 static const char *oscap_productname = "cpe:/a:open-scap:oscap";
 static const char *oval_results_report = "oval-results-report.xsl";

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -47,6 +47,13 @@
 # define PATH_SEPARATOR '/'
 #endif
 
+#if defined(_WIN32)
+# include "flock.h"
+# define GET_PROGRAM_NAME get_program_name()
+#else
+# define GET_PROGRAM_NAME program_invocation_short_name
+#endif
+
 static const struct oscap_string_map OSCAP_VERBOSITY_LEVELS[] = {
     {DBG_E, "ERROR"},
     {DBG_W, "WARNING"},
@@ -71,6 +78,34 @@ oscap_verbosity_levels __debuglog_level = DBG_UNKNOWN;
 #endif
 
 #define THREAD_NAME_LEN 16
+
+#if defined(_WIN32)
+static char * get_program_name()
+{
+        char path[MAX_PATH + 1];
+        int path_size = GetModuleFileName(NULL, path, sizeof(path) - 1);
+
+        if(path_size < 0)
+                return NULL;
+        if(path_size == sizeof(path) - 1)
+                path[path_size] = '\0';
+        return strdup(path);
+}
+
+int setenv(const char *name, const char *value, int overwrite)
+{
+        int errorcode = 0;
+
+        if(!overwrite) {
+                size_t envsize = 0;
+                errorcode = getenv_s(&envsize, NULL, 0, name);
+                if(errorcode || envsize)
+                        return errorcode;
+        }
+
+        return _putenv_s(name, value);
+}
+#endif
 
 static void __oscap_debuglog_close(void)
 {
@@ -169,7 +204,7 @@ static void debug_message_start(int level, int indent)
 	default:
 		l = '0';
 	}
-	fprintf(__debuglog_fp, "%c: %s: ", l, program_invocation_short_name);
+	fprintf(__debuglog_fp, "%c: %s: ", l, GET_PROGRAM_NAME);
 	for (int i = 0; i < indent; i++) {
 		fprintf(__debuglog_fp, "  ");
 	}
@@ -188,7 +223,7 @@ static void debug_message_devel_metadata(const char *file, const char *fn, size_
 #endif
 	/* XXX: non-portable usage of pthread_t */
 	fprintf(__debuglog_fp, " [%s(%ld):%s(%llx):%s:%zu:%s]",
-		program_invocation_short_name, (long) getpid(), thread_name,
+		GET_PROGRAM_NAME, (long) getpid(), thread_name,
 		(unsigned long long) thread, f, line, fn);
 #else
 	fprintf(__debuglog_fp, " [%ld:%s:%zu:%s]", (long) getpid(),
@@ -248,7 +283,9 @@ void __oscap_debuglog_object (const char *file, const char *fn, size_t line, int
 	debug_message_start(DBG_D, 0);
 	switch (objtype) {
 	case OSCAP_DEBUGOBJ_SEXP:
+#if defined(OVAL_PROBES_ENABLED)
 		SEXP_fprintfa(__debuglog_fp, (SEXP_t *)obj);
+#endif
 		break;
 	default:
 		fprintf(__debuglog_fp, "Attempt to dump a not supported object.");

--- a/src/common/public/oscap_debug.h
+++ b/src/common/public/oscap_debug.h
@@ -49,8 +49,9 @@ bool oscap_set_verbose(const char *verbosity_level, const char *filename, bool i
  */
 oscap_verbosity_levels oscap_verbosity_level_from_cstr(const char *level_name);
 
+#if defined(_WIN32)
 errno_t getenv_s(size_t *pReturnValue, char* buffer, size_t numberOfElements, const char * varname);
-
 int setenv(const char *name, const char *value, int overwrite);
+#endif
 
 #endif

--- a/src/common/public/oscap_debug.h
+++ b/src/common/public/oscap_debug.h
@@ -49,4 +49,8 @@ bool oscap_set_verbose(const char *verbosity_level, const char *filename, bool i
  */
 oscap_verbosity_levels oscap_verbosity_level_from_cstr(const char *level_name);
 
+errno_t getenv_s(size_t *pReturnValue, char* buffer, size_t numberOfElements, const char * varname);
+
+int setenv(const char *name, const char *value, int overwrite);
+
 #endif


### PR DESCRIPTION
- Implement OSS version of flock and setenv that can be used only by MinGW.
- Use custom get_program_name function for WIN32.
- Fix various issues when using --disable-probes.
- Update Windows cross-compilation instructions.
- Update #195 