### PR TITLE
test/file: Add test to strange filenames (missing fix)

### DIFF
--- a/tests/probes/file/Makefile.am
+++ b/tests/probes/file/Makefile.am
@@ -10,4 +10,7 @@ TESTS_ENVIRONMENT= \
 
 TESTS = test_probes_file.sh
 
-EXTRA_DIST += test_probes_file.sh test_probes_file.xml
+EXTRA_DIST += test_probes_file.sh \
+	test_probes_file.xml \
+	test_probes_file_filename.xml
+

--- a/tests/probes/file/test_probes_file.sh
+++ b/tests/probes/file/test_probes_file.sh
@@ -31,11 +31,87 @@ function test_probes_file {
     if [ -f $RF ]; then
 	verify_results "def" $DF $RF 13 && verify_results "tst" $DF $RF 204
 	ret_val=$?
-    else 
+    else
 	ret_val=1
     fi
 
     return $ret_val
+}
+
+function test_probes_file_filenames {
+
+	probecheck "file" || return 255
+
+	local ret_val=0
+	local DF="$srcdir/test_probes_file_filename.xml"
+	result="results.xml"
+	files_dir=$(mktemp -d)
+	DF_INJECTED=$(mktemp)
+
+	echo "Files dir:	${files_dir}"
+	echo "Content file:	${DF_INJECTED}"
+
+	# create ascii files - should be processed correctly
+	pushd "$files_dir" && {
+		for i in {1..127};
+		do
+			[ $i == 47 ] && continue ; # '/' cannot be in filename
+			hex=\\x$(printf "%x" "$i")
+			touch "$(printf filename_ok_${i}_$hex$hex$hex)"
+		done
+		popd
+	}
+
+	# inject real path to content
+	sed "s;<!--injected-path -->;${files_dir};" "$DF" > $DF_INJECTED
+
+	$OSCAP oval eval --results $result $DF_INJECTED || ret_val=1
+	$OSCAP oval validate $result || ret_val=1
+
+	# some of files maybe weren't successfully created
+	# (possibly not supported filenames by filesystem)
+	# get real count of them
+	filesCount=$(find "$files_dir" -type f | wc -l)
+
+	assert_exists 1 '//results//criterion' || ret_val=1
+	assert_exists 1 '//results//criterion[@result="true"]' || ret_val=1
+	assert_exists "$filesCount" '//unix-sys:file_item' || ret_val=1
+
+	rm $DF_INJECTED
+	rm -rf "$files_dir"
+
+	return $ret_val
+}
+
+function test_probes_file_invalid_utf8 {
+
+	probecheck "file" || return 255
+
+	local ret_val=0
+	local DF="$srcdir/test_probes_file_filename.xml"
+	result="results.xml"
+	files_dir=$(mktemp -d)
+	DF_INJECTED=$(mktemp)
+
+	echo "Files dir:	${files_dir}"
+	echo "Content file:	${DF_INJECTED}"
+
+	# known invalid utf-8 sequence
+	touch $(printf "${files_dir}/filename_\xf0\x28\x8c\xbc") || ret_val=1
+
+	# inject real path to content
+	sed "s;<!--injected-path -->;${files_dir};" "$DF" > $DF_INJECTED
+
+	$OSCAP oval eval --results $result $DF_INJECTED || ret_val=1
+	$OSCAP oval validate $result || ret_val=1
+
+	assert_exists 1 '//results//criterion' || ret_val=1
+	assert_exists 1 '//results//criterion[@result="error"]' || ret_val=1
+
+	rm $DF_INJECTED
+	rm -rf "$files_dir"
+
+	return $ret_val
 }
 
 # Testing.
@@ -43,5 +119,7 @@ function test_probes_file {
 test_init "test_probes_file.log"
 
 test_run "test_probes_file" test_probes_file
+test_run "test_probes_file_filenames" test_probes_file_filenames
+test_run "test_probes_file_invalid_utf8" test_probes_file_invalid_utf8
 
 test_exit

--- a/tests/probes/file/test_probes_file_filename.xml
+++ b/tests/probes/file/test_probes_file_filename.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<oval_definitions xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
+
+	<generator>
+		<oval:product_name>file</oval:product_name>
+		<oval:product_version>1.0</oval:product_version>
+		<oval:schema_version>5.10.1</oval:schema_version>
+		<oval:timestamp>2008-03-31T00:00:00-00:00</oval:timestamp>
+	</generator>
+
+	<definitions>
+		<definition class="compliance" version="1" id="oval:1:def:1">
+			<metadata>
+				<title></title>
+				<description></description>
+			</metadata>
+			<criteria>
+				<criteria>
+					<criterion test_ref="oval:1:tst:1"/>
+				</criteria>
+			</criteria>
+		</definition>
+	</definitions>
+
+	<tests>
+		<file_test version="1" id="oval:1:tst:1" check="all" comment="true" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+			<object object_ref="oval:1:obj:1"/>
+			<state state_ref="oval:1:ste:1"/>
+		</file_test>
+	</tests>
+
+	<objects>
+		<file_object version="1" id="oval:1:obj:1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+			<path><!--injected-path --></path>
+			<filename operation="pattern match">filename_.*</filename>
+		</file_object>
+	</objects>
+
+	<states>
+		<unix-def:file_state version="1" id="oval:1:ste:1">
+			<unix-def:size datatype="int">0</unix-def:size>
+		</unix-def:file_state>
+	</states>
+
+</oval_definitions>


### PR DESCRIPTION
Only test - without fix - should fail currently.

It should be test for https://github.com/OpenSCAP/openscap/issues/467, but it doesn't crash.

But I have found another problem; we don't escape correctly filenames in xml result

```
Entity: line 3457: parser error : PCDATA invalid Char value 27
            <unix-sys:filepath>/tmp/tmp.5mogjwJMK2/filename_</unix-sys:filepa
                                                             ^
```