### PR TITLE
Added support for --without-syschar in XCCDF modules, now it is

### DIFF
--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -195,6 +195,14 @@ void xccdf_session_set_custom_oval_eval_fn(struct xccdf_session *session, xccdf_
 bool xccdf_session_set_product_cpe(struct xccdf_session *session, const char *product_cpe);
 
 /**
+ * Set whether the System Characteristics shall be exported in result files.
+ * @memberof xccdf_session
+ * @param session XCCDF Session
+ * @param without_sys_chars whether to export System Characteristics or not.
+ */
+void xccdf_session_set_without_sys_chars_export(struct xccdf_session *session, bool without_sys_chars);
+
+/**
  * Set whether the OVAL result files shall be exported.
  * @memberof xccdf_session
  * @param session XCCDF Session

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -98,7 +98,8 @@ struct xccdf_session {
 		char *report_file;			///< Path to HTML file to eport
 		bool oval_results;			///< Shall be the OVAL results files exported?
 		bool oval_variables;			///< Shall be the OVAL variable files exported?
-		bool check_engine_plugins_results; ///< Shall the check engine plugins results be exported?
+		bool check_engine_plugins_results;	///< Shall the check engine plugins results be exported?
+		bool without_sys_chars;			///< Shall system characteristics be exported?
 	} export;					///< Settings of Session export
 	char *user_cpe;					///< Path to CPE dictionary required by user
 	struct {
@@ -351,6 +352,11 @@ bool xccdf_session_set_product_cpe(struct xccdf_session *session, const char *pr
 	oscap_free(session->oval.product_cpe);
 	session->oval.product_cpe = oscap_strdup(product_cpe);
 	return true;
+}
+
+void xccdf_session_set_without_sys_chars_export(struct xccdf_session *session, bool without_sys_chars)
+{
+	session->export.without_sys_chars = without_sys_chars;
 }
 
 void xccdf_session_set_oval_results_export(struct xccdf_session *session, bool to_export_oval_results)
@@ -1249,6 +1255,8 @@ static char *_xccdf_session_export_oval_result_file(struct xccdf_session *sessio
 {
 	/* get result model and session name */
 	struct oval_results_model *res_model = oval_agent_get_results_model(oval_session);
+	/* Import XCCDF session without_sys_chars flag to res_model */
+	oval_results_model_set_export_system_characteristics(res_model, !session->export.without_sys_chars);
 	const char* oval_results_directory = NULL;
 
 	if (session->export.oval_results == true) {

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -148,6 +148,7 @@ static struct oscap_module XCCDF_EVAL = {
         "   --export-variables\r\t\t\t\t - Export OVAL external variables provided by XCCDF.\n"
         "   --results <file>\r\t\t\t\t - Write XCCDF Results into file.\n"
         "   --results-arf <file>\r\t\t\t\t - Write ARF (result data stream) into file.\n"
+        "   --without-syschar \r\t\t\t\t - Don't provide system characteristic in result file.\n"
         "   --report <file>\r\t\t\t\t - Write HTML report into file.\n"
         "   --skip-valid \r\t\t\t\t - Skip validation.\n"
 	"   --fetch-remote-resources \r\t\t\t\t - Download remote content referenced by XCCDF.\n"
@@ -492,6 +493,7 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 	if (xccdf_session_evaluate(session) != 0)
 		goto cleanup;
 
+	xccdf_session_set_without_sys_chars_export(session, action->without_sys_chars);
 	xccdf_session_set_oval_results_export(session, action->oval_results);
 	xccdf_session_set_oval_variables_export(session, action->export_variables);
 	xccdf_session_set_arf_export(session, action->f_results_arf);
@@ -955,6 +957,7 @@ bool getopt_xccdf(int argc, char **argv, struct oscap_action *action)
 		{"hide-profile-info",	no_argument, &action->hide_profile_info, 1},
 		{"export-variables",	no_argument, &action->export_variables, 1},
 		{"schematron",          no_argument, &action->schematron, 1},
+		{"without-syschar",    no_argument, &action->without_sys_chars, 1},
 	// end
 		{0, 0, 0, 0}
 	};

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -148,7 +148,7 @@ static struct oscap_module XCCDF_EVAL = {
         "   --export-variables\r\t\t\t\t - Export OVAL external variables provided by XCCDF.\n"
         "   --results <file>\r\t\t\t\t - Write XCCDF Results into file.\n"
         "   --results-arf <file>\r\t\t\t\t - Write ARF (result data stream) into file.\n"
-        "   --without-syschar \r\t\t\t\t - Don't provide system characteristic in result file.\n"
+        "   --without-syschar \r\t\t\t\t - Don't provide system characteristic in OVAL/ARF result files.\n"
         "   --report <file>\r\t\t\t\t - Write HTML report into file.\n"
         "   --skip-valid \r\t\t\t\t - Skip validation.\n"
 	"   --fetch-remote-resources \r\t\t\t\t - Download remote content referenced by XCCDF.\n"

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -100,6 +100,11 @@ Write XCCDF results into FILE.
 Writes results to a given FILE in Asset Reporting Format. It is recommended to use this option instead of --results when dealing with datastreams.
 .RE
 .TP
+\fB\-\-without-syschar\fR
+.RS
+Don't provide system characteristics in result file.
+.RE
+.TP
 \fB\-\-report FILE\fR
 .RS
 Write HTML report into FILE. You also have to specify --results for this feature to work. Please see --oval-results to enable additional information in the report.

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -102,7 +102,7 @@ Writes results to a given FILE in Asset Reporting Format. It is recommended to u
 .TP
 \fB\-\-without-syschar\fR
 .RS
-Don't provide system characteristics in result file.
+Don't provide system characteristics in OVAL/ARF result files.
 .RE
 .TP
 \fB\-\-report FILE\fR


### PR DESCRIPTION
possible to generate OVAL and/or XCCDF results with or without
OVAL System Characteristics.