### PR TITLE
Make WARNING the default verbosity level

### DIFF
--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -358,8 +358,11 @@ int xccdf_session_load_oval(struct xccdf_session *session);
  *
  * @memberof xccdf_session
  * @param session XCCDF Session
+ * @param plugin_name Name of the plugin to load
+ * @param quiet If true we will not output errors if loading fails
  * @returns zero on success
  */
+int xccdf_session_load_check_engine_plugin2(struct xccdf_session *session, const char* plugin_name, bool quiet);
 int xccdf_session_load_check_engine_plugin(struct xccdf_session *session, const char* plugin_name);
 
 /**

--- a/src/XCCDF/tailoring.c
+++ b/src/XCCDF/tailoring.c
@@ -187,7 +187,7 @@ struct xccdf_tailoring *xccdf_tailoring_parse(xmlTextReaderPtr reader, struct xc
 		}
 		case XCCDFE_PROFILE: {
 			if (benchmark != NULL) {
-				dW("Parsing Tailoring Profiles without reference to Benchmark");
+				dI("Parsing Tailoring Profiles without reference to Benchmark");
 			}
 			struct xccdf_item *item = xccdf_profile_parse(reader, benchmark);
 			if (!xccdf_tailoring_add_profile(tailoring, XPROFILE(item))) {

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -945,9 +945,9 @@ int xccdf_session_load_oval(struct xccdf_session *session)
 	return 0;
 }
 
-int xccdf_session_load_check_engine_plugin(struct xccdf_session *session, const char *plugin_name)
+int xccdf_session_load_check_engine_plugin2(struct xccdf_session *session, const char *plugin_name, bool quiet)
 {
-	struct check_engine_plugin_def *plugin = check_engine_plugin_load(plugin_name);
+	struct check_engine_plugin_def *plugin = check_engine_plugin_load2(plugin_name, quiet);
 
 	if (!plugin)
 		return -1; // error already set
@@ -964,6 +964,11 @@ int xccdf_session_load_check_engine_plugin(struct xccdf_session *session, const 
 	}
 }
 
+int xccdf_session_load_check_engine_plugin(struct xccdf_session *session, const char *plugin_name)
+{
+	return xccdf_session_load_check_engine_plugin2(session, plugin_name, false);
+}
+
 int xccdf_session_load_check_engine_plugins(struct xccdf_session *session)
 {
 	xccdf_session_unload_check_engine_plugins(session);
@@ -973,7 +978,7 @@ int xccdf_session_load_check_engine_plugins(struct xccdf_session *session)
 	while (*known_plugins) {
 		// We do not report failure when a known plugin doesn't load properly, that's because they
 		// are optional and we don't know if it's not there or if it just failed to load.
-		if (xccdf_session_load_check_engine_plugin(session, *known_plugins) != 0)
+		if (xccdf_session_load_check_engine_plugin2(session, *known_plugins, true) != 0)
 			oscap_clearerr();
 
 		known_plugins++;

--- a/src/XCCDF_POLICY/public/check_engine_plugin.h
+++ b/src/XCCDF_POLICY/public/check_engine_plugin.h
@@ -52,6 +52,7 @@ struct check_engine_plugin_def
 	const char *(*get_capabilities_fn)(void**);
 };
 
+struct check_engine_plugin_def *check_engine_plugin_load2(const char* path, bool quiet);
 struct check_engine_plugin_def *check_engine_plugin_load(const char* path);
 void check_engine_plugin_unload(struct check_engine_plugin_def *plugin);
 

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -85,7 +85,7 @@ oscap_verbosity_levels oscap_verbosity_level_from_cstr(const char *level_name)
 bool oscap_set_verbose(const char *verbosity_level, const char *filename, bool is_probe)
 {
 	if (verbosity_level == NULL) {
-		return true;
+		verbosity_level = "WARNING";
 	}
 	__debuglog_level = oscap_verbosity_level_from_cstr(verbosity_level);
 	if (__debuglog_level == DBG_UNKNOWN) {

--- a/tests/API/OVAL/unittests/test_external_variable.sh
+++ b/tests/API/OVAL/unittests/test_external_variable.sh
@@ -9,7 +9,10 @@ stderr=$(mktemp ${name}.err.XXXXXX)
 echo "stderr file: $stderr"
 
 $OSCAP oval eval --results $result --variables $srcdir/external_variables.xml $srcdir/$name.oval.xml 2> $stderr
-[ ! -s $stderr ] && rm $stderr
+# filter out the expected warnings in stderr
+sed -i -E "/^W: oscap:     Referenced variable has no values \(oval:x:var:[13689]\)/d" "$stderr"
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
 [ -s $result ]
 
 assert_exists 10 '/oval_results/oval_definitions/variables/external_variable'

--- a/tests/API/OVAL/unittests/test_external_variable.sh
+++ b/tests/API/OVAL/unittests/test_external_variable.sh
@@ -10,7 +10,8 @@ echo "stderr file: $stderr"
 
 $OSCAP oval eval --results $result --variables $srcdir/external_variables.xml $srcdir/$name.oval.xml 2> $stderr
 # filter out the expected warnings in stderr
-sed -i -E "/^W: oscap:     Referenced variable has no values \(oval:x:var:[13689]\)/d" "$stderr"
+
+sed -i -E "/^W: oscap:[ ]+Referenced variable has no values \(oval:x:var:[13689]\)/d" "$stderr"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
 [ -s $result ]

--- a/tests/API/OVAL/unittests/test_object_component_type.sh
+++ b/tests/API/OVAL/unittests/test_object_component_type.sh
@@ -9,7 +9,7 @@ $OSCAP oval eval $srcdir/test_object_component_type.oval.xml 2> $stderr || ret=$
 [ $ret -eq 1 ]
 
 stderr_line_count=`cat $stderr | wc -l`
-[ $stderr_line_count -eq 2 ]
+[ $stderr_line_count -eq 6 ]
 grep -q "Entity [']something_bogus['] has not been found in textfilecontent_item (id: [0-9]\+) specified by object [']oval:oscap:obj:10[']." $stderr
 grep -q "Expected record data type, but found string data type in subexpression entity in textfilecontent_item (id: [0-9]\+) specified by object [']oval:oscap:obj:10[']."  $stderr
 

--- a/tests/API/XCCDF/unittests/test_remediation_subs_unresolved.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_unresolved.sh
@@ -35,6 +35,8 @@ assert_exists 1 '//score[text()="0.000000"]'
 ret=0
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
 [ $ret -eq 2 ]
+# filter out the expected warning in stderr
+sed -i -E "/^W: oscap: The xccdf:rule-result\/xccdf:instance element was not found./d" "$stderr"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
 $OSCAP xccdf validate-xml $result

--- a/tests/probes/sql57/unsupported_engine.sh
+++ b/tests/probes/sql57/unsupported_engine.sh
@@ -10,6 +10,8 @@ echo "stderr file: $stderr"
 
 echo "Evaluating content."
 $OSCAP oval eval --results $result $srcdir/${name}.oval.xml 2> $stderr
+# filter out the expected error in stderr
+sed -i -E "/^E: lt-probe_sql57: DB engine not supported: sqlserver/d" "$stderr"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 echo "Validating results."
 #$OSCAP oval validate-xml --results --schematron $result

--- a/tests/probes/sysctl/test_sysctl_probe_all.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_all.sh
@@ -28,6 +28,8 @@ grep unix-sys:name "$result" | sed -E 's;.*>(.*)<.*;\1;g' | sort > "$ourNames"
 
 diff "$sysctlNames" "$ourNames"
 
+# remove oscap error message related to permissions from stderr
+sed -i -E "/^E: lt-probe_sysctl: Can't read sysctl value from /d" "$stderr"
 [ ! -s $stderr ]
 
 rm $stderr $result $ourNames $sysctlNames

--- a/utils/oscap.c
+++ b/utils/oscap.c
@@ -126,7 +126,8 @@ static int print_versions(const struct oscap_action *action)
 	const char * const *known_plugins = check_engine_plugin_get_known_plugins();
 	bool known_plugin_found = false;
 	while (*known_plugins) {
-		struct check_engine_plugin_def *plugin = check_engine_plugin_load(*known_plugins);
+		// try to load the plugin but output no errors if it fails (quiet=true)
+		struct check_engine_plugin_def *plugin = check_engine_plugin_load2(*known_plugins, true);
 		if (plugin) {
 			printf("%s (from %s)\n", check_engine_plugin_get_capabilities(plugin), *known_plugins);
 			check_engine_plugin_unload(plugin);


### PR DESCRIPTION
~~DO NOT MERGE, up for discussion.~~

@jan-cerny I have noticed that your oscap_set_verbose code defaults to unknown verbosity and no output. Do you recall what was the reasoning behind that? I expected WARNING level by default and stderr output, which is what this PR does.

Does the UNKNOWN verbose level have any meaning? It seems it's just used to flag that `oscap_set_verbose` was never run with non-NULL verbosity level.

Perhaps I am missing something.