### PR TITLE
Fix SCE stderr stalling

### DIFF
--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -571,31 +571,26 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 			const int flag_stderr = fcntl(stderr_pipefd[0], F_GETFL, 0);
 			fcntl(stderr_pipefd[0], F_SETFL, flag_stderr | O_NONBLOCK);
 
-			char* stdout_buffer = NULL;
-			char* stderr_buffer = NULL;
-
 			// we have to read from both pipes at the same time to avoid stalling
-			{
-				struct oscap_string *stdout_string = oscap_string_new();
-				struct oscap_string *stderr_string = oscap_string_new();
+			struct oscap_string *stdout_string = oscap_string_new();
+			struct oscap_string *stderr_string = oscap_string_new();
 
-				bool stdout_open = true;
-				bool stderr_open = true;
+			bool stdout_open = true;
+			bool stderr_open = true;
 
-				while (stdout_open || stderr_open) {
-					if (stdout_open)
-						_pipe_try_read_into_string(stdout_pipefd[0], stdout_string, &stdout_open);
+			while (stdout_open || stderr_open) {
+				if (stdout_open)
+					_pipe_try_read_into_string(stdout_pipefd[0], stdout_string, &stdout_open);
 
-					if (stderr_open)
-						_pipe_try_read_into_string(stderr_pipefd[0], stderr_string, &stderr_open);
+				if (stderr_open)
+					_pipe_try_read_into_string(stderr_pipefd[0], stderr_string, &stderr_open);
 
-					// sleep for a second to avoid wasting CPU
-					sleep(1);
-				}
-
-				stdout_buffer = oscap_string_bequeath(stdout_string);
-				stderr_buffer = oscap_string_bequeath(stderr_string);
+				// sleep for a second to avoid wasting CPU
+				sleep(1);
 			}
+
+			char *stdout_buffer = oscap_string_bequeath(stdout_string);
+			char *stderr_buffer = oscap_string_bequeath(stderr_string);
 
 			// we are the parent process
 			int wstatus;

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -342,22 +342,18 @@ static void _pipe_try_read_into_string(int fd, struct oscap_string *string, bool
 			} else {
 				oscap_string_append_char(string, readbuf);
 			}
-			//printf("Read %i from fd=%i\n", readbuf, fd);
 		}
 		else if (read_status == 0) {  // EOF
 			*eof = true;
-			//printf("fd=%i EOF\n", fd);
 			break;
 		}
 		else {
 			if (errno == EAGAIN) {
 				// NOOP, we are waiting for more input
-				//printf("fd=%i NOOP waiting for input\n", fd);
 				break;
 			}
 			else {
 				*eof = true;  // signal EOF to exit the loops
-				//printf("fd=%i error\n", fd);
 				break;
 			}
 		}

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -579,8 +579,8 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 				if (!stderr_eof)
 					_pipe_try_read_into_string(stderr_pipefd[0], stderr_string, &stderr_eof);
 
-				// sleep for a second to avoid wasting CPU
-				sleep(1);
+				// sleep for 10ms to avoid wasting CPU
+				usleep(10 * 1000);
 			}
 
 			close(stdout_pipefd[0]);

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -527,6 +527,11 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 			close(stdout_pipefd[1]);
 			close(stderr_pipefd[1]);
 
+			int flag_stdout = fcntl(stdout_pipefd[0], F_GETFL, 0);
+			fcntl(stdout_pipefd[0], F_SETFL, flag_stdout | O_NONBLOCK);
+			int flag_stderr = fcntl(stderr_pipefd[0], F_GETFL, 0);
+			fcntl(stderr_pipefd[0], F_SETFL, flag_stderr | O_NONBLOCK);
+
 			char* stdout_buffer = oscap_acquire_pipe_to_string(stdout_pipefd[0]);
 			char* stderr_buffer = oscap_acquire_pipe_to_string(stderr_pipefd[0]);
 

--- a/src/common/oscap_string.h
+++ b/src/common/oscap_string.h
@@ -58,6 +58,13 @@ void oscap_string_append_string(struct oscap_string *s, const char *t);
  */
 const char *oscap_string_get_cstr(const struct oscap_string *s);
 
+/**
+ * Return pointer to internal string
+ * Free oscap_string structure
+ * @param s buffer
+ */
+char* oscap_string_bequeath(struct oscap_string *s);
+
 OSCAP_HIDDEN_START;
 
 /**
@@ -66,13 +73,6 @@ OSCAP_HIDDEN_START;
  * @return true if empty
  */
 bool oscap_string_empty(const struct oscap_string *s);
-
-/**
- * Return pointer to internal string
- * Free oscap_string structure
- * @param s buffer
- */
-char* oscap_string_bequeath(struct oscap_string *s);
 
 /**
  * Erases the contents of the string. Length of string becomes 0

--- a/tests/sce/Makefile.am
+++ b/tests/sce/Makefile.am
@@ -12,7 +12,8 @@ TESTS = test_sce.sh \
 		test_sce_parse_errors.sh \
 		test_sce_in_ds.sh \
 		test_sce_in_report.sh \
-		test_sce_stdout_stderr.sh
+		test_sce_stdout_stderr.sh \
+		test_sce_streams_fill.sh
 
 EXTRA_DIST =	test_sce.sh \
 		sce_xccdf.xml \
@@ -39,4 +40,7 @@ EXTRA_DIST =	test_sce.sh \
 		test_sce_parse_errors_stub-oval.xml \
 		test_sce_stdout_stderr.sh \
 		test_sce_stdout_stderr.xccdf.xml \
-		stdout_stderr.sh
+		stdout_stderr.sh \
+		test_sce_streams_fill.sh \
+		test_sce_streams_fill.xccdf.xml \
+		streams_fill.sh

--- a/tests/sce/streams_fill.sh
+++ b/tests/sce/streams_fill.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 lines=${XCCDF_VALUE_LINES}
 
-for i in `seq -w 1 ${lines}`; do
+# padding numbers so one line is exactly 10 bytes - 9 numbers and newline
+# this way last line prints size of the output
+for i in `seq -w 0000001 ${lines}`; do
     echo "0${i}0"
 done
 
-for i in `seq -w 1 ${lines}`; do
+for i in `seq -w 0000001 ${lines}`; do
     echo "1${i}0" >&2
 done
 

--- a/tests/sce/streams_fill.sh
+++ b/tests/sce/streams_fill.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 lines=${XCCDF_VALUE_LINES}
 
-for i in `seq -w 00000001 0000${lines}`; do
-    echo "${i}0"
+for i in `seq -w 1 ${lines}`; do
+    echo "0${i}0"
 done
 
-for i in `seq -w 10000001 1000${lines}`; do
-    echo "${i}0" >&2
+for i in `seq -w 1 ${lines}`; do
+    echo "1${i}0" >&2
 done
 
 exit ${XCCDF_RESULT_PASS}

--- a/tests/sce/streams_fill.sh
+++ b/tests/sce/streams_fill.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+lines=${XCCDF_VALUE_LINES}
+
+for i in `seq -w 00000001 0000${lines}`; do
+    echo "${i}0"
+done
+
+for i in `seq -w 10000001 1000${lines}`; do
+    echo "${i}0" >&2
+done
+
+exit ${XCCDF_RESULT_PASS}

--- a/tests/sce/test_sce_streams_fill.sh
+++ b/tests/sce/test_sce_streams_fill.sh
@@ -21,7 +21,7 @@ function test_sce_streams_fill {
     cat $result
 
     # zero is generated into stdout, 1 is stderr
-    grep "012345670" $result && grep "112345670" $result
+    grep "000099990" $result && grep "100099990" $result
 }
 
 # Testing.

--- a/tests/sce/test_sce_streams_fill.sh
+++ b/tests/sce/test_sce_streams_fill.sh
@@ -21,7 +21,7 @@ function test_sce_streams_fill {
     cat $result
 
     # zero is generated into stdout, 1 is stderr
-    grep "000099990" $result && grep "100099990" $result
+    grep "0999990" $result && grep "1999990" $result
 }
 
 # Testing.

--- a/tests/sce/test_sce_streams_fill.sh
+++ b/tests/sce/test_sce_streams_fill.sh
@@ -21,7 +21,7 @@ function test_sce_streams_fill {
     cat $result
 
     # zero is generated into stdout, 1 is stderr
-    grep "0999990" $result && grep "1999990" $result
+    grep "001999990" $result && grep "101999990" $result
 }
 
 # Testing.

--- a/tests/sce/test_sce_streams_fill.sh
+++ b/tests/sce/test_sce_streams_fill.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Test to check there are output streams separated
+#
+# Author:
+#   Marek Haicman <mhaicman@redhat.com>
+
+. ../test_common.sh
+
+set -e -o pipefail
+
+function test_sce_streams_fill {
+    local xccdf_file=${srcdir}/$1
+    local stderr=$(mktemp)
+    local result=$(mktemp)
+
+    # the test is actually pretty slow, which means it takes ~10 seconds on
+    # my laptop. 60s is safe margin in case of slow virtual jenkins nodes
+    timeout "60s" $OSCAP xccdf eval --results "$result" "$xccdf_file" 2> $stderr
+    echo "===== result ====="
+    cat $result
+
+    # zero is generated into stdout, 1 is stderr
+    grep "012345670" $result && grep "112345670" $result
+}
+
+# Testing.
+test_init "test_sce_streams_fill.log"
+
+test_run "SCE stream filling up" test_sce_streams_fill test_sce_streams_fill.xccdf.xml
+
+test_exit

--- a/tests/sce/test_sce_streams_fill.xccdf.xml
+++ b/tests/sce/test_sce_streams_fill.xccdf.xml
@@ -8,11 +8,8 @@
   <Value id="xccdf_test_value_small" type="string" operator="equals">
     <value>6544</value>
   </Value>
-  <Value id="xccdf_test_value_bigger" type="string" operator="equals">
-    <value>6545</value>
-  </Value>
   <Value id="xccdf_test_value_huge" type="string" operator="equals">
-    <value>99999</value>
+    <value>199999</value>
   </Value>
 
 
@@ -26,15 +23,6 @@
     </check>
   </Rule>
   <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_2">
-    <title>Bigger stream filling</title>
-    <check system="http://open-scap.org/page/SCE">
-      <check-import import-name="stdout" />
-      <check-import import-name="stderr" />
-      <check-export value-id="xccdf_test_value_bigger" export-name="LINES"/>
-      <check-content-ref href="streams_fill.sh"/>
-    </check>
-  </Rule>
-  <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_3">
     <title>Bigger stream filling</title>
     <check system="http://open-scap.org/page/SCE">
       <check-import import-name="stdout" />

--- a/tests/sce/test_sce_streams_fill.xccdf.xml
+++ b/tests/sce/test_sce_streams_fill.xccdf.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+  <status>incomplete</status>
+  <version>1.0</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <model system="urn:xccdf:scoring:flat"/>
+
+  <Value id="xccdf_test_value_small" type="string" operator="equals">
+    <value>6544</value>
+  </Value>
+  <Value id="xccdf_test_value_bigger" type="string" operator="equals">
+    <value>6545</value>
+  </Value>
+  <Value id="xccdf_test_value_huge" type="string" operator="equals">
+    <value>1234567</value>
+  </Value>
+
+
+  <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_1">
+    <title>Smaller stream filling</title>
+    <check system="http://open-scap.org/page/SCE">
+      <check-import import-name="stdout" />
+      <check-import import-name="stderr" />
+      <check-export value-id="xccdf_test_value_small" export-name="LINES"/>
+      <check-content-ref href="streams_fill.sh"/>
+    </check>
+  </Rule>
+  <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_2">
+    <title>Bigger stream filling</title>
+    <check system="http://open-scap.org/page/SCE">
+      <check-import import-name="stdout" />
+      <check-import import-name="stderr" />
+      <check-export value-id="xccdf_test_value_bigger" export-name="LINES"/>
+      <check-content-ref href="streams_fill.sh"/>
+    </check>
+  </Rule>
+  <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_3">
+    <title>Bigger stream filling</title>
+    <check system="http://open-scap.org/page/SCE">
+      <check-import import-name="stdout" />
+      <check-import import-name="stderr" />
+      <check-export value-id="xccdf_test_value_huge" export-name="LINES"/>
+      <check-content-ref href="streams_fill.sh"/>
+    </check>
+  </Rule>
+</Benchmark>

--- a/tests/sce/test_sce_streams_fill.xccdf.xml
+++ b/tests/sce/test_sce_streams_fill.xccdf.xml
@@ -12,7 +12,7 @@
     <value>6545</value>
   </Value>
   <Value id="xccdf_test_value_huge" type="string" operator="equals">
-    <value>9999</value>
+    <value>99999</value>
   </Value>
 
 

--- a/tests/sce/test_sce_streams_fill.xccdf.xml
+++ b/tests/sce/test_sce_streams_fill.xccdf.xml
@@ -12,7 +12,7 @@
     <value>6545</value>
   </Value>
   <Value id="xccdf_test_value_huge" type="string" operator="equals">
-    <value>1234567</value>
+    <value>9999</value>
   </Value>
 
 


### PR DESCRIPTION
We have been reading stdout and only then stderr. This caused stalls when stderr was filled up and stdout was still waiting for input. This PR changes the SCE stdout and stderr pipe reading to be interleaved. We do non-blocking reads from both pipes.

Thx goes to @dahaic for the test
Thx goes to @rsprudencio for the fcntl nonblock impl

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1420811