### PR TITLE
Fixed spb_pick() to add 0 sized S-Expression even if our

### DIFF
--- a/src/OVAL/probes/SEAP/generic/spb.c
+++ b/src/OVAL/probes/SEAP/generic/spb.c
@@ -124,7 +124,7 @@ int spb_pick (spb_t *spb, spb_size_t start, spb_size_t size, void *dst)
 
         b_idx = spb_bindex (spb, start);
 
-        if (b_idx < spb->btotal) {
+        if (b_idx < spb->btotal || (b_idx == spb->btotal && size == 0)) {
                 size_t l_off;
                 size_t l_len;
 


### PR DESCRIPTION
position index points to end of the string.

This fix #310, which is the same bug in described in #447 comments, but was probably mistakenly related to #447 as it was an issue about not parsing a corner case which didn't lead to SIGSEGV.