### PR TITLE
Do not rely on number of lines on stderr

### DIFF
--- a/tests/API/OVAL/unittests/test_object_component_type.sh
+++ b/tests/API/OVAL/unittests/test_object_component_type.sh
@@ -8,8 +8,6 @@ set -o pipefail
 $OSCAP oval eval $srcdir/test_object_component_type.oval.xml 2> $stderr || ret=$?
 [ $ret -eq 1 ]
 
-stderr_line_count=`cat $stderr | wc -l`
-[ $stderr_line_count -eq 6 ]
 grep -q "Entity [']something_bogus['] has not been found in textfilecontent_item (id: [0-9]\+) specified by object [']oval:oscap:obj:10[']." $stderr
 grep -q "Expected record data type, but found string data type in subexpression entity in textfilecontent_item (id: [0-9]\+) specified by object [']oval:oscap:obj:10[']."  $stderr
 


### PR DESCRIPTION
We fixed duplicate error messages (issue #707). But in this test,
we assumed that there are 6 lines on stderr. Actually two of them
were duplicated. We should not count number of lines on stderr
because we may add a new warning somewhere in our code and it will
break the test again. This commit stops testing stderr line count.