### PR TITLE
Show severity in HTML guide

### DIFF
--- a/xsl/xccdf-guide-impl.xsl
+++ b/xsl/xccdf-guide-impl.xsl
@@ -213,6 +213,11 @@ Authors:
                     </p>
                 </xsl:if>
 
+                <div class="severity">
+                    <span class="label label-warning">severity:</span>&#160;
+                    <xsl:call-template name="item-severity"><xsl:with-param name="item" select="$item" /></xsl:call-template>
+                </div>
+
                 <div class="identifiers">
                     <xsl:call-template name="item-idents-refs">
                         <xsl:with-param name="item" select="$item"/>

--- a/xsl/xccdf-guide-impl.xsl
+++ b/xsl/xccdf-guide-impl.xsl
@@ -214,8 +214,10 @@ Authors:
                 </xsl:if>
 
                 <div class="severity">
-                    <span class="label label-warning">severity:</span>&#160;
-                    <xsl:call-template name="item-severity"><xsl:with-param name="item" select="$item" /></xsl:call-template>
+                    <p>
+                        <span class="label label-warning">severity:</span>&#160;
+                        <xsl:call-template name="item-severity"><xsl:with-param name="item" select="$item" /></xsl:call-template>
+                    </p>
                 </div>
 
                 <div class="identifiers">

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -361,7 +361,7 @@ Authors:
                 &#160;<span class="label label-warning">waived</span>
             </xsl:if>
         </td>
-        <td class="rule-severity" style="text-align: center"><xsl:value-of select="$ruleresult/@severity"/></td>
+        <td class="rule-severity" style="text-align: center"><xsl:call-template name="item-severity"><xsl:with-param name="item" select="$ruleresult" /></xsl:call-template></td>
         <td class="rule-result rule-result-{$result}">
             <xsl:variable name="result_tooltip">
                 <xsl:call-template name="rule-result-tooltip">
@@ -788,7 +788,7 @@ Authors:
                         </div>
                     </td></tr>
                     <tr><td>Time</td><td><xsl:value-of select="$ruleresult/@time"/></td></tr>
-                    <tr><td>Severity</td><td><xsl:value-of select="$ruleresult/@severity"/></td></tr>
+                    <tr><td>Severity</td><td><xsl:call-template name="item-severity"><xsl:with-param name="item" select="$ruleresult" /></xsl:call-template></td></tr>
                     <tr><td>Identifiers and References</td><td class="identifiers">
                         <!-- XCCDF 1.2 spec says that idents in rule-result should be copied from
                              the Rule itself. That means that we can just use the same code as guide

--- a/xsl/xccdf-share.xsl
+++ b/xsl/xccdf-share.xsl
@@ -125,6 +125,12 @@ Authors:
     </xsl:if>
 </xsl:template>
 
+<!-- works for both XCCDF Rule elements and rule-result elements -->
+<xsl:template name="item-severity">
+    <xsl:param name="item"/>
+    <xsl:choose><xsl:when test="$item/@severity"><xsl:value-of select="$item/@severity"/></xsl:when><xsl:otherwise>unknown</xsl:otherwise></xsl:choose>
+</xsl:template>
+
 <!-- substitution for testresults, used in HTML report -->
 <xsl:template mode="sub-testresult" match="text()">
     <xsl:param name="testresult"/>


### PR DESCRIPTION
Ran into this today when demoing HTML guide in a meeting. No idea why we didn't show severity in HTML guide.

I also have to say that the HTML guide looks much worse than our HTML report. And the filtering, searching and grouping features are not there. Wish we could bring some of those features to the HTML guide in the future.

I also sneaked in a bugfix. In HTML report we just assume severity attribute is there. This is not guaranteed by the specification! If severity is missing we should assume it's "unknown". I have made changes so that that's what gets displayed in HTML report and HTML guide.

![image](https://cloud.githubusercontent.com/assets/753153/21909969/2b910ecc-d8e8-11e6-92e8-54348960abd7.png)
