### PR TITLE
Print error message if oscap loads bz2 files and doesn't support them

### DIFF
--- a/src/XCCDF/benchmark.c
+++ b/src/XCCDF/benchmark.c
@@ -697,8 +697,8 @@ bool xccdf_add_item(struct oscap_list *list, struct xccdf_item *parent, struct x
 	assert(list != NULL);
 	assert(item != NULL);
 
-    if (parent == NULL)
-        return false;
+	if (parent == NULL)
+		return false;
 
 	struct xccdf_benchmark *bench = xccdf_item_get_benchmark(parent);
 
@@ -715,7 +715,7 @@ bool xccdf_add_item(struct oscap_list *list, struct xccdf_item *parent, struct x
 	}
 	else return true;
 
-    return false;
+	return false;
 }
 
 struct xccdf_item *

--- a/src/source/bz2.c
+++ b/src/source/bz2.c
@@ -25,25 +25,23 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_BZ2
-
-#include <bzlib.h>
 #include <libxml/tree.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-
 #include "bz2_priv.h"
 #include "common/_error.h"
+
+#ifdef HAVE_BZ2
+
+#include <bzlib.h>
 
 struct bz2_file {
 	FILE *f;
 	BZFILE *file;
 	bool eof;
 };
-
-static const char magic_number[] = {'B','Z'};
 
 static struct bz2_file *bz2_fd_open(int fd)
 {
@@ -182,6 +180,10 @@ xmlDoc *bz2_mem_read_doc(const char *buffer, size_t size)
 	return xmlReadIO((xmlInputReadCallback) bz2_mem_read, bz2_mem_close, bzmem, "url", NULL, XML_PARSE_PEDANTIC);
 }
 
+#endif
+
+static const char magic_number[] = {'B','Z'};
+
 bool bz2_memory_is_bzip(const char* memory, const size_t size){
 	if (size < 2){
 		return false; // Cannot read magic number
@@ -211,4 +213,3 @@ bool bz2_fd_is_bzip(int fd)
 	return is_bzip;
 
 }
-#endif

--- a/src/source/bz2_priv.h
+++ b/src/source/bz2_priv.h
@@ -25,14 +25,13 @@
 #include <config.h>
 #endif
 
-#ifdef HAVE_BZ2
-
 #include "common/public/oscap.h"
 #include "common/util.h"
 #include <libxml/tree.h>
 
 OSCAP_HIDDEN_START;
 
+#ifdef HAVE_BZ2
 
 /**
  * Parse *.xml.bz2 file to XML DOM
@@ -48,6 +47,8 @@ xmlDoc *bz2_fd_read_doc(int fd);
  * @returns DOM representation of the data
  */
 xmlDoc *bz2_mem_read_doc(const char *buffer, size_t size);
+
+#endif // HAVE_BZ2
 
 /**
  * Recognize whether the file can be parsed by this
@@ -68,5 +69,4 @@ bool bz2_memory_is_bzip(const char* memory, const size_t size);
 
 OSCAP_HIDDEN_END;
 
-#endif
-#endif
+#endif // OSCAP_SOURCE_BZIP2_H

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -237,11 +237,13 @@ xmlDoc *oscap_source_get_xmlDoc(struct oscap_source *source)
 
 	if (source->xml.doc == NULL) {
 		if (source->origin.memory != NULL) {
-#ifdef HAVE_BZ2
 			if (bz2_memory_is_bzip(source->origin.memory, source->origin.memory_size)) {
+#ifdef HAVE_BZ2
 				source->xml.doc = bz2_mem_read_doc(source->origin.memory, source->origin.memory_size);
-			} else
+#else
+				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Unable to unpack bz2 from buffer memory '%s'. Please compile OpenSCAP with bz2 support.", oscap_source_readable_origin(source));
 #endif
+			} else
 			{
 				source->xml.doc = xmlReadMemory(source->origin.memory, source->origin.memory_size, NULL, NULL, 0);
 				if (source->xml.doc == NULL) {
@@ -263,11 +265,14 @@ xmlDoc *oscap_source_get_xmlDoc(struct oscap_source *source)
 				source->xml.doc = NULL;
 				oscap_seterr(OSCAP_EFAMILY_GLIBC, "Unable to open file: '%s'", oscap_source_readable_origin(source));
 			} else {
-#ifdef HAVE_BZ2
 				if (bz2_fd_is_bzip(fd)) {
+#ifdef HAVE_BZ2
 					source->xml.doc = bz2_fd_read_doc(fd);
-				} else
+#else
+					source->xml.doc = NULL;
+					oscap_seterr(OSCAP_EFAMILY_OSCAP, "Unable to unpack bz2 file '%s'. Please compile OpenSCAP with bz2 support.", oscap_source_readable_origin(source));
 #endif
+				} else
 				{
 					source->xml.doc = xmlReadFd(fd, NULL, NULL, 0);
 					if (source->xml.doc == NULL) {


### PR DESCRIPTION
oscap is able to recognize bz2 format even if it was compiled without bzip2 support.

If user with oscap(without bzip2 support) wanted to load bzip2 file, he got an ugly xml parsing error message. Now he will get less ugly error message.


https://github.com/OpenSCAP/scap-security-guide/issues/1509