### PR TITLE
RHBZ #1420038: Identify Red Hat Enterprise Virtualization Host as RHEL7

### DIFF
--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -60,8 +60,12 @@
                         <reference ref_id="cpe:/o:redhat:enterprise_linux:7" source="CPE"/>
                         <description>The operating system installed on the system is Red Hat Enterprise Linux 7</description>
                   </metadata>
-                  <criteria>
+                  <criteria operator="OR">
                         <criterion comment="Red Hat Enterprise Linux 7 is installed" test_ref="oval:org.open-scap.cpe.rhel:tst:7"/>
+                        <criteria operator="AND" comment="Red Hat Enterpise Virtualization Host is installed">
+                              <criterion comment="redhat-release-virtualization-host RPM package is installed" test_ref="oval:org.open-scap.cpe.rhevh:tst:1" />
+                              <criterion comment="Red Hat Enterpise Virtualization Host is based on RHEL 7" test_ref="oval:org.open-scap.cpe.rhevh:tst:2" />
+                         </criteria>
                   </criteria>
             </definition>
             <definition class="inventory" id="oval:org.open-scap.cpe.rhel:def:1005" version="1">
@@ -710,6 +714,13 @@
                   <object object_ref="oval:org.open-scap.cpe.wrlinux-release:obj:2"/>
                   <state state_ref="oval:org.open-scap.cpe.wrlinux-release:ste:8"/>
             </textfilecontent54_test>
+            <rpminfo_test check="all" check_existence="only_one_exists" comment="redhat-release-virtualization-host RPM package is installed" id="oval:org.open-scap.cpe.rhevh:tst:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+                  <object object_ref="oval:org.open-scap.cpe.rhevh:obj:1" />
+            </rpminfo_test>
+            <textfilecontent54_test check="all" comment="RHEVH base RHEL is version 7" id="oval:org.open-scap.cpe.rhevh:tst:2" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                  <object object_ref="oval:org.open-scap.cpe.rhevh:obj:2" />
+                  <state state_ref="oval:org.open-scap.cpe.rhevh:ste:2" />
+            </textfilecontent54_test>
       </tests>
       <objects>
             <family_object id="oval:org.open-scap.cpe.unix:obj:1" version="1"  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"/>
@@ -750,6 +761,14 @@
                 <path>/etc</path>
                 <filename>wrlinux-release</filename>
                 <pattern operation="pattern match">^VERSION=.([[:digit:]]*)</pattern>
+                <instance operation="greater than or equal" datatype="int">1</instance>
+            </textfilecontent54_object>
+            <rpminfo_object id="oval:org.open-scap.cpe.rhevh:obj:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+                <name>redhat-release-virtualization-host</name>
+            </rpminfo_object>
+            <textfilecontent54_object id="oval:org.open-scap.cpe.rhevh:obj:2" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                <filepath>/etc/redhat-release</filepath>
+                <pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</pattern>
                 <instance operation="greater than or equal" datatype="int">1</instance>
             </textfilecontent54_object>
       </objects>
@@ -880,6 +899,9 @@
                             xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
                             >
                   <subexpression operation="pattern match">8</subexpression>
+            </textfilecontent54_state>
+            <textfilecontent54_state id="oval:org.open-scap.cpe.rhevh:ste:2" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                  <subexpression operation="pattern match">7</subexpression>
             </textfilecontent54_state>
       </states>
 </oval_definitions>


### PR DESCRIPTION
RHEVH is based on RHEL7, therefore RHEL7 profiles should be applicable
on this system. This commit enables evaluating RHEL7 profiles on RHEVH.
However the underlying RHEL version cannot be determined from
redhat-release RPM package version, because RHEVH obsoletes
the redhat-release RPM package. Instead we should check for presence
of redhat-release-virtualization-host and then we will parse the
RHEL version from /etc/redhat-release file. Note that
redhat-release-virtualization-host RPM version represents RHEVH
version (currently 4.0.6), not RHEL version, so it's not possible
to rely only on rpminfo tests.