### PR TITLE
Separate stderr from stdout in SCE

### DIFF
--- a/schemas/sce/1.0/sce-result-schema.xsd
+++ b/schemas/sce/1.0/sce-result-schema.xsd
@@ -21,6 +21,7 @@
     <sequence>
       <element name="environment" type="sceres:environment_type"></element>
       <element name="stdout" type="string"></element>
+      <element name="stderr" type="string" minOccurs="0"></element>
       <element name="exit_code" type="int"></element>
       <element name="result" type="xccdf:resultEnumType"></element>
     </sequence>

--- a/src/SCE/public/sce_engine_api.h
+++ b/src/SCE/public/sce_engine_api.h
@@ -63,7 +63,7 @@ const char* sce_check_result_get_basename(struct sce_check_result* v);
 /**
  * Sets stdout that was captured while script was evaluating
  *
- * @param stdout should contain output from both stdout and stderr (interleaved)
+ * @param stdout should contain output only from stdout
  * @memberof sce_check_result
  */
 void sce_check_result_set_stdout(struct sce_check_result* v, const char* details);
@@ -72,6 +72,19 @@ void sce_check_result_set_stdout(struct sce_check_result* v, const char* details
  * @memberof sce_check_result
  */
 const char* sce_check_result_get_stdout(struct sce_check_result* v);
+
+/**
+ * Sets stderr that was captured while script was evaluating
+ *
+ * @param stderr should contain output only from stderr
+ * @memberof sce_check_result
+ */
+void sce_check_result_set_stderr(struct sce_check_result* v, const char* details);
+
+/**
+ * @memberof sce_check_result
+ */
+const char* sce_check_result_get_stderr(struct sce_check_result* v);
 
 /**
  * Sets exit code with which the script ended execution after evaluation

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -57,6 +57,7 @@ struct sce_check_result
 	char* href;
 	char* basename;
 	char* std_out;
+	char* std_err;
 	int exit_code;
 	struct oscap_stringlist* environment_variables;
 	xccdf_test_result_type_t xccdf_result;
@@ -68,6 +69,7 @@ struct sce_check_result* sce_check_result_new(void)
 	ret->href = NULL;
 	ret->basename = NULL;
 	ret->std_out = NULL;
+	ret->std_err = NULL;
 	ret->environment_variables = oscap_stringlist_new();
 	ret->xccdf_result = XCCDF_RESULT_UNKNOWN;
 
@@ -85,6 +87,8 @@ void sce_check_result_free(struct sce_check_result* v)
 		oscap_free(v->basename);
 	if (v->std_out)
 		oscap_free(v->std_out);
+	if (v->std_err)
+		oscap_free(v->std_err);
 
 	oscap_stringlist_free(v->environment_variables);
 
@@ -128,6 +132,19 @@ void sce_check_result_set_stdout(struct sce_check_result* v, const char* _stdout
 const char* sce_check_result_get_stdout(struct sce_check_result* v)
 {
 	return v->std_out;
+}
+
+void sce_check_result_set_stderr(struct sce_check_result* v, const char* _stderr)
+{
+	if (v->std_err)
+		oscap_free(v->std_err);
+
+	v->std_err = strdup(_stderr);
+}
+
+const char* sce_check_result_get_stderr(struct sce_check_result* v)
+{
+	return v->std_err;
 }
 
 void sce_check_result_set_exit_code(struct sce_check_result* v, int exit_code)
@@ -184,6 +201,9 @@ void sce_check_result_export(struct sce_check_result* v, const char* target_file
 	fprintf(f, "\t<sceres:stdout><![CDATA[\n");
 	fwrite(v->std_out, 1, strlen(v->std_out), f);
 	fprintf(f, "\t]]></sceres:stdout>\n");
+	fprintf(f, "\t<sceres:stderr><![CDATA[\n");
+	fwrite(v->std_err, 1, strlen(v->std_err), f);
+	fprintf(f, "\t]]></sceres:stderr>\n");
 	fprintf(f, "\t<sceres:exit_code>%i</sceres:exit_code>\n", sce_check_result_get_exit_code(v));
 	fprintf(f, "\t<sceres:result>%s</sceres:result>\n", xccdf_test_result_type_get_text(sce_check_result_get_xccdf_result(v)));
 	fprintf(f, "</sceres:sce_results>\n");
@@ -444,8 +464,9 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 	env_values[env_value_count] = NULL;
 
 	// We open a pipe for communication with the forked process
-	int pipefd[2];
-	if (pipe(pipefd) == -1)
+	int stdout_pipefd[2];
+	int stderr_pipefd[2];
+	if (pipe(stdout_pipefd) == -1 || pipe(stderr_pipefd))
 	{
 		perror("pipe");
 		// the first 9 values (0 to 8) are compiled in
@@ -467,17 +488,19 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 
 		if (fork_result == 0)
 		{
-		    // we won't read from the pipe, so close the reading fd
-		    close(pipefd[0]);
+		    // we won't read from the pipes, so close the reading fd
+		    close(stdout_pipefd[0]);
+		    close(stderr_pipefd[0]);
 
 		    // forward stdout and stderr to the opened pipe
-			dup2(pipefd[1], fileno(stdout));
-			dup2(pipefd[1], fileno(stderr));
+			dup2(stdout_pipefd[1], fileno(stdout));
+			dup2(stderr_pipefd[1], fileno(stderr));
 
-			// we duplicated the file description twice, we can close the original
-			// one now, stdout and stderr will be closed properly after the execved
+			// we duplicated the file descriptors twice, we can close the original
+			// ones now, stdout and stderr will be closed properly after the execved
 			// script/executable finishes
-			close(pipefd[1]);
+			close(stdout_pipefd[1]);
+			close(stderr_pipefd[1]);
 
 			// before we execute the script, lets make sure we get SIGTERM when
 			// oscap is killed, crashes or otherwise terminates
@@ -500,10 +523,12 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 		}
 		else
 		{
-			// we won't write to the pipe, so close the writing fd
-			close(pipefd[1]);
+			// we won't write to the pipes, so close the writing fd
+			close(stdout_pipefd[1]);
+			close(stderr_pipefd[1]);
 
-			char* stdout_buffer = oscap_acquire_pipe_to_string(pipefd[0]);
+			char* stdout_buffer = oscap_acquire_pipe_to_string(stdout_pipefd[0]);
+			char* stderr_buffer = oscap_acquire_pipe_to_string(stderr_pipefd[0]);
 
 			// we are the parent process
 			int wstatus;
@@ -524,6 +549,7 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 				sce_check_result_set_href(check_result, tmp_href);
 				sce_check_result_set_basename(check_result, basename(tmp_href));
 				sce_check_result_set_stdout(check_result, stdout_buffer);
+				sce_check_result_set_stderr(check_result, stderr_buffer);
 				sce_check_result_set_exit_code(check_result, WEXITSTATUS(wstatus));
 				sce_check_result_set_xccdf_result(check_result, (xccdf_test_result_type_t)raw_result);
 
@@ -553,10 +579,15 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 				{
 					xccdf_check_import_set_content(check_import, stdout_buffer);
 				}
+				else if (strcmp(name, "stderr") == 0)
+				{
+					xccdf_check_import_set_content(check_import, stderr_buffer);
+				}
 			}
 
 			oscap_free(tmp_href);
 			oscap_free(stdout_buffer);
+			oscap_free(stderr_buffer);
 
 			return (xccdf_test_result_type_t)raw_result;
 		}
@@ -570,8 +601,10 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 		}
 		oscap_free(env_values);
 
-		close(pipefd[0]);
-		close(pipefd[1]);
+		close(stdout_pipefd[0]);
+		close(stdout_pipefd[1]);
+		close(stderr_pipefd[0]);
+		close(stderr_pipefd[1]);
 		return XCCDF_RESULT_ERROR;
 	}
 }

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -466,7 +466,7 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 	// We open a pipe for communication with the forked process
 	int stdout_pipefd[2];
 	int stderr_pipefd[2];
-	if (pipe(stdout_pipefd) == -1 || pipe(stderr_pipefd))
+	if (pipe(stdout_pipefd) == -1 || pipe(stderr_pipefd) == -1)
 	{
 		perror("pipe");
 		// the first 9 values (0 to 8) are compiled in

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -492,7 +492,7 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 		    close(stdout_pipefd[0]);
 		    close(stderr_pipefd[0]);
 
-		    // forward stdout and stderr to the opened pipe
+			// forward stdout and stderr to our custom opened pipes
 			dup2(stdout_pipefd[1], fileno(stdout));
 			dup2(stderr_pipefd[1], fileno(stderr));
 

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -662,11 +662,19 @@ Authors:
     <xsl:param name="sce-tmpl"/>
 
     <xsl:choose>
-        <xsl:when test="$check/cdf:check-import[@import-name = 'stdout']/text()">
-            <span class="label label-default"><abbr title="Script Check Engine stdout taken from check-import">SCE stdout</abbr></span>
-            <pre><code>
-                <xsl:value-of select="$check/cdf:check-import[@import-name = 'stdout']/text()"/>
-            </code></pre>
+        <xsl:when test="$check/cdf:check-import[@import-name = 'stdout']/text() or $check/cdf:check-import[@import-name = 'stderr']/text()">
+            <xsl:if test="$check/cdf:check-import[@import-name = 'stdout']/text()">
+                <span class="label label-default"><abbr title="Script Check Engine stdout taken from check-import">SCE stdout</abbr></span>
+                <pre><code>
+                    <xsl:value-of select="$check/cdf:check-import[@import-name = 'stdout']/text()"/>
+                </code></pre>
+            </xsl:if>
+            <xsl:if test="$check/cdf:check-import[@import-name = 'stderr']/text()">
+                <span class="label label-default"><abbr title="Script Check Engine stderr taken from check-import">SCE stderr</abbr></span>
+                <pre><code>
+                    <xsl:value-of select="$check/cdf:check-import[@import-name = 'stderr']/text()"/>
+                </code></pre>
+            </xsl:if>
         </xsl:when>
         <xsl:otherwise>
             <xsl:variable name="filename">
@@ -678,11 +686,18 @@ Authors:
 
             <xsl:if test="$filename != ''">
                 <xsl:variable name="stdout" select="document($filename)/sceres:sce_results/sceres:stdout/text()"/>
+                <xsl:variable name="stderr" select="document($filename)/sceres:sce_results/sceres:stderr/text()"/>
 
                 <xsl:if test="normalize-space($stdout)">
                     <span class="label label-default"><abbr title="Script Check Engine stdout taken from '{$filename}'">SCE stdout</abbr></span>
                     <pre><code>
                         <xsl:copy-of select="$stdout"/>
+                    </code></pre>
+                </xsl:if>
+                <xsl:if test="normalize-space($stderr)">
+                    <span class="label label-default"><abbr title="Script Check Engine stderr taken from '{$filename}'">SCE stderr</abbr></span>
+                    <pre><code>
+                        <xsl:copy-of select="$stderr"/>
                     </code></pre>
                 </xsl:if>
             </xsl:if>


### PR DESCRIPTION
We used to put both into interleaved output. This makes reuse of SCE results difficult for some of our users. This patch separates them.

Keep in mind that while this doesn't break API or ABI it does alter behavior! "stdout" is no longer stdout and stderr interleaved, it just has stdout in it now. I have added stderr into the HTML report so I think for the vast majority of use-cases this will improve the experience and not break it. However I see this as a gray area so I'd appreciate discussion.

I know we suggested stdout_only, stdout and stderr to keep current behavior but I thought that that was to confusing.

![image](https://cloud.githubusercontent.com/assets/753153/19357200/9782dc56-913e-11e6-944f-629611795415.png)
