### PR TITLE
probes/oval_fts: Return error if regex issue occurs

### DIFF
--- a/src/OVAL/probes/independent/filehash.c
+++ b/src/OVAL/probes/independent/filehash.c
@@ -262,7 +262,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
 		return (PROBE_EFATAL);
         }
 
-	if ((ofts = oval_fts_open(path, filename, filepath, behaviors)) != NULL) {
+	if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			filehash_cb(ofts_ent->path, ofts_ent->file, ctx, over);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/independent/filehash58.c
+++ b/src/OVAL/probes/independent/filehash58.c
@@ -281,7 +281,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
 		goto cleanup;
 	}
 
-	if ((ofts = oval_fts_open(path, filename, filepath, behaviors)) != NULL) {
+	if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			/* find hash types to compare with entity, think "not satisfy" */
 			const struct oscap_string_map *p = CRAPI_ALG_MAP;

--- a/src/OVAL/probes/independent/filemd5.c
+++ b/src/OVAL/probes/independent/filemd5.c
@@ -240,7 +240,7 @@ int probe_main (SEXP_t *probe_in, SEXP_t *probe_out, void *mutex, SEXP_t *filter
 		return (PROBE_EFATAL);
         }
 
-	if ((ofts = oval_fts_open(path, filename, filepath, behaviors)) != NULL) {
+	if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			filehash_cb(ofts_ent->path, ofts_ent->file, probe_out, filters);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/independent/textfilecontent.c
+++ b/src/OVAL/probes/independent/textfilecontent.c
@@ -383,7 +383,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 	pfd.filename_ent = filename_ent;
 	pfd.ctx = ctx;
 
-	if ((ofts = oval_fts_open(path_ent, filename_ent, filepath_ent, behaviors_ent)) != NULL) {
+	if ((ofts = oval_fts_open(path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			if (ofts_ent->fts_info == FTS_F
 			    || ofts_ent->fts_info == FTS_SL) {

--- a/src/OVAL/probes/independent/textfilecontent54.c
+++ b/src/OVAL/probes/independent/textfilecontent54.c
@@ -479,7 +479,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 		goto cleanup;
 	}
 #endif
-	if ((ofts = oval_fts_open(path_ent, file_ent, filepath_ent, bh_ent)) != NULL) {
+	if ((ofts = oval_fts_open(path_ent, file_ent, filepath_ent, bh_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			if (ofts_ent->fts_info == FTS_F
 			    || ofts_ent->fts_info == FTS_SL) {

--- a/src/OVAL/probes/independent/xmlfilecontent.c
+++ b/src/OVAL/probes/independent/xmlfilecontent.c
@@ -316,7 +316,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 	pfd.filename_ent = filename_ent;
         pfd.ctx = ctx;
 
-	if ((ofts = oval_fts_open(path_ent, filename_ent, filepath_ent, behaviors_ent)) != NULL) {
+	if ((ofts = oval_fts_open(path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			process_file(ofts_ent->path, ofts_ent->file, &pfd);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -492,7 +492,7 @@ static int process_pattern_match(const char *path, pcre **regex_out)
 #undef TEST_PATH1
 #undef TEST_PATH2
 
-OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors)
+OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result)
 {
 	OVAL_FTS *ofts;
 
@@ -724,6 +724,8 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 		ofts->ofts_sfilepath = SEXP_ref(filepath);
 	}
 
+	ofts->result = result;
+
 	return (ofts);
 }
 
@@ -925,8 +927,20 @@ static FTSENT *oval_fts_read_recurse_path(OVAL_FTS *ofts)
 					SEXP_t *stmp;
 
 					stmp = SEXP_string_newf("%s", fts_ent->fts_name);
-					if (probe_entobj_cmp(ofts->ofts_sfilename, stmp) == OVAL_RESULT_TRUE)
-						out_fts_ent = fts_ent;
+					oval_result_t result = probe_entobj_cmp(ofts->ofts_sfilename, stmp);
+					switch (result){
+						case OVAL_RESULT_TRUE:
+							out_fts_ent = fts_ent;
+							break;
+
+						case OVAL_RESULT_ERROR:
+							probe_cobj_set_flag(ofts->result, SYSCHAR_FLAG_ERROR);
+							break;
+
+						default:
+							break;
+					}
+
 					SEXP_free(stmp);
 				}
 			}

--- a/src/OVAL/probes/oval_fts.h
+++ b/src/OVAL/probes/oval_fts.h
@@ -83,6 +83,7 @@ typedef struct {
 	SEXP_t *ofts_spath;
 	SEXP_t *ofts_sfilename;
 	SEXP_t *ofts_sfilepath;
+	SEXP_t *result;
 
 	int max_depth;
 	int direction;
@@ -118,7 +119,7 @@ typedef struct {
 /*
  * OVAL FTS public API
  */
-OVAL_FTS    *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors);
+OVAL_FTS    *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result);
 OVAL_FTSENT *oval_fts_read(OVAL_FTS *ofts);
 int          oval_fts_close(OVAL_FTS *ofts);
 

--- a/src/OVAL/probes/unix/file.c
+++ b/src/OVAL/probes/unix/file.c
@@ -469,7 +469,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
         cbargs.ctx     = ctx;
 	cbargs.error   = 0;
 
-	if ((ofts = oval_fts_open(path, filename, filepath, behaviors)) != NULL) {
+	if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			if (file_cb(ofts_ent->path, ofts_ent->file, &cbargs) != 0) {
 				oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/unix/fileextendedattribute.c
+++ b/src/OVAL/probes/unix/fileextendedattribute.c
@@ -299,7 +299,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
 	cbargs.error    = 0;
         cbargs.attr_ent = attribute_;
 
-	if ((ofts = oval_fts_open(path, filename, filepath, behaviors)) != NULL) {
+	if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			file_cb(ofts_ent->path, ofts_ent->file, &cbargs);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/unix/gconf.c
+++ b/src/OVAL/probes/unix/gconf.c
@@ -201,7 +201,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 
 		probe_filebehaviors_canonicalize(&behaviors);
 
-                if ((ofts = oval_fts_open(NULL, NULL, gconf_src, behaviors)) != NULL) {
+                if ((ofts = oval_fts_open(NULL, NULL, gconf_src, behaviors, probe_ctx_getresult(ctx))) != NULL) {
                         while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
                                 assume_r(ofts_ent->path_len
                                          + ofts_ent->file_len + 2 <= PATH_MAX, PROBE_EFATAL);

--- a/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
+++ b/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
@@ -310,7 +310,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 	if (filepath || (path && filename)) {
 		probe_filebehaviors_canonicalize(&behaviors);
 
-		if ((ofts = oval_fts_open(path, filename, filepath, behaviors)) != NULL) {
+		if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 			while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 				selinuxsecuritycontext_file_cb(ofts_ent->path, ofts_ent->file, ctx);
 				oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/unix/sysctl.c
+++ b/src/OVAL/probes/unix/sysctl.c
@@ -99,10 +99,10 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
          * collect sysctls
          *  XXX: use direct access for the "equals" op
          */
-        ofts = oval_fts_open(path_entity, filename_entity, NULL, bh_entity);
+        ofts = oval_fts_open(path_entity, filename_entity, NULL, bh_entity, probe_ctx_getresult(ctx));
 
         if (ofts == NULL) {
-                dE("oval_ftp_open(%s, %s) failed", PROC_SYS_DIR, ".\\+");
+                dE("oval_fts_open(%s, %s) failed", PROC_SYS_DIR, ".\\+");
                 SEXP_vfree(path_entity, filename_entity, bh_entity, name_entity, NULL);
 
                 return (PROBE_EFATAL);

--- a/tests/API/probes/oval_fts_list.c
+++ b/tests/API/probes/oval_fts_list.c
@@ -7,13 +7,14 @@
 #include <string.h>
 #include "sexp.h"
 #include "oval_fts.h"
+#include "probe-api.h"
 
 int main(int argc, char *argv[])
 {
 	OVAL_FTS    *ofts;
 	OVAL_FTSENT *ofts_ent;
 
-	SEXP_t *path, *filename, *behaviors, *filepath;
+	SEXP_t *path, *filename, *behaviors, *filepath, *result;
 
 	SEXP_psetup_t *psetup = NULL;
 	SEXP_pstate_t *pstate = NULL;
@@ -24,6 +25,7 @@ int main(int argc, char *argv[])
 	filename  = SEXP_list_first(SEXP_parse(psetup, argv[2], strlen(argv[2]), &pstate));
 	filepath  = SEXP_list_first(SEXP_parse(psetup, argv[3], strlen(argv[3]), &pstate));
 	behaviors = SEXP_list_first(SEXP_parse(psetup, argv[4], strlen(argv[4]), &pstate));
+	result    = probe_cobj_new(SYSCHAR_FLAG_UNKNOWN, NULL, NULL, NULL);
 
 	fprintf(stderr,
 		"path=%p\n"
@@ -31,7 +33,7 @@ int main(int argc, char *argv[])
 		"filepath=%p\n"
 		"behaviors=%p\n", path, filename, filepath, behaviors);
 
-	ofts = oval_fts_open(path, filename, filepath, behaviors);
+	ofts = oval_fts_open(path, filename, filepath, behaviors, result);
 
 	if (ofts != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {


### PR DESCRIPTION
When we cannot match filename by regex (due to non-utf8-characters) we used to ignore it, but now we will set result to error.

Maybe we could return `message` to oval result, but I haven't found any current probe what does it. So I don't know if it is a good idea. What do you think?

---
Error: `For example, if there was an error returned by an api when trying to determine if an object exists on a system.` https://oval.mitre.org/language/version5.6/ovalresults/documentation/oval-results-schema.html