### PR TITLE
oscap-docker: Fix argparse.set_default()

### DIFF
--- a/utils/oscap-docker.in
+++ b/utils/oscap-docker.in
@@ -65,7 +65,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='oscap docker',
                                      epilog='See `man oscap` to learn \
                                      more about OSCAP-ARGUMENTS')
-    parser.set_defaults(func=parser.print_help)
+
+    if sys.version_info >= (3,):
+        parser.set_defaults(func=parser.print_help)
+
     subparser = parser.add_subparsers(help="commands")
 
     # Scan CVEs in image


### PR DESCRIPTION
This is workaround. Argparse has different behavior with different python versions.

We have to call *parser.set_defaults()* only with python 3.x.
Across python2.x can have the function different behavior.

Issue: https://github.com/OpenSCAP/openscap/issues/419