### PR TITLE
Issue #393: Fix rpmverifyfile compilation on RHEL5

### DIFF
--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -240,7 +240,7 @@ PKG_CHECK_MODULES([rpm], [rpm >= 4.6],[
 PKG_CHECK_MODULES([rpm], [rpm >= 4.7],[
 	AC_DEFINE([HAVE_RPM47], [1], [Define to 1 if rpm is newer than 4.7.])
 ],[
-	AC_MSG_NOTICE([libprm is older than 4.7])
+	AC_MSG_NOTICE([librpm is older than 4.7])
 ])
 echo
 echo '* Checking for bz2 library (optional dependency of libopenscap)'

--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -237,6 +237,11 @@ PKG_CHECK_MODULES([rpm], [rpm >= 4.6],[
 ],[
 	AC_MSG_NOTICE([libprm is older than 4.6])
 ])
+PKG_CHECK_MODULES([rpm], [rpm >= 4.7],[
+	AC_DEFINE([HAVE_RPM47], [1], [Define to 1 if rpm is newer than 4.7.])
+],[
+	AC_MSG_NOTICE([libprm is older than 4.7])
+])
 echo
 echo '* Checking for bz2 library (optional dependency of libopenscap)'
 AC_CHECK_LIB([bz2], [BZ2_bzReadOpen],

--- a/configure.ac
+++ b/configure.ac
@@ -413,6 +413,11 @@ PKG_CHECK_MODULES([rpm], [rpm >= 4.6],[
 ],[
 	AC_MSG_NOTICE([libprm is older than 4.6])
 ])
+PKG_CHECK_MODULES([rpm], [rpm >= 4.7],[
+	AC_DEFINE([HAVE_RPM47], [1], [Define to 1 if rpm is newer than 4.7.])
+],[
+	AC_MSG_NOTICE([libprm is older than 4.7])
+])
 echo
 echo '* Checking for bz2 library (optional dependency of libopenscap)'
 AC_CHECK_LIB([bz2], [BZ2_bzReadOpen],
@@ -587,7 +592,7 @@ AC_CHECK_HEADERS([dirent.h errno.h fcntl.h limits.h pthread.h selinux/context.h 
 
 echo
 echo ' * Checking presence of required headers for the rpminfo probe'
-AC_CHECK_HEADERS([assert.h errno.h fcntl.h pthread.h regex.h rpm/header.h rpm/rpmdb.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h ],[],[probe_rpminfo_req_deps_ok=no; probe_rpminfo_req_deps_missing='header files'],[-])
+AC_CHECK_HEADERS([assert.h errno.h fcntl.h pthread.h regex.h rpm/header.h rpm/rpmdb.h rpm/rpmfi.h rpm/rpmlib.h rpm/rpmlog.h rpm/rpmmacro.h rpm/rpmts.h stdio.h string.h sys/stat.h sys/types.h ],[],[probe_rpminfo_req_deps_ok=no; probe_rpminfo_req_deps_missing='header files'],[-])
 
 echo
 echo ' * Checking presence of required headers for the rpmverify probe'

--- a/configure.ac
+++ b/configure.ac
@@ -416,7 +416,7 @@ PKG_CHECK_MODULES([rpm], [rpm >= 4.6],[
 PKG_CHECK_MODULES([rpm], [rpm >= 4.7],[
 	AC_DEFINE([HAVE_RPM47], [1], [Define to 1 if rpm is newer than 4.7.])
 ],[
-	AC_MSG_NOTICE([libprm is older than 4.7])
+	AC_MSG_NOTICE([librpm is older than 4.7])
 ])
 echo
 echo '* Checking for bz2 library (optional dependency of libopenscap)'

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -25,6 +25,7 @@
 #endif
 
 #include <rpm/rpmdb.h>
+#include <rpm/rpmfi.h>
 #include <rpm/rpmlib.h>
 #include <rpm/rpmts.h>
 #include <rpm/rpmmacro.h>

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -76,6 +76,12 @@ struct rpmverify_res {
 #define RPMVERIFY_SKIP_GHOST  0x2000000000000000
 #define RPMVERIFY_RPMATTRMASK 0x00000000ffffffff
 
+#ifndef HAVE_RPM47
+	#define RPMVERIFY_FILEDIGEST RPMVERIFY_MD5
+	#define VERIFY_FILEDIGEST VERIFY_MD5
+	#define VERIFY_CAPS 0
+#endif
+
 static struct rpm_probe_global g_rpm;
 
 #define RPMVERIFY_LOCK   RPM_MUTEX_LOCK(&g_rpm.mutex)

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -76,9 +76,18 @@ struct rpmverify_res {
 #define RPMVERIFY_SKIP_GHOST  0x2000000000000000
 #define RPMVERIFY_RPMATTRMASK 0x00000000ffffffff
 
+/* In rmplib older than 4.7 some of the enum values aren't defined.
+ * We need to provide fallback definitions.
+ */
 #ifndef HAVE_RPM47
+	/* *VERIFY_FILEDIGEST were introduced as aliases to *VERIFY_MD5
+	 * They all have the same value (1) - see 'rpm/rpmvf.h'.
+	 */
 	#define RPMVERIFY_FILEDIGEST RPMVERIFY_MD5
 	#define VERIFY_FILEDIGEST VERIFY_MD5
+	/* VERIFY_CAPS is not supported in older rpmlib.
+	 * We can set it to 0 because 0 is neutral to bit OR operation.
+	 */
 	#define VERIFY_CAPS 0
 #endif
 


### PR DESCRIPTION
One missing include and some fallback definition of macros
will fix the issue.