### PR TITLE
RHBZ #1414303, #1414312: Fix a segfault in rpm probes

### DIFF
--- a/src/OVAL/probes/unix/linux/dpkginfo.c
+++ b/src/OVAL/probes/unix/linux/dpkginfo.c
@@ -91,6 +91,9 @@ int probe_main (probe_ctx *ctx, void *arg)
         struct dpkginfo_reply_t *dpkginfo_reply = NULL;
         int errflag;
 
+	if (arg == NULL) {
+		return PROBE_EINIT;
+	}
         ent = probe_obj_getent(probe_ctx_getobject(ctx), "name", 1);
 
         if (ent == NULL) {

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -384,6 +384,9 @@ int probe_main (probe_ctx *ctx, void *arg)
         struct rpminfo_req request_st;
         struct rpminfo_rep *reply_st;
 
+	if (arg == NULL) {
+		return PROBE_EINIT;
+	}
 	if (g_rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -317,6 +317,9 @@ int probe_main (probe_ctx *ctx, void *arg)
         uint64_t collect_flags = 0;
         unsigned int i;
 
+	if (arg == NULL) {
+		return PROBE_EINIT;
+	}
 	if (g_rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -386,6 +386,10 @@ int probe_main (probe_ctx *ctx, void *arg)
 	uint64_t collect_flags = 0;
 	unsigned int i;
 
+	if (arg == NULL) {
+		return PROBE_EINIT;
+	}
+
 	if (g_rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -355,6 +355,10 @@ int probe_main (probe_ctx *ctx, void *arg)
 	uint64_t collect_flags = 0;
 	unsigned int i;
 
+	if (arg == NULL) {
+		return PROBE_EINIT;
+	}
+
 	if (g_rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;


### PR DESCRIPTION
Function probe_init() can possibly fail and return NULL.
We should check if initialization has been done properly
before we start the function.
Now we don't check the return value, which can possibly lead
to synchronization errors between threads and causes
a segmentation fault in probe_fini().