### PR TITLE
Added a button into rule details that allows you to scroll back up quickly

### DIFF
--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -949,6 +949,7 @@ Authors:
             <xsl:with-param name="item" select="$benchmark"/>
             <xsl:with-param name="profile" select="$profile"/>
         </xsl:call-template>
+        <a href="#result-details"><button type="button" class="btn btn-secondary">Scroll back to the first rule</button></a>
     </div>
 </xsl:template>
 


### PR DESCRIPTION
Avoids tedious scrolling back up to perhaps hide the rule result details. If you click that button you will be teleported back to the first rule result details. There it gets easy to just click `hide result details` if necessary.

![image](https://cloud.githubusercontent.com/assets/753153/21943510/8a9ef6ba-d99f-11e6-86a1-dd8424682542.png)

I think this fixes #620 but it is not the solution suggested in that ticket.

Handcrafted for @shawndwells ! :-D