### PR TITLE
xccdf_session.c: Fix free of dirname

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -178,7 +178,7 @@ static int _xccdf_session_autonegotiate_tailoring_file(struct xccdf_session *ses
 	char *real_source_path = source_path[0] == '/' ?
 		oscap_strdup(source_path) : oscap_sprintf("%s/%s", base_dir, source_path);
 
-	oscap_free(base_dir);
+	oscap_free(original_path_cpy);
 	oscap_free(source_path);
 
 	struct oscap_source *real_source = oscap_source_new_from_file(real_source_path);


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1367896

According to man page, dirname can return pointer to original
path. So we should not call free on returned value.

(But we should free result of oscap_strdup)
