### PR TITLE
User manual: Mention --results-arf in the XCCDF/SDS evaluation section

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -238,7 +238,7 @@ This file can be loaded by OpenSCAP using *--directives <file>* option.
 $ oscap oval eval --directives directives.xml --datastream-id ds.xml --oval-id xccdf.xml --results oval-results.xml scap-ds.xml
 ---------------------------------------------------------------------------------------------------
 
-==== XCCDF
+==== XCCDF and Source DataStream
 When evaluating an XCCDF benchmark, ```oscap``` usually processes an XCCDF
 file, an OVAL file and the CPE dictionary. It performs system
 analysis and produces XCCDF results based on this analysis. The results
@@ -306,6 +306,14 @@ Where *scap-ds.xml* is a file representing the SCAP data stream
 collection, *benchmark_id* is a string matching the "id" attribute of
 xccdf:Benchmark containing in a component, and *xccdf-results.xml* is a
 file containing the scan results.
+
+In the examples above we are generating XCCDF result files using the `--results`
+command-line argument. You can use `--results-arf` to generate a Result DataStream
+(also called ARF - asset reporting format) result instead.
+
+--------------------------------------------------------------------------------------
+$ oscap xccdf eval --benchmark-id benchmark_id --results-arf arf-results.xml scap-ds.xml
+--------------------------------------------------------------------------------------
 
 === Remediate System
 OpenSCAP allows to automatically remediate systems that have been found in a

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -168,7 +168,7 @@ vulnerability scans of a local system. Oscap is able to evaluate both
 XCCDF benchmarks and OVAL definitions and generate the appropriate
 results. Please note that SCAP content can be provided either in a
 single file (as an OVAL file or SCAP Data Stream), or as multiple
-separate XML files. The following examples distinguish between these two
+separate XML files. The following examples distinguish between these
 approaches.
 
 ==== OVAL
@@ -238,7 +238,7 @@ This file can be loaded by OpenSCAP using *--directives <file>* option.
 $ oscap oval eval --directives directives.xml --datastream-id ds.xml --oval-id xccdf.xml --results oval-results.xml scap-ds.xml
 ---------------------------------------------------------------------------------------------------
 
-==== XCCDF and Source DataStream
+==== XCCDF
 When evaluating an XCCDF benchmark, ```oscap``` usually processes an XCCDF
 file, an OVAL file and the CPE dictionary. It performs system
 analysis and produces XCCDF results based on this analysis. The results
@@ -273,9 +273,14 @@ Where *scap-xccdf.xml* is the XCCDF document, *Desktop* is the selected
 profile from the XCCDF document, *xccdf-results.xml* is a file storing
 the scan results, and *cpe-dictionary.xml* is the CPE dictionary.
 
+==== Source DataStream
+Commonly, all required input files are bundled together in Source DataStream.
+Scanning using Source DataStream is also handled by ```oscap xccdf eval``` command,
+with some additional parameters required to determine which of the bundled
+benchmarks should be performed.
 
 * To evaluate a specific XCCDF benchmark that is part of a data stream
-within a SCAP data stream collection run the following command:
+within a SCAP data stream collection, run the following command:
 
 ----
 $ oscap xccdf eval --datastream-id ds.xml --xccdf-id xccdf.xml --results xccdf-results.xml scap-ds.xml
@@ -307,9 +312,11 @@ collection, *benchmark_id* is a string matching the "id" attribute of
 xccdf:Benchmark containing in a component, and *xccdf-results.xml* is a
 file containing the scan results.
 
+==== Results DataStream (ARF)
+
 In the examples above we are generating XCCDF result files using the `--results`
 command-line argument. You can use `--results-arf` to generate a Result DataStream
-(also called ARF - asset reporting format) result instead.
+(also called ARF - Asset Reporting Format) XML instead.
 
 --------------------------------------------------------------------------------------
 $ oscap xccdf eval --benchmark-id benchmark_id --results-arf arf-results.xml scap-ds.xml

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -276,7 +276,7 @@ the scan results, and *cpe-dictionary.xml* is the CPE dictionary.
 ==== Source DataStream
 Commonly, all required input files are bundled together in Source DataStream.
 Scanning using Source DataStream is also handled by ```oscap xccdf eval``` command,
-with some additional parameters required to determine which of the bundled
+with some additional parameters available to determine which of the bundled
 benchmarks should be performed.
 
 * To evaluate a specific XCCDF benchmark that is part of a data stream

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -279,40 +279,40 @@ Scanning using Source DataStream is also handled by ```oscap xccdf eval``` comma
 with some additional parameters available to determine which of the bundled
 benchmarks should be performed.
 
-* To evaluate a specific XCCDF benchmark that is part of a data stream
-within a SCAP data stream collection, run the following command:
+* To evaluate a specific XCCDF benchmark that is part of a DataStream
+within a SCAP DataStream collection, run the following command:
 
 ----
 $ oscap xccdf eval --datastream-id ds.xml --xccdf-id xccdf.xml --results xccdf-results.xml scap-ds.xml
 ----
 
-Where *scap-ds.xml* is a file representing the SCAP data stream
-collection, *ds.xml* is the particular data stream, *xccdf.xml* is ID of
+Where *scap-ds.xml* is a file representing the SCAP DataStream
+collection, *ds.xml* is the particular DataStream, *xccdf.xml* is ID of
 the component-ref pointing to the desired XCCDF document, and
 *xccdf-results.xml* is a file containing the scan results.
 
 NOTE: If you omit ```--datastream-id``` on the command line, the first data
 stream from the collection will be used. If you omit ```--xccdf-id```, the
 first component from the checklists element will be used. If you omit
-both, the first data stream that has a component in the checklists
+both, the first DataStream that has a component in the checklists
 element will be used - the first component in its checklists element
 will be used.
 
 
 * (Alternative, not recommended) To evaluate a specific XCCDF benchmark
-that is part of a data stream within a SCAP data stream collection run
+that is part of a DataStream within a SCAP DataStream collection run
 the following command:
 
 --------------------------------------------------------------------------------------
 $ oscap xccdf eval --benchmark-id benchmark_id --results xccdf-results.xml scap-ds.xml
 --------------------------------------------------------------------------------------
 
-Where *scap-ds.xml* is a file representing the SCAP data stream
+Where *scap-ds.xml* is a file representing the SCAP DataStream
 collection, *benchmark_id* is a string matching the "id" attribute of
 xccdf:Benchmark containing in a component, and *xccdf-results.xml* is a
 file containing the scan results.
 
-==== Results DataStream (ARF)
+==== Result DataStream (ARF)
 
 In the examples above we are generating XCCDF result files using the `--results`
 command-line argument. You can use `--results-arf` to generate a Result DataStream


### PR DESCRIPTION
It was not clear before that you can use `--results` or `--results-arf` when evaluation an XCCDF or SDS.