### PR TITLE
Change RPM probes to return "not applicable" when run on non-RPM environment

### DIFF
--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -387,16 +387,12 @@ int probe_main (probe_ctx *ctx, void *arg)
         struct rpminfo_req request_st;
         struct rpminfo_rep *reply_st;
 
-	/*
-	 * arg is NULL if regex compilation failed
-	 */
+	// arg is NULL if regex compilation failed
 	if (arg == NULL) {
 		return PROBE_EINIT;
 	}
 
-	/*
-	 * There was no rpm config files
-	 */
+	// There was no rpm config files
 	if (g_rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -296,13 +296,21 @@ void probe_fini (void *ptr)
 {
         struct rpm_probe_global *r = (struct rpm_probe_global *)ptr;
 
-        rpmtsFree(r->rpmts);
 	rpmFreeCrypto();
-        rpmFreeRpmrc();
-        rpmFreeMacros(NULL);
-        rpmlogClose();
-        pthread_mutex_destroy (&(r->mutex));
+	rpmFreeRpmrc();
+	rpmFreeMacros(NULL);
+	rpmlogClose();
+
+	if (r == NULL)
+		return;
+
 	regfree(&g_keyid_regex);
+
+	if (r->rpmts == NULL)
+		return;
+
+        rpmtsFree(r->rpmts);
+        pthread_mutex_destroy (&(r->mutex));
 
         return;
 }

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -246,12 +246,19 @@ void probe_fini (void *ptr)
 {
         struct rpm_probe_global *r = (struct rpm_probe_global *)ptr;
 
-        rpmtsFree(r->rpmts);
 	rpmFreeCrypto();
-        rpmFreeRpmrc();
-        rpmFreeMacros(NULL);
-        rpmlogClose();
-        pthread_mutex_destroy (&(r->mutex));
+	rpmFreeRpmrc();
+	rpmFreeMacros(NULL);
+	rpmlogClose();
+
+	/*
+	 * If probe_init() failed r->rpmts and r->mutex were not initialized
+	 */
+	if (r == NULL)
+		return;
+
+	rpmtsFree(r->rpmts);
+	pthread_mutex_destroy (&(r->mutex));
 
         return;
 }

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -251,9 +251,7 @@ void probe_fini (void *ptr)
 	rpmFreeMacros(NULL);
 	rpmlogClose();
 
-	/*
-	 * If probe_init() failed r->rpmts and r->mutex were not initialized
-	 */
+	// If probe_init() failed r->rpmts and r->mutex were not initialized
 	if (r == NULL)
 		return;
 
@@ -328,9 +326,7 @@ int probe_main (probe_ctx *ctx, void *arg)
         uint64_t collect_flags = 0;
         unsigned int i;
 
-	/*
-	 * If probe_init() failed it's because there was no rpm config files
-	 */
+	// If probe_init() failed it's because there was no rpm config files
 	if (arg == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -321,10 +321,10 @@ int probe_main (probe_ctx *ctx, void *arg)
         uint64_t collect_flags = 0;
         unsigned int i;
 
+	/*
+	 * If probe_init() failed it's because there was no rpm config files
+	 */
 	if (arg == NULL) {
-		return PROBE_EINIT;
-	}
-	if (g_rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;
 	}

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -335,9 +335,7 @@ void probe_fini (void *ptr)
 	rpmFreeMacros(NULL);
 	rpmlogClose();
 
-	/*
-	 * If probe_init() failed r->rpmts and r->mutex were not initialized
-	 */
+	// If probe_init() failed r->rpmts and r->mutex were not initialized
 	if (r == NULL)
 		return;
 
@@ -442,9 +440,7 @@ int probe_main (probe_ctx *ctx, void *arg)
 	uint64_t collect_flags = 0;
 	unsigned int i;
 
-	/*
-	 * If probe_init() failed it's because there was no rpm config files
-	 */
+	// If probe_init() failed it's because there was no rpm config files
 	if (arg == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -330,11 +330,18 @@ void probe_fini (void *ptr)
 {
 	struct rpm_probe_global *r = (struct rpm_probe_global *)ptr;
 
-	rpmtsFree(r->rpmts);
 	rpmFreeCrypto();
 	rpmFreeRpmrc();
 	rpmFreeMacros(NULL);
 	rpmlogClose();
+
+	/*
+	 * If probe_init() failed r->rpmts and r->mutex were not initialized
+	 */
+	if (r == NULL)
+		return;
+
+	rpmtsFree(r->rpmts);
 	pthread_mutex_destroy (&(r->mutex));
 
 	return;

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -435,11 +435,10 @@ int probe_main (probe_ctx *ctx, void *arg)
 	uint64_t collect_flags = 0;
 	unsigned int i;
 
+	/*
+	 * If probe_init() failed it's because there was no rpm config files
+	 */
 	if (arg == NULL) {
-		return PROBE_EINIT;
-	}
-
-	if (g_rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;
 	}

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -360,12 +360,29 @@ void probe_fini (void *ptr)
 {
 	struct verifypackage_global *r = (struct verifypackage_global *)ptr;
 
-	rpmtsFree(r->rpm.rpmts);
-	probe_chroot_free(&(r->chr));
 	rpmFreeCrypto();
 	rpmFreeRpmrc();
 	rpmFreeMacros(NULL);
 	rpmlogClose();
+
+	/*
+	 * This will be always set by probe_init(), lets free it
+	 */
+	probe_chroot_free(&g_rpm.chr);
+
+	/*
+	 * If r is null, probe_init() failed during chroot
+	 */
+	if (r == NULL)
+		return;
+
+	/*
+	 * If r->rpm.rpmts was not initialized the mutex was not as well
+	 */
+	if (r->rpm.rpmts == NULL)
+		return;
+
+	rpmtsFree(r->rpm.rpmts);
 	pthread_mutex_destroy (&(r->rpm.mutex));
 
 	return;

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -365,20 +365,14 @@ void probe_fini (void *ptr)
 	rpmFreeMacros(NULL);
 	rpmlogClose();
 
-	/*
-	 * This will be always set by probe_init(), lets free it
-	 */
+	// This will be always set by probe_init(), lets free it
 	probe_chroot_free(&g_rpm.chr);
 
-	/*
-	 * If r is null, probe_init() failed during chroot
-	 */
+	// If r is null, probe_init() failed during chroot
 	if (r == NULL)
 		return;
 
-	/*
-	 * If r->rpm.rpmts was not initialized the mutex was not as well
-	 */
+	// If r->rpm.rpmts was not initialized the mutex was not as well
 	if (r->rpm.rpmts == NULL)
 		return;
 
@@ -435,16 +429,12 @@ int probe_main (probe_ctx *ctx, void *arg)
 	uint64_t collect_flags = 0;
 	unsigned int i;
 
-	/*
-	 * arg is NULL if we were not able to chroot during probe_init()
-	 */
+	// arg is NULL if we were not able to chroot during probe_init()
 	if (arg == NULL) {
 		return PROBE_EINIT;
 	}
 
-	/*
-	 * There was no rpm config files
-	 */
+	// There was no rpm config files
 	if (g_rpm.rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -336,7 +336,8 @@ void *probe_init (void)
 
 	if (rpmReadConfigFiles (NULL, (const char *)NULL) != 0) {
 		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
-		return (NULL);
+		g_rpm.rpm.rpmts = NULL;
+		return ((void *)&g_rpm);
 	}
 
 	g_rpm.rpm.rpmts = rpmtsCreate();
@@ -417,10 +418,16 @@ int probe_main (probe_ctx *ctx, void *arg)
 	uint64_t collect_flags = 0;
 	unsigned int i;
 
+	/*
+	 * arg is NULL if we were not able to chroot during probe_init()
+	 */
 	if (arg == NULL) {
 		return PROBE_EINIT;
 	}
 
+	/*
+	 * There was no rpm config files
+	 */
 	if (g_rpm.rpm.rpmts == NULL) {
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
 		return 0;


### PR DESCRIPTION
These changes makes RPM probes return "not applicable" when RPM config files are not found.
They also fix possible undefined behaviours when destroying an uninitialised mutex.

I have changed order rpmFreeXXXX calls in probe_fini() functions, but I'm not sure if I can do it.

I will still look into writing checks for init and fini functions.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1447629