### PR TITLE
Mangle the '@' symbol when adding components to datastream

### DIFF
--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -793,6 +793,10 @@ static char* ds_sds_mangle_filepath(const char* filepath)
 			*dst_it++ = '-';
 			*dst_it++ = '-';
 		}
+		else if (*src_it == '@') {
+			*dst_it++ = '-';
+			*dst_it++ = '-';
+		}
 		else
 		{
 			*dst_it++ = *src_it;


### PR DESCRIPTION
We recently moved to cmake in SSG and that exposed a couple new bugs, including this one.

When adding files into SDS we mangle the path to figure out a descriptive component ID. We correctly mangle the forward slashes but we don't mangle the @ (at symbol) at all. The at symbol is used in jenkins when building more tasks to separate workspaces. This leads to failures when validating SDS with components with the at symbol in them.

Check out end of https://jenkins.open-scap.org/job/scap-security-guide-pull-requests/1168/label=node-fedora23/console for an example.

TODO: We should probably rework the whole mangle function and do a better job being really defensive and using oscap_string. But this will do for now, unless somebody wants to rewrite it.