### PR TITLE
--enable-debug on windows

### DIFF
--- a/src/common/assume.h
+++ b/src/common/assume.h
@@ -62,8 +62,8 @@
 #define __RB(l, ...) __VA_ARGS__
 #define __emitmsg_fp stderr
 
+#ifndef _WIN32
 /*
- * == Implementation note #1 ==
  * We use ftrylockfile here because it's better to drop the message than to
  * cause a deadlock.
  */
@@ -74,6 +74,13 @@
                         funlockfile(__emitmsg_fp);      \
                 }                                       \
         } while (0)
+#else
+// TODO: Locking on Windows, for now we just tolerate potentially garbled messages
+#define __atomic_emitmsg(...)                           \
+        do {                                            \
+                fprintf (__emitmsg_fp, __VA_ARGS__);    \
+        } while (0)
+#endif
 
 #ifndef NDEBUG
 # define __terminate(retval) abort()

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -35,8 +35,10 @@
 # include <time.h>
 # include <errno.h>
 
+#if defined(OVAL_PROBES_ENABLED)
 # include <sexp.h>
 # include <sexp-output.h>
+#endif
 
 # include "debug_priv.h"
 


### PR DESCRIPTION
Fixes required to make `./configure --enable-debug` build and work on Windows.