### PR TITLE
Introduce a test for XCCDF 1.1 to XCCDF 1.2 transformation

### DIFF
--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -193,6 +193,7 @@ EXTRA_DIST += \
 	test_xccdf_sub_title.xccdf.xml \
 	test_xccdf_test_system.sh \
 	test_xccdf_test_system.xccdf.xml \
+	test_xccdf_transformation.sh \
 	test_xccdf_xml_escaping_value.sh \
 	test_xccdf_xml_escaping_value.xccdf.xml \
 	unit_helper.c \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -62,6 +62,7 @@ test_run "XCCDF Substitute within Title" $srcdir/test_xccdf_sub_title.sh
 test_run "TestResult element should contain test-system attribute" $srcdir/test_xccdf_test_system.sh
 
 test_run "libxml errors handled correctly" $srcdir/test_unfinished.sh
+test_run "XCCDF 1.1 to 1.2 transformation" $srcdir/test_xccdf_transformation.sh
 
 #
 # Tests for 'oscap xccdf eval --remediate' and substitution

--- a/tests/API/XCCDF/unittests/test_xccdf_transformation.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_transformation.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+name=$(basename $0 .sh)
+result=$(mktemp -t ${name}.xccdf12.XXXXXX)
+
+xsltproc --stringparam reverse_DNS com.example.www $srcdir/../../../../xsl/xccdf_1.1_to_1.2.xsl $srcdir/../../../nist/R1100/r1100-scap11-win_rhel-xccdf.xml > $result
+
+[ -s $result ]
+
+$OSCAP xccdf validate $result
+
+assert_exists 1 '/Benchmark[namespace-uri()="http://checklists.nist.gov/xccdf/1.2"]'
+
+rm $result


### PR DESCRIPTION
We ship an XSLT template that allows us to convert older
XCCDF files in XCCDF 1.1 to XCCDF 1.2. The template can be found
in xsl/xccdf_1.1_to_1.2.xsl. However we don't test the transformation.
Since the transforamtion is mentioned in user manual, we should
have a test that ensures it is working. This commit introduces
a simple test based on XCCDF content from NIST test suite.