### PR TITLE
Fix autoconf issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -555,19 +555,19 @@ AC_CHECK_HEADERS([dirent.h errno.h fcntl.h limits.h pthread.h selinux/context.h 
 
 echo
 echo ' * Checking presence of required headers for the rpminfo probe'
-AC_CHECK_HEADERS([assert.h errno.h fcntl.h regex.h rpm/header.h rpm/rpmdb.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h ],[],[probe_rpminfo_req_deps_ok=no; probe_rpminfo_req_deps_missing='header files'],[-])
+AC_CHECK_HEADERS([assert.h errno.h fcntl.h pthread.h regex.h rpm/header.h rpm/rpmdb.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h ],[],[probe_rpminfo_req_deps_ok=no; probe_rpminfo_req_deps_missing='header files'],[-])
 
 echo
 echo ' * Checking presence of required headers for the rpmverify probe'
-AC_CHECK_HEADERS([assert.h errno.h fcntl.h limits.h pcre.h rpm/header.h rpm/rpmcli.h rpm/rpmdb.h rpm/rpmfi.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h ],[],[probe_rpmverify_req_deps_ok=no; probe_rpmverify_req_deps_missing='header files'],[-])
+AC_CHECK_HEADERS([assert.h errno.h fcntl.h limits.h pcre.h pthread.h rpm/header.h rpm/rpmcli.h rpm/rpmdb.h rpm/rpmfi.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h ],[],[probe_rpmverify_req_deps_ok=no; probe_rpmverify_req_deps_missing='header files'],[-])
 
 echo
 echo ' * Checking presence of required headers for the rpmverifyfile probe'
-AC_CHECK_HEADERS([assert.h errno.h fcntl.h limits.h pcre.h rpm/header.h rpm/rpmcli.h rpm/rpmdb.h rpm/rpmfi.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h ],[],[probe_rpmverifyfile_req_deps_ok=no; probe_rpmverifyfile_req_deps_missing='header files'],[-])
+AC_CHECK_HEADERS([assert.h errno.h fcntl.h limits.h pcre.h pthread.h rpm/header.h rpm/rpmcli.h rpm/rpmdb.h rpm/rpmfi.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h ],[],[probe_rpmverifyfile_req_deps_ok=no; probe_rpmverifyfile_req_deps_missing='header files'],[-])
 
 echo
 echo ' * Checking presence of required headers for the rpmverifypackage probe'
-AC_CHECK_HEADERS([assert.h errno.h fcntl.h limits.h pcre.h popt.h rpm/header.h rpm/rpmcli.h rpm/rpmdb.h rpm/rpmfi.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h ],[],[probe_rpmverifypackage_req_deps_ok=no; probe_rpmverifypackage_req_deps_missing='header files'],[-])
+AC_CHECK_HEADERS([assert.h errno.h fcntl.h limits.h pcre.h popt.h pthread.h rpm/header.h rpm/rpmcli.h rpm/rpmdb.h rpm/rpmfi.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h ],[],[probe_rpmverifypackage_req_deps_ok=no; probe_rpmverifypackage_req_deps_missing='header files'],[-])
 
 echo
 echo ' * Checking presence of required headers for the dpkginfo probe'

--- a/src/OVAL/probes/Makefile.am
+++ b/src/OVAL/probes/Makefile.am
@@ -241,40 +241,28 @@ endif
 
 if probe_rpminfo_enabled
 pkglibexec_PROGRAMS += probe_rpminfo
-probe_rpminfo_SOURCES= \
-    unix/linux/rpminfo.c \
-    unix/linux/rpm-helper.h \
-    unix/linux/rpm-helper.c
+probe_rpminfo_SOURCES= unix/linux/rpminfo.c unix/linux/rpm-helper.h unix/linux/rpm-helper.c
 probe_rpminfo_CFLAGS= @rpm_CFLAGS@
 probe_rpminfo_LDFLAGS= @rpm_LIBS@
 endif
 
 if probe_rpmverify_enabled
 pkglibexec_PROGRAMS += probe_rpmverify
-probe_rpmverify_SOURCES= \
-    unix/linux/rpmverify.c \
-    unix/linux/rpm-helper.h \
-    unix/linux/rpm-helper.c
+probe_rpmverify_SOURCES= unix/linux/rpmverify.c unix/linux/rpm-helper.h unix/linux/rpm-helper.c
 probe_rpmverify_CFLAGS= @rpm_CFLAGS@
 probe_rpmverify_LDFLAGS= @rpm_LIBS@
 endif
 
 if probe_rpmverifyfile_enabled
 pkglibexec_PROGRAMS += probe_rpmverifyfile
-probe_rpmverifyfile_SOURCES= \
-    unix/linux/rpmverifyfile.c \
-    unix/linux/rpm-helper.h \
-    unix/linux/rpm-helper.c
+probe_rpmverifyfile_SOURCES= unix/linux/rpmverifyfile.c unix/linux/rpm-helper.h unix/linux/rpm-helper.c
 probe_rpmverifyfile_CFLAGS= @rpm_CFLAGS@
 probe_rpmverifyfile_LDFLAGS= @rpm_LIBS@
 endif
 
 if probe_rpmverifypackage_enabled
 pkglibexec_PROGRAMS += probe_rpmverifypackage
-probe_rpmverifypackage_SOURCES= \
-    unix/linux/rpmverifypackage.c \
-    unix/linux/rpm-helper.h \
-    unix/linux/rpm-helper.c
+probe_rpmverifypackage_SOURCES= unix/linux/rpmverifypackage.c unix/linux/rpm-helper.h unix/linux/rpm-helper.c
 probe_rpmverifypackage_CFLAGS= @rpm_CFLAGS@
 probe_rpmverifypackage_LDFLAGS= @rpm_LIBS@ -lpopt
 endif


### PR DESCRIPTION
Changes made recently in src/OVAL/probes/Makefile.am caused that
./confgen.sh removed check macros for header files that are needed
for rpm probes from configure.ac.
This commit fixes the syntax of respective Makefile.am and also
includes freshly generated configure.ac.