### PR TITLE
We always build the system_info probe in OpenSCAP, mark it as such

### DIFF
--- a/ac_probes/ac_probes.sh
+++ b/ac_probes/ac_probes.sh
@@ -249,7 +249,9 @@ mkdir  "${TEMPDIR}"
 cd "${PROBE_SRCDIR}" || exit 9
 
 # Generate source file list for each probe from Makefile.am
+# skip system_info because we always build system_info
 grep -E "${SOURCES_REGEXP}" Makefile.am | \
+    grep -v "probe_system_info" | \
     sed -e '{:q;N;s/\\\n//g;t q;/\\$/ b q;}' | \
     sed 's|^[[:space:]]*\(probe_.*SOURCES\)[[:space:]]*=[[:space:]]*\(.*\)[[:space:]]*$|export \1="\2"|' > "${TEMPDIR}/vars" || exit 1
 

--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -742,6 +742,7 @@ echo "debugging flags enabled:       $debug"
 echo "CCE enabled:                   $cce"
 echo
 @@@@PROBE_TABLE@@@@
+echo "  system_info:                 always enabled"
 echo
 echo "  === configuration ==="
 echo "  probe directory set to:      $probe_dir"

--- a/configure.ac
+++ b/configure.ac
@@ -85,10 +85,6 @@ CFLAGS="$my_save_cflags"
 AC_SUBST([AM_CFLAGS])
 
 
-probe_system_info_req_deps_ok=yes
-probe_system_info_req_deps_missing=
-probe_system_info_opt_deps_ok=yes
-probe_system_info_opt_deps_missing=
 probe_family_req_deps_ok=yes
 probe_family_req_deps_missing=
 probe_family_opt_deps_ok=yes
@@ -433,10 +429,6 @@ AM_CONDITIONAL([HAVE_BZIP2], [test "x${HAVE_BZIP2}" = xyes])
 
 SAVE_CPPFLAGS="$CPPFLAGS"
 CPPFLAGS="$CPPFLAGS  $(pkg-config libapt-pkg --cflags) $(pkg-config blkid --cflags) $(pkg-config dbus-1 --cflags) $(pkg-config gconf-2.0 --cflags) $(pkg-config libpcre --cflags) $(pkg-config libprocps --cflags) $(pkg-config rpm --cflags) $(pkg-config libselinux --cflags) $(pkg-config libxml-2.0 --cflags) $(pkg-config libxslt --cflags) "
-
-echo
-echo ' * Checking presence of required headers for the system_info probe'
-AC_CHECK_HEADERS([arpa/inet.h ctype.h errno.h ifaddrs.h libdlpi.h netdb.h net/if.h net/if_types.h stdlib.h string.h sys/ioctl.h sys/socket.h sys/sockio.h sys/utsname.h unistd.h ],[],[probe_system_info_req_deps_ok=no; probe_system_info_req_deps_missing='header files'],[-])
 
 echo
 echo ' * Checking presence of required headers for the family probe'
@@ -1297,8 +1289,6 @@ OSCAPDOCKER_PYTHONDIR=`$preferred_python -c "import distutils.sysconfig; print(d
 AC_SUBST(oscapdocker_pythondir, $OSCAPDOCKER_PYTHONDIR)
 
 
-AM_CONDITIONAL([probe_system_info_enabled], test "$probe_system_info_req_deps_ok" = yes)
-probe_system_info_enabled=$probe_system_info_req_deps_ok
 AM_CONDITIONAL([probe_family_enabled], test "$probe_family_req_deps_ok" = yes)
 probe_family_enabled=$probe_family_req_deps_ok
 AM_CONDITIONAL([probe_textfilecontent_enabled], test "$probe_textfilecontent_req_deps_ok" = yes)
@@ -1555,12 +1545,6 @@ echo "debugging flags enabled:       $debug"
 echo "CCE enabled:                   $cce"
 echo
 echo '  === probes ==='
-if test "$probe_system_info_req_deps_ok" = "yes"; then
-  probe_system_info_table_result="yes"
-else
-  probe_system_info_table_result="NO (missing: $probe_system_info_req_deps_missing)"
-fi
-printf "  %-28s %s\n" "system_info:" "$probe_system_info_table_result"
 if test "$probe_family_req_deps_ok" = "yes"; then
   probe_family_table_result="yes"
 else
@@ -1819,6 +1803,7 @@ else
   probe_systemdunitdependency_table_result="NO (missing: $probe_systemdunitdependency_req_deps_missing)"
 fi
 printf "  %-28s %s\n" "systemdunitdependency:" "$probe_systemdunitdependency_table_result"
+echo "  system_info:                 always enabled"
 echo
 echo "  === configuration ==="
 echo "  probe directory set to:      $probe_dir"

--- a/tests/probes/Makefile.am
+++ b/tests/probes/Makefile.am
@@ -4,6 +4,8 @@ LINUX_SUBDIRS=
 SOLARIS_SUBDIRS=
 ENV_SUBDIRS=
 
+INDEPENDENT_SUBDIRS += sysinfo
+
 if WANT_PROBES_INDEPENDENT
 if probe_family_enabled
 INDEPENDENT_SUBDIRS += family
@@ -16,9 +18,6 @@ INDEPENDENT_SUBDIRS += filehash58
 endif
 if probe_textfilecontent54_enabled
 INDEPENDENT_SUBDIRS += textfilecontent54
-endif
-if probe_system_info_enabled
-INDEPENDENT_SUBDIRS += sysinfo
 endif
 if probe_sql57_enabled
 INDEPENDENT_SUBDIRS += sql57


### PR DESCRIPTION
Previously we were testing for headers and disabling the tests if they were missing. Not disabling the probe. That makes no sense, let's always build and always test system_info.

system_info deps are hard to check for because the probe has different implementations for BSD, Linux and Solaris.