### PR TITLE
Fix injecting references to check-content-ref@href

### DIFF
--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -476,7 +476,9 @@ static void ds_rds_report_inject_rule_result_check_refs(xmlDocPtr doc, xmlNodePt
 
 	while (child) {
 		if (child->type == XML_ELEMENT_NODE) {
-			if (strcmp((const char*)child->name, "check") == 0) {
+			if (strcmp((const char*)child->name, "complex-check") == 0) {
+				ds_rds_report_inject_rule_result_check_refs(doc, child, arf_report_mapping);
+			} else if (strcmp((const char*)child->name, "check") == 0) {
 				xmlNodePtr check_content_ref = child->children;
 
 				while (check_content_ref) {


### PR DESCRIPTION
This enables to reference OVAL results in arf:report
if the XCCDF rule contains xccdf:complex-check.
Previously xccdf:complex-check were ignored.