### PR TITLE
Issue #401: OVAL tests can reference only objects of same type

### DIFF
--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -361,6 +361,7 @@ static int oval_probe_query_criteria(oval_probe_session_t *sess, struct oval_cri
 		struct oval_test *test;
 		struct oval_object *object;
 		struct oval_state_iterator *ste_itr;
+		oval_subtype_t test_subtype, object_subtype;
 
 		test = oval_criteria_node_get_test(cnode);
 		if (test == NULL)
@@ -368,6 +369,15 @@ static int oval_probe_query_criteria(oval_probe_session_t *sess, struct oval_cri
 		object = oval_test_get_object(test);
 		if (object == NULL)
 			return 0;
+		test_subtype = oval_test_get_subtype(test);
+		object_subtype = oval_object_get_subtype(object);
+		if (test_subtype != object_subtype) {
+			oscap_seterr(OSCAP_EFAMILY_OVAL, "%s_test '%s' is not compatible with %s_object '%s'.",
+					oval_subtype_to_str(test_subtype), oval_test_get_id(test),
+					oval_subtype_to_str(object_subtype), oval_object_get_id(object));
+			return 0;
+		}
+
 		/* probe object */
 		ret = oval_probe_query_object(sess, object, 0, NULL);
 		if (ret == -1)

--- a/tests/API/OVAL/report_variable_values/report_variable_values.def.xml
+++ b/tests/API/OVAL/report_variable_values/report_variable_values.def.xml
@@ -70,10 +70,10 @@
             comment="unreferenced test; verify no variables are exported for it">
             <ind-def:object object_ref="oval:x:obj:7"/>
         </ind-def:textfilecontent54_test>
-        <ind-def:textfilecontent54_test id="oval:x:tst:8" check="all" version="1"
+        <ind-def:variable_test id="oval:x:tst:8" check="all" version="1"
             comment="a variable_object">
             <ind-def:object object_ref="oval:x:obj:8"/>
-        </ind-def:textfilecontent54_test>
+        </ind-def:variable_test>
         <ind-def:textfilecontent54_test id="oval:x:tst:9" check="all" version="1"
             comment="an object with a filter">
             <ind-def:object object_ref="oval:x:obj:9"/>
@@ -98,7 +98,7 @@
         </ind-def:textfilecontent54_object>
         <ind-def:textfilecontent54_object id="oval:x:obj:4" version="1" comment="x">
             <ind-def:filepath datatype="string" operation="equals">/etc/passwd</ind-def:filepath>
-            <ind-def:pattern datatype="string" operation="equals" var_ref="oval:x:var:4"/>
+            <ind-def:pattern datatype="string" operation="pattern match" var_ref="oval:x:var:4"/>
             <ind-def:instance datatype="int" operation="equals" var_ref="oval:x:var:3"/>
         </ind-def:textfilecontent54_object>
         <ind-def:textfilecontent54_object id="oval:x:obj:5" version="1" comment="x">


### PR DESCRIPTION
This pull request:
1) fixes invalid OVAL file in our upstream test suite (fixes warnings reported by schemtaron validation)
2) introduces a check for this kind of invalid content into OpenSCAP to ensure that we do not process invalid content
This pull request fixes issue #401.
Replaces PR #446 .