### PR TITLE
Fix a double free

### DIFF
--- a/src/XCCDF/benchmark.c
+++ b/src/XCCDF/benchmark.c
@@ -142,7 +142,6 @@ bool xccdf_benchmark_parse(struct xccdf_item * benchmark, xmlTextReaderPtr reade
 	xccdf_benchmark_set_schema_version(XBENCHMARK(benchmark), xccdf_detect_version_parser(reader));
 
 	if (!xccdf_item_process_attributes(benchmark, reader)) {
-		xccdf_benchmark_free(XBENCHMARK(benchmark));
 		return false;
 	}
 	benchmark->sub.benchmark.style = xccdf_attribute_copy(reader, XCCDFA_STYLE);


### PR DESCRIPTION
Related to https://github.com/OpenSCAP/scap-workbench/issues/63

Addressing:
```
Invalid free() / delete / delete[] / realloc()
   at 0x4C29CF0: free (vg_replace_malloc.c:530)
   by 0x4EC6DD5: xccdf_benchmark_import (benchmark.c:70)
   by 0x40CD38: app_info (oscap-info.c:151)
   by 0x4079BD: oscap_module_call (oscap-tool.c:261)
   by 0x4079BD: oscap_module_process (oscap-tool.c:346)
   by 0x4069BE: main (oscap.c:79)
 Address 0xc84a6a0 is 0 bytes inside a block of size 312 free'd
   at 0x4C29CF0: free (vg_replace_malloc.c:530)
   by 0x4EC6C97: xccdf_benchmark_parse (benchmark.c:145)
   by 0x4EC6D54: xccdf_benchmark_import (benchmark.c:65)
   by 0x40CD38: app_info (oscap-info.c:151)
   by 0x4079BD: oscap_module_call (oscap-tool.c:261)
   by 0x4079BD: oscap_module_process (oscap-tool.c:346)
   by 0x4069BE: main (oscap.c:79)
 Block was alloc'd at
   at 0x4C2A988: calloc (vg_replace_malloc.c:711)
   by 0x4E7E1C8: __oscap_calloc (alloc.c:68)
   by 0x4EC7B2D: xccdf_item_new (item.c:120)
   by 0x4EC5461: xccdf_benchmark_new (benchmark.c:96)
   by 0x4EC6D46: xccdf_benchmark_import (benchmark.c:64)
   by 0x40CD38: app_info (oscap-info.c:151)
   by 0x4079BD: oscap_module_call (oscap-tool.c:261)
   by 0x4079BD: oscap_module_process (oscap-tool.c:346)
   by 0x4069BE: main (oscap.c:79)
```