### PR TITLE
Maint 1.2 improve generate fix

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -514,6 +514,11 @@ static const struct xccdf_fix *_find_fix_for_template(struct xccdf_policy *polic
 	struct xccdf_fix *fix = NULL;
 	struct oscap_list *fixes = _get_fixes(policy, rule);
 
+	if (template) {
+		const struct _interpret_map map[] = {	{template, "Cloud!"},
+							{NULL, NULL}};
+		fixes = _filter_fixes_by_system(fixes, _search_interpret_map, map);
+	}
 	fixes = _filter_fixes_by_distruption_and_reboot(fixes);
 	struct xccdf_fix_iterator *fix_it = oscap_iterator_new(fixes);
 	if (xccdf_fix_iterator_has_more(fix_it))

--- a/tests/API/XCCDF/applicability/test_report_anaconda_fixes.sh
+++ b/tests/API/XCCDF/applicability/test_report_anaconda_fixes.sh
@@ -16,8 +16,8 @@ line3='^\W*passwd --minlen=14$'
 $OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
-grep "$line1" $result && true
-grep "$line2" $result && true
+grep "$line1" $result
+grep "$line2" $result
 grep "$line3" $result && false
 :> $result
 
@@ -25,9 +25,9 @@ $OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
 	--profile xccdf_moc.elpmaxe.www_profile_1 \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
-grep "$line1" $result && true
-grep "$line2" $result && true
-grep "$line3" $result && true
+grep "$line1" $result
+grep "$line2" $result
+grep "$line3" $result
 :> $result
 
 $OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \

--- a/tests/API/XCCDF/applicability/test_report_anaconda_fixes.sh
+++ b/tests/API/XCCDF/applicability/test_report_anaconda_fixes.sh
@@ -16,8 +16,8 @@ line3='^\W*passwd --minlen=14$'
 $OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
-grep "$line1" $result && false
-grep "$line2" $result && false
+grep "$line1" $result && true
+grep "$line2" $result && true
 grep "$line3" $result && false
 :> $result
 
@@ -25,9 +25,9 @@ $OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
 	--profile xccdf_moc.elpmaxe.www_profile_1 \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
-grep "$line1" $result && false
-grep "$line2" $result && false
-grep "$line3" $result && false
+grep "$line1" $result && true
+grep "$line2" $result && true
+grep "$line3" $result && true
 :> $result
 
 $OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -753,6 +753,10 @@ static bool _some_result_exists(struct oscap_source *xccdf_source, const char *n
 
 int app_generate_fix(const struct oscap_action *action)
 {
+	if (!oscap_set_verbose(action->verbosity_level, action->f_verbose_log, false)) {
+		return OSCAP_ERROR;
+	}
+
 	if (action->id != NULL) {
 		/* Listen very carefully -- I shall say this only once. This is temporaly
 		 * fallback mode. Which may be dropped from future OpenSCAP releases.


### PR DESCRIPTION
Added --verbose support in generate fix.

Removed a filter in generate fix that was filtering all fixes by current machine CPE, which makes no sense.