### PR TITLE
Small refactor in spb_pick() fix when size == 0, just return

### DIFF
--- a/src/OVAL/probes/SEAP/generic/spb.c
+++ b/src/OVAL/probes/SEAP/generic/spb.c
@@ -124,7 +124,10 @@ int spb_pick (spb_t *spb, spb_size_t start, spb_size_t size, void *dst)
 
         b_idx = spb_bindex (spb, start);
 
-        if (b_idx < spb->btotal || (b_idx == spb->btotal && size == 0)) {
+        if (size == 0)
+            return (0); /* No bytes to copy, return as success */
+
+        if (b_idx < spb->btotal) {
                 size_t l_off;
                 size_t l_len;
 


### PR DESCRIPTION
right away instead of getting inside of copy block.