### PR TITLE
Fix systemd test on fedora24

### DIFF
--- a/tests/probes/systemdunitproperty/Makefile.am
+++ b/tests/probes/systemdunitproperty/Makefile.am
@@ -17,4 +17,6 @@ TESTS = all.sh
 EXTRA_DIST = \
 	all.sh \
 	test_probes_systemdunitproperty.sh \
-	test_probes_systemdunitproperty.xml
+	test_probes_systemdunitproperty.xml \
+	test_probes_systemdunitproperty_mount_wants.sh \
+	test_probes_systemdunitproperty_mount_wants.xml

--- a/tests/probes/systemdunitproperty/all.sh
+++ b/tests/probes/systemdunitproperty/all.sh
@@ -4,4 +4,5 @@
 
 test_init "test_probes_systemdunitproperty.log"
 test_run "systemdunitproperty general functionality" $srcdir/test_probes_systemdunitproperty.sh
+test_run "systemdunitproperty mount Wants - only on some systems" $srcdir/test_probes_systemdunitproperty_mount_wants.sh
 test_exit

--- a/tests/probes/systemdunitproperty/test_probes_systemdunitproperty.xml
+++ b/tests/probes/systemdunitproperty/test_probes_systemdunitproperty.xml
@@ -13,9 +13,8 @@
     <definition class="compliance" version="1" id="oval:0:def:1"> <!-- comment="true" -->
       <metadata><title></title><description></description></metadata>
       <notes><note>asdasd</note></notes>
-      <criteria operator="AND">
+      <criteria>
         <criterion test_ref="oval:0:tst:1"/>
-        <criterion test_ref="oval:0:tst:2"/>
       </criteria>
     </definition>
 
@@ -23,49 +22,49 @@
       <metadata><title></title><description></description></metadata>
       <notes><oval:note>asdasd</oval:note></notes>
       <criteria>
-        <criterion test_ref="oval:0:tst:3"/>
+        <criterion test_ref="oval:0:tst:2"/>
       </criteria>
     </definition>
 
     <definition class="compliance" version="1" id="oval:0:def:3"> <!-- comment="true" -->
       <metadata><title></title><description></description></metadata>
       <criteria>
-        <criterion test_ref="oval:0:tst:4"/>
+        <criterion test_ref="oval:0:tst:3"/>
       </criteria>
     </definition>
 
     <definition class="compliance" version="1" id="oval:0:def:4"> <!-- comment="true" -->
       <metadata><title></title><description></description></metadata>
       <criteria>
-        <criterion test_ref="oval:0:tst:5"/>
+        <criterion test_ref="oval:0:tst:4"/>
       </criteria>
     </definition>
 
     <definition class="compliance" version="1" id="oval:0:def:5"> <!-- comment="true" -->
       <metadata><title></title><description></description></metadata>
       <criteria>
-        <criterion test_ref="oval:0:tst:6"/>
+        <criterion test_ref="oval:0:tst:5"/>
       </criteria>
     </definition>
 
     <definition class="compliance" version="1" id="oval:0:def:6"> <!-- comment="false" -->
       <metadata><title></title><description></description></metadata>
       <criteria>
-        <criterion test_ref="oval:0:tst:7"/>
+        <criterion test_ref="oval:0:tst:6"/>
       </criteria>
     </definition>
 
     <definition class="compliance" version="1" id="oval:0:def:7"> <!-- comment="false" -->
       <metadata><title></title><description></description></metadata>
       <criteria>
-        <criterion test_ref="oval:0:tst:8"/>
+        <criterion test_ref="oval:0:tst:7"/>
       </criteria>
     </definition>
 
     <definition class="compliance" version="1" id="oval:0:def:8"> <!-- comment="true" -->
       <metadata><title></title><description></description></metadata>
       <criteria>
-        <criterion test_ref="oval:0:tst:9"/>
+        <criterion test_ref="oval:0:tst:8"/>
       </criteria>
     </definition>
 
@@ -76,49 +75,46 @@
     <systemdunitproperty_test check_existence="only_one_exists" version="1" id="oval:0:tst:1" check="all" comment="true" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
       <object object_ref="oval:0:obj:1"/>
     </systemdunitproperty_test>
-    <systemdunitproperty_test check_existence="at_least_one_exists" version="1" id="oval:0:tst:2" check="all" comment="true" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-      <object object_ref="oval:0:obj:2"/>
-    </systemdunitproperty_test>
 
     <!-- test if there's at least one service unit having LoadState equal to 'loaded' or 'not-found' -->
+    <systemdunitproperty_test id="oval:0:tst:2" check="at least one" check_existence="all_exist" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="true" version="1">
+      <object object_ref="oval:0:obj:2"/>
+      <state state_ref="oval:0:ste:1"/>
+    </systemdunitproperty_test>
+
+    <!-- test if there's at least one service unit having LoadState equal to 'loaded' excluding those with LoadState 'not-found' -->
     <systemdunitproperty_test id="oval:0:tst:3" check="at least one" check_existence="all_exist" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="true" version="1">
       <object object_ref="oval:0:obj:3"/>
       <state state_ref="oval:0:ste:1"/>
     </systemdunitproperty_test>
 
-    <!-- test if there's at least one service unit having LoadState equal to 'loaded' excluding those with LoadState 'not-found' -->
+    <!-- test if there's at least one service conflicting the shutdown.target -->
     <systemdunitproperty_test id="oval:0:tst:4" check="at least one" check_existence="all_exist" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="true" version="1">
       <object object_ref="oval:0:obj:4"/>
-      <state state_ref="oval:0:ste:1"/>
-    </systemdunitproperty_test>
-
-    <!-- test if there's at least one service conflicting the shutdown.target -->
-    <systemdunitproperty_test id="oval:0:tst:5" check="at least one" check_existence="all_exist" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="true" version="1">
-      <object object_ref="oval:0:obj:5"/>
       <state state_ref="oval:0:ste:3"/>
     </systemdunitproperty_test>
 
     <!-- check that there doesn't exist systemd-journald.service unit with valid Conflicts property -->
-    <systemdunitproperty_test id="oval:0:tst:6" check="all" check_existence="none_exist" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="true" version="1">
-      <object object_ref="oval:0:obj:6"/>
+    <systemdunitproperty_test id="oval:0:tst:5" check="all" check_existence="none_exist" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="true" version="1">
+      <object object_ref="oval:0:obj:5"/>
     </systemdunitproperty_test>
 
     <!-- check if there is at least one systemd-journald.service unit it has value of Conflicts property equal to empty string -->
-    <systemdunitproperty_test id="oval:0:tst:7" check="all" check_existence="at_least_one_exists" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="false" version="1">
-      <object object_ref="oval:0:obj:6"/>
+    <systemdunitproperty_test id="oval:0:tst:6" check="all" check_existence="at_least_one_exists" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="false" version="1">
+      <object object_ref="oval:0:obj:5"/>
       <state state_ref="oval:0:ste:4"/>
     </systemdunitproperty_test>
 
     <!-- check if abcdefghijklmnopqrstuvwxyz.target unit has value of UnitFileState property (case-insensitively) equal to 'enabled' -->
     <!-- made up unit name, should fail -->
-    <systemdunitproperty_test id="oval:0:tst:8" check="all" check_existence="at_least_one_exists" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="false" version="1">
-      <object object_ref="oval:0:obj:7"/>
+    <systemdunitproperty_test id="oval:0:tst:7" check="all" check_existence="at_least_one_exists" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" comment="false" version="1">
+      <object object_ref="oval:0:obj:6"/>
       <state state_ref="oval:0:ste:5"/>
     </systemdunitproperty_test>
 
     <!-- check if sockets.target unit has two or more values of Wants property -->
-    <variable_test id="oval:0:tst:9" check="all" check_existence="at_least_one_exists" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="true" version="1">
-      <object object_ref="oval:0:obj:8"/>
+    <variable_test id="oval:0:tst:8" check="all" check_existence="at_least_one_exists" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="true" version="1">
+      <object object_ref="oval:0:obj:7"/>
       <state state_ref="oval:0:ste:6"/>
     </variable_test>
 
@@ -131,42 +127,37 @@
       <property>LoadState</property>
     </systemdunitproperty_object>
 
-    <systemdunitproperty_object version="1" id="oval:0:obj:2" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-      <unit>-.mount</unit>
-      <property>Wants</property>
+    <systemdunitproperty_object id="oval:0:obj:2" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+      <unit operation="pattern match">.*\.service</unit>
+      <property>LoadState</property>
     </systemdunitproperty_object>
 
     <systemdunitproperty_object id="oval:0:obj:3" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
       <unit operation="pattern match">.*\.service</unit>
       <property>LoadState</property>
+      <filter action="exclude" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:0:ste:2</filter>
     </systemdunitproperty_object>
 
     <systemdunitproperty_object id="oval:0:obj:4" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
       <unit operation="pattern match">.*\.service</unit>
-      <property>LoadState</property>
-      <filter action="exclude" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:0:ste:2</filter>
-    </systemdunitproperty_object>
-
-    <systemdunitproperty_object id="oval:0:obj:5" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-      <unit operation="pattern match">.*\.service</unit>
       <property>Conflicts</property>
     </systemdunitproperty_object>
 
-    <systemdunitproperty_object id="oval:0:obj:6" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+    <systemdunitproperty_object id="oval:0:obj:5" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
       <unit>systemd-journald.service</unit>
       <property>Conflicts</property>
     </systemdunitproperty_object>
 
-    <systemdunitproperty_object id="oval:0:obj:7" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+    <systemdunitproperty_object id="oval:0:obj:6" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
       <unit>abcdefghijklmnopqrstuvwxyz.target</unit>
       <property>UnitFileState</property>
     </systemdunitproperty_object>
 
-    <variable_object id="oval:0:obj:8" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+    <variable_object id="oval:0:obj:7" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
       <var_ref>oval:0:var:1</var_ref>
     </variable_object>
 
-    <systemdunitproperty_object id="oval:0:obj:9" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+    <systemdunitproperty_object id="oval:0:obj:8" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
       <unit>sockets.target</unit>
       <property>Wants</property>
     </systemdunitproperty_object>
@@ -205,7 +196,7 @@
 
     <local_variable id="oval:0:var:1" datatype="int" comment="count of items in the value of Wants property of the sockets.target unit" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
       <count>
-        <object_component object_ref="oval:0:obj:9" item_field="value"/>
+        <object_component object_ref="oval:0:obj:8" item_field="value"/>
       </count>
     </local_variable>
 

--- a/tests/probes/systemdunitproperty/test_probes_systemdunitproperty_mount_wants.sh
+++ b/tests/probes/systemdunitproperty/test_probes_systemdunitproperty_mount_wants.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2014--2016 Red Hat Inc., Durham, North Carolina.
+# All Rights Reserved.
+#
+# OpenScap Probes Test Suite.
+
+set -e -o pipefail
+
+. ../../test_common.sh
+
+function test_probes_systemdunitproperty_mount_wants {
+    probecheck "systemdunitproperty" || return 255
+    pidof systemd > /dev/null || return 255
+    systemctl show -- -.mount | grep -Eq "Wants=\S+" || return 255
+
+    local DF="${srcdir}/test_probes_systemdunitproperty_mount_wants.xml"
+    local RF="results.xml"
+
+    [ -f $RF ] && rm -f $RF
+
+    $OSCAP oval eval --results $RF $DF
+
+    [ -f $RF ]
+    verify_results "def" $DF $RF 1
+    verify_results "tst" $DF $RF 1
+    rm $RF
+}
+
+test_probes_systemdunitproperty_mount_wants

--- a/tests/probes/systemdunitproperty/test_probes_systemdunitproperty_mount_wants.xml
+++ b/tests/probes/systemdunitproperty/test_probes_systemdunitproperty_mount_wants.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<oval_definitions xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
+
+  <generator>
+    <oval:product_name>systemdunitproperty</oval:product_name>
+    <oval:product_version>1.0</oval:product_version>
+    <oval:schema_version>5.11</oval:schema_version>
+    <oval:timestamp>2014-06-18T00:00:00-00:00</oval:timestamp>
+  </generator>
+
+  <definitions>
+
+    <definition class="compliance" version="1" id="oval:0:def:1"> <!-- comment="true" -->
+      <metadata><title></title><description></description></metadata>
+      <notes><note>asdasd</note></notes>
+      <criteria>
+        <criterion test_ref="oval:0:tst:1"/>
+      </criteria>
+    </definition>
+  </definitions>
+  <tests>
+    <systemdunitproperty_test check_existence="at_least_one_exists" version="1" id="oval:0:tst:1" check="all" comment="true" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+      <object object_ref="oval:0:obj:1"/>
+    </systemdunitproperty_test>
+  </tests>
+
+  <objects>
+
+    <systemdunitproperty_object version="1" id="oval:0:obj:1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+      <unit>-.mount</unit>
+      <property>Wants</property>
+    </systemdunitproperty_object>
+
+  </objects>
+
+</oval_definitions>


### PR DESCRIPTION
"-.mount Wants" isn't presented on Fedora24, so part of test
was separated and now it should be tested only on "supported systems"

mostly copy & paste