### PR TITLE
Updates for Python 3 bindings

### DIFF
--- a/swig/python2/Makefile.am
+++ b/swig/python2/Makefile.am
@@ -11,6 +11,7 @@ AM_CPPFLAGS =	@xml2_CFLAGS@ \
 		-I${top_srcdir}/src/common/public \
 		-I${top_srcdir}/src/source/public \
 		-I$(top_srcdir)/src/CVE/public \
+		-I$(top_srcdir)/src/DS/public \
 		-I/usr/include -include "sys/types.h" \
 		-D_LARGEFILE64_SOURCE \
 		-D_LARGEFILE_SOURCE=1

--- a/swig/python3/Makefile.am
+++ b/swig/python3/Makefile.am
@@ -10,6 +10,7 @@ AM_CPPFLAGS =	@xml2_CFLAGS@ \
 		-I${top_srcdir}/src/common/public \
 		-I${top_srcdir}/src/source/public \
 		-I$(top_srcdir)/src/CVE/public \
+		-I$(top_srcdir)/src/DS/public \
 		-I/usr/include -include "sys/types.h" \
 		-D_LARGEFILE64_SOURCE \
 		-D_LARGEFILE_SOURCE=1

--- a/swig/src/openscap.i
+++ b/swig/src/openscap.i
@@ -215,6 +215,17 @@
 
 %module openscap
 %{
+ #include "../../src/DS/public/ds_rds_session.h"
+ #include "../../src/DS/public/ds_sds_session.h"
+ #include "../../src/DS/public/scap_ds.h"
+%}
+%include "../../src/DS/public/ds_rds_session.h"
+%include "../../src/DS/public/ds_sds_session.h"
+%include "../../src/DS/public/scap_ds.h"
+
+
+%module openscap
+%{
  #include "../../src/XCCDF/public/xccdf_benchmark.h"
  #include "../../src/XCCDF/public/xccdf_session.h"
  #include "../../src/XCCDF_POLICY/public/xccdf_policy.h"
@@ -226,22 +237,32 @@
 
 %module openscap
 %{
+ #include "../../src/OVAL/public/oval_adt.h"
  #include "../../src/OVAL/public/oval_agent_api.h"
  #include "../../src/OVAL/public/oval_definitions.h"
+ #include "../../src/OVAL/public/oval_directives.h"
  #include "../../src/OVAL/public/oval_system_characteristics.h"
  #include "../../src/OVAL/public/oval_results.h"
+ #include "../../src/OVAL/public/oval_schema_version.h"
+ #include "../../src/OVAL/public/oval_session.h"
  #include "../../src/OVAL/public/oval_types.h"
  #include "../../src/OVAL/public/oval_variables.h"
+ #include "../../src/OVAL/public/oval_version.h"
  #include "../../src/OVAL/public/oval_probe.h"
  #include "../../src/OVAL/public/oval_probe_handler.h"
  #include "../../src/OVAL/public/oval_probe_session.h"
 %}
+%include "../../src/OVAL/public/oval_adt.h"
 %include "../../src/OVAL/public/oval_agent_api.h"
 %include "../../src/OVAL/public/oval_definitions.h"
+%include "../../src/OVAL/public/oval_directives.h"
 %include "../../src/OVAL/public/oval_system_characteristics.h"
 %include "../../src/OVAL/public/oval_results.h"
+%include "../../src/OVAL/public/oval_schema_version.h"
+%include "../../src/OVAL/public/oval_session.h"
 %include "../../src/OVAL/public/oval_types.h"
 %include "../../src/OVAL/public/oval_variables.h"
+%include "../../src/OVAL/public/oval_version.h"
 %include "../../src/OVAL/public/oval_probe.h"
 %include "../../src/OVAL/public/oval_probe_handler.h"
 %include "../../src/OVAL/public/oval_probe_session.h"
@@ -251,6 +272,12 @@
  #include "../../src/OVAL/public/oval_agent_xccdf_api.h"
 %}
 %include "../../src/OVAL/public/oval_agent_xccdf_api.h"
+
+%module openscap
+%{
+ #include "../../src/source/public/oscap_source.h"
+%}
+%include "../../src/source/public/oscap_source.h"
 
 /*%typemap(in) value[ANY] {
 


### PR DESCRIPTION
Added a Vagrantfile with ansible provisioning for easy creation of a build environment.
Updated the swig files so all the public functions get exported to python
Changed enable python3 to default to yes
Added some extra accessor and mutator functions so we can export functioning XCCDF and OVAL files made from scratch in python.