### PR TITLE
Issue #634: Coverity: Check return value of fgetc

### DIFF
--- a/src/OVAL/probes/unix/runlevel.c
+++ b/src/OVAL/probes/unix/runlevel.c
@@ -307,11 +307,11 @@ static int parse_os_release(const char *cpe)
 	memset(releasename, 0, RELEASENAME_MAX_SIZE);
 
 	int got = -1;
+	int c;
 	do {
 		got = fscanf(osrelease, RELEASENAME_PATTERN, releasename);
-		/*const char c = */fgetc(osrelease);
-	}
-	while (got == 0);
+		c = fgetc(osrelease);
+	} while (got == 0 && c != EOF);
 
 	int ret;
 	if (got < 0) {


### PR DESCRIPTION
Adressing:
Calling "fgetc(osrelease)" without checking return value. This library
function may fail and return an error code.

Fixes https://github.com/OpenSCAP/openscap/issues/634