### PR TITLE
Fixed a potential null deref in ds_rds_lookup_container().

### DIFF
--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -59,6 +59,10 @@ xmlNode *ds_rds_lookup_container(xmlDocPtr doc, const char *container_name)
 {
 	xmlNodePtr root = xmlDocGetRootElement(doc);
 	xmlNodePtr ret = NULL;
+
+	if (root == NULL)
+		return ret;
+
 	xmlNodePtr candidate = root->children;
 
 	for (; candidate != NULL; candidate = candidate->next)


### PR DESCRIPTION
If xmlDocGetRootElement returns NULL to root, it will dereference a null pointers, leading to a crash or maybe something worse.