### PR TITLE
Runlevel probe fixes

### DIFF
--- a/src/OVAL/probes/unix/runlevel.c
+++ b/src/OVAL/probes/unix/runlevel.c
@@ -296,8 +296,7 @@ static int parse_os_release(const char * cpe)
 	if (osrelease < 0)
 		return !errno;
 
-	char buf[RELEASENAME_MAX_SIZE];
-	char *releasename = &buf[0];
+	char releasename[RELEASENAME_MAX_SIZE];
 	memset(releasename, 0, RELEASENAME_MAX_SIZE);
 
 	got = fscanf(osrelease, RELEASENAME_PATTERN, releasename);
@@ -369,9 +368,9 @@ static int is_solaris (void)
         return (stat ("/etc/release", &st)   == 0);
 }
 
-static int is_wrlinux (void)
+static int is_wrlinux(void)
 {
-	return (parse_os_release("cpe:/o:windriver:wrlinux"));
+	return parse_os_release("cpe:/o:windriver:wrlinux");
 }
 
 static int is_common (void)

--- a/src/OVAL/probes/unix/runlevel.c
+++ b/src/OVAL/probes/unix/runlevel.c
@@ -287,37 +287,37 @@ static int get_runlevel_common (struct runlevel_req *req, struct runlevel_rep **
 
 static int parse_os_release(const char * cpe)
 {
-        struct stat st;
-        int got;
-        int ret;
-        FILE * osrelease;
-        char buf[RELEASENAME_MAX_SIZE];
-        char *releasename = &buf[0];
-        char c;
+	struct stat st;
+	int got;
+	int ret;
+	FILE * osrelease;
+	char buf[RELEASENAME_MAX_SIZE];
+	char *releasename = &buf[0];
+	char c;
 
-        got = stat ("/etc/os-release", &st);
-        if ( got ) return (got == 0);
+	got = stat("/etc/os-release", &st);
+	if ( got ) return (got == 0);
 
-        osrelease = fopen("/etc/os-release", "r");
-        if ( osrelease < 0 ) return (! errno);
+	osrelease = fopen("/etc/os-release", "r");
+	if ( osrelease < 0 ) return (! errno);
 
-        memset(releasename, 0, RELEASENAME_MAX_SIZE);
+	memset(releasename, 0, RELEASENAME_MAX_SIZE);
 
-        got = fscanf(osrelease, RELEASENAME_PATTERN , releasename);
-        while ( got == 0 ) {
-                c = fgetc(osrelease);
-                got = fscanf(osrelease, RELEASENAME_PATTERN , releasename);
-        }
-        if ( got < 0 ) {
-                ret = !got;
-                goto done;
-        }
+	got = fscanf(osrelease, RELEASENAME_PATTERN , releasename);
+	while ( got == 0 ) {
+		c = fgetc(osrelease);
+		got = fscanf(osrelease, RELEASENAME_PATTERN , releasename);
+	}
+	if ( got < 0 ) {
+		ret = !got;
+		goto done;
+	}
 
-        ret = strncmp(releasename, cpe, strlen(cpe)) == 0;
+	ret = strncmp(releasename, cpe, strlen(cpe)) == 0;
 
 done:
-        fclose(osrelease);
-        return(ret);
+	fclose(osrelease);
+	return(ret);
 }
 
 static int is_redhat (void)

--- a/src/OVAL/probes/unix/runlevel.c
+++ b/src/OVAL/probes/unix/runlevel.c
@@ -53,7 +53,6 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 #include <assert.h>
 #include <unistd.h>
@@ -302,7 +301,7 @@ static int parse_os_release(const char * cpe)
         osrelease = fopen("/etc/os-release", "r");
         if ( osrelease < 0 ) return (! errno);
 
-        bzero(releasename, RELEASENAME_MAX_SIZE);
+        memset(releasename, 0, RELEASENAME_MAX_SIZE);
 
         got = fscanf(osrelease, RELEASENAME_PATTERN , releasename);
         while ( got == 0 ) {


### PR DESCRIPTION
Fixed coverity warnings and other issues found in `parse_os_release` in `runlevel.c`. I found some logic errors in the code and many things were over-complicated.

Would be awesome if @radzy could review this.

I tested it using gdb.

```
./run cgdb src/OVAL/probes/.libs/probe_runlevel
```

Inside gdb do:
```
break main
run
print parse_os_release("whatever_you_wish");
```

Fixes #591