### PR TITLE
Fix offline scan of rpmverifypackage

### DIFF
--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -237,6 +237,11 @@ PKG_CHECK_MODULES([rpm], [rpm >= 4.6],[
 ],[
 	AC_MSG_NOTICE([libprm is older than 4.6])
 ])
+PKG_CHECK_MODULES([rpm], [rpm >= 4.12],[
+	AC_DEFINE([HAVE_RPM412], [1], [Define to 1 if rpm is newer than 4.12.])
+],[
+	AC_MSG_NOTICE([libprm is older than 4.12])
+])
 echo
 echo '* Checking for bz2 library (optional dependency of libopenscap)'
 AC_CHECK_LIB([bz2], [BZ2_bzReadOpen],

--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -237,11 +237,6 @@ PKG_CHECK_MODULES([rpm], [rpm >= 4.6],[
 ],[
 	AC_MSG_NOTICE([libprm is older than 4.6])
 ])
-PKG_CHECK_MODULES([rpm], [rpm >= 4.12],[
-	AC_DEFINE([HAVE_RPM412], [1], [Define to 1 if rpm is newer than 4.12.])
-],[
-	AC_MSG_NOTICE([libprm is older than 4.12])
-])
 echo
 echo '* Checking for bz2 library (optional dependency of libopenscap)'
 AC_CHECK_LIB([bz2], [BZ2_bzReadOpen],

--- a/configure.ac
+++ b/configure.ac
@@ -413,6 +413,11 @@ PKG_CHECK_MODULES([rpm], [rpm >= 4.6],[
 ],[
 	AC_MSG_NOTICE([libprm is older than 4.6])
 ])
+PKG_CHECK_MODULES([rpm], [rpm >= 4.12],[
+	AC_DEFINE([HAVE_RPM412], [1], [Define to 1 if rpm is newer than 4.12.])
+],[
+	AC_MSG_NOTICE([libprm is older than 4.12])
+])
 echo
 echo '* Checking for bz2 library (optional dependency of libopenscap)'
 AC_CHECK_LIB([bz2], [BZ2_bzReadOpen],
@@ -599,7 +604,7 @@ AC_CHECK_HEADERS([assert.h errno.h fcntl.h limits.h pcre.h pthread.h rpm/header.
 
 echo
 echo ' * Checking presence of required headers for the rpmverifypackage probe'
-AC_CHECK_HEADERS([assert.h errno.h fcntl.h limits.h pcre.h popt.h pthread.h rpm/header.h rpm/rpmcli.h rpm/rpmdb.h rpm/rpmfi.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h ],[],[probe_rpmverifypackage_req_deps_ok=no; probe_rpmverifypackage_req_deps_missing='header files'],[-])
+AC_CHECK_HEADERS([assert.h errno.h fcntl.h limits.h pcre.h popt.h pthread.h rpm/header.h rpm/rpmcli.h rpm/rpmdb.h rpm/rpmfi.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h unistd.h ],[],[probe_rpmverifypackage_req_deps_ok=no; probe_rpmverifypackage_req_deps_missing='header files'],[-])
 
 echo
 echo ' * Checking presence of required headers for the dpkginfo probe'

--- a/configure.ac
+++ b/configure.ac
@@ -413,11 +413,6 @@ PKG_CHECK_MODULES([rpm], [rpm >= 4.6],[
 ],[
 	AC_MSG_NOTICE([libprm is older than 4.6])
 ])
-PKG_CHECK_MODULES([rpm], [rpm >= 4.12],[
-	AC_DEFINE([HAVE_RPM412], [1], [Define to 1 if rpm is newer than 4.12.])
-],[
-	AC_MSG_NOTICE([libprm is older than 4.12])
-])
 echo
 echo '* Checking for bz2 library (optional dependency of libopenscap)'
 AC_CHECK_LIB([bz2], [BZ2_bzReadOpen],

--- a/src/OVAL/probes/Makefile.am
+++ b/src/OVAL/probes/Makefile.am
@@ -268,7 +268,7 @@ endif
 
 if probe_rpmverifypackage_enabled
 pkglibexec_PROGRAMS += probe_rpmverifypackage
-probe_rpmverifypackage_SOURCES= unix/linux/rpmverifypackage.c unix/linux/rpm-helper.h unix/linux/rpm-helper.c
+probe_rpmverifypackage_SOURCES= unix/linux/rpmverifypackage.c unix/linux/rpm-helper.h unix/linux/rpm-helper.c unix/linux/probe-chroot.h unix/linux/probe-chroot.c
 probe_rpmverifypackage_CFLAGS= @rpm_CFLAGS@
 probe_rpmverifypackage_LDFLAGS= @rpm_LIBS@ -lpopt
 endif

--- a/src/OVAL/probes/probe/Makefile.am
+++ b/src/OVAL/probes/probe/Makefile.am
@@ -15,6 +15,7 @@ libprobe_la_CFLAGS=	@pthread_CFLAGS@				\
 
 libprobe_la_SOURCES=	\
 			fini.c		\
+			offline_mode.c		\
 			preload.c		\
 			init.c			\
 			main.c			\

--- a/src/OVAL/probes/probe/offline_mode.c
+++ b/src/OVAL/probes/probe/offline_mode.c
@@ -30,8 +30,7 @@
 #include <probe-api.h>
 
 /**
- * Dummy probe_preload function
- * Return type of supported offline mode.
+ * In this function can be set supported type of offline mode
  */
 void probe_offline_mode(void)
 {

--- a/src/OVAL/probes/probe/offline_mode.c
+++ b/src/OVAL/probes/probe/offline_mode.c
@@ -1,12 +1,10 @@
 /**
- * @file   probe-skeleton.c
- * @brief  probe skeleton
- * @author "Daniel Kopecek" <dkopecek@redhat.com>
- *
+ * @file   offline_mode.c
+ * @brief  file containg the dummy probe_offline_mode function
  */
 
 /*
- * Copyright 2011 Red Hat Inc., Durham, North Carolina.
+ * Copyright 2016 Red Hat Inc., Durham, North Carolina.
  * All Rights Reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -23,8 +21,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- * Authors:
- *      "Daniel Kopecek" <dkopecek@redhat.com>
  */
 
 #ifdef HAVE_CONFIG_H
@@ -33,30 +29,11 @@
 
 #include <probe-api.h>
 
+/**
+ * Dummy probe_preload function
+ * Return type of supported offline mode.
+ */
 void probe_offline_mode(void)
 {
 	return;
-}
-
-void probe_preload()
-{
-	/* preload dynamic libraries */
-	return;
-}
-
-void *probe_init(void)
-{
-        /* initialize stuff */
-        return (NULL);
-}
-
-void probe_fini(void *probe_arg)
-{
-        /* cleanup stuff */
-        return;
-}
-
-int probe_main(SEXP_t *probe_in, SEXP_t *probe_out, void *probe_arg, SEXP_t *filters)
-{
-        return (PROBE_EUNKNOWN);
 }

--- a/src/OVAL/probes/probe/probe.h
+++ b/src/OVAL/probes/probe/probe.h
@@ -75,6 +75,7 @@ typedef enum {
 	PROBE_OFFLINE_NONE = 0x00,
 	PROBE_OFFLINE_CHROOT = 0x01,
 	PROBE_OFFLINE_RPMDB = 0x02,
+	PROBE_OFFLINE_OWN = 0x04,
 	PROBE_OFFLINE_ALL = 0x0f
 } probe_offline_flags;
 

--- a/src/OVAL/probes/public/probe-api.h
+++ b/src/OVAL/probes/public/probe-api.h
@@ -468,6 +468,8 @@ void probe_tfc54behaviors_canonicalize(SEXP_t **behaviors);
 #define PROBECMD_OBJ_EVAL  2 /**< Object eval command code */
 #define PROBECMD_RESET     3 /**< Reset command code */
 
+
+void probe_offline_mode(void);
 void probe_preload(void);
 void *probe_init(void) __attribute__ ((unused));
 void probe_fini(void *) __attribute__ ((unused));

--- a/src/OVAL/probes/unix/linux/probe-chroot.c
+++ b/src/OVAL/probes/unix/linux/probe-chroot.c
@@ -18,6 +18,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "probe-chroot.h"
 #include <errno.h>
 #include "common/debug_priv.h"

--- a/src/OVAL/probes/unix/linux/probe-chroot.c
+++ b/src/OVAL/probes/unix/linux/probe-chroot.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include "probe-chroot.h"
+#include <errno.h>
+#include "common/debug_priv.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+
+void probe_chroot_init(struct probe_chroot *ch, const char *scan_path) {
+	assert(ch != NULL);
+
+	if (scan_path == NULL) {
+		ch->scan_path = NULL;
+		ch->root_fd = -1;
+	} else {
+		// Copy path
+		ch->scan_path = oscap_strdup(scan_path);
+
+		// Open descriptor to original root
+		// It will be used to unchroot
+		ch->root_fd = open("/", O_RDONLY);
+		if (ch->root_fd < 0) {
+			dE("Unable to open root directory: errno: %d \"%s\"", errno, strerror(errno));
+			abort();
+		}
+	}
+}
+
+
+int probe_chroot_enter(const struct probe_chroot *ch)
+{
+	assert(ch != NULL);
+
+	// chdir() is not really required for our purposes of chroot()
+	// but it could help us with debugging of unsuccessfull chroot
+	if (chdir(ch->scan_path) < 0 ) {
+		dE("Unable to chdir to '%s', errno: %d \"%s\"", ch->scan_path, errno, strerror(errno));
+		return -1;
+	}
+
+	if (chroot(ch->scan_path) < 0) {
+		dE("Unable to chroot to '%s', errno: %d \"%s\"", ch->scan_path, errno, strerror(errno));
+		return -1;
+	}
+
+	dD("Probe has just entered to new root: '%s'", ch->scan_path);
+	return 0;
+}
+
+bool probe_chroot_is_set(const struct probe_chroot *ch)
+{
+	return (ch->scan_path != NULL);
+}
+
+const char *probe_chroot_get_path(const struct probe_chroot *ch)
+{
+	return ch->scan_path;
+}
+
+int probe_chroot_leave(const struct probe_chroot *ch)
+{
+	assert(ch != NULL);
+
+	if (fchdir(ch->root_fd)) {
+		dE("Unable to chdir to host root, errno: %d \"%s\"", errno, strerror(errno));
+		return -1;
+	}
+
+	if (chroot(".") < 0) {
+		dE("Unable to leave chroot environment, errno: %d \"%s\"", errno, strerror(errno));
+		return -1;
+	}
+
+	dD("Probe has just escaped chroot environment (previous root: '%s')", ch->scan_path);
+	return 0;
+}
+
+
+void probe_chroot_free(struct probe_chroot* ch)
+{
+	assert(ch != NULL);
+
+	if (ch->scan_path == NULL) {
+		return;
+	}
+	close(ch->root_fd);
+	ch->root_fd = -1;
+
+	oscap_free(ch->scan_path);
+	ch->scan_path = NULL;
+}

--- a/src/OVAL/probes/unix/linux/probe-chroot.h
+++ b/src/OVAL/probes/unix/linux/probe-chroot.h
@@ -20,10 +20,6 @@
 #ifndef __PROBE_CHROOT__
 #define __PROBE_CHROOT__
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "common/util.h"
 
 OSCAP_HIDDEN_START;

--- a/src/OVAL/probes/unix/linux/probe-chroot.h
+++ b/src/OVAL/probes/unix/linux/probe-chroot.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+#ifndef __PROBE_CHROOT__
+#define __PROBE_CHROOT__
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "common/util.h"
+
+OSCAP_HIDDEN_START;
+
+struct probe_chroot {
+	const char* scan_path;
+	int root_fd;
+
+};
+
+/**
+ * Init structure
+ * @param ch should be allocated
+ * @param scan_path will be duplicated, can be NULL
+ * No chroot will be executed then
+ */
+void probe_chroot_init(struct probe_chroot *ch, const char *scan_path);
+
+/**
+ * Enter to chroot environment of target
+ */
+int probe_chroot_enter(const struct probe_chroot *ch);
+
+/**
+ * Leave chroot environment - restore original root
+ */
+int probe_chroot_leave(const struct probe_chroot *ch);
+
+/**
+ * Check if scan path is set
+ * @return true if scan path != NULL
+ */
+bool probe_chroot_is_set(const struct probe_chroot *ch);
+
+/**
+ * Return path to scan
+ * @return can return NULL
+ */
+const char *probe_chroot_get_path(const struct probe_chroot *ch);
+
+/**
+ * Free structures in probe_chroot
+ * @param probe_chroot Memory of probe_chroot is not free'ed by this function
+ */
+void probe_chroot_free(struct probe_chroot *ch);
+
+OSCAP_HIDDEN_END;
+
+#endif

--- a/src/OVAL/probes/unix/linux/rpm-helper.c
+++ b/src/OVAL/probes/unix/linux/rpm-helper.c
@@ -39,5 +39,8 @@ void rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data)
 
 void rpmLibsPreload()
 {
-	rpmReadConfigFiles(NULL, NULL);
+	// Don't load rpmrc files. The are useless for us,
+	// because we only need to preload libraries
+	const char* rcfiles = "";
+	rpmReadConfigFiles(rcfiles, NULL);
 }

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -81,6 +81,11 @@ typedef void *rpmlogCallbackData;
 void rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data);
 #endif
 
+#ifdef HAVE_RPM412
+#define DISABLE_PLUGINS(ts) rpmtsSetFlags(ts, RPMTRANS_FLAG_NOPLUGINS)
+#else
+#define DISABLE_PLUGINS(ts) rpmDefineMacro(NULL,"__plugindir \"\"", 0);
+#endif
 
 /**
  * Preload libraries required by rpm

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -81,6 +81,8 @@ typedef void *rpmlogCallbackData;
 void rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data);
 #endif
 
+// todo: HAVE_RPM412 needs to be set by configure,
+// although fallback solution should have same result
 #ifdef HAVE_RPM412
 #define DISABLE_PLUGINS(ts) rpmtsSetFlags(ts, RPMTRANS_FLAG_NOPLUGINS)
 #else

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -44,6 +44,7 @@
 #include <pcre.h>
 
 #include "rpm-helper.h"
+#include "probe-chroot.h"
 
 /* Individual RPM headers */
 #include <rpm/rpmfi.h>
@@ -88,7 +89,10 @@ struct rpmverify_res {
 #define RPMVERIFY_SKIP_GHOST  0x2000000000000000
 #define RPMVERIFY_RPMATTRMASK 0x00000000ffffffff
 
-static struct rpm_probe_global g_rpm;
+static struct verifypackage_global {
+	struct rpm_probe_global rpm;
+	struct probe_chroot chr;
+} g_rpm;
 
 static struct poptOption optionsTable[] = {
 	{ NULL, '\0', POPT_ARG_INCLUDE_TABLE, rpmcliAllPoptTable, 0,
@@ -100,9 +104,17 @@ static struct poptOption optionsTable[] = {
 	POPT_TABLEEND
 };
 
-#define RPMVERIFY_LOCK   RPM_MUTEX_LOCK(&g_rpm.mutex)
+#define RPMVERIFY_LOCK   RPM_MUTEX_LOCK(&g_rpm.rpm.mutex)
 
-#define RPMVERIFY_UNLOCK RPM_MUTEX_UNLOCK(&g_rpm.mutex)
+#define RPMVERIFY_UNLOCK RPM_MUTEX_UNLOCK(&g_rpm.rpm.mutex)
+
+#define CHROOT_ENTER() probe_chroot_enter(&g_rpm.chr)
+
+#define CHROOT_LEAVE() probe_chroot_leave(&g_rpm.chr)
+
+#define CHROOT_IS_SET() probe_chroot_is_set(&g_rpm.chr)
+
+#define CHROOT_PATH() probe_chroot_get_path(&g_rpm.chr)
 
 /* modify passed-in iterator to test also given entity */
 static int adjust_filter(rpmdbMatchIterator iterator, SEXP_t *ent, rpmTag rpm_tag) {
@@ -151,7 +163,7 @@ static int rpmverify_collect(probe_ctx *ctx,
 
 	RPMVERIFY_LOCK;
 
-	match = rpmtsInitIterator (g_rpm.rpmts, RPMDBI_PACKAGES, NULL, 0);
+	match = rpmtsInitIterator (g_rpm.rpm.rpmts, RPMDBI_PACKAGES, NULL, 0);
 	if (match == NULL) {
 		ret = 0;
 		goto ret;
@@ -240,15 +252,38 @@ static int rpmverify_collect(probe_ctx *ctx,
 			rpmcli_argv[rpmcli_argc++] = res.name;
 			rpmcli_argv[rpmcli_argc] = NULL;
 
+			if (CHROOT_IS_SET())
+			{
+				rpmLibsPreload();
+				if (CHROOT_ENTER() < 0) {
+					ret = 1;
+					goto ret;
+				}
+			}
+
 			rpmcli_context = rpmcliInit(rpmcli_argc, (char * const*)rpmcli_argv, optionsTable);
 			qva = &rpmQVKArgs;
 			rpmVerifyFlags verifyFlags = VERIFY_ALL;
 			verifyFlags &= ~qva->qva_flags;
 			qva->qva_flags = (rpmQueryFlags) verifyFlags;
 
+			// rpmcliFini() causes free of rpmrc, macros, ...
+			// so we have to reload everything again
 			rpmReadConfigFiles ((const char *)NULL, (const char *)NULL);
+
 			rpmts ts = rpmtsCreate();
-			ret = rpmcliVerify(ts, qva, (char * const *) poptGetArgs(rpmcli_context));
+			char* const * args = (char* const *)poptGetArgs(rpmcli_context);
+
+			if (CHROOT_IS_SET()){
+
+				// plugins for offline mode can cause, that .so from
+				// container are loaded - we don't want it
+				DISABLE_PLUGINS(ts);
+				CHROOT_LEAVE();
+			} else {
+				ret = rpmcliVerify(ts, qva, args);
+			}
+
 			ts = rpmtsFree(ts);
 			rpmcli_context = rpmcliFini(rpmcli_context);
 
@@ -275,41 +310,64 @@ ret:
 	return (ret);
 }
 
-void probe_preload ()
+void probe_offline_mode ()
 {
-	rpmLibsPreload();
+	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_OWN);
 }
 
 void *probe_init (void)
 {
-	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
+	const char* root = getenv("OSCAP_PROBE_ROOT");
+	if ((root!= NULL) && (strlen(root) == 0)) {
+		root = NULL;
+	}
+	probe_chroot_init(&g_rpm.chr, root);
 
 #ifdef HAVE_RPM46
 	rpmlogSetCallback(rpmErrorCb, NULL);
 #else
 	rpmlogSetCallback(rpmErrorCb);
 #endif
-	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
+
+	if (CHROOT_IS_SET()) {
+		rpmLibsPreload();
+		if (CHROOT_ENTER() < 0) {
+			return (NULL);
+		}
+	}
+
+	if (rpmReadConfigFiles (NULL, (const char *)NULL) != 0) {
 		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
 		return (NULL);
 	}
 
-	g_rpm.rpmts = rpmtsCreate();
+	g_rpm.rpm.rpmts = rpmtsCreate();
 
-	pthread_mutex_init(&(g_rpm.mutex), NULL);
+	if (CHROOT_IS_SET()) {
+		CHROOT_LEAVE();
+
+		// plugins for offline mode can cause, that .so from
+		// container are loaded - we don't want it
+		DISABLE_PLUGINS(g_rpm.rpm.rpmts);
+
+		rpmtsSetRootDir(g_rpm.rpm.rpmts, CHROOT_PATH());
+	}
+
+	pthread_mutex_init(&(g_rpm.rpm.mutex), NULL);
 	return ((void *)&g_rpm);
 }
 
 void probe_fini (void *ptr)
 {
-	struct rpm_probe_global *r = (struct rpm_probe_global *)ptr;
+	struct verifypackage_global *r = (struct verifypackage_global *)ptr;
 
-	rpmtsFree(r->rpmts);
+	rpmtsFree(r->rpm.rpmts);
+	probe_chroot_free(&(r->chr));
 	rpmFreeCrypto();
 	rpmFreeRpmrc();
 	rpmFreeMacros(NULL);
 	rpmlogClose();
-	pthread_mutex_destroy (&(r->mutex));
+	pthread_mutex_destroy (&(r->rpm.mutex));
 
 	return;
 }
@@ -361,7 +419,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 	uint64_t collect_flags = 0;
 	unsigned int i;
 
-	if (g_rpm.rpmts == NULL) {
+	if (g_rpm.rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;
 	}


### PR DESCRIPTION
- should fix rpmverify package offline scan issue - use chroot back to host root to load libraries
- some of commits are not part of the PR - I need them to passing tests - before merging they will be removed

Questions:
- what do you think about `probe_offline_mode()? - currently no other probe use it, I would like to use it in all probes