### PR TITLE
Comments in generated remedition bash snippets

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -533,9 +533,9 @@ static int _write_fix_header_to_fd(const char *sys, int output_fd, struct xccdf_
 	if (oscap_streq(sys, "") || oscap_streq(sys, "urn:xccdf:fix:script:sh") || oscap_streq(sys, "urn:xccdf:fix:commands")) {
 		char *fix_header = oscap_sprintf(
 				"###############################################################################\n"
-				"# BEGIN fix for '%s' (%i / %i)\n"
+				"# BEGIN fix (%i / %i) for '%s'\n"
 				"###############################################################################\n",
-				xccdf_rule_get_id(rule), current, total);
+				current, total, xccdf_rule_get_id(rule));
 		return _write_text_to_fd_and_free(output_fd, fix_header);
 	} else {
 		return 0;

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -534,8 +534,9 @@ static int _write_fix_header_to_fd(const char *sys, int output_fd, struct xccdf_
 		char *fix_header = oscap_sprintf(
 				"###############################################################################\n"
 				"# BEGIN fix (%i / %i) for '%s'\n"
-				"###############################################################################\n",
-				current, total, xccdf_rule_get_id(rule));
+				"###############################################################################\n"
+				"(>&2 echo \"Remediating rule %i/%i: '%s'\")",
+				current, total, xccdf_rule_get_id(rule), current, total, xccdf_rule_get_id(rule));
 		return _write_text_to_fd_and_free(output_fd, fix_header);
 	} else {
 		return 0;

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -535,7 +535,7 @@ static int _write_fix_header_to_fd(const char *sys, int output_fd, struct xccdf_
 				"###############################################################################\n"
 				"# BEGIN fix (%i / %i) for '%s'\n"
 				"###############################################################################\n"
-				"(>&2 echo \"Remediating rule %i/%i: '%s'\")",
+				"(>&2 echo \"Remediating rule %i/%i: '%s'\")\n",
 				current, total, xccdf_rule_get_id(rule), current, total, xccdf_rule_get_id(rule));
 		return _write_text_to_fd_and_free(output_fd, fix_header);
 	} else {

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -531,7 +531,11 @@ static const struct xccdf_fix *_find_fix_for_template(struct xccdf_policy *polic
 static int _write_fix_header_to_fd(const char *sys, int output_fd, struct xccdf_rule *rule, unsigned int current, unsigned int total)
 {
 	if (oscap_streq(sys, "") || oscap_streq(sys, "urn:xccdf:fix:script:sh") || oscap_streq(sys, "urn:xccdf:fix:commands")) {
-		char *fix_header = oscap_sprintf("# BEGIN fix for '%s' (%i / %i)\n", xccdf_rule_get_id(rule), current, total);
+		char *fix_header = oscap_sprintf(
+				"###############################################################################\n"
+				"# BEGIN fix for '%s' (%i / %i)\n"
+				"###############################################################################\n",
+				xccdf_rule_get_id(rule), current, total);
 		return _write_text_to_fd_and_free(output_fd, fix_header);
 	} else {
 		return 0;

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -530,7 +530,7 @@ static const struct xccdf_fix *_find_fix_for_template(struct xccdf_policy *polic
 
 static int _write_fix_header_to_fd(const char *sys, int output_fd, struct xccdf_rule *rule, unsigned int current, unsigned int total)
 {
-	if (oscap_streq(sys, "urn:xccdf:fix:script:sh")) {
+	if (oscap_streq(sys, "") || oscap_streq(sys, "urn:xccdf:fix:script:sh") || oscap_streq(sys, "urn:xccdf:fix:commands")) {
 		char *fix_header = oscap_sprintf("# BEGIN fix for '%s' (%i / %i)\n", xccdf_rule_get_id(rule), current, total);
 		return _write_text_to_fd_and_free(output_fd, fix_header);
 	} else {
@@ -540,7 +540,7 @@ static int _write_fix_header_to_fd(const char *sys, int output_fd, struct xccdf_
 
 static int _write_fix_footer_to_fd(const char *sys, int output_fd, struct xccdf_rule *rule)
 {
-	if (oscap_streq(sys, "urn:xccdf:fix:script:sh")) {
+	if (oscap_streq(sys, "") || oscap_streq(sys, "urn:xccdf:fix:script:sh") || oscap_streq(sys, "urn:xccdf:fix:commands")) {
 		char *fix_footer = oscap_sprintf("# END fix for '%s'\n\n", xccdf_rule_get_id(rule));
 		return _write_text_to_fd_and_free(output_fd, fix_footer);
 	} else {
@@ -550,7 +550,7 @@ static int _write_fix_footer_to_fd(const char *sys, int output_fd, struct xccdf_
 
 static int _write_fix_missing_warning_to_fd(const char *sys, int output_fd, struct xccdf_rule *rule)
 {
-	if (oscap_streq(sys, "urn:xccdf:fix:script:sh")) {
+	if (oscap_streq(sys, "") || oscap_streq(sys, "urn:xccdf:fix:script:sh") || oscap_streq(sys, "urn:xccdf:fix:commands")) {
 		char *fix_footer = oscap_sprintf("# FIX FOR THIS RULE IS MISSING\n");
 		return _write_text_to_fd_and_free(output_fd, fix_footer);
 	} else {

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -614,15 +614,19 @@ cleanup:
 	return ret;
 }
 
-static int _xccdf_item_recursive_gather_rules(struct xccdf_item *item, struct oscap_list *rule_list)
+static int _xccdf_item_recursive_gather_selected_rules(struct xccdf_policy *policy, struct xccdf_item *item, struct oscap_list *rule_list)
 {
 	int ret = 0;
+	const bool is_selected = xccdf_policy_is_item_selected(policy, xccdf_item_get_id(item));
+	if (!is_selected) {
+		return ret;
+	}
 	switch (xccdf_item_get_type(item)) {
 	case XCCDF_GROUP:{
 		struct xccdf_item_iterator *child_it = xccdf_group_get_content((struct xccdf_group *) item);
 		while (xccdf_item_iterator_has_more(child_it)) {
 			struct xccdf_item *child = xccdf_item_iterator_next(child_it);
-			ret = _xccdf_item_recursive_gather_rules(child, rule_list);
+			ret = _xccdf_item_recursive_gather_selected_rules(policy, child, rule_list);
 			if (ret != 0)
 				break;
 		}
@@ -676,7 +680,7 @@ int xccdf_policy_generate_fix(struct xccdf_policy *policy, struct xccdf_result *
 		struct xccdf_item_iterator *item_it = xccdf_benchmark_get_content(benchmark);
 		while (xccdf_item_iterator_has_more(item_it)) {
 			struct xccdf_item *item = xccdf_item_iterator_next(item_it);
-			ret = _xccdf_item_recursive_gather_rules(item, rules_to_fix);
+			ret = _xccdf_item_recursive_gather_selected_rules(policy, item, rules_to_fix);
 			if (ret != 0)
 				break;
 		}

--- a/tests/API/XCCDF/fix/all.sh
+++ b/tests/API/XCCDF/fix/all.sh
@@ -12,7 +12,9 @@ function test_generate_fix {
     local TESTRESULT_ID=$2
     local EXPECTED_FIX=$3
 
-    local GENERATED_FIX=$($OSCAP xccdf generate fix --result-id "$TESTRESULT_ID" "$INPUT" | grep -v -E "^([\t ]*|[\t ]*#.+)$")
+    # grep to strip out whitespace and comments
+    # `tail -n +2` to skip the first line with progress reporting
+    local GENERATED_FIX=$($OSCAP xccdf generate fix --result-id "$TESTRESULT_ID" "$INPUT" | grep -v -E "^([\t ]*|[\t ]*#.+)$" | tail -n +2)
     if [ "$?" != "0" ]; then
         return 1
     fi

--- a/tests/API/XCCDF/fix/all.sh
+++ b/tests/API/XCCDF/fix/all.sh
@@ -12,10 +12,11 @@ function test_generate_fix {
     local TESTRESULT_ID=$2
     local EXPECTED_FIX=$3
 
-    local GENERATED_FIX=$($OSCAP xccdf generate fix --result-id "$TESTRESULT_ID" "$INPUT" | grep -v -E "^([\t ]*|#.+)$")
+    local GENERATED_FIX=$($OSCAP xccdf generate fix --result-id "$TESTRESULT_ID" "$INPUT" | grep -v -E "^([\t ]*|[\t ]*#.+)$")
     if [ "$?" != "0" ]; then
         return 1
     fi
+    echo "$GENERATED_FIX"
 
     if [ "$GENERATED_FIX" == "$EXPECTED_FIX" ]; then
         return 0


### PR DESCRIPTION
We have plans to generate remediation roles in SSG. Some of these scripts will be very large. It makes sense to add some more context information to the generate fixes, this commit does just that.

Right now it only adds comments but I want to improve this to print remediation status or even status bar in the future. Let me know what you think.

Example:
```
$ ./run ./utils/.libs/oscap xccdf generate fix --template urn:xccdf:fix:script:sh --profile pci-dss ~/d/scap-security-guide/build/ssg-rhel7-xccdf.xm

...

# BEGIN fix for 'chronyd_or_ntpd_specify_remote_server' (93 / 94)

var_multiple_time_servers="0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org"

if ! `/usr/sbin/pidof ntpd`; then
  if ! `grep -q ^server /etc/chrony.conf` ; then
    if ! `grep -q '#[[:space:]]*server' /etc/chrony.conf` ; then
      for i in `echo "$var_multiple_time_servers" | tr ',' '\n'` ; do
        echo -ne "\nserver $i iburst" >> /etc/chrony.conf
      done
    else
      sed -i 's/#[ ]*server/server/g' /etc/chrony.conf
    fi
  fi
else
  if ! `grep -q ^server /etc/ntp.conf` ; then
    if ! `grep -q '#[[:space:]]*server' /etc/ntp.conf` ; then
      for i in `echo "$var_multiple_time_servers" | tr ',' '\n'` ; do
        echo -ne "\nserver $i iburst" >> /etc/ntp.conf
      done
    else
      sed -i 's/#[ ]*server/server/g' /etc/ntp.conf
    fi
  fi
fi
# END fix for 'chronyd_or_ntpd_specify_remote_server'

# BEGIN fix for 'chronyd_or_ntpd_specify_multiple_servers' (94 / 94)

var_multiple_time_servers="0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org"

if ! `/usr/sbin/pidof ntpd`; then
  if [ `grep -c '^server' /etc/chrony.conf` -lt 2 ]; then 
    if ! `grep -q '#[[:space:]]*server' /etc/chrony.conf` ; then
      for i in `echo "$var_multiple_time_servers" | tr ',' '\n'` ; do
        echo -ne "\nserver $i iburst" >> /etc/chrony.conf
      done
    else
      sed -i 's/#[ ]*server/server/g' /etc/chrony.conf
    fi
  fi
else
  if [ `grep -c '^server' /etc/ntp.conf` -lt 2 ]; then
    if ! `grep -q '#[[:space:]]*server' /etc/ntp.conf` ; then
      for i in `echo "$var_multiple_time_servers" | tr ',' '\n'` ; do
        echo -ne "\nserver $i iburst" >> /etc/ntp.conf
      done
    else
      sed -i 's/#[ ]*server/server/g' /etc/ntp.conf
    fi
  fi
fi
# END fix for 'chronyd_or_ntpd_specify_multiple_servers'
```

~~TODO: Support ansible and other fix systems, not just bash.~~ Will only add comments for bash remediation roles. Ansible already has this implied using the `-item` tagging. And Ansible does report progress on its own.