### PR TITLE
Issue #372: Add xccdf:TestResult@test-system attribute

### DIFF
--- a/src/XCCDF/result.c
+++ b/src/XCCDF/result.c
@@ -774,6 +774,10 @@ void xccdf_result_to_dom(struct xccdf_result *result, xmlNode *result_node, xmlD
 	const char *version = xccdf_result_get_version(result);
         if (version != NULL)
 		xmlNewProp(result_node, BAD_CAST "version", BAD_CAST version);
+	const char *test_system = xccdf_result_get_test_system(result);
+	if (test_system != NULL) {
+		xmlNewProp(result_node, BAD_CAST "test-system", BAD_CAST test_system);
+	}
 
 	/* Handle children */
 	xccdf_texts_to_dom(xccdf_result_get_remarks(result), result_node, "remark");

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -2185,6 +2185,7 @@ struct xccdf_result * xccdf_policy_evaluate(struct xccdf_policy * policy)
     struct xccdf_result * result = xccdf_result_new();
 
 	xccdf_result_set_start_time_current(result);
+	xccdf_result_set_test_system(result, "cpe:/a:redhat:openscap:" VERSION);
 
     /** Set ID of TestResult */
     const char * id = NULL;

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -172,6 +172,8 @@ EXTRA_DIST += \
 	test_xccdf_selectors_cluster3.xccdf.xml \
 	test_xccdf_sub_title.sh \
 	test_xccdf_sub_title.xccdf.xml \
+	test_xccdf_test_system.sh \
+	test_xccdf_test_system.xccdf.xml \
 	test_xccdf_xml_escaping_value.sh \
 	test_xccdf_xml_escaping_value.xccdf.xml \
 	oval \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -54,6 +54,7 @@ test_run "inherit selector for xccdf value" $srcdir/test_inherit_selector.sh
 test_run "test xccdf resolve" $srcdir/test_xccdf_resolve.sh
 test_run "Exported arf results from xccdf without reference to oval" $srcdir/test_xccdf_results_arf_no_oval.sh
 test_run "XCCDF Substitute within Title" $srcdir/test_xccdf_sub_title.sh
+test_run "TestResult element should contain test-system attribute" $srcdir/test_xccdf_test_system.sh
 
 test_run "libxml errors handled correctly" $srcdir/test_unfinished.sh
 

--- a/tests/API/XCCDF/unittests/test_xccdf_test_system.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_test_system.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+name=$(basename $0 .sh)
+result=$(mktemp -t ${name}.out.XXXXXX)
+stderr=$(mktemp -t ${name}.err.XXXXXX)
+
+openscap_cpe="cpe:/a:redhat:openscap:"
+
+$OSCAP xccdf eval --results $result $srcdir/${name}.xccdf.xml 2> $stderr
+
+echo "Stderr file = $stderr"
+echo "Result file = $result"
+
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 1 '//TestResult'
+assert_exists 1 '//TestResult[@test-system]'
+assert_exists 1 '//TestResult[starts-with(@test-system,"'$openscap_cpe'")]'
+
+rm $result

--- a/tests/API/XCCDF/unittests/test_xccdf_test_system.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_xccdf_test_system.xccdf.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+  <status>incomplete</status>
+  <version>1.0</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_1" role="unscored">
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="oval/pass/oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
+    </check>
+  </Rule>
+</Benchmark>


### PR DESCRIPTION
The xccdf:TestResult element should contain a test-system
attribute which is defined in specification as follows:
Name of the benchmark consumer program that generated this
<xccdf:TestResult> element; SHOULD be either a CPE name or a
CPE applicability language expression.