### PR TITLE
Terminate HTML guide generation if the profile ID doesn't match any p…

### DIFF
--- a/xsl/xccdf-guide-impl.xsl
+++ b/xsl/xccdf-guide-impl.xsl
@@ -484,6 +484,9 @@ Authors:
     </xsl:call-template>
 
     <xsl:variable name="profile" select="$benchmark/cdf:Profile[@id = $profile_id]"/>
+    <xsl:if test="$profile_id != '' and not($profile)">
+        <xsl:message terminate="yes">Profile "<xsl:value-of select="$profile_id"/>" was not found. Get available profiles using "oscap info".</xsl:message>
+    </xsl:if>
 
     <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html></xsl:text>
     <html lang="en">


### PR DESCRIPTION
…rofile

Improves but doesn't fully fix #656, to fix it entirely (exit code = 1) we need to change to xsltApplyStylesheetUser and check contents of the context.

```
$ ./run ./utils/.libs/oscap xccdf generate guide --profile asdfasdfvzxcv ~/d/scap-security-guide/RHEL/7/output/ssg-rhel7-xccdf.xml
Profile "asdfasdfvzxcv" was not found. Get available profiles using "oscap info".
$ echo $?
0
```