### PR TITLE
Support absolute oval path - both simple and file:// prefixed

### DIFF
--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -879,7 +879,7 @@ static int ds_sds_compose_add_component_dependencies(xmlDocPtr doc, xmlNodePtr d
 					continue;
 				}
 
-				char* real_path = (strcmp(dir, "") == 0 || strcmp(dir, ".") == 0) ?
+				char* real_path = (strcmp(dir, "") == 0 || strcmp(dir, ".") == 0 || href[0] == '/') ?
 					oscap_strdup(href) : oscap_sprintf("%s/%s", dir, href);
 
 				char* mangled_path = ds_sds_mangle_filepath(real_path);

--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -879,8 +879,11 @@ static int ds_sds_compose_add_component_dependencies(xmlDocPtr doc, xmlNodePtr d
 					continue;
 				}
 
-				char* real_path = (strcmp(dir, "") == 0 || strcmp(dir, ".") == 0 || href[0] == '/') ?
-					oscap_strdup(href) : oscap_sprintf("%s/%s", dir, href);
+				// skip over file:// if it's used in the file href
+				const char *altered_href = oscap_str_startswith(href, "file://") ? href + 7 : href;
+
+				char* real_path = (strcmp(dir, "") == 0 || strcmp(dir, ".") == 0 || altered_href[0] == '/') ?
+					oscap_strdup(altered_href) : oscap_sprintf("%s/%s", dir, altered_href);
 
 				char* mangled_path = ds_sds_mangle_filepath(real_path);
 				char* cref_id = oscap_sprintf("scap_org.open-scap_cref_%s", mangled_path);

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -784,6 +784,9 @@ static int _xccdf_session_get_oval_from_model(struct xccdf_session *session)
 		if (file_path[0] == '/') { // it's a simple absolute path
 			tmp_path = oscap_strdup(file_path);
 		}
+		else if (oscap_str_startswith(file_path, "file://")) { // it's an absolute path prefixed with file://
+			snprintf(tmp_path, PATH_MAX, "%s", file_path + 7);
+		}
 		else { // assume it's a relative path
 			snprintf(tmp_path, PATH_MAX, "%s/%s", dir_path, file_path);
 		}

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -774,13 +774,19 @@ static int _xccdf_session_get_oval_from_model(struct xccdf_session *session)
 		if (strcmp(oscap_file_entry_get_system(file_entry), oval_sysname))
 			continue;
 
+		const char *file_path = oscap_file_entry_get_file(file_entry);
 		struct oscap_source *source = NULL;
 		if (xccdf_session_get_ds_sds_session(session) != NULL) {
-			source = ds_sds_session_get_component_by_href(xccdf_session_get_ds_sds_session(session), oscap_file_entry_get_file(file_entry));
+			source = ds_sds_session_get_component_by_href(xccdf_session_get_ds_sds_session(session), file_path);
 		}
 
 		tmp_path = malloc(PATH_MAX * sizeof(char));
-		snprintf(tmp_path, PATH_MAX, "%s/%s", dir_path, oscap_file_entry_get_file(file_entry));
+		if (file_path[0] == '/') { // it's a simple absolute path
+			tmp_path = oscap_strdup(file_path);
+		}
+		else { // assume it's a relative path
+			snprintf(tmp_path, PATH_MAX, "%s/%s", dir_path, file_path);
+		}
 
 		if (source != NULL || stat(tmp_path, &sb) == 0) {
 			resources[idx] = malloc(sizeof(struct oval_content_resource));

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -782,7 +782,7 @@ static int _xccdf_session_get_oval_from_model(struct xccdf_session *session)
 
 		tmp_path = malloc(PATH_MAX * sizeof(char));
 		if (file_path[0] == '/') { // it's a simple absolute path
-			tmp_path = oscap_strdup(file_path);
+			snprintf(tmp_path, PATH_MAX, "%s", file_path);
 		}
 		else if (oscap_str_startswith(file_path, "file://")) { // it's an absolute path prefixed with file://
 			snprintf(tmp_path, PATH_MAX, "%s", file_path + 7);

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -46,6 +46,8 @@ test_xccdf_overrides_SOURCES = test_xccdf_overrides.c
 
 EXTRA_DIST += \
 	all.sh \
+	oval \
+	oval_without_definitions.oval.xml \
 	test_default_selector.oval.xml \
 	test_default_selector.sh \
 	test_default_selector.xccdf.xml \
@@ -158,6 +160,8 @@ EXTRA_DIST += \
 	test_xccdf_multiple_testresults.xccdf.xml \
 	test_xccdf_notchecked_has_check.sh \
 	test_xccdf_notchecked_has_check.xccdf.xml \
+	test_xccdf_oval_absolute_path.sh \
+	test_xccdf_oval_absolute_path.xccdf.xml \
 	test_xccdf_oval_relative_path.sh \
 	test_xccdf_oval_relative_path.xccdf.xml \
 	test_xccdf_overlaping_IDs.xccdf.xml \
@@ -189,8 +193,6 @@ EXTRA_DIST += \
 	test_xccdf_test_system.xccdf.xml \
 	test_xccdf_xml_escaping_value.sh \
 	test_xccdf_xml_escaping_value.xccdf.xml \
-	oval \
-	oval_without_definitions.oval.xml \
 	unit_helper.c \
 	unit_helper.h
 # HELLO PAL, THIS LIST IS ALPHABETICALLY SORTED.

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -41,6 +41,7 @@ test_run "Check Processing Algorithm -- none selected for candidate" $srcdir/tes
 test_run "Check Processing Algorithm -- none check-content-ref resolvable." $srcdir/test_xccdf_check_processing_invalid_content_refs.sh
 test_run "Check Processing Algorithm -- don't include xccdf:check if result is notchecked" $srcdir/test_xccdf_notchecked_has_check.sh
 test_run "Check Processing Algorithm -- notchecked & unselected" $srcdir/test_xccdf_role_unchecked.sh
+test_run "Load OVAL using absolute path" $srcdir/test_xccdf_oval_absolute_path.sh
 test_run "Load OVAL using relative path" $srcdir/test_xccdf_oval_relative_path.sh
 test_run "xccdf:select and @cluster-id -- disable group" $srcdir/test_xccdf_selectors_cluster1.sh
 test_run "xccdf:select and @cluster-id -- enable a set of items" $srcdir/test_xccdf_selectors_cluster2.sh

--- a/tests/API/XCCDF/unittests/test_xccdf_oval_absolute_path.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_oval_absolute_path.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Test loading of OVAL results files located referenced absolutely
+
+set -e
+set -o pipefail
+
+# cd to directory and run test
+function testInDirectory(){
+	local directory="$1"
+	local xccdf="$2"
+
+	pushd "$directory"
+
+	local result=$(mktemp -t ${name}.out.result.XXXXXX)
+	local report=$(mktemp -t ${name}.out.report.XXXXXX)
+	local stderr=$(mktemp -t ${name}.err.XXXXXX)
+
+	echo "Stderr file = $stderr"
+	echo "Result file = $result"
+	echo "Report file = $report"
+
+	$OSCAP xccdf eval --oval-results --results $result --report $report "$xccdf" 2> $stderr 
+
+	# Check existence of oval-results
+	[ -f $directory/*oval*always-fail*oval.xml.result.xml ]
+
+	[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
+	# Check result
+	assert_exists 2 '//rule-result/result'
+	assert_exists 2 '//rule-result/result[text()="pass" or text()="fail"]'
+
+	# Check report
+	grep "Testing permissions on /not_executable" "$report" --quiet
+
+	rm -f $result $report
+
+	popd
+}
+
+name=$(basename $0 .sh)
+ORIGINAL_XCCDF="$(readlink -e "$srcdir/${name}.xccdf.xml")"
+
+### test in XCCDF's directory
+
+# We don't have write access to directory with XCCDF (after make distcheck),
+# so we have to copy required files to directory with right access and do tests there
+
+# there are two possible ways to define absolute path
+# simple abs path /a/b/c
+for prefix in "" "file://";do
+    testDir=`mktemp -d`
+    mkdir -p "$testDir/oval/always-fail"
+
+    cp "$ORIGINAL_XCCDF" "$srcdir/test_default_selector.oval.xml" "$testDir"
+    cp "$srcdir/oval/always-fail/oval.xml" "$testDir/oval/always-fail"
+    XCCDF="$(readlink -e "$testDir/${name}.xccdf.xml")"
+
+    sed -i "s|%%TEST_DIR_PATH%%|${prefix}${testDir}|" $XCCDF
+
+    testInDirectory "$testDir" "$XCCDF"
+    rm -rf "$testDir"
+done

--- a/tests/API/XCCDF/unittests/test_xccdf_oval_absolute_path.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_xccdf_oval_absolute_path.xccdf.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+	<status>incomplete</status>
+	<version>1.0</version>
+
+	<Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_1">
+		<check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" negate="true">
+			<check-content-ref href="%%TEST_DIR_PATH%%/oval/always-fail/oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
+		</check>
+	</Rule>
+
+	<Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_2">
+		<check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+			<check-content-ref href="%%TEST_DIR_PATH%%/test_default_selector.oval.xml" name="oval:x:def:1"/>
+		</check>
+	</Rule>
+
+</Benchmark>


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1312831 and https://bugzilla.redhat.com/show_bug.cgi?id=1312824

CC @dahaic 