### PR TITLE
Fix results of XCCDF rules with @role="unscored".

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -1079,6 +1079,10 @@ _xccdf_policy_rule_evaluate(struct xccdf_policy * policy, const struct xccdf_rul
 	}
 	if ((xccdf_test_result_type_t) ret == XCCDF_RESULT_NOT_CHECKED)
 		message = "None of the check-content-ref elements was resolvable.";
+
+	if (role == XCCDF_ROLE_UNSCORED)
+        ret = XCCDF_RESULT_INFORMATIONAL;
+
 	xccdf_check_content_ref_iterator_free(content_it);
 	oscap_list_free(bindings, (oscap_destruct_func) xccdf_value_binding_free);
 	/* Negate only once */

--- a/tests/API/XCCDF/unittests/test_xccdf_role_unscored.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_role_unscored.sh
@@ -19,7 +19,7 @@ $OSCAP xccdf validate-xml $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'
-assert_exists 1 '//rule-result/result[text()="pass"]'
+assert_exists 1 '//rule-result/result[text()="informational"]'
 assert_exists 1 '//rule-result/check'
 assert_exists 1 '//rule-result/check/check-content-ref'
 assert_exists 1 '//score[@system="urn:xccdf:scoring:default" and text()="0.000000"]'


### PR DESCRIPTION
When a XCCDF rule has @role="unscored", perform all the checks but mark
the result as XCCDF_RESULT_INFORMATIONAL.

https://github.com/OpenSCAP/openscap/issues/525