### PR TITLE
Do not remove consecutive newlines from ansible fixes when generating

### DIFF
--- a/tests/API/XCCDF/unittests/test_fix_arf.playbook1.yml
+++ b/tests/API/XCCDF/unittests/test_fix_arf.playbook1.yml
@@ -1,9 +1,7 @@
 ---
 # - hosts: localhost # set required host
    tasks:
-
     - name: ensure everything passes
         shell: /bin/true
-
     - name: correct the failing case
         shell: /bin/false

--- a/tests/API/XCCDF/unittests/test_fix_arf.playbook2.yml
+++ b/tests/API/XCCDF/unittests/test_fix_arf.playbook2.yml
@@ -1,6 +1,5 @@
 ---
 # - hosts: localhost # set required host
    tasks:
-
     - name: correct the failing case
         shell: /bin/false


### PR DESCRIPTION
Use thread-safe strchr instead of strtok that uses global state.