### PR TITLE
Fix export of overrided oscap_text

### DIFF
--- a/src/common/text.c
+++ b/src/common/text.c
@@ -146,7 +146,7 @@ xmlNode *oscap_text_to_dom(struct oscap_text *text, xmlNode *parent, const char 
 
 	if (text->lang)
 		xmlNodeSetLang(text_node, BAD_CAST text->lang);
-	if (text->traits.can_override && text->traits.override_given)
+	if (text->traits.can_override)
 		xmlNewProp(text_node, BAD_CAST "override", BAD_CAST (text->traits.overrides ? "true" : "false"));
 
 
@@ -161,7 +161,7 @@ bool oscap_text_export(struct oscap_text *text, xmlTextWriter *writer, const cha
 
 	if (text->lang)
 		xmlTextWriterWriteAttribute(writer, BAD_CAST "xml:lang", BAD_CAST text->lang);
-	if (text->traits.can_override && text->traits.override_given)
+	if (text->traits.can_override)
 		xmlTextWriterWriteAttribute(writer, BAD_CAST "override", BAD_CAST (text->traits.overrides ? "true" : "false"));
 
 	if (text->traits.html || text->traits.can_substitute)

--- a/src/common/text.c
+++ b/src/common/text.c
@@ -146,8 +146,8 @@ xmlNode *oscap_text_to_dom(struct oscap_text *text, xmlNode *parent, const char 
 
 	if (text->lang)
 		xmlNodeSetLang(text_node, BAD_CAST text->lang);
-	if (text->traits.can_override)
-		xmlNewProp(text_node, BAD_CAST "override", BAD_CAST (text->traits.overrides ? "true" : "false"));
+	if (text->traits.can_override && text->traits.overrides)
+		xmlNewProp(text_node, BAD_CAST "override", BAD_CAST "true");
 
 
 	return text_node;
@@ -161,8 +161,8 @@ bool oscap_text_export(struct oscap_text *text, xmlTextWriter *writer, const cha
 
 	if (text->lang)
 		xmlTextWriterWriteAttribute(writer, BAD_CAST "xml:lang", BAD_CAST text->lang);
-	if (text->traits.can_override)
-		xmlTextWriterWriteAttribute(writer, BAD_CAST "override", BAD_CAST (text->traits.overrides ? "true" : "false"));
+	if (text->traits.can_override && text->traits.overrides)
+		xmlTextWriterWriteAttribute(writer, BAD_CAST "override", BAD_CAST "true");
 
 	if (text->traits.html || text->traits.can_substitute)
 		xmlTextWriterWriteRaw(writer, BAD_CAST text->text);


### PR DESCRIPTION
This change allows attributes marked as overriders by
oscap_text_set_override() to be exported.

Exportation of an overrider attribute is conditioned by override_given.
But override_given is only set when an imported attribute has override
capability set. So, when an oscap_text was marked as overrider by
oscap_text_set_set_override() the attribute was never exported.

Related to RHBZ#1320194.