### PR TITLE
Add GConf2-devel to build dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ make
 ```
 Build dependencies:
 (some of these can be turned off via configure)
+ * GConf2-devel
  * libacl-devel
  * libblkid-devel
  * libcap-devel


### PR DESCRIPTION
This package is needed to build gconf probe.