### PR TITLE
Change category of a message, emit warning only if necessary

### DIFF
--- a/src/OVAL/oval_sexp.c
+++ b/src/OVAL/oval_sexp.c
@@ -182,15 +182,16 @@ static int oval_varref_attr_to_sexp(void *sess, struct oval_entity *entity, stru
 		/* fall through */
 	case SYSCHAR_FLAG_DOES_NOT_EXIST:
 		snprintf(msg, sizeof(msg), "Referenced variable has no values (%s).", oval_variable_get_id(var));
+		dI("%s", msg);
 		ret = 1;
 		break;
 	default:
 		snprintf(msg, sizeof(msg), "There was a problem processing referenced variable (%s).", oval_variable_get_id(var));
+		dW("%s", msg);
 		ret = 1;
 	}
 
 	if (ret) {
-		dW("%s", msg);
 		oval_syschar_add_new_message(syschar, msg, OVAL_MESSAGE_LEVEL_WARNING);
 		oval_syschar_set_flag(syschar, SYSCHAR_FLAG_DOES_NOT_EXIST);
 		return ret;


### PR DESCRIPTION
It is pretty common to have variables with no values, but
the warnings flood the stderr after we have enabled them by default.
Still, this will keep informing user if there was a problem.