### PR TITLE
Easier language and more colors in OVAL details

### DIFF
--- a/xsl/xccdf-report-oval-details.xsl
+++ b/xsl/xccdf-report-oval-details.xsl
@@ -71,16 +71,16 @@ Authors:
         <!-- if there are items to display, go ahead -->
         <xsl:when test='$items'>
             <h4>
-                <xsl:choose>
-                    <xsl:when test='$result="pass"'>Items found satisfying </xsl:when>
-                    <xsl:otherwise>Items found violating </xsl:otherwise>
-                </xsl:choose>
                 <span class="label label-primary">
                     <xsl:choose>
                         <xsl:when test='$title'><xsl:value-of select='$title'/></xsl:when>
                         <xsl:otherwise>OVAL test <xsl:value-of select='@test_id'/></xsl:otherwise>
                     </xsl:choose>
-                </span>:
+                </span><!-- #160 is nbsp -->&#160;
+                <xsl:choose>
+                    <xsl:when test='$result="pass"'><span class="label label-success">passed</span> because of these items:</xsl:when>
+                    <xsl:otherwise><span class="label label-danger">failed</span> because these items were missing:</xsl:otherwise>
+                </xsl:choose>
             </h4>
 
             <table class="table table-striped table-bordered">
@@ -115,11 +115,11 @@ Authors:
             <xsl:variable name='comment' select='$object_info[1]/@comment'/>
             <xsl:if test="$object_info">
                 <h4>
+                    <span class="label label-primary"><xsl:value-of select="$title"/></span><!-- #160 is nbsp -->&#160;
                     <xsl:choose>
-                        <xsl:when test='$result="pass"'>Items not found satisfying </xsl:when>
-                        <xsl:otherwise>Items not found violating </xsl:otherwise>
+                        <xsl:when test='$result="pass"'><span class="label label-success">passed</span> because these items were not found:</xsl:when>
+                        <xsl:otherwise><span class="label label-danger">failed</span> because these items were missing:</xsl:otherwise>
                     </xsl:choose>
-                    <span class="label label-primary"><xsl:value-of select="$title"/></span>:
                 </h4>
                 <h5>Object <strong><abbr>
                 <xsl:if test='$comment'>

--- a/xsl/xccdf-report-oval-details.xsl
+++ b/xsl/xccdf-report-oval-details.xsl
@@ -79,7 +79,7 @@ Authors:
                 </span><!-- #160 is nbsp -->&#160;
                 <xsl:choose>
                     <xsl:when test='$result="pass"'><span class="label label-success">passed</span> because of these items:</xsl:when>
-                    <xsl:otherwise><span class="label label-danger">failed</span> because these items were missing:</xsl:otherwise>
+                    <xsl:otherwise><span class="label label-danger">failed</span> because of these items:</xsl:otherwise>
                 </xsl:choose>
             </h4>
 


### PR DESCRIPTION
I am always confused when reading the OVAL details and have to read the lines several times to understand it. This PR aims to improve that. I use colors to highlight which condition passed and failed. I use simpler language - passed or failed - instead of satisfying and violating.

Before:
![image](https://cloud.githubusercontent.com/assets/753153/25542026/e13b2d32-2c1e-11e7-9e0f-7aed686f87de.png)

![image](https://cloud.githubusercontent.com/assets/753153/25542055/f8a0192e-2c1e-11e7-85ed-e9aa14a16f30.png)

After:
![image](https://cloud.githubusercontent.com/assets/753153/25542080/07f6d9a8-2c1f-11e7-8979-7474693e9a72.png)

![image](https://cloud.githubusercontent.com/assets/753153/25542085/12dfdd4c-2c1f-11e7-9b0a-36542856b798.png)


I feel like this makes the report way easier to read, especially for users not familiar with OVAL and XCCDF. Let me know what you think.