### PR TITLE
Update SUSE 11 CPE

### DIFF
--- a/cpe/openscap-cpe-dict.xml
+++ b/cpe/openscap-cpe-dict.xml
@@ -93,13 +93,13 @@
             <title xml:lang="en-us">SUSE Linux Enterprise Desktop 10</title>
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.sled:def:10</check>
       </cpe-item>
-      <cpe-item name="cpe:/o:suse:sles:11">
+      <cpe-item name="cpe:/o:suse:linux_enterprise_server:11">
             <title xml:lang="en-us">SUSE Linux Enterprise Server 11</title>
-            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.sles:def:11</check>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.sle:def:11</check>
       </cpe-item>
-      <cpe-item name="cpe:/o:suse:sled:11">
+      <cpe-item name="cpe:/o:suse:linux_enterprise_desktop:11">
             <title xml:lang="en-us">SUSE Linux Enterprise Desktop 11</title>
-            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.sled:def:11</check>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.sle:def:11</check>
       </cpe-item>
       <cpe-item name="cpe:/o:suse:sles:12">
             <title xml:lang="en-us">SUSE Linux Enterprise Server 12</title>

--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -318,31 +318,24 @@
                   </criteria>
             </definition>
 
-            <definition class="inventory" id="oval:org.open-scap.cpe.sles:def:11" version="1">
+            <definition class="inventory" id="oval:org.open-scap.cpe.sle:def:11" version="1">
                   <metadata>
-                        <title>SUSE Linux Enterprise Server 11</title>
+                        <title>SUSE Linux Enterprise 11</title>
                         <affected family="unix">
                             <platform>SUSE Linux Enterprise Server 11</platform>
-                        </affected>
-                        <reference ref_id="cpe:/o:suse:sles:11" source="CPE"/>
-                        <description>The operating system installed on the system is SUSE Linux Enterprise Server 11</description>
-                  </metadata>
-                  <criteria>
-                        <criterion comment="SLES 11 is installed" test_ref="oval:org.open-scap.cpe.sles:tst:11"/>
-                  </criteria>
-            </definition>
-
-            <definition class="inventory" id="oval:org.open-scap.cpe.sled:def:11" version="1">
-                  <metadata>
-                        <title>SUSE Linux Enterprise Desktop 11</title>
-                        <affected family="unix">
                             <platform>SUSE Linux Enterprise Desktop 11</platform>
                         </affected>
-                        <reference ref_id="cpe:/o:suse:sles:11" source="CPE"/>
-                        <description>The operating system installed on the system is SUSE Linux Enterprise Desktop 11</description>
+                        <reference ref_id="cpe:/o:suse:linux_enterprise_server:11" source="CPE" />
+                        <reference ref_id="cpe:/o:suse:linux_enterprise_desktop:11" source="CPE" />
+                        <description>The operating system installed on the system is SUSE Linux Enterprise 11.</description>
+                        <reference source="galford" ref_id="20160920" ref_url="test_attestation" />
                   </metadata>
                   <criteria>
-                        <criterion comment="SLED 11 is installed" test_ref="oval:org.open-scap.cpe.sled:tst:11"/>
+                        <criterion comment="Installed operating system is part of the unix family" test_ref="oval:org.open-scap.cpe.sle:tst:1" />
+                        <criteria operator="OR">
+                              <criterion comment="SLE 11 Desktop is installed" test_ref="oval:org.open-scap.cpe.sled:tst:11" />
+                              <criterion comment="SLE 11 Server is installed" test_ref="oval:org.open-scap.cpe.sles:tst:11" />
+                        </criteria>
                   </criteria>
             </definition>
 
@@ -646,6 +639,12 @@
             <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check_existence="at_least_one_exists" version="1" id="oval:org.open-scap.cpe.wrlinux:tst:2" check="all" comment="Test presence of /etc/wrlinux-release.">
                 <object object_ref="oval:org.open-scap.cpe.wrlinux-release:obj:1" />
             </file_test>
+            <family_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.sle:tst:1" version="1" check="only one"
+                  comment="Installed operating system is part of the Unix family."
+                  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                  <object object_ref="oval:org.open-scap.cpe.unix:obj:1" />
+                  <state state_ref="oval:org.open-scap.cpe.unix:ste:1" />
+            </family_test>
             <textfilecontent54_test
                             id="oval:org.open-scap.cpe.wrlinux:tst:8"
                             check="all"


### PR DESCRIPTION
Hello,

This PR is to update the SUSE 11 CPE to address issue 1469 raised in SSG based on the comment from @redhatrises . [https://github.com/OpenSCAP/scap-security-guide/issues/1469#issuecomment-248900441]

I have used the OVAL content from "installed_OS_is_sle11" in SSG's shared OVAL folder as reference.[https://github.com/OpenSCAP/scap-security-guide/blob/master/shared/oval/installed_OS_is_sle11.xml]

If the changes look good, I will make them for SUSE 10 and 12 as well.

Thank you!