### PR TITLE
Remove callback on RPM < 4.6

### DIFF
--- a/src/OVAL/probes/unix/linux/rpm-helper.c
+++ b/src/OVAL/probes/unix/linux/rpm-helper.c
@@ -30,11 +30,6 @@ int rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data)
 	dE("RPM: %s", rpmlogRecMessage(rec));
 	return RPMLOG_DEFAULT;
 }
-#else
-void rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data)
-{
-	dE("RPM: %s", rpmlogRecMessage(rec));
-}
 #endif
 
 void rpmLibsPreload()

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -76,9 +76,6 @@ struct rpm_probe_global {
 
 #ifdef HAVE_RPM46
 int rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data);
-#else
-typedef void *rpmlogCallbackData;
-void rpmErrorCb (rpmlogRec rec, rpmlogCallbackData data);
 #endif
 
 

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -273,8 +273,6 @@ void *probe_init (void)
 
 #ifdef HAVE_RPM46
 	rpmlogSetCallback(rpmErrorCb, NULL);
-#else
-	rpmlogSetCallback(rpmErrorCb);
 #endif
         if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
                 dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -225,8 +225,6 @@ void *probe_init (void)
 {
 #ifdef HAVE_RPM46
 	rpmlogSetCallback(rpmErrorCb, NULL);
-#else
-	rpmlogSetCallback(rpmErrorCb);
 #endif
         if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
                 dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -295,8 +295,6 @@ void *probe_init (void)
 {
 #ifdef HAVE_RPM46
 	rpmlogSetCallback(rpmErrorCb, NULL);
-#else
-	rpmlogSetCallback(rpmErrorCb);
 #endif
 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
 		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -281,8 +281,6 @@ void *probe_init (void)
 {
 #ifdef HAVE_RPM46
 	rpmlogSetCallback(rpmErrorCb, NULL);
-#else
-	rpmlogSetCallback(rpmErrorCb);
 #endif
 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
 		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));


### PR DESCRIPTION
Recently we have merged a fix to compile the rpm probes
on maint-1.0 on systems with older versions of rpmlib.
However, the reporting function  is not present there,
so it does not make any sense to set the logging callback,
because it has no effect. This commit removes the callback
on those systems.