### PR TITLE
Register CPE dictionaries when doing ds sds-split

### DIFF
--- a/src/DS/ds_sds_session.c
+++ b/src/DS/ds_sds_session.c
@@ -266,6 +266,24 @@ struct oscap_source *ds_sds_session_get_component_by_href(struct ds_sds_session 
 	return component;
 }
 
+bool ds_sds_session_can_register_component(struct ds_sds_session *session, const char *container_name, const char *component_id)
+{
+	xmlNode *datastream = ds_sds_session_get_selected_datastream(session);
+	if (!datastream)
+		return false;
+
+	xmlNodePtr container = node_get_child_element(datastream, container_name);
+	if (!container)
+		return false;
+
+	// it's fine if component_id is NULL, it will return any component in that case
+	xmlNode *component_ref = containter_get_component_ref_by_id(container, component_id);
+	if (component_ref == NULL)
+		return false;
+
+	return true;
+}
+
 int ds_sds_session_register_component_with_dependencies(struct ds_sds_session *session, const char *container_name, const char *component_id, const char *target_filename)
 {
 	xmlNode *datastream = ds_sds_session_get_selected_datastream(session);

--- a/src/DS/public/ds_sds_session.h
+++ b/src/DS/public/ds_sds_session.h
@@ -132,13 +132,23 @@ const char *ds_sds_session_get_checklist_id(const struct ds_sds_session *session
 struct oscap_source *ds_sds_session_get_component_by_href(struct ds_sds_session *session, const char *href);
 
 /**
+ * Check whether given component can be registered.
+ * @param session The Source DataStream session
+ * @param container_name The name of container like: "checks", "checklists", or "dictionaries".
+ * @param component_id Id of component within selected datastream or NULL
+ * @returns true if at least one matching component exists, false otherwise
+ * @see ds_sds_session_register_component_with_dependencies
+ */
+bool ds_sds_session_can_register_component(struct ds_sds_session *session, const char *container_name, const char *component_id);
+
+/**
  * Register component and its dependencies to internal cache. This functions extracts
  * component from selected datastream within collection and all it dependencies.
  * The components may be later queried by ds_sds_session_get_component_by_href.
  * @memberof ds_sds_session
  * @param session The Source DataStream session
  * @param container_name The name of container like: "checks", "checklists", or "dictionaries".
- * @param component_id Id of component within selected datastream
+ * @param component_id Id of component within selected datastream or NULL
  * @param target filename or NULL
  * @returns 0 on success
  */

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -304,9 +304,12 @@ int app_ds_sds_split(const struct oscap_action *action) {
 	if (ds_sds_session_register_component_with_dependencies(session, "checklists", f_component_id, NULL) != 0) {
 		goto cleanup;
 	}
-	if (ds_sds_session_register_component_with_dependencies(session, "dictionaries", NULL, NULL) != 0) {
-		// CPE dictionaries aren't required in datastreams, just silently
-		// continue if we can't register them
+	// CPE dictionaries aren't required in datastreams, just silently continue
+	// if we can't register them
+	if (ds_sds_session_can_register_component(session, "dictionaries", NULL)) {
+		if (ds_sds_session_register_component_with_dependencies(session, "dictionaries", NULL, NULL) != 0) {
+			goto cleanup;
+		}
 	}
 	if (ds_sds_session_dump_component_files(session) != 0) {
 		goto cleanup;

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -304,6 +304,10 @@ int app_ds_sds_split(const struct oscap_action *action) {
 	if (ds_sds_session_register_component_with_dependencies(session, "checklists", f_component_id, NULL) != 0) {
 		goto cleanup;
 	}
+	if (ds_sds_session_register_component_with_dependencies(session, "dictionaries", NULL, NULL) != 0) {
+		// CPE dictionaries aren't required in datastreams, just silently
+		// continue if we can't register them
+	}
 	if (ds_sds_session_dump_component_files(session) != 0) {
 		goto cleanup;
 	}


### PR DESCRIPTION
These dictionaries are auto-registered when doing xccdf eval so it only makes sense we split them all out when splitting datastreams.