### PR TITLE
Issue #281: Fix invalid characters in remediation results

### DIFF
--- a/src/XCCDF/result.c
+++ b/src/XCCDF/result.c
@@ -1094,7 +1094,9 @@ xmlNode *xccdf_rule_result_to_dom(struct xccdf_rule_result *result, xmlDoc *doc,
 	while (xccdf_message_iterator_has_more(messages)) {
 		struct xccdf_message *message = xccdf_message_iterator_next(messages);
 		const char *content = xccdf_message_get_content(message);
-		xmlNode *message_node = xmlNewTextChild(result_node, ns_xccdf, BAD_CAST "message", BAD_CAST content);
+		xmlChar *encoded_content = xmlEncodeEntitiesReentrant(doc, BAD_CAST content);
+		xmlNode *message_node = xmlNewTextChild(result_node, ns_xccdf, BAD_CAST "message", encoded_content);
+		xmlFree(encoded_content);
 
                 xccdf_level_t message_severity = xccdf_message_get_severity(message);
 		if (message_severity != XCCDF_LEVEL_NOT_DEFINED)

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -91,6 +91,8 @@ EXTRA_DIST += \
 	test_remediation_cdata.xccdf.xml \
 	test_remediation_fix_without_system.sh \
 	test_remediation_fix_without_system.xccdf.xml \
+	test_remediation_invalid_characters.sh \
+	test_remediation_invalid_characters.xccdf.xml \
 	test_remediation_simple.oval.xml \
 	test_remediation_simple.sh \
 	test_remediation_simple.xccdf.xml \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -74,6 +74,7 @@ test_run "XCCDF Remediation bypass XML Comments" $srcdir/test_remediation_xml_co
 test_run "XCCDF Remediation understands <[CDATA[." $srcdir/test_remediation_cdata.sh
 test_run "XCCDF Remediation Aborts on unresolved element." $srcdir/test_remediation_subs_unresolved.sh
 test_run "XCCDF Remediation requires fix/@system attribute" $srcdir/test_remediation_fix_without_system.sh
+test_run "XCCDF Remediation output should not contain unallowed characters" $srcdir/test_remediation_invalid_characters.sh
 #
 # Tests for 'oscap xccdf remediate'
 #

--- a/tests/API/XCCDF/unittests/test_remediation_invalid_characters.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_invalid_characters.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+name=$(basename $0 .sh)
+result=$(mktemp -t ${name}.out.XXXXXX)
+stderr=$(mktemp -t ${name}.err.XXXXXX)
+
+$OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
+
+echo "Stderr file = $stderr"
+echo "Result file = $result"
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+[ -f $result ]; [ -s $result ]
+
+$OSCAP xccdf validate-xml $result
+rm test_file
+
+rm $result

--- a/tests/API/XCCDF/unittests/test_remediation_invalid_characters.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_remediation_invalid_characters.xccdf.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+  <status>accepted</status>
+  <version>1.0</version>
+  <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_1">
+    <title>Ensure that file exists and it is not executable</title>
+    <fix system="urn:xccdf:fix:script:sh">
+      echo -e "\a \b \r \x1F"
+      touch test_file
+      chmod a-x test_file
+    </fix>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_remediation_simple.oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
+    </check>
+  </Rule>
+</Benchmark>


### PR DESCRIPTION
We include stdout of a remediation script to the XCCDF results.
But the output of the remediation script can contain characters
that are forbidden in XML documents, eg. most of the non-printable
characters. We need to escape or remove them from the string
before we include it to the XML document. Libxml provides a
function to get rid of those characters.