### PR TITLE
Fix invalid ARF results

### DIFF
--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -586,7 +586,7 @@ static int ds_rds_report_inject_refs(xmlDocPtr doc, xmlNodePtr report, const cha
 
 static void ds_rds_add_xccdf_test_results(xmlDocPtr doc, xmlNodePtr reports,
 		xmlDocPtr xccdf_result_file_doc, xmlNodePtr relationships, xmlNodePtr assets,
-		const char* report_request_id)
+		const char* report_request_id, struct oscap_htable *arf_report_mapping)
 {
 	xmlNodePtr root_element = xmlDocGetRootElement(xccdf_result_file_doc);
 
@@ -718,7 +718,7 @@ static int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr x
 	xmlNodePtr reports = xmlNewNode(arf_ns, BAD_CAST "reports");
 
 	ds_rds_add_xccdf_test_results(doc, reports, xccdf_result_file_doc,
-			relationships, assets, "collection1");
+			relationships, assets, "collection1", arf_report_mapping);
 
 	struct oscap_htable_iterator *hit = oscap_htable_iterator_new(arf_report_mapping);
 	while (oscap_htable_iterator_has_more(hit)) {

--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -738,7 +738,7 @@ static int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr x
 	return 0;
 }
 
-struct oscap_source *ds_rds_create_source(struct oscap_source *sds_source, struct oscap_source *xccdf_result_source, struct oscap_htable *oval_result_sources, const char *target_file)
+struct oscap_source *ds_rds_create_source(struct oscap_source *sds_source, struct oscap_source *xccdf_result_source, struct oscap_htable *oval_result_sources, struct oscap_htable *oval_result_mapping, struct oscap_htable *arf_report_mapping, const char *target_file)
 {
 	xmlDoc *sds_doc = oscap_source_get_xmlDoc(sds_source);
 	if (sds_doc == NULL) {
@@ -761,6 +761,8 @@ int ds_rds_create(const char* sds_file, const char* xccdf_result_file, const cha
 	struct oscap_source *sds_source = oscap_source_new_from_file(sds_file);
 	struct oscap_source *xccdf_result_source = oscap_source_new_from_file(xccdf_result_file);
 	struct oscap_htable *oval_result_sources = oscap_htable_new();
+	struct oscap_htable *oval_result_mapping = oscap_htable_new();
+	struct oscap_htable *arf_report_mapping = oscap_htable_new();
 
 	int result = 0;
 	// this check is there to allow passing NULL instead of having to allocate
@@ -780,7 +782,7 @@ int ds_rds_create(const char* sds_file, const char* xccdf_result_file, const cha
 		}
 	}
 	if (result == 0) {
-		struct oscap_source *target_rds = ds_rds_create_source(sds_source, xccdf_result_source, oval_result_sources, target_file);
+		struct oscap_source *target_rds = ds_rds_create_source(sds_source, xccdf_result_source, oval_result_sources, oval_result_mapping, arf_report_mapping, target_file);
 		result = target_rds == NULL;
 		if (result == 0) {
 			result = oscap_source_save_as(target_rds, NULL);
@@ -788,6 +790,8 @@ int ds_rds_create(const char* sds_file, const char* xccdf_result_file, const cha
 		oscap_source_free(target_rds);
 	}
 	oscap_htable_free(oval_result_sources, (oscap_destruct_func) oscap_source_free);
+	oscap_htable_free(oval_result_mapping, (oscap_destruct_func) oscap_free);
+	oscap_htable_free(arf_report_mapping, (oscap_destruct_func) arf_report_mapping);
 	oscap_source_free(sds_source);
 	oscap_source_free(xccdf_result_source);
 

--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -804,7 +804,7 @@ int ds_rds_create(const char* sds_file, const char* xccdf_result_file, const cha
 	}
 	oscap_htable_free(oval_result_sources, (oscap_destruct_func) oscap_source_free);
 	oscap_htable_free(oval_result_mapping, (oscap_destruct_func) oscap_free);
-	oscap_htable_free(arf_report_mapping, (oscap_destruct_func) arf_report_mapping);
+	oscap_htable_free(arf_report_mapping, (oscap_destruct_func) oscap_free);
 	oscap_source_free(sds_source);
 	oscap_source_free(xccdf_result_source);
 

--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -726,9 +726,9 @@ static int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr x
 	struct oscap_htable_iterator *hit = oscap_htable_iterator_new(arf_report_mapping);
 	while (oscap_htable_iterator_has_more(hit)) {
 		const struct oscap_htable_item *report_mapping_item = oscap_htable_iterator_next(hit);
-		char *oval_filename = report_mapping_item->key;
-		char *report_id = report_mapping_item->value;
-		char *report_file = oscap_htable_get(oval_result_mapping, oval_filename);
+		const char *oval_filename = report_mapping_item->key;
+		const char *report_id = report_mapping_item->value;
+		const char *report_file = oscap_htable_get(oval_result_mapping, oval_filename);
 		struct oscap_source *oval_source = oscap_htable_get(oval_result_sources, report_file);
 		xmlDoc *oval_result_doc = oscap_source_get_xmlDoc(oval_source);
 

--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -490,14 +490,6 @@ static void ds_rds_report_inject_rule_result_check_refs(xmlDocPtr doc, xmlNodePt
 	}
 }
 
-/*
- * This function replaces all check-content-ref/@href with "#" + id of ancestor arf:report.
- * Doing this replaces potentially valuable data with a value easily calculated from the XML.
- *
- * The only reason we do this is to pass requirement 370-1.
- *
- * TODO: Consider dropping this functionality if 370-1 is changed / clarified.
- */
 static void ds_rds_report_inject_rule_result_refs(xmlDocPtr doc, xmlNodePtr test_result_node, struct oscap_htable *arf_report_mapping)
 {
 	xmlNodePtr child = test_result_node->children;

--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -499,7 +499,7 @@ static void ds_rds_report_inject_rule_result_refs(xmlDocPtr doc, xmlNodePtr test
 	oscap_free(desired_href);
 }
 
-static int ds_rds_report_inject_refs(xmlDocPtr doc, xmlNodePtr report, const char *asset_id)
+static int ds_rds_report_inject_refs(xmlDocPtr doc, xmlNodePtr report, const char *asset_id, struct oscap_htable* arf_report_mapping)
 {
 	xmlNodePtr content_node = ds_rds_get_inner_content(doc, report);
 
@@ -608,7 +608,7 @@ static void ds_rds_add_xccdf_test_results(xmlDocPtr doc, xmlNodePtr reports,
 
 		// We deliberately don't act on errors in inject refs as
 		// these aren't fatal errors.
-		ds_rds_report_inject_refs(doc, report, asset_id);
+		ds_rds_report_inject_refs(doc, report, asset_id, arf_report_mapping);
 
 		xmlFree(asset_id);
 	}
@@ -652,7 +652,7 @@ static void ds_rds_add_xccdf_test_results(xmlDocPtr doc, xmlNodePtr reports,
 
 			// We deliberately don't act on errors in inject ref as
 			// these aren't fatal errors.
-			ds_rds_report_inject_refs(doc, report, asset_id);
+			ds_rds_report_inject_refs(doc, report, asset_id, arf_report_mapping);
 
 			xmlFree(asset_id);
 

--- a/src/DS/rds_priv.h
+++ b/src/DS/rds_priv.h
@@ -37,7 +37,7 @@ OSCAP_HIDDEN_START;
 xmlNode *ds_rds_lookup_container(xmlDocPtr doc, const char *container_name);
 xmlNode *ds_rds_lookup_component(xmlDocPtr doc, const char *container_name, const char *component_name, const char *id);
 int ds_rds_dump_arf_content(struct ds_rds_session *session, const char *container_name, const char *component_name, const char *content_id);
-struct oscap_source *ds_rds_create_source(struct oscap_source *sds_source, struct oscap_source *xccdf_result_source, struct oscap_htable *oval_result_sources, const char *target_file);
+struct oscap_source *ds_rds_create_source(struct oscap_source *sds_source, struct oscap_source *xccdf_result_source, struct oscap_htable *oval_result_sources, struct oscap_htable *oval_result_mapping, struct oscap_htable *arf_report_mapping, const char *target_file);
 xmlNodePtr ds_rds_create_report(xmlDocPtr target_doc, xmlNodePtr reports_node, xmlDocPtr source_doc, const char* report_id);
 
 OSCAP_HIDDEN_END;

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -226,7 +226,7 @@ static struct oscap_source* xccdf_session_create_arf_source(struct xccdf_session
 		free(sds_path);
 	}
 
-	session->oval.arf_report = ds_rds_create_source(sds_source, session->xccdf.result_source, session->oval.result_sources, session->export.arf_file);
+	session->oval.arf_report = ds_rds_create_source(sds_source, session->xccdf.result_source, session->oval.result_sources, session->oval.results_mapping, session->oval.arf_report_mapping, session->export.arf_file);
 	if (!xccdf_session_is_sds(session)) {
 		oscap_source_free(sds_source);
 	}

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1284,6 +1284,13 @@ static char *_xccdf_session_export_oval_result_file(struct xccdf_session *sessio
 		return NULL;
 	}
 
+	static int counter = 0;
+	char *report_id = oscap_sprintf("oval%d", counter++);
+	const char *original_name = oval_agent_get_filename(oval_session);
+	char *results_file_name = oscap_strdup(name);
+	oscap_htable_add(session->oval.results_mapping, original_name, results_file_name);
+	oscap_htable_add(session->oval.arf_report_mapping, original_name, report_id);
+
 	/* validate OVAL Results */
 	if (session->validate && session->full_validation) {
 		if (oscap_source_validate(source, _reporter, NULL)) {

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -89,6 +89,8 @@ struct xccdf_session {
 		char *product_cpe;			///< CPE of scanner product.
 		struct oscap_source* arf_report;	///< ARF report
 		struct oscap_htable *result_sources;    ///< mapping 'filepath' to oscap_source for OVAL results
+		struct oscap_htable *results_mapping;    ///< mapping OVAL filename to filepath for OVAL results
+		struct oscap_htable *arf_report_mapping;    ///< mapping OVAL filename to ARF report ID for OVAL results
 	} oval;
 	struct {
 		char *arf_file;				///< Path to ARF file to export
@@ -260,6 +262,8 @@ void xccdf_session_free(struct xccdf_session *session)
 	oscap_source_free(session->source);
 	oscap_source_free(session->tailoring.user_file);
 	oscap_free(session->tailoring.user_component_id);
+	oscap_htable_free(session->oval.results_mapping, (oscap_destruct_func) oscap_free);
+	oscap_htable_free(session->oval.arf_report_mapping, (oscap_destruct_func) oscap_free);
 	oscap_free(session);
 }
 
@@ -1300,6 +1304,8 @@ static int _build_oval_result_sources(struct xccdf_session *session)
 
 	/* Export OVAL results */
 	session->oval.result_sources = oscap_htable_new();
+	session->oval.results_mapping = oscap_htable_new();
+	session->oval.arf_report_mapping = oscap_htable_new();
 	for (int i = 0; session->oval.agents[i]; i++) {
 		char *filename = _xccdf_session_export_oval_result_file(session, session->oval.agents[i]);
 		if (filename == NULL) {


### PR DESCRIPTION
We don't pass validation performed by the SCAPVal tool.

```
ERROR: SCHEMATRON - [results.xml] If the <xccdf:result> value for a <xccdf:rule-result> is 'error', 'unknown', 'notapplicable', or 'notchecked', then the result of at least one OVAL definition referenced by that rule SHALL be 'error', 'unknown', 'not applicable', or 'not evaluated', respectively. If the <xccdf:result> value is 'fail' then the result of at least one of the OVAL definitions referenced SHALL match the fail category as defined in the SCAP table. If the <xccdf:result> value is 'pass' then the result of all of the OVAL definitions referenced SHALL match the pass category as defined in the SCAP table.
ERROR: SCHEMATRON - [results.xml] The @href attribute SHALL contain "#" + the @id of the <arf:report> containing the check result. This approach provides traceability between XCCDF and check results.
ERROR: SCHEMATRON - [results.xml] Depending on the checking engine used (OVAL or OCIL), the the <arf:report> element should contain the relevant (OVAL or OCIL) content.
```
etc.

Those errors are reported because in XCCDF results part of ARF file, in xccdf:check-content-ref@href attribute OpenSCAP provides references to the XCCDF. This is wrong because it should contain reference to arf:report where OVAL results can be found.

This pull request wants to fix those errors reported by SCAPVal. Basically, when publishing XCCDF results to ARF it will replace a reference to OVAL definitions by reference to OVAL results document.

To be honest, I don't like the way how is this done, but I wasn't able to find anything better now. Any suggestions are welcome.