### PR TITLE
rpminfo: fix handling of probe_item_collect return value

### DIFF
--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -517,9 +517,9 @@ int probe_main (probe_ctx *ctx, void *arg)
 				SEXP_free(name);
                                 __rpminfo_rep_free (&(reply_st[i]));
 
-				if (probe_item_collect(ctx, item)) {
+				if (probe_item_collect(ctx, item) < 0) {
 					SEXP_vfree(ent, NULL);
-					return 1;
+					return PROBE_EUNKNOWN;
 				}
                         }
 


### PR DESCRIPTION
The probe_item_collect function uses its return value to signal several things. The previous usage was wrong by assuming that it could be coerced to a boolean value and interpreting 1/true as an error state.

The function returns an integer value. Negative values can be interpreted as fatal errors, 0 as success, 1 as an indication of the collected item being filtered out from the result (which is normal behaviour when using filters) and the value 2 as an indication of not including the item because of memory shortage (at which point the probe might decide wheter to do something to release memory to be able to continue or short-circuit the collection process).

Related: https://www.redhat.com/archives/open-scap-list/2016-May/msg00036.html

Addresses:
```
OpenSCAP Error: Probe at sd=1 (rpminfo) reported an error: Invalid type, value or format [oval_probe_ext.c:393]
Unable to receive a message from probe [oval_probe_ext.c:579]
Invalid oval result type: -1. [oval_resultTest.c:179]
```

**NOTE**: The OpenSCAP team should consider reviewing all the other usages of the `probe_item_collect` function in all probes.