### PR TITLE
Fix double escape + test fix

### DIFF
--- a/src/OVAL/oval_sysEnt.c
+++ b/src/OVAL/oval_sysEnt.c
@@ -288,7 +288,7 @@ void oval_sysent_to_dom(struct oval_sysent *sysent, xmlDoc * doc, xmlNode * pare
 		sysent_tag = xmlNewTextChild(parent, ent_ns, BAD_CAST tagname, BAD_CAST "");
 	} else {
 		xmlChar *encoded_content = xmlEncodeEntitiesReentrant(doc, BAD_CAST content);
-		sysent_tag = xmlNewTextChild(parent, ent_ns, BAD_CAST tagname, encoded_content);
+		sysent_tag = xmlNewChild(parent, ent_ns, BAD_CAST tagname, encoded_content);
 		xmlFree(encoded_content);
 	}
 

--- a/src/XCCDF/result.c
+++ b/src/XCCDF/result.c
@@ -1095,7 +1095,7 @@ xmlNode *xccdf_rule_result_to_dom(struct xccdf_rule_result *result, xmlDoc *doc,
 		struct xccdf_message *message = xccdf_message_iterator_next(messages);
 		const char *content = xccdf_message_get_content(message);
 		xmlChar *encoded_content = xmlEncodeEntitiesReentrant(doc, BAD_CAST content);
-		xmlNode *message_node = xmlNewTextChild(result_node, ns_xccdf, BAD_CAST "message", encoded_content);
+		xmlNode *message_node = xmlNewChild(result_node, ns_xccdf, BAD_CAST "message", encoded_content);
 		xmlFree(encoded_content);
 
                 xccdf_level_t message_severity = xccdf_message_get_severity(message);

--- a/tests/API/XCCDF/unittests/test_remediation_invalid_characters.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_invalid_characters.sh
@@ -14,6 +14,9 @@ echo "Result file = $result"
 [ -f $result ]; [ -s $result ]
 
 $OSCAP xccdf validate-xml $result
+
+assert_exists 1 "//message[contains(text(),'<tag>')]"
+
 rm test_file
 
 rm $result

--- a/tests/API/XCCDF/unittests/test_remediation_invalid_characters.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_invalid_characters.sh
@@ -6,6 +6,8 @@ name=$(basename $0 .sh)
 result=$(mktemp -t ${name}.out.XXXXXX)
 stderr=$(mktemp -t ${name}.err.XXXXXX)
 
+rm -f test_file # ensure not existence of test_file
+
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 
 echo "Stderr file = $stderr"

--- a/tests/API/XCCDF/unittests/test_remediation_invalid_characters.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_remediation_invalid_characters.xccdf.xml
@@ -6,6 +6,7 @@
     <title>Ensure that file exists and it is not executable</title>
     <fix system="urn:xccdf:fix:script:sh">
       echo -e "\a \b \r \x1F"
+      echo "&lt;tag&gt;"
       touch test_file
       chmod a-x test_file
     </fix>


### PR DESCRIPTION
We have recently merged some changes to fix not escaped invalid characters.

But our solution was causing, that characters like <,>,.. were escaped twice