### PR TITLE
[README] Fix wget install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Choose *1a* or *1b* depending on whether you want sources from a release tarball
 # replace ${version} with the desired version
 wget https://fedorahosted.org/releases/o/p/openscap/openscap-${version}.tar.gz
 tar -xzpf openscap-${version}.tar.gz
-cd openscap-${version}.tar.gz
+cd openscap-${version}
 ```
 
 **OR**


### PR DESCRIPTION
Looks like we have a dangling `.tar.gz` and we probably want the directory we just extracted.
```
root@packer:~# tar -xzpf openscap-${version}.tar.gz
root@packer:~# cd openscap-${version}.tar.gz
bash: cd: openscap-1.2.13.tar.gz: Not a directory
root@packer:~# ls
openscap-1.2.13  openscap-1.2.13.tar.gz
```