### PR TITLE
[v2] Initial Wind River Linux support

### DIFF
--- a/cpe/openscap-cpe-dict.xml
+++ b/cpe/openscap-cpe-dict.xml
@@ -142,4 +142,12 @@
                  We assume that the productivity is equal to RHEL5. We are unable to write a better OVAL check. -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.rhel:def:5</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:windriver:wrlinux">
+            <title xml:lang="en-us">Wind River Linux all versions</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.wrlinux:def:1</check>
+      </cpe-item>
+      <cpe-item name="cpe:/o:windriver:wrlinux:8">
+            <title xml:lang="en-us">WR Linux 8</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.wrlinux:def:8</check>
+      </cpe-item>
 </cpe-list>

--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -442,6 +442,21 @@
                         <criterion comment="openSUSE 42.1 is installed" test_ref="oval:org.open-scap.cpe.opensuse:tst:421"/>
                   </criteria>
             </definition>
+            <definition class="inventory" id="oval:org.open-scap.cpe.wrlinux:def:8" version="1" >
+                  <metadata>
+                        <title>WR Linux 8</title>
+                        <affected family="unix">
+                            <platform>WR Linux 8</platform>
+                        </affected>
+                        <reference ref_id="cpe:/o:windriver:wrlinux:8" source="CPE"/>
+                        <description>The operating system installed on the system is WR Linux 8</description>
+                  </metadata>
+                  <criteria>
+                        <criterion comment="Installed operating system is part of the unix family." test_ref="oval:org.open-scap.cpe.wrlinux:tst:1" />
+                        <criterion comment="WR Linux is installed." test_ref="oval:org.open-scap.cpe.wrlinux:tst:2" />
+                        <criterion comment="WR Linux version is 8." test_ref="oval:org.open-scap.cpe.wrlinux:tst:8" />
+                  </criteria>
+            </definition>
       </definitions>
       <tests>
             <rpmverifyfile_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:2" version="1" check="at least one" comment="/etc/redhat-release is provided by redhat-release package"
@@ -610,8 +625,29 @@
                   <object object_ref="oval:org.open-scap.cpe.openSUSE-release:obj:1"/>
                   <state state_ref="oval:org.open-scap.cpe.opensuse:ste:421"/>
             </rpminfo_test>
+            <family_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.wrlinux:tst:1" version="1" check="only one"
+                  comment="Installed operating system is part of the Unix family."
+                  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                  <object object_ref="oval:org.open-scap.cpe.unix:obj:1" />
+                  <state state_ref="oval:org.open-scap.cpe.unix:ste:1" />
+            </family_test>
+            <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check_existence="at_least_one_exists" version="1" id="oval:org.open-scap.cpe.wrlinux:tst:2" check="all" comment="Test presence of /etc/wrlinux-release.">
+                <object object_ref="oval:org.open-scap.cpe.wrlinux-release:obj:1" />
+            </file_test>
+            <textfilecontent_test
+                            id="oval:org.open-scap.cpe.wrlinux:tst:8"
+                            check="all"
+                            check_existence="all_exist"
+                            comment="Check /etc/wrlinux-release for VERSION 8 specification."
+                            version="1"
+                            xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                            >
+                  <object object_ref="oval:org.open-scap.cpe.wrlinux-release:obj:2"/>
+                  <state state_ref="oval:org.open-scap.cpe.wrlinux-release:ste:8"/>
+            </textfilecontent_test>
       </tests>
       <objects>
+            <family_object id="oval:org.open-scap.cpe.unix:obj:1" version="1"  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"/>
             <lin-def:rpminfo_object id="oval:org.open-scap.cpe.redhat-release:obj:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <lin-def:name>redhat-release</lin-def:name>
             </lin-def:rpminfo_object>
@@ -637,8 +673,24 @@
             <lin-def:rpminfo_object id="oval:org.open-scap.cpe.openSUSE-release:obj:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <lin-def:name>openSUSE-release</lin-def:name>
             </lin-def:rpminfo_object>
+            <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" version="1" id="oval:org.open-scap.cpe.wrlinux-release:obj:1" >
+                <filepath>/etc/wrlinux-release</filepath>
+            </file_object>
+            <textfilecontent_object
+                            id="oval:org.open-scap.cpe.wrlinux-release:obj:2"
+                            comment="Check VERSION specification in /etc/wrlinux-release."
+                            version="1"
+                            xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                            >
+                <path>/etc</path>
+                <filename>wrlinux-release</filename>
+                <line operation="pattern match">VERSION=.8</line>
+            </textfilecontent_object>
       </objects>
       <states>
+            <family_state id="oval:org.open-scap.cpe.unix:ste:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                  <family>unix</family>
+            </family_state>
             <rpmverifyfile_state id="oval:org.open-scap.cpe.rhel:ste:2" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <name operation="pattern match">^redhat-release</name>
             </rpmverifyfile_state>
@@ -746,5 +798,15 @@
             <rpminfo_state id="oval:org.open-scap.cpe.opensuse:ste:421" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <version operation="pattern match">^42.1$</version>
             </rpminfo_state>
+            <textfilecontent_state
+                            id="oval:org.open-scap.cpe.wrlinux-release:ste:8"
+                            comment="Check the /etc/wrlinux-release file for VERSION 8 specification."
+                            version="1"
+                            xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+                            >
+                  <path>/etc</path>
+                  <filename>wrlinux-release</filename>
+                  <line operation="pattern match">VERSION=.8</line>
+            </textfilecontent_state>
       </states>
 </oval_definitions>

--- a/src/OVAL/probes/unix/runlevel.c
+++ b/src/OVAL/probes/unix/runlevel.c
@@ -269,6 +269,11 @@ static int get_runlevel_suse (struct runlevel_req *req, struct runlevel_rep **re
 	return (get_runlevel_sysv (req, rep, suse, init_path, rc_path));
 }
 
+static int get_runlevel_wrlinux (struct runlevel_req *req, struct runlevel_rep **rep)
+{
+	return (-1);
+}
+
 static int get_runlevel_common (struct runlevel_req *req, struct runlevel_rep **rep)
 {
         return (-1);
@@ -327,6 +332,12 @@ static int is_solaris (void)
         return (stat ("/etc/release", &st)   == 0);
 }
 
+static int is_wrlinux (void)
+{
+	struct stat st;
+	return (stat ("/etc/wrlinux-release", &st) == 0 );
+}
+
 static int is_common (void)
 {
         return (1);
@@ -346,6 +357,7 @@ const distro_tbl_t distro_tbl[] = {
         { &is_mandriva, &get_runlevel_mandriva },
         { &is_suse,     &get_runlevel_suse     },
         { &is_solaris,  &get_runlevel_redhat   },
+        { &is_wrlinux,  &get_runlevel_wrlinux  },
         { &is_common,   &get_runlevel_common   }
 };
 


### PR DESCRIPTION
Changes since [V1] :
use file_test to check for the presence of /etc/wrlinux-release and textfilecontent_test to check the WR Linux version.
For runlevel check, use stat("/etc/wrlinux-release"...) as the only check.

Signed-off-by: T.O. Radzy Radzykewycz <radzy@windriver.com>