### PR TITLE
Exposed xccdf_benchmark_export_source()

### DIFF
--- a/src/XCCDF/public/xccdf_benchmark.h
+++ b/src/XCCDF/public/xccdf_benchmark.h
@@ -726,6 +726,13 @@ struct xccdf_benchmark* xccdf_benchmark_import_source(struct oscap_source *sourc
 int xccdf_benchmark_export(struct xccdf_benchmark *benchmark, const char *file);
 
 /**
+ * Export a benchmark to a source object
+ * @memberof xccdf_benchmark
+ * @returns newly created source object or NULL
+ */
+struct oscap_source *xccdf_benchmark_export_source(struct xccdf_benchmark *benchmark, const char *filename);
+
+/**
  * Import the content of oscap_source into a xccdf_result
  * @memberof xccdf_result
  * @param source The oscap_source to import from

--- a/src/XCCDF/xccdf_impl.h
+++ b/src/XCCDF/xccdf_impl.h
@@ -54,8 +54,6 @@ xmlNode *xccdf_ident_to_dom(struct xccdf_ident *ident, xmlDoc *doc, xmlNode *par
 xmlNode *xccdf_setvalue_to_dom(struct xccdf_setvalue *setvalue, xmlDoc *doc, xmlNode *parent, const struct xccdf_version_info* version_info);
 xmlNode *xccdf_override_to_dom(struct xccdf_override *override, xmlDoc *doc, xmlNode *parent, const struct xccdf_version_info* version_info);
 
-struct oscap_source *xccdf_benchmark_export_source(struct xccdf_benchmark *benchmark, const char *filename);
-
 OSCAP_HIDDEN_END;
 
 #endif


### PR DESCRIPTION
Added a function to export a benchmark to a source object so I can put one into a datastream