### PR TITLE
 Fix for dubious assert when renaming benchmarks

### DIFF
--- a/src/XCCDF/benchmark.c
+++ b/src/XCCDF/benchmark.c
@@ -849,7 +849,7 @@ bool xccdf_benchmark_rename_item(struct xccdf_item *item, const char *newid)
 struct oscap_htable *
 xccdf_benchmark_find_target_htable(const struct xccdf_benchmark *benchmark, xccdf_type_t type)
 {
-	assert(type & (XCCDF_ITEM | XCCDF_PROFILE | XCCDF_RESULT));
+	assert(type & XCCDF_OBJECT);
 	if (type == XCCDF_PROFILE)
 		return XITEM(benchmark)->sub.benchmark.profiles_dict;
 	if (type == XCCDF_RESULT)

--- a/src/XCCDF/public/xccdf_benchmark.h
+++ b/src/XCCDF/public/xccdf_benchmark.h
@@ -49,7 +49,7 @@
  * Type of an XCCDF object.
  *
  * When checking the type, you can use either operator == for type equivalence,
- * or operator &amp; to take a type inheriritance hierarchy into account.
+ * or operator &amp; to take a type inheritance hierarchy into account.
  * For example, XCCDF_ITEM & XCCDF_RULE evaluates to true,
  * as the rule type is a subclass of the xccdf item type.
  */


### PR DESCRIPTION
Changed xccdf_find_target_htable to work with benchmarks too because benchmarks are definitely going through this code when they get renamed.