### PR TITLE
Issue #655: Capitalize first letters in labels in HTML guide

### DIFF
--- a/xsl/xccdf-guide-impl.xsl
+++ b/xsl/xccdf-guide-impl.xsl
@@ -194,7 +194,7 @@ Authors:
                 <xsl:for-each select="$item/cdf:warning">
                     <div class="panel panel-warning">
                         <div class="panel-heading">
-                            <span class="label label-warning">warning</span>&#160;
+                            <span class="label label-warning">Warning:</span>&#160;
                             <xsl:apply-templates mode="sub-testresult" select=".">
                                 <xsl:with-param name="benchmark" select="$item/ancestor::cdf:Benchmark"/>
                                 <xsl:with-param name="profile" select="$profile"/>
@@ -215,7 +215,7 @@ Authors:
 
                 <div class="severity">
                     <p>
-                        <span class="label label-warning">severity:</span>&#160;
+                        <span class="label label-warning">Severity:</span>&#160;
                         <xsl:call-template name="item-severity"><xsl:with-param name="item" select="$item" /></xsl:call-template>
                     </p>
                 </div>
@@ -349,7 +349,7 @@ Authors:
                     <xsl:for-each select="$item/cdf:warning">
                         <div class="panel panel-warning">
                             <div class="panel-heading">
-                                <span class="label label-warning">warning</span>&#160;
+                                <span class="label label-warning">Warning:</span>&#160;
                                 <xsl:apply-templates mode="sub-testresult" select=".">
                                     <xsl:with-param name="benchmark" select="$item/ancestor::cdf:Benchmark"/>
                                     <xsl:with-param name="profile" select="$profile"/>

--- a/xsl/xccdf-share.xsl
+++ b/xsl/xccdf-share.xsl
@@ -107,7 +107,7 @@ Authors:
 
     <xsl:if test="$item/cdf:ident">
         <p>
-            <span class="label label-info" title="A globally meaningful identifiers for this rule. MAY be the name or identifier of a security configuration issue or vulnerability that the rule remediates. By setting an identifier on a rule, the benchmark author effectively declares that the rule instantiates, implements, or remediates the issue for which the name was assigned.">identifiers:</span>&#160;
+            <span class="label label-info" title="A globally meaningful identifiers for this rule. MAY be the name or identifier of a security configuration issue or vulnerability that the rule remediates. By setting an identifier on a rule, the benchmark author effectively declares that the rule instantiates, implements, or remediates the issue for which the name was assigned.">Identifiers:</span>&#160;
             <xsl:for-each select="$item/cdf:ident">
                 <xsl:apply-templates mode="ident" select="."/>
                 <xsl:if test="position() != last()">, </xsl:if>
@@ -116,7 +116,7 @@ Authors:
     </xsl:if>
     <xsl:if test="$item/cdf:reference">
         <p>
-            <span class="label label-default" title="Provide a reference to a document or resource where the user can learn more about the subject of the Rule or Group.">references:</span>&#160;
+            <span class="label label-default" title="Provide a reference to a document or resource where the user can learn more about the subject of the Rule or Group.">References:</span>&#160;
             <xsl:for-each select="$item/cdf:reference">
                 <xsl:apply-templates mode="reference" select="."/>
                 <xsl:if test="position() != last()">, </xsl:if>


### PR DESCRIPTION
Just a cosmetic change. We were incosistent here. 


Fixes https://github.com/OpenSCAP/openscap/issues/655