### PR TITLE
Add a missing build dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ make
 ```
 Build dependencies:
 (some of these can be turned off via configure)
+ * dbus-devel
  * GConf2-devel
  * libacl-devel
  * libblkid-devel


### PR DESCRIPTION
The header file dbus.h provided by the dbus-devel package is required
to build systemd probes, we should list the package in our build
dependencies list.