### PR TITLE
Adjust the valgrind test to detect all kinds of memory errors

### DIFF
--- a/tests/valgrind_test.sh
+++ b/tests/valgrind_test.sh
@@ -9,8 +9,9 @@
 oscap_program=$actualdir/utils/.libs/oscap
 valgrind_output=/tmp/valgrind_$$.log
 logfile=$actualdir/tests/valgrind_test.log
+error_code=66
 suppfile=$actualdir/tests/suppressions.supp
-valgrind_args="--trace-children=yes --free-fill=55 --malloc-fill=55 --leak-check=full --show-reachable=yes --show-leak-kinds=all --log-file=$valgrind_output --suppressions=$suppfile"
+valgrind_args="--trace-children=yes --free-fill=55 --malloc-fill=55 --leak-check=full --show-reachable=yes --show-leak-kinds=all --log-file=$valgrind_output.%p --suppressions=$suppfile --error-exitcode=$error_code"
 
 
 echo "VALGRIND TEST" >> $logfile
@@ -21,28 +22,15 @@ echo "command: oscap $@" >> $logfile
 valgrind $valgrind_args $oscap_program "$@" 
 ret_val=$?
 
-# analyse the valgrind log
-if cat $valgrind_output | grep "All heap blocks were freed -- no leaks are possible" >/dev/null ;then
-  echo "OK" >> $logfile
+if [ $ret_val -eq $error_code ] ; then
+    echo "Memory error detected!" >> $logfile
+    cat $valgrind_output* >> $logfile
+    result=1 # fail the test
 else
-  cat $valgrind_output | grep "definitely lost: 0 bytes in 0 blocks" >/dev/null
-  definitely_lost=$?
-  cat $valgrind_output | grep "indirectly lost: 0 bytes in 0 blocks" >/dev/null
-  indirectly_lost=$?
-  cat $valgrind_output | grep "possibly lost: 0 bytes in 0 blocks" >/dev/null
-  possibly_lost=$?
-  cat $valgrind_output | grep "still reachable: 0 bytes in 0 blocks" >/dev/null
-  still_reachable=$?
-  # all errors weren't suppressed
-  if ! [ $definitely_lost -eq 0 -a $indirectly_lost -eq 0 -a $possibly_lost -eq 0 -a $still_reachable -eq 0 ]; then
-    echo "Memory leak detected!" >> $logfile
-    cat $valgrind_output | sed 's/==.*== //' | sed '/^$/d' >> $logfile
-    ret_val=1 # fail the test
-  else
     echo "OK" >> $logfile
-  fi
+    result=0 # pass the test
 fi
 
 echo "" >> $logfile
-rm $valgrind_output
-exit $ret_val
+rm $valgrind_output*
+exit $result


### PR DESCRIPTION
This commit enables us to detect also other memory errors,
not only the memory leaks, but also invalid reads etc.
We will use --error-code to detect that valgrind failed.
This option is designed for usage in automated test suites (see man).
Parsing the log is not necessary to detect the fail.
Also valgrind has to generate a special logfile for each child process
to avoid undefined results (see man).