### PR TITLE
Improve test of Ansible fixes

### DIFF
--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -62,6 +62,8 @@ EXTRA_DIST += \
 	test_empty_variable.oval.xml \
 	test_empty_variable.sh \
 	test_empty_variable.xccdf.xml \
+	test_fix_arf.playbook1.yml \
+	test_fix_arf.playbook2.yml \
 	test_fix_arf.xccdf.xml \
 	test_fix_arf.sh \
 	test_fix_instance.oval.xml \

--- a/tests/API/XCCDF/unittests/test_fix_arf.playbook1.yml
+++ b/tests/API/XCCDF/unittests/test_fix_arf.playbook1.yml
@@ -1,0 +1,9 @@
+---
+# - hosts: localhost # set required host
+   tasks:
+
+    - name: ensure everything passes
+        shell: /bin/true
+
+    - name: correct the failing case
+        shell: /bin/false

--- a/tests/API/XCCDF/unittests/test_fix_arf.playbook2.yml
+++ b/tests/API/XCCDF/unittests/test_fix_arf.playbook2.yml
@@ -1,0 +1,6 @@
+---
+# - hosts: localhost # set required host
+   tasks:
+
+    - name: correct the failing case
+        shell: /bin/false

--- a/tests/API/XCCDF/unittests/test_fix_arf.sh
+++ b/tests/API/XCCDF/unittests/test_fix_arf.sh
@@ -34,6 +34,7 @@ grep -q "$bash_line2" $script
 
 # Generate an Ansible playbook from a profile in ARF file
 $OSCAP xccdf generate fix --profile $profile --template $ansible_template --output $playbook $results_arf >$stdout 2>$stderr
+diff $playbook $srcdir/$name.playbook1.yml
 [ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 grep -q "$ansible_task1a" $playbook
@@ -50,6 +51,7 @@ grep -q "$bash_line2" $script
 
 # Generate  an Ansible playbook based on scan results stored in ARF file
 $OSCAP xccdf generate fix --result-id $result_id --template $ansible_template --output $playbook $results_arf >$stdout 2>$stderr
+diff $playbook $srcdir/$name.playbook2.yml
 [ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 grep -q -v "$ansible_task1a" $playbook


### PR DESCRIPTION
We shouldn't change the format of the output to ensure
the fix generated by oscap is consumable by Ansible.