### PR TITLE
oscap-docker: *-cve scan of non-rhel fix

### DIFF
--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -220,22 +220,25 @@ class OscapScan(object):
         # Remeber actual mounted fs in 'rootfs'
         chroot = os.path.join(_tmp_mnt_dir, 'rootfs')
 
-        # Figure out which RHEL dist is in the chroot
-        dist = self.helper._get_dist(chroot)
 
-        # Fetch the CVE input data for the dist
-        fetch = getInputCVE(self.tmp_dir)
+        try:
+            # Figure out which RHEL dist is in the chroot
+            dist = self.helper._get_dist(chroot)
 
-        # TODO
-        # This should probably be in a try/except
-        fetch._fetch_single(dist)
+            # Fetch the CVE input data for the dist
+            fetch = getInputCVE(self.tmp_dir)
 
-        # Scan the chroot
-        sys.stdout.write(self.helper._scan_cve(chroot, dist, scan_args))
+            # TODO
+            # This should probably be in a try/except
+            fetch._fetch_single(dist)
 
-        # Clean up
-        self.helper._cleanup_by_path(_tmp_mnt_dir)
-        self._remove_mnt_dir(mnt_dir)
+            # Scan the chroot
+            sys.stdout.write(self.helper._scan_cve(chroot, dist, scan_args))
+
+        finally:
+            # Clean up
+            self.helper._cleanup_by_path(_tmp_mnt_dir)
+            self._remove_mnt_dir(mnt_dir)
 
     def scan(self, image, scan_args):
         '''

--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -225,6 +225,10 @@ class OscapScan(object):
             # Figure out which RHEL dist is in the chroot
             dist = self.helper._get_dist(chroot)
 
+            if dist is None:
+                sys.stderr.write("{0} is not based on RHEL\n".format(image))
+                return None
+
             # Fetch the CVE input data for the dist
             fetch = getInputCVE(self.tmp_dir)
 

--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -231,9 +231,6 @@ class OscapScan(object):
 
             # Fetch the CVE input data for the dist
             fetch = getInputCVE(self.tmp_dir)
-
-            # TODO
-            # This should probably be in a try/except
             fetch._fetch_single(dist)
 
             # Scan the chroot


### PR DESCRIPTION
Fix:
https://github.com/OpenSCAP/openscap/issues/426

Changes:
- Print error message when target is not rhel based
- unmount container when exception error occur