### PR TITLE
Improve user manual

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1135,6 +1135,22 @@ $ xsltproc --stringparam reverse_DNS com.example.www /usr/share/openscap/xsl/xcc
 And then patch the content using a text editor, adding ```multi-check``` as
 shown in the example Rule snippet above.
 
+To create a source DataStream from the patched content, the following command can be used:
+
+----
+$ oscap ds sds-compose xccdf-1.2.xml source_ds.xml
+----
+
+If the original XCCDF file referenced a custom CPE dictionary, you also have to inject
+the CPE dictionary into the DataStream in order to create a valid source DataStream.
+To add a CPE dictionary component into your DataStream in place, use this command:
+
+----
+$ oscap ds sds-add cpe_dictionary.xml source_ds.xml
+----
+
+Now the ```source_ds.xml``` DataStream can be evaluated as normally.
+
 == Practical Examples
 This section demonstrates practical usage of certain security content provided
 for Red Hat products.


### PR DESCRIPTION
This commit covers using DataStreams and CPEs in section
"Evaluating XCCDF rules with multiple checks" of the OpenSCAP
user manual.