### PR TITLE
Issue #408: Fix compilation on older systems

### DIFF
--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -232,6 +232,11 @@ PKG_CHECK_MODULES([rpm], [rpm >= 4.4],[
 ],[
 	AC_MSG_NOTICE([!!! librpm not found. The rpmvercmp function will be emulated. !!!])
 ])
+PKG_CHECK_MODULES([rpm], [rpm >= 4.6],[
+	AC_DEFINE([HAVE_RPM46], [1], [Define to 1 if rpm is newer than 4.6.])
+],[
+	AC_MSG_NOTICE([libprm is older than 4.6])
+])
 
 
 @@@@PROBE_HEADERS@@@@

--- a/configure.ac
+++ b/configure.ac
@@ -396,6 +396,11 @@ PKG_CHECK_MODULES([rpm], [rpm >= 4.4],[
 ],[
 	AC_MSG_NOTICE([!!! librpm not found. The rpmvercmp function will be emulated. !!!])
 ])
+PKG_CHECK_MODULES([rpm], [rpm >= 4.6],[
+	AC_DEFINE([HAVE_RPM46], [1], [Define to 1 if rpm is newer than 4.6.])
+],[
+	AC_MSG_NOTICE([libprm is older than 4.6])
+])
 
 
 SAVE_CPPFLAGS="$CPPFLAGS"

--- a/src/OVAL/probes/unix/linux/rpm-helper.c
+++ b/src/OVAL/probes/unix/linux/rpm-helper.c
@@ -24,11 +24,18 @@
 #include <config.h>
 #endif
 
+#ifdef HAVE_RPM46
 int rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data)
 {
 	dE("RPM: %s", rpmlogRecMessage(rec));
 	return RPMLOG_DEFAULT;
 }
+#else
+void rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data)
+{
+	dE("RPM: %s", rpmlogRecMessage(rec));
+}
+#endif
 
 void rpmLibsPreload()
 {

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -74,7 +74,13 @@ struct rpm_probe_global {
 		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &prev_cancel_state); \
 	} while(0)
 
+#ifdef HAVE_RPM46
 int rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data);
+#else
+typedef void *rpmlogCallbackData;
+void rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data);
+#endif
+
 
 /**
  * Preload libraries required by rpm

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -271,7 +271,11 @@ void *probe_init (void)
 {
 	probe_offline_flags offline_mode = PROBE_OFFLINE_NONE;
 
+#ifdef HAVE_RPM46
 	rpmlogSetCallback(rpmErrorCb, NULL);
+#else
+	rpmlogSetCallback(rpmErrorCb);
+#endif
         if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
                 dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
                 return (NULL);

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -223,7 +223,11 @@ void probe_preload ()
 
 void *probe_init (void)
 {
+#ifdef HAVE_RPM46
 	rpmlogSetCallback(rpmErrorCb, NULL);
+#else
+	rpmlogSetCallback(rpmErrorCb);
+#endif
         if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
                 dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
                 return (NULL);

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -293,7 +293,11 @@ void probe_preload ()
 
 void *probe_init (void)
 {
+#ifdef HAVE_RPM46
 	rpmlogSetCallback(rpmErrorCb, NULL);
+#else
+	rpmlogSetCallback(rpmErrorCb);
+#endif
 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
 		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
 		return (NULL);

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -279,7 +279,11 @@ void probe_preload ()
 
 void *probe_init (void)
 {
+#ifdef HAVE_RPM46
 	rpmlogSetCallback(rpmErrorCb, NULL);
+#else
+	rpmlogSetCallback(rpmErrorCb);
+#endif
 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
 		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
 		return (NULL);


### PR DESCRIPTION
Function rpmLogSetCallback has changed its prototype in RPM 4.6 API.
Before it had only one parameter, now it has two parameters.
Older version (RPM 4.4.x) is shipped in RHEL5, therefore we must use
conditional compilation to get the rpm probes compiled on RHEL5.