### PR TITLE
Deprecate oval_subtype_to_str

### DIFF
--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1359,7 +1359,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_OBJECTREF(oval_ar
 			struct oval_sysitem *sysitem = oval_sysitem_iterator_next(sysitems);
 			struct oval_sysent_iterator *sysent_itr = oval_sysitem_get_sysents(sysitem);
 			const char *oval_sysitem_id = oval_sysitem_get_id(sysitem);
-			const char *oval_sysitem_subtype = oval_subtype_to_str(oval_sysitem_get_subtype(sysitem));
+			const char *oval_sysitem_subtype = oval_subtype_get_text(oval_sysitem_get_subtype(sysitem));
 			bool entity_matched = false;
 			while (oval_sysent_iterator_has_more(sysent_itr)) {
 				oval_datatype_t dt;

--- a/src/OVAL/oval_enumerations.c
+++ b/src/OVAL/oval_enumerations.c
@@ -740,6 +740,13 @@ const char *oval_subtype_get_text(oval_subtype_t subtype)
 	}
 }
 
+bool oval_subtype_is_valid(oval_subtype_t subtype)
+{
+	const char *str = oval_subtype_get_text(subtype);
+	return (str != NULL && strcmp(str, _invalid) != 0);
+}
+
+
 static const struct oscap_string_map OVAL_RESULT_MAP[] = {
 	{OVAL_RESULT_TRUE, "true"},
 	{OVAL_RESULT_FALSE, "false"},

--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -175,14 +175,7 @@ static void __init_once(void)
 
 const char *oval_subtype_to_str(oval_subtype_t subtype)
 {
-        oval_subtypedsc_t *d;
-
-        __init_once();
-
-        d = oscap_bfind(OSCAP_GSYM(__s2n_tbl), __s2n_tbl_count, sizeof(oval_subtypedsc_t), &subtype,
-                        (int(*)(void *, void *))__s2n_tbl_cmp);
-
-        return (d == NULL ? NULL : d->name);
+	return oval_subtype_get_text(subtype);
 }
 
 oval_subtype_t oval_str_to_subtype(const char *str)

--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -390,7 +390,7 @@ static inline int _handle_SEAP_receive_failure(SEAP_CTX_t *ctx, oval_pd_t *pd, S
 		case SEAP_ETYPE_USER:
 		{
 			oscap_seterr(OSCAP_EFAMILY_OVAL, "Probe at sd=%d (%s) reported an error: %s",
-					pd->sd, oval_subtype_to_str(pd->subtype), _probe_strerror(err->code));
+					pd->sd, oval_subtype_get_text(pd->subtype), _probe_strerror(err->code));
 			break;
 		}
 		case SEAP_ETYPE_INT:
@@ -1059,7 +1059,7 @@ int oval_probe_ext_eval(SEAP_CTX_t *ctx, oval_pd_t *pd, oval_pext_t *pext, struc
 	}
 
 	object = oval_syschar_get_object(syschar);
-	ret = oval_object_to_sexp(pext->sess_ptr, oval_subtype_to_str(oval_object_get_subtype(object)), syschar, &s_obj);
+	ret = oval_object_to_sexp(pext->sess_ptr, oval_subtype_get_text(oval_object_get_subtype(object)), syschar, &s_obj);
 
 	if (ret != 0)
 		return (1);

--- a/src/OVAL/oval_probe_impl.h
+++ b/src/OVAL/oval_probe_impl.h
@@ -67,7 +67,7 @@ typedef struct {
 } oval_subtypedsc_t;
 
 void oval_probe_tblinit(void);
-const char *oval_subtype_to_str(oval_subtype_t subtype);
+OSCAP_DEPRECATED(const char *oval_subtype_to_str(oval_subtype_t subtype));
 oval_subtype_t oval_str_to_subtype(const char *str);
 
 int oval_probe_hint_definition(oval_probe_session_t *sess, struct oval_definition *definition, int variable_instance_hint);

--- a/src/OVAL/oval_sexp.c
+++ b/src/OVAL/oval_sexp.c
@@ -671,13 +671,16 @@ int oval_state_to_sexp(void *sess, struct oval_state *state, SEXP_t **out_sexp)
 	size_t buflen;
 	const char *subtype_name;
 	struct oval_state_content_iterator *contents;
+	oval_subtype_t subtype;
 
-        subtype_name = oval_subtype_to_str(oval_state_get_subtype(state));
+	subtype = oval_state_get_subtype(state);
 
-	if (subtype_name == NULL) {
-		dI("FAIL: unknown subtype: %d", oval_state_get_subtype(state));
+	if (!oval_subtype_is_valid(subtype) && subtype != OVAL_SUBTYPE_SYSINFO) {
+		dI("FAIL: unknown subtype: %d", subtype);
 		return (-1);
 	}
+
+	subtype_name = oval_subtype_get_text(subtype);
 
 	buflen = snprintf(buffer, sizeof buffer, "%s_state", subtype_name);
 	_A(buflen < sizeof buffer);

--- a/src/OVAL/probes/probe-api.c
+++ b/src/OVAL/probes/probe-api.c
@@ -1405,12 +1405,12 @@ SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attr
         bool    multiplied;
         int     value_i, multiply;
 
-        subtype_name = oval_subtype_to_str(item_subtype);
-
-        if (subtype_name == NULL) {
+        if (!oval_subtype_is_valid(item_subtype) && item_subtype != OVAL_SUBTYPE_SYSINFO) {
                 dE("Invalid/Unknown subtype: %d", (int)item_subtype);
                 return (NULL);
         }
+
+        subtype_name = oval_subtype_get_text(item_subtype);
 
         if (strlen(subtype_name) + strlen("_item") < sizeof item_name) {
                 strcpy(item_name, subtype_name);

--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -251,6 +251,7 @@ typedef enum {
 oval_family_t oval_subtype_get_family(oval_subtype_t);
 const char *oval_operator_get_text(oval_operator_t);
 const char *oval_subtype_get_text(oval_subtype_t);
+bool oval_subtype_is_valid(oval_subtype_t subtype);
 const char *oval_family_get_text(oval_family_t);
 const char *oval_check_get_text(oval_check_t);
 const char *oval_existence_get_text(oval_existence_t);


### PR DESCRIPTION
Occurrences of oval_subtype_to_str are replaced by oval_subtype_to_text

These functions are two implementations of the same thing.