### PR TITLE
Recategorize some warning messages

### DIFF
--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -810,7 +810,7 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 	   without targets are accepted. */
 	if (lstat(paths[0], &st) == -1) {
 		if (errno) {
-			dE("lstat() failed: errno: %d, '%s'.",
+			dD("lstat() failed: errno: %d, '%s'.",
 			   errno, strerror(errno));
 		}
 		free((void *) paths[0]);

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -518,9 +518,9 @@ static int process_pattern_match(const char *path, pcre **regex_out)
 		pattern = malloc(plen + 1);
 		pattern[0] = '^';
 		memcpy(pattern + 1, path, plen);
-		dW("The pattern doesn't contain a leading caret - added. "
+		dI("The pattern '%s' doesn't contain a leading caret - added. "
 		   "All paths with the 'pattern match' operation must begin "
-		   "with a caret.");
+		   "with a caret.", path);
 	} else {
 		pattern = strdup(path);
 	}

--- a/src/OVAL/probes/unix/file.c
+++ b/src/OVAL/probes/unix/file.c
@@ -256,7 +256,7 @@ static SEXP_t *has_extended_acl(const char *path)
 #if defined(HAVE_ACL_EXTENDED_FILE)
 	int has_acl = acl_extended_file(path);
 	if (has_acl == -1) {
-		dW("Getting extended ACL for file '%s' has failed, %s", path, strerror(errno));
+		dD("Getting extended ACL for file '%s' has failed, %s", path, strerror(errno));
 		return NULL;
 	}
 	return (has_acl == 1) ? gr_true : gr_false;


### PR DESCRIPTION
After merging https://github.com/OpenSCAP/openscap/pull/630 some new messages have appeared on stderr. When scanning SSG Fedora common profile using the latest OpenSCAP from git I got stderr completely convoluted with warnings. Most of them were ```Getting extended ACL for file ```... and ``lstat() failed``. However these messages don't signalise anything harmful. I propose moving them to a lower verbosity level.