### PR TITLE
Create XCCDf session result maps even when no oval agents are set

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1313,13 +1313,15 @@ static int _build_oval_result_sources(struct xccdf_session *session)
 	session->oval.result_sources = oscap_htable_new();
 	session->oval.results_mapping = oscap_htable_new();
 	session->oval.arf_report_mapping = oscap_htable_new();
-	for (int i = 0; session->oval.agents[i]; i++) {
-		char *filename = _xccdf_session_export_oval_result_file(session, session->oval.agents[i]);
-		if (filename == NULL) {
-			_xccdf_session_free_oval_result_sources(session);
-			return 1;
+	if (session->oval.agents) {
+		for (int i = 0; session->oval.agents[i]; i++) {
+			char *filename = _xccdf_session_export_oval_result_file(session, session->oval.agents[i]);
+			if (filename == NULL) {
+				_xccdf_session_free_oval_result_sources(session);
+				return 1;
+			}
+			oscap_free(filename);
 		}
-		oscap_free(filename);
 	}
 
 	struct oscap_htable_iterator *cpe_it = xccdf_policy_model_get_cpe_oval_sessions(session->xccdf.policy_model);
@@ -1342,7 +1344,7 @@ static int _build_oval_result_sources(struct xccdf_session *session)
 
 int xccdf_session_export_oval(struct xccdf_session *session)
 {
-	if ((session->export.oval_results || session->export.arf_file != NULL) && session->oval.agents) {
+	if (session->export.oval_results || session->export.arf_file != NULL) {
 		if (_build_oval_result_sources(session) != 0) {
 			return 1;
 		}


### PR DESCRIPTION
Resolves:
```
Program received signal SIGSEGV, Segmentation fault.
oscap_htable_lookup (htable=0x0, key=0x14c3470 "r3300-OCIL.xml") at list.c:441

0  oscap_htable_lookup (htable=0x0, key=0x14c3470 "r3300-OCIL.xml") at list.c:441
1  0x00007ffff7b285d9 in oscap_htable_get (htable=<optimized out>, key=<optimized out>) at list.c:495
2  0x00007ffff7b3206d in ds_rds_report_inject_check_content_ref (arf_report_mapping=0x0,
    check_content_ref=0x14c05a0) at rds.c:460
3  ds_rds_report_inject_rule_result_check_refs (doc=<optimized out>, rule_result=0x14bfbc0,
    arf_report_mapping=0x0) at rds.c:483
4  ds_rds_report_inject_rule_result_refs (doc=<optimized out>, test_result_node=<optimized out>,
    arf_report_mapping=0x0) at rds.c:499
5  ds_rds_report_inject_refs (report=report@entry=0x14bcb10,
    asset_id=asset_id@entry=0x14c2bc0 "asset0", arf_report_mapping=arf_report_mapping@entry=0x0,
    doc=<optimized out>) at rds.c:585
6  0x00007ffff7b32a35 in ds_rds_add_xccdf_test_results (
    report_request_id=0x7ffff7b9830c "collection1", arf_report_mapping=0x0, assets=0x1498300,
    relationships=0x14980c0, xccdf_result_file_doc=0x1474db0, reports=0x14b8830, doc=0x1497d80)
    at rds.c:658
7  ds_rds_create_from_dom (arf_report_mapping=0x0, oval_result_mapping=0x0, oval_result_sources=0x0,
    xccdf_result_file_doc=0x1474db0, sds_doc=<optimized out>, ret=<synthetic pointer>) at rds.c:723
8  ds_rds_create_source (sds_source=<optimized out>, xccdf_result_source=<optimized out>,
    oval_result_sources=0x0, oval_result_mapping=0x0, arf_report_mapping=0x0,
    target_file=0x1473cb0 "benchmark1.results_arf.xml") at rds.c:757
9  0x00007ffff7b8b16c in xccdf_session_create_arf_source (session=0x61ca80) at xccdf_session.c:229
10 0x00007ffff7b8cf25 in xccdf_session_create_arf_source (session=0x61ca80) at xccdf_session.c:1446
11 xccdf_session_export_arf (session=session@entry=0x61ca80) at xccdf_session.c:1428
12 0x000000000040beb0 in app_evaluate_xccdf (action=0x7fffffffde90) at oscap-xccdf.c:523
13 0x0000000000408120 in oscap_module_call (action=0x7fffffffde90) at oscap-tool.c:261
14 oscap_module_process (module=0x6154e0 <XCCDF_EVAL>, module@entry=0x614a60 <OSCAP_ROOT_MODULE>,
    argc=argc@entry=8, argv=argv@entry=0x7fffffffe128) at oscap-tool.c:346
15 0x00000000004071bf in main (argc=8, argv=0x7fffffffe128) at oscap.c:80
```