### PR TITLE
Issue #370: Fix a segmentation fault

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1335,6 +1335,7 @@ int xccdf_session_export_arf(struct xccdf_session *session)
 
 		if (oscap_source_save_as(arf_source, NULL) != 0) {
 			oscap_source_free(arf_source);
+			session->oval.arf_report = NULL;
 			return 1;
 		}
 		if (session->full_validation) {


### PR DESCRIPTION
Addressing:
```
oscap_source_free (source=0x13313d90) at oscap_source.c:129
0x00007ffff7b8ac5e in xccdf_session_free (session=0x61cb30) at xccdf_session.c:249
0x000000000040ba1f in app_evaluate_xccdf (action=<optimized out>) at oscap-xccdf.c:548
0x0000000000407f8e in oscap_module_call (action=0x7fffffffd7b0) at oscap-tool.c:261
oscap_module_process (module=0x6154c0 <XCCDF_EVAL>, module@entry=0x614a40 <OSCAP_ROOT_MODULE>,
argc=argc@entry=6, argv=argv@entry=0x7fffffffda48) at oscap-tool.c:346
0x000000000040702f in main (argc=6, argv=0x7fffffffda48) at oscap.c:80
```