### PR TITLE
Thin results OVAL steps in user manual

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -353,6 +353,12 @@ full results:
 </oval_directives>
 ----
 
+Usage of OVAL directives file when scanning a plain OVAL file:
+
+---------------------------------------------------------------------------------------------------
+$ oscap oval eval --directives directives.xml --without-syschar --results oval-results.xml oval.xml
+---------------------------------------------------------------------------------------------------
+
 Usage of OVAL directives file when scanning OVAL component from a Source DataStream:
 
 ---------------------------------------------------------------------------------------------------

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -331,12 +331,38 @@ file containing exported variables from the XCCDF file, and
 An OVAL directives file can be used to control whether results should be "thin" or "full".
 This file can be loaded by OpenSCAP using *--directives <file>* option.
 
+Example of an OVAL directive file which enables thin results instead of
+full results:
+
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<oval_directives xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-res="http://oval.mitre.org/XMLSchema/oval-results-5" xmlns="http://oval.mitre.org/XMLSchema/oval-directives-5" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-results-5 oval-results-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-directives-5 oval-directives-schema.xsd">
+  <generator>
+    <oval:product_name>OpenSCAP</oval:product_name>
+    <oval:schema_version>5.8</oval:schema_version> <!-- make sure the OVAL version matches your input -->
+    <oval:timestamp>2017-02-04T00:00:00</oval:timestamp>
+  </generator>
+  <directives include_source_definitions="true">
+    <oval-res:definition_true reported="true" content="thin"/>
+    <oval-res:definition_false reported="true" content="thin"/>
+    <oval-res:definition_unknown reported="true" content="thin"/>
+    <oval-res:definition_error reported="true" content="thin"/>
+    <oval-res:definition_not_evaluated reported="true" content="thin"/>
+    <oval-res:definition_not_applicable reported="true" content="thin"/>
+  </directives>
+</oval_directives>
+----
+
+Usage of OVAL directives file when scanning OVAL component from a Source DataStream:
+
 ---------------------------------------------------------------------------------------------------
-$ oscap oval eval --directives directives.xml --datastream-id ds.xml --oval-id xccdf.xml --results oval-results.xml scap-ds.xml
+$ oscap oval eval --directives directives.xml --without-syschar --datastream-id ds.xml --oval-id oval.xml --results oval-results.xml scap-ds.xml
 ---------------------------------------------------------------------------------------------------
 
 OVAL results file contains, by default, exported system characteristics.
 OpenSCAP provides *--without-syschar* option to change this behavior.
+If your use-case require thin OVAL results you most likely also want
+to omit system characteristics.
 
 It is not always clear which OVAL file will be used when multiple files
 are distributed. In case you are evaluating an XCCDF file you can use:

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -353,6 +353,10 @@ full results:
 </oval_directives>
 ----
 
+If your use-case requires thin OVAL results you most likely also want
+to omit system characteristics. You can use the *--without-syschar*
+option to that effect.
+
 Usage of OVAL directives file when scanning a plain OVAL file:
 
 ---------------------------------------------------------------------------------------------------
@@ -364,11 +368,6 @@ Usage of OVAL directives file when scanning OVAL component from a Source DataStr
 ---------------------------------------------------------------------------------------------------
 $ oscap oval eval --directives directives.xml --without-syschar --datastream-id ds.xml --oval-id oval.xml --results oval-results.xml scap-ds.xml
 ---------------------------------------------------------------------------------------------------
-
-OVAL results file contains, by default, exported system characteristics.
-OpenSCAP provides *--without-syschar* option to change this behavior.
-If your use-case require thin OVAL results you most likely also want
-to omit system characteristics.
 
 It is not always clear which OVAL file will be used when multiple files
 are distributed. In case you are evaluating an XCCDF file you can use:


### PR DESCRIPTION
Better instructions for OVAL thin results in user manual.

The main improvement is the OVAL directives example.