### PR TITLE
oval_sysEnt.c: fix invalid characters in oval results

### DIFF
--- a/src/OVAL/oval_sysEnt.c
+++ b/src/OVAL/oval_sysEnt.c
@@ -287,7 +287,9 @@ void oval_sysent_to_dom(struct oval_sysent *sysent, xmlDoc * doc, xmlNode * pare
 	if (mask && !xmlStrcmp(root_node->name, BAD_CAST OVAL_ROOT_ELM_RESULTS)) {
 		sysent_tag = xmlNewTextChild(parent, ent_ns, BAD_CAST tagname, BAD_CAST "");
 	} else {
-		sysent_tag = xmlNewTextChild(parent, ent_ns, BAD_CAST tagname, BAD_CAST content);
+		xmlChar *encoded_content = xmlEncodeEntitiesReentrant(doc, BAD_CAST content);
+		sysent_tag = xmlNewTextChild(parent, ent_ns, BAD_CAST tagname, encoded_content);
+		xmlFree(encoded_content);
 	}
 
 	if (mask) {


### PR DESCRIPTION
https://github.com/OpenSCAP/openscap/issues/469