### PR TITLE
Fix usage of probe_session after free

### DIFF
--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -226,8 +226,10 @@ int oval_agent_reset_session(oval_agent_session_t * ag_sess) {
         	oval_generator_set_product_name(generator, ag_sess->product_name);
 	}
 
-	oval_probe_session_destroy(ag_sess->psess);
-	ag_sess->psess = oval_probe_session_new(ag_sess->sys_model);
+	/* We have to reset probe_session inplace, because
+	 * ag_sess->res_model points to old probe_session
+	 * and we are not able to update the reference clearly */
+	oval_probe_session_reinit(ag_sess->psess, ag_sess->sys_model);
 
 	return 0;
 }

--- a/src/OVAL/oval_probe_session.c
+++ b/src/OVAL/oval_probe_session.c
@@ -118,13 +118,11 @@ static void __init_once(void)
         return;
 }
 
-oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model)
+static void oval_probe_session_init(oval_probe_session_t *sess, struct oval_syschar_model *model)
 {
-        oval_probe_session_t *sess;
         void *handler_arg;
         register size_t i;
 
-        sess = oscap_talloc(oval_probe_session_t);
         sess->ph = oval_phtbl_new();
         sess->sys_model = model;
         sess->flg = 0;
@@ -148,19 +146,37 @@ oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model)
         }
 
         oval_probe_handler_set(sess->ph, OVAL_SUBTYPE_ALL, oval_probe_ext_handler, sess->pext); /* special case for reset */
-        return(sess);
 }
 
-void oval_probe_session_destroy(oval_probe_session_t *sess)
+oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model)
+{
+        oval_probe_session_t *sess = oscap_talloc(oval_probe_session_t);
+        oval_probe_session_init(sess, model);
+        return sess;
+}
+
+void oval_probe_session_free(oval_probe_session_t *sess)
 {
 	if (sess == NULL) {
 		dE("Invalid session (NULL)");
 		return;
 	}
 
-        oval_phtbl_free(sess->ph);
-        oval_pext_free(sess->pext);
-        oscap_free(sess);
+	oval_phtbl_free(sess->ph);
+	oval_pext_free(sess->pext);
+}
+
+void oval_probe_session_reinit(oval_probe_session_t *sess, struct oval_syschar_model *model)
+{
+	oval_probe_session_free(sess);
+
+	oval_probe_session_init(sess, model);
+}
+
+void oval_probe_session_destroy(oval_probe_session_t *sess)
+{
+	oval_probe_session_free(sess);
+	oscap_free(sess);
 }
 
 int oval_probe_session_close(oval_probe_session_t *sess)

--- a/src/OVAL/public/oval_probe_session.h
+++ b/src/OVAL/public/oval_probe_session.h
@@ -42,6 +42,12 @@ typedef struct oval_probe_session oval_probe_session_t;
 oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model);
 
 /**
+ * Reinitialize already allocated probe session inplace
+ * @param model system characteristics model
+ */
+void oval_probe_session_reinit(oval_probe_session_t *sess, struct oval_syschar_model *model);
+
+/**
  * Destroy probe session. All state information created during the lifetime
  * of the session is freed, resources used by probes are freed using the probe
  * handler API.


### PR DESCRIPTION
https://github.com/OpenSCAP/openscap/issues/478

probe_session were referenced from two places. 
- oval_agent_session
- oval_agent_session->res_model (https://github.com/OpenSCAP/openscap/blob/maint-1.2/src/OVAL/results/oval_resultTest.c#L933)

When we create new session in oval_agent_reset_session, res_model will still use old pointer to free'ed memory.

`oval_probe_session_reinit` could be in OSCAP_HIDDEN in maint-1.2oval_probe_session_reinit

---
Another solution is add setter to res_model to set probe_session, but IMHO, my solution is ~~clean~~ cleaner.

