### PR TITLE
Only check ID of profile if profile exists

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -2480,12 +2480,15 @@ void xccdf_policy_model_free(struct xccdf_policy_model * model) {
 
 void xccdf_policy_free(struct xccdf_policy * policy) {
 
-        /* If ID of policy's profile is NULL then this
-         * profile is created by Policy layer and need
-         * to be freed
-         */
-        if (policy->profile && xccdf_profile_get_id(policy->profile) == NULL)
-            xccdf_profile_free((struct xccdf_item *) policy->profile);
+	/* A policy which is set to use default profile has its profile member set to NULL,
+	 * check it so we don't try to get the ID from a NULL profile.
+	 * */
+	if (policy->profile && xccdf_profile_get_id(policy->profile) == NULL)
+		/* If ID of policy's profile is NULL then this
+		 * profile is created by Policy layer and need
+		 * to be freed
+		 */
+		xccdf_profile_free((struct xccdf_item *) policy->profile);
 
 	oscap_list_free(policy->selects, (oscap_destruct_func) xccdf_select_free);
 	oscap_list_free(policy->values, (oscap_destruct_func) xccdf_value_binding_free);

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -2484,7 +2484,7 @@ void xccdf_policy_free(struct xccdf_policy * policy) {
          * profile is created by Policy layer and need
          * to be freed
          */
-        if (xccdf_profile_get_id(policy->profile) == NULL)
+        if (policy->profile && xccdf_profile_get_id(policy->profile) == NULL)
             xccdf_profile_free((struct xccdf_item *) policy->profile);
 
 	oscap_list_free(policy->selects, (oscap_destruct_func) xccdf_select_free);


### PR DESCRIPTION
Freeing a default policy, which has no profile assigned, was causing a segfault.