### PR TITLE
RHBZ #1431186: Fix crashing systemd probes

### DIFF
--- a/src/OVAL/probes/unix/linux/systemdunitdependency.c
+++ b/src/OVAL/probes/unix/linux/systemdunitdependency.c
@@ -250,7 +250,11 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 
 	if (dbus_conn == NULL) {
 		dbus_error_free(&dbus_error);
-		return PROBE_ESYSTEM;
+		SEXP_t *msg = probe_msg_creat(OVAL_MESSAGE_LEVEL_INFO, "DBus connection failed, could not identify systemd units.");
+		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
+		probe_cobj_add_msg(probe_ctx_getresult(ctx), msg);
+		SEXP_free(msg);
+		return 0;
 	}
 
 	unit_entity = probe_obj_getent(probe_in, "unit", 1);

--- a/src/OVAL/probes/unix/linux/systemdunitproperty.c
+++ b/src/OVAL/probes/unix/linux/systemdunitproperty.c
@@ -264,9 +264,6 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 		return PROBE_EOPNOTSUPP;
 	}
 
-	unit_entity = probe_obj_getent(probe_in, "unit", 1);
-	property_entity = probe_obj_getent(probe_in, "property", 1);
-
 	DBusError dbus_error;
 	DBusConnection *dbus_conn;
 
@@ -275,10 +272,15 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 
 	if (dbus_conn == NULL) {
 		dbus_error_free(&dbus_error);
-		SEXP_free(property_entity);
-		SEXP_free(unit_entity);
-		return PROBE_ESYSTEM;
+		SEXP_t *msg = probe_msg_creat(OVAL_MESSAGE_LEVEL_INFO, "DBus connection failed, could not identify systemd units.");
+		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);
+		probe_cobj_add_msg(probe_ctx_getresult(ctx), msg);
+		SEXP_free(msg);
+		return 0;
 	}
+
+	unit_entity = probe_obj_getent(probe_in, "unit", 1);
+	property_entity = probe_obj_getent(probe_in, "property", 1);
 
 	struct unit_callback_vars vars;
 


### PR DESCRIPTION
Systemd probes are crashing during scanning Docker
containers. This probably happens because containers
do not have systemd running inside them by default.
Instead, we will report an error.