### PR TITLE
Show the probe family in `oscap --v`

### DIFF
--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -538,12 +538,13 @@ void oval_probe_meta_list(FILE *output, int flags)
 
 		if (flags & OVAL_PROBEMETA_LIST_VERBOSE) {
 			if (meta[i].flags & OVAL_PROBEMETA_EXTERNAL) {
-				fprintf(output, " %-5u %s\n", meta[i].otype, probe_path);
+				fprintf(output, " %-5u %s", meta[i].otype, probe_path);
 			} else {
-				fprintf(output, " %-5u\n", meta[i].otype);
+				fprintf(output, " %-5u", meta[i].otype);
 			}
-		} else
-			fprintf(output, "\n");
+		}
+
+		fprintf(output, "\n");
 	}
 
 	return;

--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -530,6 +530,10 @@ void oval_probe_meta_list(FILE *output, int flags)
 			}
 		}
 
+		if (flags & OVAL_PROBEMETA_LIST_OTYPE) {
+			fprintf(output, "%-14s", oval_family_get_text(oval_subtype_get_family(meta[i].otype)));
+		}
+
 		fprintf(output, "%-28s %-28s", meta[i].stype, meta[i].pname);
 
 		if (flags & OVAL_PROBEMETA_LIST_VERBOSE) {

--- a/src/OVAL/public/oval_probe.h
+++ b/src/OVAL/public/oval_probe.h
@@ -81,6 +81,7 @@ int oval_probe_query_variable(oval_probe_session_t *sess, struct oval_variable *
 
 #define OVAL_PROBEMETA_LIST_VERBOSE 0x00000001 /**< Be verbose when listing supported probes */
 #define OVAL_PROBEMETA_LIST_DYNAMIC 0x00000002 /**< Perform additional checks when listing supported probes (i.e. list only existing external probes) */
+#define OVAL_PROBEMETA_LIST_OTYPE   0x00000004 /**< Show the otype / family type of the probe */
 
 void oval_probe_meta_list(FILE *output, int flags);
 

--- a/utils/oscap.c
+++ b/utils/oscap.c
@@ -181,6 +181,8 @@ static int print_versions(const struct oscap_action *action)
 	printf("\n");
 
 	printf("==== Supported OVAL objects and associated OpenSCAP probes ====\n");
+	printf("%-14s%-28s %-28s\n", "OVAL family", "OVAL object", "OpenSCAP probe");
+	printf("%-14s%-28s %-28s\n", "----------", "----------", "----------");
 	oval_probe_meta_list(stdout, OVAL_PROBEMETA_LIST_DYNAMIC | OVAL_PROBEMETA_LIST_OTYPE);
 
 	return OSCAP_OK;

--- a/utils/oscap.c
+++ b/utils/oscap.c
@@ -181,7 +181,7 @@ static int print_versions(const struct oscap_action *action)
 	printf("\n");
 
 	printf("==== Supported OVAL objects and associated OpenSCAP probes ====\n");
-	oval_probe_meta_list(stdout, OVAL_PROBEMETA_LIST_DYNAMIC);
+	oval_probe_meta_list(stdout, OVAL_PROBEMETA_LIST_DYNAMIC | OVAL_PROBEMETA_LIST_OTYPE);
 
 	return OSCAP_OK;
 }


### PR DESCRIPTION
Fixes #650 

Example:
```
==== Supported OVAL objects and associated OpenSCAP probes ====
(null)        system_info                  probe_system_info           
independent   family                       probe_family                
independent   filehash                     probe_filehash              
independent   environmentvariable          probe_environmentvariable   
independent   textfilecontent54            probe_textfilecontent54     
independent   textfilecontent              probe_textfilecontent       
independent   variable                     probe_variable              
independent   xmlfilecontent               probe_xmlfilecontent        
independent   environmentvariable58        probe_environmentvariable58 
independent   filehash58                   probe_filehash58            
linux         dpkginfo                     probe_dpkginfo              
linux         inetlisteningservers         probe_inetlisteningservers  
linux         rpminfo                      probe_rpminfo               
linux         partition                    probe_partition             
linux         iflisteners                  probe_iflisteners           
linux         rpmverify                    probe_rpmverify             
linux         rpmverifyfile                probe_rpmverifyfile         
linux         rpmverifypackage             probe_rpmverifypackage      
linux         selinuxboolean               probe_selinuxboolean        
linux         selinuxsecuritycontext       probe_selinuxsecuritycontext
linux         systemdunitproperty          probe_systemdunitproperty   
linux         systemdunitdependency        probe_systemdunitdependency 
unix          file                         probe_file                  
unix          interface                    probe_interface             
unix          password                     probe_password              
unix          process                      probe_process               
unix          runlevel                     probe_runlevel              
unix          shadow                       probe_shadow                
unix          uname                        probe_uname                 
unix          xinetd                       probe_xinetd                
unix          sysctl                       probe_sysctl                
unix          gconf                        probe_gconf                 
unix          routingtable                 probe_routingtable          
unix          symlink                      probe_symlink    
```