### PR TITLE
Support tailoring of a checklist located in a different datastream

### DIFF
--- a/src/DS/ds_sds_session.c
+++ b/src/DS/ds_sds_session.c
@@ -197,13 +197,13 @@ struct oscap_source *ds_sds_session_select_checklist(struct ds_sds_session *sess
 			return NULL;
 		}
 	}
-	if (ds_sds_session_register_component_with_dependencies(session, "checklists", session->checklist_id, "xccdf.xml") != 0) {
+	if (ds_sds_session_register_component_with_dependencies(session, "checklists", session->checklist_id, session->checklist_id) != 0) {
 		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not extract %s with all dependencies from datastream.", session->checklist_id);
 		return NULL;
 	}
-	struct oscap_source *xccdf = oscap_htable_get(session->component_sources, "xccdf.xml");
+	struct oscap_source *xccdf = oscap_htable_get(session->component_sources, session->checklist_id);
 	if (xccdf == NULL) {
-		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Internal error: Could not acquire handle to xccdf.xml source.");
+		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Internal error: Could not acquire handle to '%s' source.", session->checklist_id);
 	}
 	return xccdf;
 }

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -502,11 +502,13 @@ static int _acquire_xccdf_checklist_from_tailoring(struct xccdf_session* session
 	struct oscap_source *tailoring_source = oscap_source_new_from_xmlDoc(tailoring_xmlDoc, NULL);
 	struct xccdf_tailoring* tailoring = xccdf_tailoring_import_source(tailoring_source, NULL);
 	if (tailoring == NULL) {
+		xmlFree(tailoring_xmlDoc);
 		return 1;
 	}
 	const char *benchmark_ref = oscap_strdup(xccdf_tailoring_get_benchmark_ref(tailoring));
 	xccdf_tailoring_free(tailoring);
 	if (benchmark_ref == NULL) {
+		xmlFree(tailoring_xmlDoc);
 		return 1;
 	}
 	char *benchmark_id = strchr(benchmark_ref, '#') + 1;
@@ -516,11 +518,14 @@ static int _acquire_xccdf_checklist_from_tailoring(struct xccdf_session* session
 	if (xccdf_source == NULL) {
 		oscap_seterr(OSCAP_EFAMILY_OSCAP,
 				"Could not find benchmark '%s' referenced from tailoring", benchmark_id);
+		xmlFree(tailoring_xmlDoc);
+		oscap_free(benchmark_ref);
 		return 1;
 	}
 
 	session->xccdf.source = xccdf_source;
 	session->tailoring.user_file = tailoring_source;
+	oscap_free(benchmark_ref);
 	return 0;
 }
 

--- a/tests/DS/Makefile.am
+++ b/tests/DS/Makefile.am
@@ -55,6 +55,7 @@ EXTRA_DIST = test_ds.sh \
 		sds_simple_5_11_1/simple_oval.xml \
 		sds_simple_5_11_1/simple_xccdf.xml \
 		sds_subdir/subdir/scap-fedora14-oval.xml \
-		sds_subdir/subdir/scap-fedora14-xccdf.xml
+		sds_subdir/subdir/scap-fedora14-xccdf.xml \
+		sds_tailoring/sds.ds.xml
 
 SUBDIRS = ds_sds_index signed validate

--- a/tests/DS/sds_tailoring/sds.ds.xml
+++ b/tests/DS/sds_tailoring/sds.ds.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_cdf_collection_fedora.zip" schematron-version="1.0" xsi:schemaLocation="http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2-draft.xsd">
+
+  <!-- Data Stream with XCCDF checklist -->
+  <data-stream id="scap_com.example_datastream_with_checklist" scap-version="1.2" timestamp="2016-09-26T15:00:00" use-case="CONFIGURATION">
+    <checklists>
+      <component-ref id="scap_com.example_cref_xccdf_01" xlink:href="#scap_com.example_comp_xccdf_01">
+        <cat:catalog>
+          <cat:uri name="oval" uri="#scap_com.example_cref_oval_01"/>
+        </cat:catalog>
+      </component-ref>
+    </checklists>
+    <checks>
+      <component-ref id="scap_com.example_cref_oval_01" xlink:href="#scap_com.example_comp_oval_01"/>
+    </checks>
+  </data-stream>
+
+  <!-- Data Stream with tailoring -->
+  <data-stream id="scap_com.example_datastream_with_tailoring" scap-version="1.2" timestamp="2016-05-09T15:00:00" use-case="CONFIGURATION">
+    <checklists>
+      <component-ref id="scap_com.example_cref_tailoring_01" xlink:href="#scap_com.example_comp_tailoring_01"/>
+      <component-ref id="scap_com.example_cref_xccdf_01-source" xlink:href="#scap_com.example_comp_xccdf_01">
+        <cat:catalog>
+          <cat:uri name="oval" uri="#scap_com.example_cref_oval_01-source"/>
+        </cat:catalog>
+      </component-ref>
+    </checklists>
+    <checks>
+      <component-ref id="scap_com.example_cref_oval_01-source" xlink:href="#scap_com.example_comp_oval_01"/>
+    </checks>
+  </data-stream>
+
+  <!-- XCCDF checklist -->
+  <component id="scap_com.example_comp_xccdf_01" timestamp="2016-09-26T14:00:00">
+    <Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+      <status>incomplete</status>
+      <version>1.0</version>
+      <model system="urn:xccdf:scoring:default"/>
+      <Rule selected="true" id="xccdf_com.example_rule_1">
+        <title>Rule 1</title>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+          <check-content-ref href="oval" name="oval:x:def:1"/>
+        </check>
+      </Rule>
+      <Rule selected="false" id="xccdf_com.example_rule_2">
+        <title>Rule 2</title>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+          <check-content-ref href="oval" name="oval:x:def:2"/>
+        </check>
+      </Rule>
+    </Benchmark>
+  </component>
+
+  <!-- OVAL definitions -->
+  <component id="scap_com.example_comp_oval_01" timestamp="2016-09-26T14:00:00">
+    <oval_definitions xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
+      <generator>
+        <oval:schema_version>5.11.1</oval:schema_version>
+        <oval:timestamp>0001-01-01T00:00:00+00:00</oval:timestamp>
+      </generator>
+
+      <definitions>
+        <definition class="compliance" version="1" id="oval:x:def:1">
+          <metadata>
+            <title>First simple OVAL definition</title>
+            <description>x</description>
+            <affected family="unix">
+              <platform>x</platform>
+            </affected>
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:x:tst:1" comment="always pass"/>
+          </criteria>
+        </definition>
+        <definition class="compliance" version="1" id="oval:x:def:2">
+          <metadata>
+            <title>Second simple OVAL definition</title>
+            <description>x</description>
+            <affected family="unix">
+              <platform>x</platform>
+            </affected>
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:x:tst:1" comment="always pass"/>
+          </criteria>
+        </definition>
+      </definitions>
+
+      <tests>
+        <ind:textfilecontent54_test id="oval:x:tst:1" version="1" comment="File foo.txt cannnot contain 'Hello'"  check="none satisfy">
+            <ind:object object_ref="oval:x:obj:1"/>
+        </ind:textfilecontent54_test>
+      </tests>
+
+      <objects>
+        <ind:textfilecontent54_object id="oval:x:obj:1" version="1" comment="Object representing file">
+            <ind:filepath>/etc/passwd</ind:filepath>
+          <ind:pattern operation="pattern match">^.*$</ind:pattern>
+          <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+        </ind:textfilecontent54_object>
+      </objects>
+
+    </oval_definitions>
+  </component>
+
+  <!-- local tailoring component -->
+  <component id="scap_com.example_comp_tailoring_01" timestamp="2016-09-26T14:00:00">
+    <Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" 
+      id="xccdf_com.example_tailoring_01"
+      xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd
+      http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd">
+
+      <benchmark href="#scap_com.example_cref_xccdf_01" id="scap_com.example_benchmark_01" version="1-2.1.1.0"/>
+      <status date="2016-09-26">draft</status>
+      <version time="2016-09-26T14:00:00">1.0</version>
+      <Profile id="xccdf_com.example_profile_tailoring" abstract="false" prohibitChanges="true">
+        <title>Tailoring profile</title>
+        <description>Tailoring profile</description>
+        <select idref="xccdf_com.example_rule_1" selected="false"/>
+        <select idref="xccdf_com.example_rule_2" selected="true"/>
+      </Profile>
+    </Tailoring>
+  </component>
+
+</data-stream-collection>


### PR DESCRIPTION
This commit fixes processing of tailoring within datastreams.
It is now possible to have a datastream collection with multiple datastreams,
where XCCDF tailoring and XCCDF checklist are not both in the same datastream.