### PR TITLE
Issue #529: Fix a segmentation fault

### DIFF
--- a/src/DS/sds_index.c
+++ b/src/DS/sds_index.c
@@ -194,7 +194,8 @@ static struct ds_stream_index* ds_stream_index_parse(xmlTextReaderPtr reader)
 						oscap_seterr(OSCAP_EFAMILY_XML,
 				             "There is already a mapping from component id '%s' to component-ref id '%s'. "
 							 "Having multiple mappings is legal in a datastream but it may prove problematic "
-							 "when selecting component-refs using XCCDF Benchmark IDs.");
+							"when selecting component-refs using XCCDF Benchmark IDs.",
+							component_id, id_attr);
 					}
 
 					xmlFree(id_attr);


### PR DESCRIPTION
Strings expected in format strings were not supplied.
Compiler was OK with that because it is a function with
variable count of parameters.