### PR TITLE
Added support to not to export system characteristics

### DIFF
--- a/src/OVAL/oval_session.c
+++ b/src/OVAL/oval_session.c
@@ -74,6 +74,7 @@ struct oval_session {
 	} reporter;
 
 	bool validation;
+	bool export_sys_chars;
 	bool full_validation;
 };
 
@@ -96,6 +97,8 @@ struct oval_session *oval_session_new(const char *filename)
 		oval_session_free(session);
 		return NULL;
 	}
+
+	session->export_sys_chars = true;
 
 	dI("Created a new OVAL session from input file '%s'.", filename);
 	return session;
@@ -403,6 +406,7 @@ int oval_session_export(struct oval_session *session)
 	/* Get OVAL Results if evaluation or analyse has been done and apply
 	 * directives to them */
 	if (session->res_model && (session->export.results || session->export.report)) {
+		oval_results_model_set_export_system_characteristics(session->res_model, session->export_sys_chars);
 		result = oval_results_model_export_source(session->res_model, dir_model, NULL);
 		filename = session->export.results;
 	}
@@ -445,6 +449,11 @@ cleanup:
 	if (dir_model)
 		oval_directives_model_free(dir_model);
 	return ret;
+}
+
+void oval_session_set_export_system_characteristics(struct oval_session *session, bool export)
+{
+	session->export_sys_chars = export;
 }
 
 void oval_session_free(struct oval_session *session)

--- a/src/OVAL/oval_sysModel.c
+++ b/src/OVAL/oval_sysModel.c
@@ -317,7 +317,7 @@ struct oval_sysitem *oval_syschar_model_get_new_sysitem(struct oval_syschar_mode
 }
 
 xmlNode *oval_syschar_model_to_dom(struct oval_syschar_model * syschar_model, xmlDocPtr doc, xmlNode * parent, 
-			           oval_syschar_resolver resolver, void *user_arg)
+			           oval_syschar_resolver resolver, void *user_arg, bool export_syschar)
 {
 
 	xmlNodePtr root_node = NULL;
@@ -347,6 +347,10 @@ xmlNode *oval_syschar_model_to_dom(struct oval_syschar_model * syschar_model, xm
 
         /* Report sysinfo */
 	oval_sysinfo_to_dom(oval_syschar_model_get_sysinfo(syschar_model), doc, root_node);
+
+	if (!export_syschar) {
+		return root_node;
+	}
 
 	struct oval_smc *resolved_smc = NULL;
 	struct oval_syschar_iterator *syschars = oval_syschar_model_get_syschars(syschar_model);
@@ -412,7 +416,7 @@ int oval_syschar_model_export(struct oval_syschar_model *model, const char *file
 		return -1;
 	}
 
-	oval_syschar_model_to_dom(model, doc, NULL, NULL, NULL);
+	oval_syschar_model_to_dom(model, doc, NULL, NULL, NULL, true);
 	return oscap_xml_save_filename_free(file, doc);
 }
 

--- a/src/OVAL/oval_system_characteristics_impl.h
+++ b/src/OVAL/oval_system_characteristics_impl.h
@@ -66,7 +66,7 @@ void oval_sysent_to_print(struct oval_sysent *, char *, int);
 
 /* syschar_model */
 typedef bool oval_syschar_resolver(struct oval_syschar *, void *);
-xmlNode *oval_syschar_model_to_dom(struct oval_syschar_model *, xmlDocPtr, xmlNode *, oval_syschar_resolver, void *);
+xmlNode *oval_syschar_model_to_dom(struct oval_syschar_model *, xmlDocPtr, xmlNode *, oval_syschar_resolver, void *, bool);
 void oval_syschar_model_reset(struct oval_syschar_model *model);
 
 struct oval_syschar *oval_syschar_model_get_new_syschar(struct oval_syschar_model *, struct oval_object *);

--- a/src/OVAL/public/oval_results.h
+++ b/src/OVAL/public/oval_results.h
@@ -148,6 +148,15 @@ OSCAP_DEPRECATED(int oval_results_model_import(struct oval_results_model *model,
  */
 struct oval_results_model *oval_results_model_clone(struct oval_results_model *);
 /**
+ * @memberof oval_results_model
+ */
+void oval_results_model_set_export_system_characteristics(struct oval_results_model *, bool export);
+
+/**
+ * @memberof oval_results_model
+ */
+bool oval_results_model_get_export_system_characteristics(struct oval_results_model *);
+/**
  * Free memory allocated to a specified oval results model.
  * @param the specified oval_results model
  * @memberof oval_results_model

--- a/src/OVAL/public/oval_session.h
+++ b/src/OVAL/public/oval_session.h
@@ -222,6 +222,16 @@ int oval_session_evaluate(struct oval_session *session, char *probe_root, agent_
 int oval_session_export(struct oval_session *session);
 
 /**
+ * Set exporting of system characteristics in OVAL results
+ *
+ *
+ * @memberof oval_session
+ * @param session an \ref oval_session
+ * @param export false values indicated no system_characteristics in OVAL Results
+ */
+void oval_session_set_export_system_characteristics(struct oval_session *session, bool export);
+
+/**
  * Destructor of an \ref oval_session.
  * @memberof oval_session
  * @param session an \ref oval_session to destroy

--- a/src/OVAL/results/oval_resModel.c
+++ b/src/OVAL/results/oval_resModel.c
@@ -57,6 +57,7 @@ struct oval_results_model {
 	struct oval_definition_model *definition_model;
 	struct oval_collection *systems;
 	struct oval_probe_session *probe_session;
+	bool   export_sys_chars;
 };
 
 struct oval_results_model *oval_results_model_new(struct oval_definition_model *definition_model,
@@ -87,6 +88,7 @@ struct oval_results_model *oval_results_model_new_with_probe_session(struct oval
 	}
 	model->directives_model = oval_directives_model_new();
 	model->probe_session = probe_session;
+	model->export_sys_chars = true;
 	return model;
 }
 
@@ -104,6 +106,16 @@ struct oval_results_model *oval_results_model_clone(struct oval_results_model *o
 	/* ToDo: Directives Model clone */
 
 	return new_resmodel;
+}
+
+void oval_results_model_set_export_system_characteristics(struct oval_results_model *model, bool export)
+{
+	model->export_sys_chars = export;
+}
+
+bool oval_results_model_get_export_system_characteristics(struct oval_results_model *model)
+{
+	return model->export_sys_chars;
 }
 
 void oval_results_model_free(struct oval_results_model *model)

--- a/src/OVAL/results/oval_resultSystem.c
+++ b/src/OVAL/results/oval_resultSystem.c
@@ -504,8 +504,9 @@ xmlNode *oval_result_system_to_dom(struct oval_result_system * sys,
 	}
 	oval_smc_iterator_free(result_tests);
 
+	bool export_sys_char = oval_results_model_get_export_system_characteristics(results_model);
 	oval_syschar_model_to_dom(syschar_model, doc, system_node, 
-				  (oval_syschar_resolver *) _oval_result_system_resolve_syschar, sysmap);
+				  (oval_syschar_resolver *) _oval_result_system_resolve_syschar, sysmap, export_sys_char);
 
 	oval_string_map_free(sysmap, NULL);
 	oval_string_map_free(objmap, NULL);

--- a/tests/API/OVAL/unittests/Makefile.am
+++ b/tests/API/OVAL/unittests/Makefile.am
@@ -73,6 +73,8 @@ EXTRA_DIST = \
 	test_object_component_type.sh \
 	test_skip_valid.sh \
 	test_skip_valid.oval.xml \
+	test_without_syschars.sh \
+	test_without_syschars.xml \
 	test_xmlns_missing.oval.xml \
 	test_xmlns_missing.sh \
 	test_xsinil_envv58_pid.oval.xml \

--- a/tests/API/OVAL/unittests/all.sh
+++ b/tests/API/OVAL/unittests/all.sh
@@ -4,6 +4,7 @@
 
 test_init test_api_oval_unittests.log
 test_run "comment before root element" $srcdir/test_comment.sh
+test_run "--without-syschar" $srcdir/test_without_syschars.sh
 test_run "cim_datetime format" $srcdir/test_cim_datetime.sh
 test_run "remove <oval_definiton> using oval directives" $srcdir/test_directives.sh
 test_run "empty filename(pattern match)" $srcdir/test_empty_filename.sh

--- a/tests/API/OVAL/unittests/test_without_syschars.sh
+++ b/tests/API/OVAL/unittests/test_without_syschars.sh
@@ -6,13 +6,13 @@ set -e
 set -o pipefail
 
 # Sanity check - system characteristics are provided by default
-$OSCAP oval eval                    --results $result $srcdir/test_without_syschars.xml
+$OSCAP oval eval                   --results $result $srcdir/test_without_syschars.xml
 
 assert_exists 1 '//system_data'
 assert_exists 1 '//collected_objects'
 
-# Check --without-syschars - no system characteristics expected
-$OSCAP oval eval --without-syschars --results $result $srcdir/test_without_syschars.xml
+# Check --without-syschar - no system characteristics expected
+$OSCAP oval eval --without-syschar --results $result $srcdir/test_without_syschars.xml
 
 assert_exists 0 '//system_data'
 assert_exists 0 '//collected_objects'

--- a/tests/API/OVAL/unittests/test_without_syschars.sh
+++ b/tests/API/OVAL/unittests/test_without_syschars.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+result=`mktemp`
+
+set -e
+set -o pipefail
+
+# Sanity check - system characteristics are provided by default
+$OSCAP oval eval                    --results $result $srcdir/test_without_syschars.xml
+
+assert_exists 1 '//system_data'
+assert_exists 1 '//collected_objects'
+
+# Check --without-syschars - no system characteristics expected
+$OSCAP oval eval --without-syschars --results $result $srcdir/test_without_syschars.xml
+
+assert_exists 0 '//system_data'
+assert_exists 0 '//collected_objects'
+
+rm $result
+

--- a/tests/API/OVAL/unittests/test_without_syschars.xml
+++ b/tests/API/OVAL/unittests/test_without_syschars.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oval_definitions xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd      http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+  <generator>
+    <oval:schema_version>5.10</oval:schema_version>
+    <oval:timestamp>2009-01-12T10:41:00-05:00</oval:timestamp>
+  </generator>
+  <definitions>
+    <definition id="oval:x:def:282" version="3" class="miscellaneous">
+      <metadata>
+        <title>Test presence /etc/passwd</title>
+        <description>Test presence /etc/passwd</description>
+      </metadata>
+      <criteria>
+        <criterion comment="Test that /etc/passwd exists." test_ref="oval:x:tst:1288"/>
+      </criteria>
+    </definition>
+  </definitions>
+  <tests>
+    <file_test id="oval:x:tst:1288" version="1" comment="Test that /etc/passwd is collected if filename in object was empty." check_existence="at_least_one_exists" check="only one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+      <object object_ref="oval:x:obj:512"/>
+    </file_test>
+  </tests>
+  <objects>
+    <file_object id="oval:x:obj:512" version="1" comment="File /etc/passwd" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+      <path operation="pattern match">^/etc$</path>
+      <filename operation="pattern match">^passwd$</filename>
+    </file_object>
+  </objects>
+</oval_definitions>

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -109,6 +109,7 @@ static struct oscap_module OVAL_EVAL = {
 	"   --id <definition-id>\r\t\t\t\t - ID of the definition we want to evaluate.\n"
 	"   --variables <file>\r\t\t\t\t - Provide external variables expected by OVAL Definitions.\n"
         "   --directives <file>\r\t\t\t\t - Use OVAL Directives content to specify desired results content.\n"
+        "   --without-syschars \r\t\t\t\t - Don't provide system characteristics in result file.\n"
         "   --results <file>\r\t\t\t\t - Write OVAL Results into file.\n"
         "   --report <file>\r\t\t\t\t - Create human readable (HTML) report from OVAL Results.\n"
         "   --skip-valid\r\t\t\t\t - Skip validation.\n"
@@ -389,6 +390,7 @@ int app_evaluate_oval(const struct oscap_action *action)
 	oval_session_set_directives(session, action->f_directives);
 	oval_session_set_results_export(session, action->f_results);
 	oval_session_set_report_export(session, action->f_report);
+	oval_session_set_export_system_characteristics(session, !action->without_sys_chars);
 	if (oval_session_export(session) != 0)
 		goto cleanup;
 
@@ -557,6 +559,7 @@ bool getopt_oval_eval(int argc, char **argv, struct oscap_action *action)
 		{ "id",        	required_argument, NULL, OVAL_OPT_ID           },
 		{ "variables",	required_argument, NULL, OVAL_OPT_VARIABLES    },
 		{ "directives",	required_argument, NULL, OVAL_OPT_DIRECTIVES   },
+		{ "without-syschars",	no_argument, &action->without_sys_chars, 1},
 		{ "datastream-id",required_argument, NULL, OVAL_OPT_DATASTREAM_ID},
 		{ "oval-id",    required_argument, NULL, OVAL_OPT_OVAL_ID},
 		{ "skip-valid",	no_argument, &action->validate, 0 },

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -109,7 +109,7 @@ static struct oscap_module OVAL_EVAL = {
 	"   --id <definition-id>\r\t\t\t\t - ID of the definition we want to evaluate.\n"
 	"   --variables <file>\r\t\t\t\t - Provide external variables expected by OVAL Definitions.\n"
         "   --directives <file>\r\t\t\t\t - Use OVAL Directives content to specify desired results content.\n"
-        "   --without-syschars \r\t\t\t\t - Don't provide system characteristics in result file.\n"
+        "   --without-syschar \r\t\t\t\t - Don't provide system characteristic in result file.\n"
         "   --results <file>\r\t\t\t\t - Write OVAL Results into file.\n"
         "   --report <file>\r\t\t\t\t - Create human readable (HTML) report from OVAL Results.\n"
         "   --skip-valid\r\t\t\t\t - Skip validation.\n"
@@ -559,7 +559,7 @@ bool getopt_oval_eval(int argc, char **argv, struct oscap_action *action)
 		{ "id",        	required_argument, NULL, OVAL_OPT_ID           },
 		{ "variables",	required_argument, NULL, OVAL_OPT_VARIABLES    },
 		{ "directives",	required_argument, NULL, OVAL_OPT_DIRECTIVES   },
-		{ "without-syschars",	no_argument, &action->without_sys_chars, 1},
+		{ "without-syschar",	no_argument, &action->without_sys_chars, 1},
 		{ "datastream-id",required_argument, NULL, OVAL_OPT_DATASTREAM_ID},
 		{ "oval-id",    required_argument, NULL, OVAL_OPT_OVAL_ID},
 		{ "skip-valid",	no_argument, &action->validate, 0 },

--- a/utils/oscap-tool.h
+++ b/utils/oscap-tool.h
@@ -144,6 +144,7 @@ struct oscap_action {
 	int remote_resources;
 	int progress;
 	int oval_results;
+	int without_sys_chars;
 	int remediate;
 	char *sce_template;
 	int check_engine_results;

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -347,6 +347,9 @@ Provide external variables expected by OVAL Definition File.
 \fB\-\-directives FILE\fR
 Use OVAL Directives content to specify desired results content.
 .TP
+\fB\-\-without-syschar\fR
+Don't provide system characteristics in result file.
+.TP
 \fB\-\-results FILE\fR
 Write OVAL Results into file.
 .TP


### PR DESCRIPTION
We can export full/thin results using OVAL directives, but we always export system characteristics, too.

Added support to not export system characteristics.

More info in commit message.

How it should work, you can see from attached test.