### PR TITLE
Add ARF support in "oscap xccdf generate fix"

### DIFF
--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -51,6 +51,15 @@ struct xccdf_session;
 struct xccdf_session *xccdf_session_new(const char *filename);
 
 /**
+ * Costructor of xccdf_session. It creates a new xccdf_session from an oscap_source structure.
+ * @memberof xccdf_session
+ * @param source oscap_source which can represent a DS or XCCDF file.
+ * @returns newly created \ref xccdf_session.
+ * @retval NULL is returned in case of error. Details might be found through \ref oscap_err_desc()
+ */
+struct xccdf_session *xccdf_session_new_from_source(struct oscap_source *source);
+
+/**
  * Destructor of xccdf_session.
  * @memberof xccdf_session
  * @param session to destroy.

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -505,6 +505,15 @@ int xccdf_session_remediate(struct xccdf_session *session);
  */
 int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, const char *testresult_id);
 
+/**
+ * Load xccdf:TestResult to the session from oscap_source
+ * @memberof xccdf_session
+ * @param session XCCDF Session
+ * @param report_source Structure conataining oscap_source of the test results
+ * @returns zero on success.
+ */
+int xccdf_session_add_report_from_source(struct xccdf_session *session, struct oscap_source *report_source);
+
 /// @}
 /// @}
 #endif

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1573,18 +1573,21 @@ int xccdf_session_remediate(struct xccdf_session *session)
 
 int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, const char *testresult_id)
 {
-	session->xccdf.result = NULL;
-	struct xccdf_benchmark *benchmark = xccdf_policy_model_get_benchmark(session->xccdf.policy_model);
-	struct xccdf_result *result = xccdf_benchmark_get_result_by_id(benchmark, testresult_id);
-	if (result == NULL) {
-		if (testresult_id == NULL)
-			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not find latest TestResult element.");
-		else
-			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not find TestResult/@id=\"%s\"", testresult_id);
-		return 1;
+	if (session->xccdf.result_source == NULL) {
+		session->xccdf.result = NULL;
+		struct xccdf_benchmark *benchmark = xccdf_policy_model_get_benchmark(session->xccdf.policy_model);
+		struct xccdf_result *result = xccdf_benchmark_get_result_by_id(benchmark, testresult_id);
+		if (result == NULL) {
+			if (testresult_id == NULL)
+				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not find latest TestResult element.");
+			else
+				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not find TestResult/@id=\"%s\"", testresult_id);
+			return 1;
+		}
+		session->xccdf.result = xccdf_result_clone(result);
 	}
 
-	const char *profile_id = xccdf_result_get_profile(result);
+	const char *profile_id = xccdf_result_get_profile(session->xccdf.result);
 	if (xccdf_session_set_profile_id(session, profile_id) == false) {
 		oscap_seterr(OSCAP_EFAMILY_OSCAP,
 			"Could not find Profile/@id=\"%s\" to build policy from TestResult/@id=\"%s\"",
@@ -1594,7 +1597,6 @@ int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, co
 	struct xccdf_policy *xccdf_policy = xccdf_session_get_xccdf_policy(session);
 	if (xccdf_policy == NULL)
 		return 1;
-	session->xccdf.result = xccdf_result_clone(result);
 	xccdf_result_set_start_time_current(session->xccdf.result);
 	xccdf_policy_add_result(xccdf_policy, session->xccdf.result);
 	return 0;

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -121,11 +121,14 @@ static void _xccdf_session_free_oval_result_sources(struct xccdf_session *sessio
 static const char *oscap_productname = "cpe:/a:open-scap:oscap";
 static const char *oval_sysname = "http://oval.mitre.org/XMLSchema/oval-definitions-5";
 
-struct xccdf_session *xccdf_session_new(const char *filename)
+struct xccdf_session *xccdf_session_new_from_source(struct oscap_source *source)
 {
+	if (source == NULL) {
+		return NULL;
+	}
+	const char *filename = oscap_source_get_filepath(source);
 	struct xccdf_session *session = (struct xccdf_session *) oscap_calloc(1, sizeof(struct xccdf_session));
-
-	session->source = oscap_source_new_from_file(filename);
+	session->source = source;
 	oscap_document_type_t document_type = oscap_source_get_scap_type(session->source);
 	if (document_type == OSCAP_DOCUMENT_UNKNOWN) {
 		xccdf_session_free(session);
@@ -156,6 +159,13 @@ struct xccdf_session *xccdf_session_new(const char *filename)
 
 	dI("Created a new XCCDF session from a %s '%s'.",
 		oscap_document_type_to_string(document_type), filename);
+	return session;
+}
+
+struct xccdf_session *xccdf_session_new(const char *filename)
+{
+	struct oscap_source *source = oscap_source_new_from_file(filename);
+	struct xccdf_session *session = xccdf_session_new_from_source(source);
 	return session;
 }
 

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1589,3 +1589,15 @@ int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, co
 	xccdf_policy_add_result(xccdf_policy, session->xccdf.result);
 	return 0;
 }
+
+int xccdf_session_add_report_from_source(struct xccdf_session *session, struct oscap_source *report_source)
+{
+	struct xccdf_result *result = xccdf_result_import_source(report_source);
+	if (result == NULL) {
+		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not find TestResult element.");
+		return 1;
+	}
+	session->xccdf.result_source = report_source;
+	session->xccdf.result = result;
+	return 0;
+}

--- a/src/XCCDF_POLICY/xccdf_policy_substitute.c
+++ b/src/XCCDF_POLICY/xccdf_policy_substitute.c
@@ -83,6 +83,7 @@ static int _xccdf_text_substitution_cb(xmlNode **node, void *user_data)
 				// process the <xccdf:sub> element as if @use was set to "title". but
 				// during Document Generation or Assessment, process the <xccdf:sub>
 				// element as if @use was set to "value".
+				oscap_free(sub_use);
 				sub_use = strdup((data->processing_type & _TAILORING_TYPE) ? "title" : "value");
 			}
 

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -178,6 +178,11 @@ oscap_document_type_t oscap_source_get_scap_type(struct oscap_source *source)
 	return source->scap_type;
 }
 
+const char *oscap_source_get_filepath(struct oscap_source *source)
+{
+	return source->origin.filepath;
+}
+
 static void xmlErrorCb(struct oscap_string *buffer, const char * format, ...)
 {
 	va_list ap;

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -84,6 +84,19 @@ struct oscap_source *oscap_source_new_from_file(const char *filepath)
 	return source;
 }
 
+struct oscap_source *oscap_source_clone(struct oscap_source *old)
+{
+	struct oscap_source *new = (struct oscap_source *) oscap_calloc(1, sizeof(struct oscap_source));
+	new->scap_type = old->scap_type;
+	new->origin.type = old->origin.type;
+	new->origin.version = oscap_strdup(old->origin.version);
+	new->origin.filepath = oscap_strdup(old->origin.filepath);
+	new->origin.memory = oscap_strdup(old->origin.memory);
+	new->origin.memory_size = old->origin.memory_size;
+	new->xml.doc = xmlCopyDoc(old->xml.doc, true);
+	return new;
+}
+
 /**
  * Allocate oscap_source struct and fill for memory data
  * @param size_t size Size of data

--- a/src/source/public/oscap_source.h
+++ b/src/source/public/oscap_source.h
@@ -80,6 +80,13 @@ struct oscap_source *oscap_source_new_from_file(const char *filepath);
 struct oscap_source *oscap_source_new_from_memory(const char *buffer, size_t size, const char *filepath);
 
 /**
+ * Clone oscap_source structure.
+ * @param old Resource to clone
+ * @returns A clone of the given oscap_source.
+ */
+struct oscap_source *oscap_source_clone(struct oscap_source *old);
+
+/**
  * Dispose oscap_source structure.
  * @param source Resource to dispose
  */

--- a/src/source/public/oscap_source.h
+++ b/src/source/public/oscap_source.h
@@ -86,6 +86,14 @@ struct oscap_source *oscap_source_new_from_memory(const char *buffer, size_t siz
 void oscap_source_free(struct oscap_source *source);
 
 /**
+ * Get filepath of the given resource
+ * @memberof oscap_source
+ * @param source
+ * @returns filepath of the original source or NULL
+ */
+const char *oscap_source_get_filepath(struct oscap_source *source);
+
+/**
  * Get SCAP document type of the given resource
  * @memberof oscap_source
  * @param source

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -60,6 +60,8 @@ EXTRA_DIST += \
 	test_empty_variable.oval.xml \
 	test_empty_variable.sh \
 	test_empty_variable.xccdf.xml \
+	test_fix_arf.xccdf.xml \
+	test_fix_arf.sh \
 	test_fix_instance.oval.xml \
 	test_fix_instance.sh \
 	test_fix_instance.xccdf.xml \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -93,6 +93,10 @@ test_run "XCCDF Remediate + perl fix" $srcdir/test_remediate_perl.sh
 test_run 'generate report: xccdf:check/@selector=""' $srcdir/test_report_check_with_empty_selector.sh
 test_run "generate report: missing xsl shall not segfault" $srcdir/test_report_without_xsl_fails_gracefully.sh
 test_run "generate report: avoid warnings from libxml" $srcdir/test_report_without_oval_poses_no_errors.sh
+
+#
+# Tests for 'oscap xccdf generate fix'
+#
 test_run "generate fix: just as the anaconda does" $srcdir/test_report_anaconda_fixes.sh
 test_run "generate fix: just as the anaconda does + DataStream" $srcdir/test_report_anaconda_fixes_ds.sh
 test_run "generate fix: ensure filtering drop fixes" $srcdir/test_fix_filtering.sh

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -100,5 +100,6 @@ test_run "generate report: avoid warnings from libxml" $srcdir/test_report_witho
 test_run "generate fix: just as the anaconda does" $srcdir/test_report_anaconda_fixes.sh
 test_run "generate fix: just as the anaconda does + DataStream" $srcdir/test_report_anaconda_fixes_ds.sh
 test_run "generate fix: ensure filtering drop fixes" $srcdir/test_fix_filtering.sh
+test_run "generate fix: from result DataStream" $srcdir/test_fix_arf.sh
 
 test_exit

--- a/tests/API/XCCDF/unittests/test_fix_arf.sh
+++ b/tests/API/XCCDF/unittests/test_fix_arf.sh
@@ -8,8 +8,10 @@ result_id="xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_standard
 bash_line1="echo this_is_ok"
 bash_line2="echo fix_me_please"
 ansible_template="urn:xccdf:fix:script:ansible"
-ansible_line1="this_is_ok"
-ansible_line2="fix_me_please"
+ansible_task1a="\- name: ensure everything passes"
+ansible_task1b="shell: /bin/true"
+ansible_task2a="\- name: correct the failing case"
+ansible_task2b="shell: /bin/false"
 
 name=$(basename $0 .sh)
 results_arf=$(mktemp -t ${name}.arf.XXXXXX)
@@ -34,20 +36,26 @@ grep -q "$bash_line2" $script
 $OSCAP xccdf generate fix --profile $profile --template $ansible_template --output $playbook $results_arf >$stdout 2>$stderr
 [ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
-grep -q "$ansible_line1" $playbook
-grep -q "$ansible_line2" $playbook
+grep -q "$ansible_task1a" $playbook
+grep -q "$ansible_task1b" $playbook
+grep -q "$ansible_task2a" $playbook
+grep -q "$ansible_task2b" $playbook
 
 # Generate a bash script based on scan results stored in ARF file
 $OSCAP xccdf generate fix --result-id $result_id --output $script $results_arf >$stdout 2>$stderr
 [ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+grep -q -v "$bash_line1" $script
 grep -q "$bash_line2" $script
 
 # Generate  an Ansible playbook based on scan results stored in ARF file
 $OSCAP xccdf generate fix --result-id $result_id --template $ansible_template --output $playbook $results_arf >$stdout 2>$stderr
 [ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
-grep -q "$ansible_line2" $playbook
+grep -q -v "$ansible_task1a" $playbook
+grep -q -v "$ansible_task1b" $playbook
+grep -q "$ansible_task2a" $playbook
+grep -q "$ansible_task2b" $playbook
 
 rm $results_arf
 rm $script

--- a/tests/API/XCCDF/unittests/test_fix_arf.sh
+++ b/tests/API/XCCDF/unittests/test_fix_arf.sh
@@ -19,7 +19,7 @@ script=$(mktemp -t ${name}.sh.XXXXXX)
 playbook=$(mktemp -t ${name}.yml.XXXXXX)
 
 # Create an ARF
-$OSCAP xccdf eval --profile $profile --results-arf $results_arf $name.xccdf.xml >$stdout 2>$stderr || [ $? == 2 ]
+$OSCAP xccdf eval --profile $profile --results-arf $results_arf $srcdir/$name.xccdf.xml >$stdout 2>$stderr || [ $? == 2 ]
 [ -f $stdout ]; [ -s $stdout ]; rm $stdout
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 

--- a/tests/API/XCCDF/unittests/test_fix_arf.sh
+++ b/tests/API/XCCDF/unittests/test_fix_arf.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+profile="xccdf_moc.elpmaxe.www_profile_standard"
+result_id="xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_standard"
+bash_line1="echo this_is_ok"
+bash_line2="echo fix_me_please"
+ansible_template="urn:xccdf:fix:script:ansible"
+ansible_line1="this_is_ok"
+ansible_line2="fix_me_please"
+
+name=$(basename $0 .sh)
+results_arf=$(mktemp -t ${name}.arf.XXXXXX)
+stdout=$(mktemp -t ${name}.out.XXXXXX)
+stderr=$(mktemp -t ${name}.err.XXXXXX)
+script=$(mktemp -t ${name}.sh.XXXXXX)
+playbook=$(mktemp -t ${name}.yml.XXXXXX)
+
+# Create an ARF
+$OSCAP xccdf eval --profile $profile --results-arf $results_arf $name.xccdf.xml >$stdout 2>$stderr || [ $? == 2 ]
+[ -f $stdout ]; [ -s $stdout ]; rm $stdout
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
+# Generate a bash script from a profile in ARF file
+$OSCAP xccdf generate fix --profile $profile --output $script $results_arf >$stdout 2>$stderr
+[ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+grep -q "$bash_line1" $script
+grep -q "$bash_line2" $script
+
+# Generate an Ansible playbook from a profile in ARF file
+$OSCAP xccdf generate fix --profile $profile --template $ansible_template --output $playbook $results_arf >$stdout 2>$stderr
+[ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+grep -q "$ansible_line1" $playbook
+grep -q "$ansible_line2" $playbook
+
+# Generate a bash script based on scan results stored in ARF file
+$OSCAP xccdf generate fix --result-id $result_id --output $script $results_arf >$stdout 2>$stderr
+[ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+grep -q "$bash_line2" $script
+
+# Generate  an Ansible playbook based on scan results stored in ARF file
+$OSCAP xccdf generate fix --result-id $result_id --template $ansible_template --output $playbook $results_arf >$stdout 2>$stderr
+[ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+grep -q "$ansible_line2" $playbook
+
+rm $results_arf
+rm $script
+rm $playbook

--- a/tests/API/XCCDF/unittests/test_fix_arf.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_fix_arf.xccdf.xml
@@ -17,7 +17,8 @@
   <Rule selected="false" id="xccdf_moc.elpmaxe.www_rule_1">
     <title>Passing rule</title>
     <fix id="bash_fix_for_passing_rule" system="urn:xccdf:fix:script:sh">echo this_is_ok</fix>
-    <fix id="ansible_fix_for_passing_rule" system="urn:xccdf:fix:script:ansible">this_is_ok</fix>
+    <fix id="ansible_fix_for_passing_rule" system="urn:xccdf:fix:script:ansible">- name: ensure everything passes
+    shell: /bin/true</fix>
     <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
         <check-content-ref href="oval/pass/oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
     </check>
@@ -25,7 +26,8 @@
   <Rule selected="false" id="xccdf_moc.elpmaxe.www_rule_2">
     <title>Failing rule</title>
     <fix id="fix_for_failing_rule" system="urn:xccdf:fix:script:sh">echo fix_me_please</fix>
-    <fix id="ansible_fix_for_failing_rule" system="urn:xccdf:fix:script:ansible">fix_me_please</fix>
+    <fix id="ansible_fix_for_failing_rule" system="urn:xccdf:fix:script:ansible">- name: correct the failing case
+    shell: /bin/false</fix>
     <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
         <check-content-ref href="oval/fail/oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
     </check>

--- a/tests/API/XCCDF/unittests/test_fix_arf.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_fix_arf.xccdf.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+  <status>incomplete</status>
+  <title>Security Benchmark</title>
+  <description xml:lang="en-US">A sample benchmark</description>
+  <version>1.0</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <model system="urn:xccdf:scoring:flat"/>
+  <model system="urn:xccdf:scoring:flat-unweighted"/>
+  <model system="urn:xccdf:scoring:absolute"/>
+  <Profile id="xccdf_moc.elpmaxe.www_profile_standard">
+    <title xml:lang="en-US">Standard System Security Profile</title>
+    <description xml:lang="en-US">This profile contains rules to ensure standard security baseline of your system.</description>
+    <select idref="xccdf_moc.elpmaxe.www_rule_1" selected="true"/>
+    <select idref="xccdf_moc.elpmaxe.www_rule_2" selected="true"/>
+  </Profile>
+  <Rule selected="false" id="xccdf_moc.elpmaxe.www_rule_1">
+    <title>Passing rule</title>
+    <fix id="bash_fix_for_passing_rule" system="urn:xccdf:fix:script:sh">echo this_is_ok</fix>
+    <fix id="ansible_fix_for_passing_rule" system="urn:xccdf:fix:script:ansible">this_is_ok</fix>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref href="oval/pass/oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
+    </check>
+  </Rule>
+  <Rule selected="false" id="xccdf_moc.elpmaxe.www_rule_2">
+    <title>Failing rule</title>
+    <fix id="fix_for_failing_rule" system="urn:xccdf:fix:script:sh">echo fix_me_please</fix>
+    <fix id="ansible_fix_for_failing_rule" system="urn:xccdf:fix:script:ansible">fix_me_please</fix>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref href="oval/fail/oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
+    </check>
+  </Rule>
+</Benchmark>

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -785,8 +785,10 @@ int app_generate_fix(const struct oscap_action *action)
 			goto cleanup;
 		}
 		session = xccdf_session_new_from_source(oscap_source_clone(report_request_source));
-		if (xccdf_session_add_report_from_source(session, oscap_source_clone(report_source))) {
-			goto cleanup;
+		if (action->id != NULL) {
+			if (xccdf_session_add_report_from_source(session, oscap_source_clone(report_source))) {
+				goto cleanup;
+			}
 		}
 		oscap_source_free(source);
 	} else {


### PR DESCRIPTION
This pull request will enable:

1. Generating fix scripts from a profile in ARF file (profile-oriented fix)
This contains all the remediation scripts from a given profile.
Example:
```
oscap xccdf generate fix \
--profile xccdf_org.ssgproject.content_profile_common \
--output fix.sh \
arf.xml
```

2. Generating fix scripts based on scan results stored in ARF file (result-oriented fix)
This contains remediation only for failed rules.
Example:
```
oscap xccdf generate fix \
--result-id xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_common \
--output fix.sh \
arf.xml
```