### PR TITLE
Added --thin option to the XCCDF module, this enables thin results in OVAL and ARF files.

### DIFF
--- a/src/CPE/cpe_session.c
+++ b/src/CPE/cpe_session.c
@@ -120,22 +120,16 @@ struct oval_agent_session *cpe_session_lookup_oval_session(struct cpe_session *c
 			return NULL;
 		}
 		if (cpe->thin_results) {
-			struct oval_result_directives *dir = oval_result_directives_new();
-			if (dir == NULL) {
-				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Failed to create new directives model for: '%s'.", prefixed_href);
-				return NULL;
-			}
+			struct oval_results_model *res_model = oval_agent_get_results_model(session);
+			struct oval_directives_model *dir_model = oval_results_model_get_directives_model(res_model);
+			// This is the worst function name in existence, despite its name,
+			// it's getting the oval_result_directives of the oval_directives_model.
+			// You would expect oval_directives_model_getresdirs at least, but no..
+			struct oval_result_directives *dir = oval_directives_model_get_defdirs(dir_model);
 			oval_result_directives_set_content(dir,  OVAL_RESULT_TRUE | OVAL_RESULT_FALSE |
 							OVAL_RESULT_UNKNOWN | OVAL_RESULT_NOT_EVALUATED |
 							OVAL_RESULT_NOT_APPLICABLE | OVAL_RESULT_ERROR,
 							OVAL_DIRECTIVE_CONTENT_THIN);
-
-			struct oval_results_model *res_model = oval_agent_get_results_model(session);
-			struct oval_directives_model *dir_model = oval_results_model_get_directives_model(res_model);
-			// This is the worst function name in existence, despite its name,
-			// it's setting the oval_result_directives of the oval_directives_model.
-			// You would expect oval_directives_model_setresdirs at least, but no..
-			oval_directives_model_set_defdirs(dir_model, dir);
 		}
 		oscap_htable_add(cpe->oval_sessions, prefixed_href, session);
 	}

--- a/src/CPE/cpe_session.c
+++ b/src/CPE/cpe_session.c
@@ -53,6 +53,7 @@ struct cpe_session *cpe_session_new(void)
 	cpe->lang_models = oscap_list_new();
 	cpe->oval_sessions = oscap_htable_new();
 	cpe->applicable_platforms = oscap_htable_new();
+	cpe->thin_results = false;
 	if (!cpe_session_add_default_cpe(cpe)) {
 		oscap_seterr(OSCAP_EFAMILY_XCCDF, "Failed to add default CPE to newly created CPE Session.");
 	}
@@ -87,6 +88,11 @@ static inline struct oscap_source *_lookup_source_in_cache(struct cpe_session *s
 	return source;
 }
 
+void cpe_session_set_thin_results(struct cpe_session *cpe, bool thin_results)
+{
+	cpe->thin_results = thin_results;
+}
+
 struct oval_agent_session *cpe_session_lookup_oval_session(struct cpe_session *cpe, const char *prefixed_href)
 {
 	struct oval_agent_session* session = (struct oval_agent_session*)oscap_htable_get(cpe->oval_sessions, prefixed_href);
@@ -112,6 +118,29 @@ struct oval_agent_session *cpe_session_lookup_oval_session(struct cpe_session *c
 		if (session == NULL) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Cannot create OVAL session for '%s' for CPE applicability checking", prefixed_href);
 			return NULL;
+		}
+		if (cpe->thin_results) {
+			struct oval_result_directives *dir = oval_result_directives_new();
+			if (dir == NULL) {
+				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Failed to create new directives model for: '%s'.", prefixed_href);
+				return NULL;
+			}
+			oval_result_directives_set_reported(dir,
+						OVAL_RESULT_TRUE	| OVAL_RESULT_FALSE |
+						OVAL_RESULT_UNKNOWN | OVAL_RESULT_NOT_EVALUATED |
+						OVAL_RESULT_ERROR	| OVAL_RESULT_NOT_APPLICABLE,
+						true);
+			oval_result_directives_set_content(dir,  OVAL_RESULT_TRUE | OVAL_RESULT_FALSE |
+							OVAL_RESULT_UNKNOWN | OVAL_RESULT_NOT_EVALUATED |
+							OVAL_RESULT_NOT_APPLICABLE | OVAL_RESULT_ERROR,
+							OVAL_DIRECTIVE_CONTENT_THIN);
+
+			struct oval_results_model *res_model = oval_agent_get_results_model(session);
+			struct oval_directives_model *dir_model = oval_results_model_get_directives_model(res_model);
+			// This is the worst function name in existence, despite its name,
+			// it's setting the oval_result_directives of the oval_directives_model.
+			// You would expect oval_directives_model_setresdirs at least, but no..
+			oval_directives_model_set_defdirs(dir_model, dir);
 		}
 		oscap_htable_add(cpe->oval_sessions, prefixed_href, session);
 	}

--- a/src/CPE/cpe_session.c
+++ b/src/CPE/cpe_session.c
@@ -125,11 +125,6 @@ struct oval_agent_session *cpe_session_lookup_oval_session(struct cpe_session *c
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Failed to create new directives model for: '%s'.", prefixed_href);
 				return NULL;
 			}
-			oval_result_directives_set_reported(dir,
-						OVAL_RESULT_TRUE	| OVAL_RESULT_FALSE |
-						OVAL_RESULT_UNKNOWN | OVAL_RESULT_NOT_EVALUATED |
-						OVAL_RESULT_ERROR	| OVAL_RESULT_NOT_APPLICABLE,
-						true);
 			oval_result_directives_set_content(dir,  OVAL_RESULT_TRUE | OVAL_RESULT_FALSE |
 							OVAL_RESULT_UNKNOWN | OVAL_RESULT_NOT_EVALUATED |
 							OVAL_RESULT_NOT_APPLICABLE | OVAL_RESULT_ERROR,

--- a/src/CPE/cpe_session_priv.h
+++ b/src/CPE/cpe_session_priv.h
@@ -38,10 +38,12 @@ struct cpe_session {
 	struct oscap_htable *oval_sessions;             ///< Caches CPE OVAL check results
 	struct oscap_htable *applicable_platforms;
 	struct oscap_htable *sources_cache;             ///< Not owned cache [path -> oscap_source]
+	bool thin_results;                              ///< Should OVAL results related to CPE be exported as THIN?
 };
 
 struct cpe_session *cpe_session_new(void);
 void cpe_session_free(struct cpe_session *session);
+void cpe_session_set_thin_results(struct cpe_session *session, bool thin_results);
 struct oval_agent_session *cpe_session_lookup_oval_session(struct cpe_session *cpe, const char *prefixed_href);
 bool cpe_session_add_cpe_lang_model_source(struct cpe_session *session, struct oscap_source *source);
 bool cpe_session_add_cpe_dict_source(struct cpe_session *session, struct oscap_source *source);

--- a/src/OVAL/oval_directives.c
+++ b/src/OVAL/oval_directives.c
@@ -175,11 +175,6 @@ struct oval_result_directives *oval_directives_model_get_defdirs(struct oval_dir
 	return model->def_directives;
 }
 
-void oval_directives_model_set_defdirs(struct oval_directives_model *model, struct oval_result_directives *def_directives)
-{
-	model->def_directives = def_directives;
-}
-
 struct oval_result_directives *oval_directives_model_get_classdir(struct oval_directives_model *model, oval_definition_class_t classdir)
 {
 	/* enum -> index */

--- a/src/OVAL/oval_directives.c
+++ b/src/OVAL/oval_directives.c
@@ -172,7 +172,12 @@ struct oval_generator *oval_directives_model_get_generator(struct oval_directive
 
 struct oval_result_directives *oval_directives_model_get_defdirs(struct oval_directives_model *model)
 {
-        return model->def_directives;
+	return model->def_directives;
+}
+
+void oval_directives_model_set_defdirs(struct oval_directives_model *model, struct oval_result_directives *def_directives)
+{
+	model->def_directives = def_directives;
 }
 
 struct oval_result_directives *oval_directives_model_get_classdir(struct oval_directives_model *model, oval_definition_class_t classdir)

--- a/src/OVAL/public/oval_directives.h
+++ b/src/OVAL/public/oval_directives.h
@@ -89,6 +89,10 @@ struct oval_generator *oval_directives_model_get_generator(struct oval_directive
  */
 struct oval_result_directives *oval_directives_model_get_defdirs(struct oval_directives_model *);
 /**
+ * TODO
+ */
+void oval_directives_model_set_defdirs(struct oval_directives_model *model, struct oval_result_directives *def_directives);
+/**
  * @memberof oval_directives_model
  */
 struct oval_result_directives *oval_directives_model_get_classdir(struct oval_directives_model *, oval_definition_class_t);

--- a/src/OVAL/public/oval_directives.h
+++ b/src/OVAL/public/oval_directives.h
@@ -89,7 +89,7 @@ struct oval_generator *oval_directives_model_get_generator(struct oval_directive
  */
 struct oval_result_directives *oval_directives_model_get_defdirs(struct oval_directives_model *);
 /**
- * TODO
+ * @memberof oval_directives_model
  */
 void oval_directives_model_set_defdirs(struct oval_directives_model *model, struct oval_result_directives *def_directives);
 /**

--- a/src/OVAL/public/oval_directives.h
+++ b/src/OVAL/public/oval_directives.h
@@ -91,10 +91,6 @@ struct oval_result_directives *oval_directives_model_get_defdirs(struct oval_dir
 /**
  * @memberof oval_directives_model
  */
-void oval_directives_model_set_defdirs(struct oval_directives_model *model, struct oval_result_directives *def_directives);
-/**
- * @memberof oval_directives_model
- */
 struct oval_result_directives *oval_directives_model_get_classdir(struct oval_directives_model *, oval_definition_class_t);
 /**
  * @memberof oval_directives_model

--- a/src/OVAL/public/oval_results.h
+++ b/src/OVAL/public/oval_results.h
@@ -202,14 +202,10 @@ struct oval_generator *oval_results_model_get_generator(struct oval_results_mode
 struct oval_definition_model *oval_results_model_get_definition_model(struct oval_results_model *model);
 
 /**
- * TODO
+ * Return the OVAL directives model
+ * @memberof oval_results_model
  */
 struct oval_directives_model *oval_results_model_get_directives_model(struct oval_results_model *model);
-
-/**
- * TODO
- */
-void oval_results_model_set_directives_model(struct oval_results_model *model, struct oval_directives_model* dir_model);
 
 /**
  * Return iterator over reporting systems.

--- a/src/OVAL/public/oval_results.h
+++ b/src/OVAL/public/oval_results.h
@@ -193,12 +193,23 @@ void oval_results_model_set_generator(struct oval_results_model *model, struct o
  * @{
  */
 struct oval_generator *oval_results_model_get_generator(struct oval_results_model *model);
+
 /**
  * Return bound definition model from an oval_results_model.
  * @param model the specified oval_results_model.
  * @memberof oval_results_model
  */
 struct oval_definition_model *oval_results_model_get_definition_model(struct oval_results_model *model);
+
+/**
+ * TODO
+ */
+struct oval_directives_model *oval_results_model_get_directives_model(struct oval_results_model *model);
+
+/**
+ * TODO
+ */
+void oval_results_model_set_directives_model(struct oval_results_model *model, struct oval_directives_model* dir_model);
 
 /**
  * Return iterator over reporting systems.

--- a/src/OVAL/results/oval_resModel.c
+++ b/src/OVAL/results/oval_resModel.c
@@ -146,6 +146,18 @@ void oval_results_model_set_generator(struct oval_results_model *model, struct o
 	model->generator = generator;
 }
 
+struct oval_directives_model *oval_results_model_get_defdirectives_model(struct oval_results_model *model) {
+	__attribute__nonnull__(model);
+
+	return oval_directives_model_get_defdirs(model->directives_model);
+}
+
+void oval_results_model_set_defdirectives_model(struct oval_results_model *model, struct oval_result_directives *dir_model) {
+	__attribute__nonnull__(model);
+
+	oval_directives_model_set_defdirs(model->directives_model, dir_model);
+}
+
 struct oval_definition_model *oval_results_model_get_definition_model(struct oval_results_model *model) {
 	__attribute__nonnull__(model);
 

--- a/src/OVAL/results/oval_resModel.c
+++ b/src/OVAL/results/oval_resModel.c
@@ -146,16 +146,10 @@ void oval_results_model_set_generator(struct oval_results_model *model, struct o
 	model->generator = generator;
 }
 
-struct oval_directives_model *oval_results_model_get_defdirectives_model(struct oval_results_model *model) {
+struct oval_directives_model *oval_results_model_get_directives_model(struct oval_results_model *model) {
 	__attribute__nonnull__(model);
 
-	return oval_directives_model_get_defdirs(model->directives_model);
-}
-
-void oval_results_model_set_defdirectives_model(struct oval_results_model *model, struct oval_result_directives *dir_model) {
-	__attribute__nonnull__(model);
-
-	oval_directives_model_set_defdirs(model->directives_model, dir_model);
+	return model->directives_model;
 }
 
 struct oval_definition_model *oval_results_model_get_definition_model(struct oval_results_model *model) {

--- a/src/OVAL/results/oval_resultSystem.c
+++ b/src/OVAL/results/oval_resultSystem.c
@@ -407,7 +407,7 @@ static void _oval_result_definition_to_dom_based_on_directives(struct oval_resul
 			if (criteria)
 				_oval_result_system_scan_criteria_for_references(criteria, tstmap);
 		} else if (content == OVAL_DIRECTIVE_CONTENT_THIN) {
-			// TODO
+			// NOOP
 		}
 	}
 }

--- a/src/OVAL/results/oval_resultSystem.c
+++ b/src/OVAL/results/oval_resultSystem.c
@@ -406,6 +406,8 @@ static void _oval_result_definition_to_dom_based_on_directives(struct oval_resul
 			/* collect the tests that are referenced from reported definitions */
 			if (criteria)
 				_oval_result_system_scan_criteria_for_references(criteria, tstmap);
+		} else if (content == OVAL_DIRECTIVE_CONTENT_THIN) {
+			// TODO
 		}
 	}
 }

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -84,6 +84,11 @@ bool xccdf_session_is_sds(const struct xccdf_session *session);
 void xccdf_session_set_validation(struct xccdf_session *session, bool validate, bool full_validation);
 
 /**
+ * TODO
+ */
+void xccdf_session_set_thin_results(struct xccdf_session *session, bool thin_result);
+
+/**
  * Set requested datastream_id for this session. This datastream_id is later
  * passed down to @ref ds_sds_index_select_checklist to determine target component.
  * This function is applicable only for sessions based on a DataStream.

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -84,7 +84,12 @@ bool xccdf_session_is_sds(const struct xccdf_session *session);
 void xccdf_session_set_validation(struct xccdf_session *session, bool validate, bool full_validation);
 
 /**
- * TODO
+ * Set whether the thin results override is enabled.
+ * If true the OVAL results put in ARF or separate files will have thin results.
+ * Thin results do not contain details about the evaluated criteria, only
+ * minimal OVAL results.
+ * @memberof xccdf_session
+ * @param thin_results true to enable thin_results, default is false
  */
 void xccdf_session_set_thin_results(struct xccdf_session *session, bool thin_result);
 

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -903,22 +903,16 @@ int xccdf_session_load_oval(struct xccdf_session *session)
 		}
 
 		if (session->export.thin_results) {
-			struct oval_result_directives *dir = oval_result_directives_new();
-			if (dir == NULL) {
-				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Failed to create new directives model for: '%s'.", contents[idx]->href);
-				return 1;
-			}
+			struct oval_results_model *res_model = oval_agent_get_results_model(tmp_sess);
+			struct oval_directives_model *dir_model = oval_results_model_get_directives_model(res_model);
+			// This is the worst function name in existence, despite its name,
+			// it's getting the oval_result_directives of the oval_directives_model.
+			// You would expect oval_directives_model_getresdirs at least, but no..
+			struct oval_result_directives *dir = oval_directives_model_get_defdirs(dir_model);
 			oval_result_directives_set_content(dir,  OVAL_RESULT_TRUE | OVAL_RESULT_FALSE |
 							OVAL_RESULT_UNKNOWN | OVAL_RESULT_NOT_EVALUATED |
 							OVAL_RESULT_NOT_APPLICABLE | OVAL_RESULT_ERROR,
 							OVAL_DIRECTIVE_CONTENT_THIN);
-
-			struct oval_results_model *res_model = oval_agent_get_results_model(tmp_sess);
-			struct oval_directives_model *dir_model = oval_results_model_get_directives_model(res_model);
-			// This is the worst function name in existence, despite its name,
-			// it's setting the oval_result_directives of the oval_directives_model.
-			// You would expect oval_directives_model_setresdirs at least, but no..
-			oval_directives_model_set_defdirs(dir_model, dir);
 		}
 
 		/* store our name in the generated documents */

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -640,6 +640,12 @@ int xccdf_session_load_cpe(struct xccdf_session *session)
 	if (session == NULL || session->xccdf.policy_model == NULL)
 		return 1;
 
+	// The CPE session will load OVAL files for any CPE dicts that require it.
+	// These OVAL files are outside of scope of XCCDF session but we still want
+	// to apply the thin results settings to them.
+	struct cpe_session *cpe_session = xccdf_policy_model_get_cpe_session(session->xccdf.policy_model);
+	cpe_session_set_thin_results(cpe_session, session->export.thin_results);
+
 	/* Use custom CPE dict if given */
 	if (session->user_cpe != NULL) {
 		struct oscap_source *source = oscap_source_new_from_file(session->user_cpe);

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -897,8 +897,7 @@ int xccdf_session_load_oval(struct xccdf_session *session)
 		}
 
 		if (session->export.thin_results) {
-			struct oval_results_model *res_model = oval_agent_get_results_model(tmp_sess);
-			struct oval_result_directives *dir = oval_directives_model_new();
+			struct oval_result_directives *dir = oval_result_directives_new();
 			if (dir == NULL) {
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Failed to create new directives model for: '%s'.", contents[idx]->href);
 				return 1;
@@ -912,7 +911,13 @@ int xccdf_session_load_oval(struct xccdf_session *session)
 							OVAL_RESULT_UNKNOWN | OVAL_RESULT_NOT_EVALUATED |
 							OVAL_RESULT_NOT_APPLICABLE | OVAL_RESULT_ERROR,
 							OVAL_DIRECTIVE_CONTENT_THIN);
-			oval_results_model_set_defdirectives_model(res_model, dir);
+
+			struct oval_results_model *res_model = oval_agent_get_results_model(tmp_sess);
+			struct oval_directives_model *dir_model = oval_results_model_get_directives_model(res_model);
+			// This is the worst function name in existence, despite its name,
+			// it's setting the oval_result_directives of the oval_directives_model.
+			// You would expect oval_directives_model_setresdirs at least, but no..
+			oval_directives_model_set_defdirs(dir_model, dir);
 		}
 
 		/* store our name in the generated documents */

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -908,11 +908,6 @@ int xccdf_session_load_oval(struct xccdf_session *session)
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Failed to create new directives model for: '%s'.", contents[idx]->href);
 				return 1;
 			}
-			oval_result_directives_set_reported(dir,
-						OVAL_RESULT_TRUE	| OVAL_RESULT_FALSE |
-						OVAL_RESULT_UNKNOWN | OVAL_RESULT_NOT_EVALUATED |
-						OVAL_RESULT_ERROR	| OVAL_RESULT_NOT_APPLICABLE,
-						true);
 			oval_result_directives_set_content(dir,  OVAL_RESULT_TRUE | OVAL_RESULT_FALSE |
 							OVAL_RESULT_UNKNOWN | OVAL_RESULT_NOT_EVALUATED |
 							OVAL_RESULT_NOT_APPLICABLE | OVAL_RESULT_ERROR,

--- a/utils/oscap-tool.h
+++ b/utils/oscap-tool.h
@@ -145,6 +145,7 @@ struct oscap_action {
 	int progress;
 	int oval_results;
 	int without_sys_chars;
+	int thin_results;
 	int remediate;
 	char *sce_template;
 	int check_engine_results;

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -147,8 +147,9 @@ static struct oscap_module XCCDF_EVAL = {
         "   --check-engine-results\r\t\t\t\t - Save results from check engines loaded from plugins as well.\n"
         "   --export-variables\r\t\t\t\t - Export OVAL external variables provided by XCCDF.\n"
         "   --results <file>\r\t\t\t\t - Write XCCDF Results into file.\n"
-        "   --thin-results\r\t\t\t\t - Set OVAL/ARF results to Thin Results.\n"
         "   --results-arf <file>\r\t\t\t\t - Write ARF (result data stream) into file.\n"
+        "   --thin-results\r\t\t\t\t - Thin Results provides only minimal amount of information in OVAL/ARF results.\n"
+        "                 \r\t\t\t\t   The option --without-syschar is automatically enabled when you use Thin Results.\n"
         "   --without-syschar \r\t\t\t\t - Don't provide system characteristic in OVAL/ARF result files.\n"
         "   --report <file>\r\t\t\t\t - Write HTML report into file.\n"
         "   --skip-valid \r\t\t\t\t - Skip validation.\n"
@@ -460,8 +461,10 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 	if (session == NULL)
 		goto cleanup;
 	xccdf_session_set_validation(session, action->validate, getenv("OSCAP_FULL_VALIDATION") != NULL);
-	if (action->thin_results)
+	if (action->thin_results) {
 		xccdf_session_set_thin_results(session, true);
+		xccdf_session_set_without_sys_chars_export(session, true);
+	}
 	if (xccdf_session_is_sds(session)) {
 		xccdf_session_set_datastream_id(session, action->f_datastream_id);
 		xccdf_session_set_component_id(session, action->f_xccdf_id);

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -147,6 +147,7 @@ static struct oscap_module XCCDF_EVAL = {
         "   --check-engine-results\r\t\t\t\t - Save results from check engines loaded from plugins as well.\n"
         "   --export-variables\r\t\t\t\t - Export OVAL external variables provided by XCCDF.\n"
         "   --results <file>\r\t\t\t\t - Write XCCDF Results into file.\n"
+        "   --thin-results\r\t\t\t\t - Set OVAL/ARF results to Thin Results.\n"
         "   --results-arf <file>\r\t\t\t\t - Write ARF (result data stream) into file.\n"
         "   --without-syschar \r\t\t\t\t - Don't provide system characteristic in OVAL/ARF result files.\n"
         "   --report <file>\r\t\t\t\t - Write HTML report into file.\n"
@@ -459,7 +460,8 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 	if (session == NULL)
 		goto cleanup;
 	xccdf_session_set_validation(session, action->validate, getenv("OSCAP_FULL_VALIDATION") != NULL);
-
+	if (action->f_directives)
+		xccdf_session_set_thin_results(session, true);
 	if (xccdf_session_is_sds(session)) {
 		xccdf_session_set_datastream_id(session, action->f_datastream_id);
 		xccdf_session_set_component_id(session, action->f_xccdf_id);
@@ -958,6 +960,7 @@ bool getopt_xccdf(int argc, char **argv, struct oscap_action *action)
 		{"export-variables",	no_argument, &action->export_variables, 1},
 		{"schematron",          no_argument, &action->schematron, 1},
 		{"without-syschar",    no_argument, &action->without_sys_chars, 1},
+		{"thin-results",        no_argument, &action->f_directives, 1}, /* Small hack to use current structure */
 	// end
 		{0, 0, 0, 0}
 	};

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -460,7 +460,7 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 	if (session == NULL)
 		goto cleanup;
 	xccdf_session_set_validation(session, action->validate, getenv("OSCAP_FULL_VALIDATION") != NULL);
-	if (action->f_directives)
+	if (action->thin_results)
 		xccdf_session_set_thin_results(session, true);
 	if (xccdf_session_is_sds(session)) {
 		xccdf_session_set_datastream_id(session, action->f_datastream_id);
@@ -960,7 +960,7 @@ bool getopt_xccdf(int argc, char **argv, struct oscap_action *action)
 		{"export-variables",	no_argument, &action->export_variables, 1},
 		{"schematron",          no_argument, &action->schematron, 1},
 		{"without-syschar",    no_argument, &action->without_sys_chars, 1},
-		{"thin-results",        no_argument, &action->f_directives, 1}, /* Small hack to use current structure */
+		{"thin-results",        no_argument, &action->thin_results, 1},
 	// end
 		{0, 0, 0, 0}
 	};

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -100,6 +100,11 @@ Write XCCDF results into FILE.
 Writes results to a given FILE in Asset Reporting Format. It is recommended to use this option instead of --results when dealing with datastreams.
 .RE
 .TP
+\fB\-\-thin-results\fR
+.RS
+Thin Results provides only minimal amount of information in OVAL/ARF results. The option --without-syschar is automatically enabled when you use Thin Results.
+.RE
+.TP
 \fB\-\-without-syschar\fR
 .RS
 Don't provide system characteristics in OVAL/ARF result files.


### PR DESCRIPTION
Full Results is still the default option.

If the user needs both no syschars and thin results they can use `--without-syschar --thin --results-arf /tmp/arf.xml`.