### PR TITLE
Show Anaconda snippets labeled properly in HTML report & guide

### DIFF
--- a/xsl/xccdf-share.xsl
+++ b/xsl/xccdf-share.xsl
@@ -279,6 +279,7 @@ Authors:
             <xsl:when test="$fix/@system = 'urn:xccdf:fix:script:sh'">Shell script</xsl:when>
             <xsl:when test="$fix/@system = 'urn:xccdf:fix:script:ansible'">Ansible snippet</xsl:when>
             <xsl:when test="$fix/@system = 'urn:xccdf:fix:script:puppet'">Puppet snippet</xsl:when>
+            <xsl:when test="$fix/@system = 'urn:redhat:anaconda:pre'">Anaconda snippet</xsl:when>
             <xsl:otherwise>script</xsl:otherwise>
         </xsl:choose>
     </xsl:variable>


### PR DESCRIPTION
I noticed that we don't show Anaconda snippets labeled properly and we use them quite a bit in SSG. This PR fixes that by introducing proper labels in HTML report and guide.

![image](https://cloud.githubusercontent.com/assets/753153/23566081/5bde9524-001e-11e7-9a05-476aec790d61.png)
