### PR TITLE
Fix Issue #394 (SCE results aren't embedded in XCCDF reports) + test

### DIFF
--- a/tests/sce/Makefile.am
+++ b/tests/sce/Makefile.am
@@ -9,10 +9,12 @@ TESTS = test_sce.sh \
 		test_passing_vars.sh \
 		test_check_engine_results.sh \
 		test_sce_parse_errors.sh \
-		test_sce_in_ds.sh
+		test_sce_in_ds.sh \
+		test_sce_in_report.sh
 
 EXTRA_DIST =	test_sce.sh \
 		sce_xccdf.xml \
+		bash_list.sh \
 		bash_passer.sh \
 		lua_passer.lua \
 		python_passer.py \
@@ -25,6 +27,8 @@ EXTRA_DIST =	test_sce.sh \
 		test_passing_vars_xccdf.xml \
 		test_sce_in_ds.sh \
 		test_sce_in_ds.xml \
+		test_sce_in_report.sh \
+		test_sce_in_report.xml \
 		test_sce_parse_errors-invalid-oval.xml \
 		test_sce_parse_errors_load_corrupted_xml.xccdf.xml \
 		test_sce_parse_errors_load_script.xccdf.xml \

--- a/tests/sce/bash_list.sh
+++ b/tests/sce/bash_list.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+ls -al /
+RET=$?
+
+if [[ $RET != 0 ]] ; then
+    exit $XCCDF_RESULT_FAIL
+else
+    exit $XCCDF_RESULT_PASS
+fi

--- a/tests/sce/bash_list.sh
+++ b/tests/sce/bash_list.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 ls -al /
 RET=$?

--- a/tests/sce/test_sce_in_report.sh
+++ b/tests/sce/test_sce_in_report.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Author:
 #	Jan Černý <jcerny@redhat.com>

--- a/tests/sce/test_sce_in_report.sh
+++ b/tests/sce/test_sce_in_report.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Author:
+#	Jan Černý <jcerny@redhat.com>
+
+. ../test_common.sh
+
+set -e -o pipefail
+
+function test_sce_in_report {
+
+    local ret_val=0
+    local DEFFILE=${srcdir}/$1
+    local RESFILE=$1.results
+	local REPORTFILE=$1.report.html
+
+    [ -f $RESFILE ] && rm $RESFILE
+
+    $OSCAP xccdf eval --check-engine-results --results "$RESFILE" "$DEFFILE"
+	$OSCAP xccdf generate report "$RESFILE" > "$REPORTFILE"
+	list=`ls -al /`
+	grep "$list" "$REPORTFILE"
+
+}
+
+test_init "test_sce_in_ds.log"
+test_run "sce results in HTML report" test_sce_in_report test_sce_in_report.xml
+test_exit

--- a/tests/sce/test_sce_in_report.xml
+++ b/tests/sce/test_sce_in_report.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="RHEL-6" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="0" xml:lang="en-US">
+  <status date="2011-12-08">draft</status>
+  <title xml:lang="en-US">Sample XCCDF using SCE test engine</title>
+  <description xml:lang="en-US">The SCE results should appear in XCCDF report</description>
+  <version>0.1</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <model system="urn:xccdf:scoring:flat"/>
+  <Group id="bash-passer" hidden="false">
+    <title xml:lang="en-US">Check in bash</title>
+    <description xml:lang="en-US">abcd</description>
+    <Rule id="rule-1000" selected="true" weight="10.000000">
+      <title xml:lang="en-US">List files (bash)</title>
+      <check system="http://open-scap.org/page/SCE">
+        <check-content-ref href="bash_list.sh"/>
+      </check>
+    </Rule>
+  </Group>
+</Benchmark>

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -298,6 +298,9 @@ Specify what result types shall be displayed in the result report. The default i
 .TP
 \fB\-\-oval-template \fItemplate-string\fR
 To use the ability to include additional information from OVAL in xccdf result file, a template which will be used to obtain OVAL result file names has to be specified. The template can be either a filename or a string containing wildcard character (percent sign '%'). Wildcard will be replaced by the original OVAL definition file name as referenced from the XCCDF file. This way it is possible to obtain OVAL information even from XCCDF documents referencing several OVAL files. To use this option with results from an XCCDF evaluation, specify \fI%.result.xml\fR as a OVAL file name template.
+.TP
+\fB\-\-sce-template \fItemplate-string\fR
+To use the ability to include additional information from SCE in XCCDF result file, a template which will be used to obtain SCE result file names has to be specified. The template can be either a filename or a string containing wildcard character (percent sign '%'). Wildcard will be replaced by the original SCE script file name as referenced from the XCCDF file. This way it is possible to obtain SCE information even from XCCDF documents referencing several SCE files. To use this option with results from an XCCDF evaluation, specify \fI%.result.xml\fR as a SCE file name template.
 .RE
 .TP
 .B \fBfix\fR  [\fIoptions\fR] xccdf-file


### PR DESCRIPTION
This pull request tries to fix issues related to generating a HTML report form XCCDF with SCE checks.

This pull request contains three commits:
1) Add into man page a description for already existing, but undocumented option "--sce-template"
2) Add missing default template for SCE results
3) A new simple test checking whether SCE script stdout is shown in the HTML report

Thanks for review && comments.