### PR TITLE
Update compliance score after remediation.

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1558,7 +1558,7 @@ int xccdf_session_remediate(struct xccdf_session *session)
 	if ((res = xccdf_policy_remediate(xccdf_session_get_xccdf_policy(session), session->xccdf.result)) != 0)
 		return res;
 
-	return xccdf_policy_update_score(xccdf_session_get_xccdf_policy(session), session->xccdf.result);
+	return xccdf_policy_recalculate_score(xccdf_session_get_xccdf_policy(session), session->xccdf.result);
 }
 
 int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, const char *testresult_id)

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1554,7 +1554,11 @@ int xccdf_session_remediate(struct xccdf_session *session)
 	xccdf_result_set_version(session->xccdf.result,
 			benchmark != NULL ? xccdf_benchmark_get_version(benchmark) : NULL);
 	xccdf_result_fill_sysinfo(session->xccdf.result);
-	return xccdf_policy_remediate(xccdf_session_get_xccdf_policy(session), session->xccdf.result);
+
+	if ((res = xccdf_policy_remediate(xccdf_session_get_xccdf_policy(session), session->xccdf.result)) != 0)
+		return res;
+
+	return xccdf_policy_update_score(xccdf_session_get_xccdf_policy(session), session->xccdf.result);
 }
 
 int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, const char *testresult_id)

--- a/src/XCCDF_POLICY/public/xccdf_policy.h
+++ b/src/XCCDF_POLICY/public/xccdf_policy.h
@@ -703,12 +703,12 @@ void xccdf_value_binding_iterator_reset(struct xccdf_value_binding_iterator *it)
 struct xccdf_score * xccdf_policy_get_score(struct xccdf_policy * policy, struct xccdf_result * test_result, const char * system);
 
 /**
- * Update score of the XCCDF Benchmark
+ * Recalculate score of the XCCDF Benchmark
  * @param policy XCCDF Policy
  * @param test_result Test Result model
  * @returns zero on success
  */
-int xccdf_policy_update_score(struct xccdf_policy * policy, struct xccdf_result * test_result);
+int xccdf_policy_recalculate_score(struct xccdf_policy * policy, struct xccdf_result * test_result);
 
 /**
  * Get value of given value item in context of given policy

--- a/src/XCCDF_POLICY/public/xccdf_policy.h
+++ b/src/XCCDF_POLICY/public/xccdf_policy.h
@@ -703,6 +703,14 @@ void xccdf_value_binding_iterator_reset(struct xccdf_value_binding_iterator *it)
 struct xccdf_score * xccdf_policy_get_score(struct xccdf_policy * policy, struct xccdf_result * test_result, const char * system);
 
 /**
+ * Update score of the XCCDF Benchmark
+ * @param policy XCCDF Policy
+ * @param test_result Test Result model
+ * @returns zero on success
+ */
+int xccdf_policy_update_score(struct xccdf_policy * policy, struct xccdf_result * test_result);
+
+/**
  * Get value of given value item in context of given policy
  * @memberof xccdf_policy
  * @param policy XCCDF policy

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -2060,7 +2060,7 @@ struct xccdf_score * xccdf_policy_get_score(struct xccdf_policy * policy, struct
 	return xccdf_result_calculate_score(test_result, (struct xccdf_item *) benchmark, scsystem);
 }
 
-int xccdf_policy_update_score(struct xccdf_policy * policy, struct xccdf_result * test_result)
+int xccdf_policy_recalculate_score(struct xccdf_policy * policy, struct xccdf_result * test_result)
 {
     struct xccdf_benchmark * benchmark = xccdf_policy_model_get_benchmark(xccdf_policy_get_model(policy));
 	return xccdf_result_recalculate_scores(test_result, (struct xccdf_item *) benchmark);

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -2060,6 +2060,11 @@ struct xccdf_score * xccdf_policy_get_score(struct xccdf_policy * policy, struct
 	return xccdf_result_calculate_score(test_result, (struct xccdf_item *) benchmark, scsystem);
 }
 
+int xccdf_policy_update_score(struct xccdf_policy * policy, struct xccdf_result * test_result)
+{
+    struct xccdf_benchmark * benchmark = xccdf_policy_model_get_benchmark(xccdf_policy_get_model(policy));
+	return xccdf_result_recalculate_scores(test_result, (struct xccdf_item *) benchmark);
+}
 
 const char *xccdf_policy_get_value_of_item(struct xccdf_policy * policy, struct xccdf_item * item)
 {

--- a/tests/API/XCCDF/unittests/test_remediation_amp_escaping.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_amp_escaping.sh
@@ -50,7 +50,7 @@ assert_exists 1 '//rule-result/message'
 assert_exists 1 '//rule-result/message[@severity="info"]'
 assert_exists 1 '//rule-result/message[text()="Fix execution completed and returned: 0"]'
 assert_exists 1 '//score'
-assert_exists 1 '//score[text()="0.000000"]'
+assert_exists 1 '//score[text()="100.000000"]'
 
 rm test_file
 rm $result

--- a/tests/API/XCCDF/unittests/test_remediation_cdata.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_cdata.sh
@@ -50,7 +50,7 @@ assert_exists 1 '//rule-result/message'
 assert_exists 1 '//rule-result/message[@severity="info"]'
 assert_exists 1 '//rule-result/message[text()="Fix execution completed and returned: 0"]'
 assert_exists 1 '//score'
-assert_exists 1 '//score[text()="0.000000"]'
+assert_exists 1 '//score[text()="100.000000"]'
 
 rm test_file
 rm $result

--- a/tests/API/XCCDF/unittests/test_remediation_simple.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_simple.sh
@@ -40,7 +40,7 @@ assert_exists 1 '//rule-result/message'
 assert_exists 1 '//rule-result/message[@severity="info"]'
 assert_exists 1 '//rule-result/message[text()="Fix execution completed and returned: 0"]'
 assert_exists 1 '//score'
-assert_exists 1 '//score[text()="0.000000"]'
+assert_exists 1 '//score[text()="100.000000"]'
 
 rm test_file
 rm $result

--- a/tests/API/XCCDF/unittests/test_remediation_subs_plain_text.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_plain_text.sh
@@ -52,7 +52,7 @@ assert_exists 1 '//rule-result/message'
 assert_exists 1 '//rule-result/message[@severity="info"]'
 assert_exists 1 '//rule-result/message[text()="Fix execution completed and returned: 0"]'
 assert_exists 1 '//score'
-assert_exists 1 '//score[text()="0.000000"]'
+assert_exists 1 '//score[text()="100.000000"]'
 
 rm test_file
 rm $result

--- a/tests/API/XCCDF/unittests/test_remediation_subs_plain_text_empty.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_plain_text_empty.sh
@@ -52,7 +52,7 @@ assert_exists 1 '//rule-result/message'
 assert_exists 1 '//rule-result/message[@severity="info"]'
 assert_exists 1 '//rule-result/message[text()="Fix execution completed and returned: 0"]'
 assert_exists 1 '//score'
-assert_exists 1 '//score[text()="0.000000"]'
+assert_exists 1 '//score[text()="100.000000"]'
 
 rm test_file
 rm $result

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_refine_value.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_refine_value.sh
@@ -58,7 +58,7 @@ assert_exists 1 '//rule-result/message'
 assert_exists 1 '//rule-result/message[@severity="info"]'
 assert_exists 1 '//rule-result/message[text()="Fix execution completed and returned: 0"]'
 assert_exists 1 '//score'
-assert_exists 1 '//score[text()="0.000000"]'
+assert_exists 1 '//score[text()="100.000000"]'
 
 rm test_file
 rm $result

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_take_first.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_take_first.sh
@@ -58,7 +58,7 @@ assert_exists 1 '//rule-result/message'
 assert_exists 1 '//rule-result/message[@severity="info"]'
 assert_exists 1 '//rule-result/message[text()="Fix execution completed and returned: 0"]'
 assert_exists 1 '//score'
-assert_exists 1 '//score[text()="0.000000"]'
+assert_exists 1 '//score[text()="100.000000"]'
 
 rm test_file
 rm $result

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_title.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_title.sh
@@ -61,7 +61,7 @@ assert_exists 1 '//rule-result/message'
 assert_exists 1 '//rule-result/message[@severity="info"]'
 assert_exists 1 '//rule-result/message[text()="Fix execution completed and returned: 0"]'
 assert_exists 1 '//score'
-assert_exists 1 '//score[text()="0.000000"]'
+assert_exists 1 '//score[text()="100.000000"]'
 
 rm test_file
 rm $result

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_without_selector.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_without_selector.sh
@@ -58,7 +58,7 @@ assert_exists 1 '//rule-result/message'
 assert_exists 1 '//rule-result/message[@severity="info"]'
 assert_exists 1 '//rule-result/message[text()="Fix execution completed and returned: 0"]'
 assert_exists 1 '//score'
-assert_exists 1 '//score[text()="0.000000"]'
+assert_exists 1 '//score[text()="100.000000"]'
 
 rm test_file
 rm $result

--- a/tests/API/XCCDF/unittests/test_remediation_xml_comments.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_xml_comments.sh
@@ -50,7 +50,7 @@ assert_exists 1 '//rule-result/message'
 assert_exists 1 '//rule-result/message[@severity="info"]'
 assert_exists 1 '//rule-result/message[text()="Fix execution completed and returned: 0"]'
 assert_exists 1 '//score'
-assert_exists 1 '//score[text()="0.000000"]'
+assert_exists 1 '//score[text()="100.000000"]'
 
 rm test_file
 rm $result


### PR DESCRIPTION
This PR addresses the issue discussed in #617. 

I have introduced a new wrapper function `xccdf_policy_update_score` similar to `xccdf_policy_get_score`. This function calls the `xccdf_result_recalculate_scores` routine.

In `xccdf_session_remediate`, rather than returning `xccdf_policy_remediate`, on success, it returns `xccdf_policy_update_score`. Both `xccdf_policy_update_score` and `xccdf_policy_remediate` have status as the return value.

I have also updated some of the unit tests to check for the corrected compliance score after remediation.

Thank you!