### PR TITLE
Warn when injecting XCCDF 1.1 results into an ARF

### DIFF
--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -32,6 +32,7 @@
 #include "common/_error.h"
 #include "common/util.h"
 #include "common/list.h"
+#include "common/debug_priv.h"
 
 #include "ds_common.h"
 #include "ds_rds_session.h"
@@ -600,6 +601,13 @@ static void ds_rds_add_xccdf_test_results(xmlDocPtr doc, xmlNodePtr reports,
 		const char* report_request_id, struct oscap_htable *arf_report_mapping)
 {
 	xmlNodePtr root_element = xmlDocGetRootElement(xccdf_result_file_doc);
+
+	if (root_element->ns && root_element->ns->href &&
+			oscap_str_endswith((const char*)root_element->ns->href, "xccdf/1.1")) {
+		dW("Exporting ARF from XCCDF 1.1 is not allowed by SCAP specification. "
+		   "The resulting ARF will not validate. Convert the input to XCCDF 1.2 "
+		   "to get valid ARF results.");
+	}
 
 	// There are 2 possible scenarios here:
 

--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -606,7 +606,8 @@ static void ds_rds_add_xccdf_test_results(xmlDocPtr doc, xmlNodePtr reports,
 			oscap_str_endswith((const char*)root_element->ns->href, "xccdf/1.1")) {
 		dW("Exporting ARF from XCCDF 1.1 is not allowed by SCAP specification. "
 		   "The resulting ARF will not validate. Convert the input to XCCDF 1.2 "
-		   "to get valid ARF results.");
+		   "to get valid ARF results. The xccdf_1.1_to_1.2.xsl transformation."
+		   "that ships with OpenSCAP can do that automatically.");
 	}
 
 	// There are 2 possible scenarios here:


### PR DESCRIPTION
OpenSCAP can do it but the result won't be a valid ARF, only XCCDF 1.2
is allowed in ARFs.

Example:
```
oscap xccdf eval --verbose WARNING --results-arf /tmp/arf.xml ~/d/scap-security-guide/RHEL/7/output/ssg-rhel7-xccdf-1.2.xml 
WARNING: This content points out to the remote resources. Use `--fetch-remote-resources' option to download them.
WARNING: Skipping https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2 file which is referenced from XCCDF content
```

vs.

```
$ oscap xccdf eval --verbose WARNING --results-arf /tmp/arf.xml ~/d/scap-security-guide/RHEL/7/output/ssg-rhel7-xccdf.xml 
WARNING: This content points out to the remote resources. Use `--fetch-remote-resources' option to download them.
WARNING: Skipping https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2 file which is referenced from XCCDF content
W: oscap: Exporting ARF from XCCDF 1.1 is not allowed by SCAP specification. The resulting ARF will not validate. Convert the input to XCCDF 1.2 to get valid ARF results.
```