### PR TITLE
Manual more detailed idents

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -479,8 +479,6 @@ elements.
 
 Since OpenSCAP 1.2.9 you can use the Group-By feature of HTML report
 to get an overview of results based on their identifiers and references.
-For example if you select "CCE" in the group-by combobox the results
-will be listed by their CCE ID instead of the usual XCCDF hierarchy.
 
 The HTML report can also be used to look-up Rules by their identifiers.
 You can type the identifier (e.g.: CCE-27173-4) in the search box in

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -489,7 +489,7 @@ This can be used for any type of XCCDF identifier or reference.
 
 If you want to map two identifiers -- e.g.: map CCE identifier to
 NIST 800-53 identifier -- you need to look-up the XCCDF rule in the
-HTNML report using the first identifier. Then click its title to show
+HTML report using the first identifier. Then click its title to show
 more details. The rule details will show all identifiers, including
 the identifier you want to map to. This relies heavily on SCAP content
 quality, if the identifiers are not present in the source content they

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -482,6 +482,11 @@ to get an overview of results based on their identifiers and references.
 For example if you select "CCE" in the group-by combobox the results
 will be listed by their CCE ID instead of the usual XCCDF hierarchy.
 
+The HTML report can also be used to look-up Rules by their identifiers.
+You can type the identifier (e.g.: CCE-27173-4) in the search box in
+the HTML report and only rules with this identifier will be shown.
+This can be used for any type of XCCDF identifier or reference.
+
 
 ==== Bundled CCE data
 OpenSCAP does not provide any static or product bundled CCE data. Thus

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -477,6 +477,11 @@ elements.
 </rule-result>
 ----
 
+Since OpenSCAP 1.2.9 you can use the Group-By feature of HTML report
+to get an overview of results based on their identifiers and references.
+For example if you select "CCE" in the group-by combobox the results
+will be listed by their CCE ID instead of the usual XCCDF hierarchy.
+
 
 ==== Bundled CCE data
 OpenSCAP does not provide any static or product bundled CCE data. Thus

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -467,6 +467,16 @@ This file can be generated during the scan by adding *--results-arf* option.
 Result data stream file **results.xml** contains these identifiers in <rule-result>
 elements.
 
+----
+<rule-result idref="xccdf_org.ssgproject.content_rule_partition_for_tmp" time="2017-01-20T14:30:18" severity="low" weight="1.000000">
+  <result>pass</result>
+  <ident system="https://nvd.nist.gov/cce/index.cfm">CCE-27173-4</ident>
+  <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+    <check-content-ref name="oval:ssg-partition_for_tmp:def:1" href="#oval0"/>
+  </check>
+</rule-result>
+----
+
 
 ==== Bundled CCE data
 OpenSCAP does not provide any static or product bundled CCE data. Thus

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -487,6 +487,14 @@ You can type the identifier (e.g.: CCE-27173-4) in the search box in
 the HTML report and only rules with this identifier will be shown.
 This can be used for any type of XCCDF identifier or reference.
 
+If you want to map two identifiers -- e.g.: map CCE identifier to
+NIST 800-53 identifier -- you need to look-up the XCCDF rule in the
+HTNML report using the first identifier. Then click its title to show
+more details. The rule details will show all identifiers, including
+the identifier you want to map to. This relies heavily on SCAP content
+quality, if the identifiers are not present in the source content they
+will not be available in the HTML report.
+
 
 ==== Bundled CCE data
 OpenSCAP does not provide any static or product bundled CCE data. Thus

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -486,14 +486,17 @@ The HTML report can also be used to look-up Rules by their identifiers.
 You can type the identifier (e.g.: CCE-27173-4) in the search box in
 the HTML report and only rules with this identifier will be shown.
 This can be used for any type of XCCDF identifier or reference.
+You can also click on the rule title to show more details and see all
+its identifiers, including the identifier you looked for.
+This relies heavily on SCAP content quality, if the identifiers are
+not present in the source content they will not be available in the
+HTML report.
 
 If you want to map two identifiers -- e.g.: map CCE identifier to
-NIST 800-53 identifier -- you need to look-up the XCCDF rule in the
-HTML report using the first identifier. Then click its title to show
-more details. The rule details will show all identifiers, including
-the identifier you want to map to. This relies heavily on SCAP content
-quality, if the identifiers are not present in the source content they
-will not be available in the HTML report.
+NIST 800-53 identifier -- you need to look-up the CCE ID in the
+HTML report through the search box using the first identifier. And then,
+by grouping by NIST SP 800-53 ID, you can see all NIST 800-53 IDs
+related to the searched CCE ID.
 
 
 ==== Bundled CCE data

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -426,10 +426,10 @@ check implemented. *notchecked* means that there was no check in that
 particular rule that could be evaluated.
 
 
-==== CVE, CCE and other identifiers
+==== CVE, CCE, CPE and other identifiers
 Each XCCDF Rule can have xccdf:ident elements inside. These elements
 allow the content creator to reference various external identifiers like
-CVE, CCE and others.
+CVE, CCE, CPE and others.
 
 When scanning, oscap output identifiers of scanned rules regardless of
 their results. For example:


### PR DESCRIPTION
For `maint-1.2` mainly because of group-by and identifier/reference lookup. Both of these are `maint-1.2` only.