### PR TITLE
Offline scan option position

### DIFF
--- a/src/OVAL/probes/independent/filehash.c
+++ b/src/OVAL/probes/independent/filehash.c
@@ -180,6 +180,8 @@ static int filehash_cb (const char *p, const char *f, probe_ctx *ctx, oval_versi
 
 void *probe_init (void)
 {
+	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
+
         /*
          * Initialize crypto API
          */
@@ -196,7 +198,6 @@ void *probe_init (void)
                 dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
         }
 
-        probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
 
         return (NULL);
 }

--- a/src/OVAL/probes/independent/filehash58.c
+++ b/src/OVAL/probes/independent/filehash58.c
@@ -200,6 +200,8 @@ static int filehash58_cb (const char *p, const char *f, const char *h, probe_ctx
 
 void *probe_init (void)
 {
+	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
+
 	/*
 	 * Initialize crypto API
 	 */
@@ -215,8 +217,6 @@ void *probe_init (void)
 	default:
 		dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
 	}
-
-	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
 
 	return (NULL);
 }


### PR DESCRIPTION
The option was enabled too late -> when probe initialization failed -> we got error message, that offline scan is not supported.