### PR TITLE
Changed the previous error message to a debug warning in

### DIFF
--- a/src/DS/ds_sds_session.c
+++ b/src/DS/ds_sds_session.c
@@ -253,7 +253,7 @@ xmlDoc *ds_sds_session_get_xmlDoc(struct ds_sds_session *session)
 int ds_sds_session_register_component_source(struct ds_sds_session *session, const char *relative_filepath, struct oscap_source *component)
 {
 	if (!oscap_htable_add(session->component_sources, relative_filepath, component)) {
-		oscap_seterr(OSCAP_EFAMILY_OSCAP, "File %s has already been register with Source DataStream session: %s",
+		dW("File %s has already been registered in Source DataStream session: %s",
 			relative_filepath, oscap_source_readable_origin(session->source));
 		return -1;
 	}


### PR DESCRIPTION
ds_sds_session_register_component_source() when the component
has already been added before.