### PR TITLE
CPE Notes bugfix

### DIFF
--- a/src/CPE/public/cpe_dict.h
+++ b/src/CPE/public/cpe_dict.h
@@ -55,6 +55,12 @@ struct cpe_dict_model;
 struct cpe_item;
 
 /**
+ * @struct cpe_notes
+ * Structure with information about notes
+ */
+struct cpe_notes;
+
+/**
  * @struct cpe_vendor
  * Structure with information about vendor
  */
@@ -231,6 +237,24 @@ struct oscap_text_iterator *cpe_item_get_titles(const struct cpe_item *item);
  */
 OSCAP_DEPRECATED(struct oscap_text_iterator *cpe_item_get_notes(const struct cpe_item *item));
 
+/** cpe_item function to get CPE notes
+ * @memberof cpe_item
+ * @param item CPE item
+ */
+struct cpe_notes_iterator *cpe_item_get_notes2(const struct cpe_item *item);
+
+/** cpe_notes function to get language
+ * @memberof cpe_notes
+ * @param notes object
+ */
+const char *cpe_notes_get_lang(const struct cpe_notes *notes);
+
+/** cpe_notes function to get notes list
+ * @memberof cpe_notes
+ * @param notes object
+ */
+struct oscap_text_iterator *cpe_notes_get_notes(const struct cpe_notes *notes);
+
 /** cpe_generator functions to get product name
  * @memberof cpe_generator
  * @param item document generator
@@ -400,6 +424,8 @@ void cpe_itemmetadata_free(struct cpe_item_metadata *meta);
 void cpe_dict_model_free(struct cpe_dict_model *dict);
 /// @memberof cpe_generator
 void cpe_generator_free(struct cpe_generator *generator);
+/// @memberof cpe_notes
+void cpe_notes_free(struct cpe_notes *notes);
 /// @memberof cpe_item
 void cpe_item_free(struct cpe_item *item);
 
@@ -411,6 +437,8 @@ struct cpe_generator *cpe_generator_new(void);
 struct cpe_check *cpe_check_new(void);
 /// @memberof cpe_reference
 struct cpe_reference *cpe_reference_new(void);
+/// @memberof cpe_notes
+struct cpe_notes *cpe_notes_new(void);
 /// @memberof cpe_item
 struct cpe_item *cpe_item_new(void);
 /// @memberof cpe_vendor
@@ -444,6 +472,9 @@ bool cpe_item_set_deprecated_by(struct cpe_item *item, const struct cpe_name *ne
 
 /// @memberof cpe_item
 bool cpe_item_set_deprecation_date(struct cpe_item *item, const char *new_deprecation_date);
+
+/// @memberof cpe_item
+bool cpe_notes_set_lang(struct cpe_notes *notes, const char *new_lang);
 
 /// @memberof cpe_item_metadata
 bool cpe_item_metadata_set_modification_date(struct cpe_item_metadata *item_metadata,
@@ -527,6 +558,12 @@ bool cpe_item_add_title(struct cpe_item *item, struct oscap_text *new_title);
  */
 OSCAP_DEPRECATED(bool cpe_item_add_note(struct cpe_item *item, struct oscap_text *new_title));
 
+/// @memberof cpe_item
+bool cpe_item_add_notes(struct cpe_item *item, struct cpe_notes *new_notes);
+
+/// @memberof cpe_notes
+bool cpe_notes_add_note(struct cpe_notes *notes, struct oscap_text * new_note);
+
 /// @memberof cpe_dict_model
 bool cpe_dict_model_add_item(struct cpe_dict_model *dict, struct cpe_item *new_item);
 
@@ -589,10 +626,43 @@ bool cpe_item_iterator_has_more(struct cpe_item_iterator *it);
  */
 void cpe_item_iterator_free(struct cpe_item_iterator *it);
 
-/// @memberof cpe_item
+/// @memberof cpe_item_iterator
 void cpe_item_iterator_remove(struct cpe_item_iterator *it);
 /// @memberof cpe_item_iterator
 void cpe_item_iterator_reset(struct cpe_item_iterator *it);
+
+/**
+ * @struct cpe_notes_iterator
+ * Iterator over CPE notes objects.
+ * @see oscap_iterator
+ */
+struct cpe_notes_iterator;
+
+/**
+ * Iterator over CPE notes objects.
+ * @see oscap_iterator
+ * @memberof cpe_notes_iterator
+ */
+struct cpe_notes *cpe_notes_iterator_next(struct cpe_notes_iterator *it);
+
+/**
+ * Iterator over CPE notes objects.
+ * @see oscap_iterator
+ * @memberof cpe_notes_iterator
+ */
+bool cpe_notes_iterator_has_more(struct cpe_notes_iterator *it);
+
+/**
+ * Iterator over CPE notes objects.
+ * @see oscap_iterator
+ * @memberof cpe_notes_iterator
+ */
+void cpe_notes_iterator_free(struct cpe_notes_iterator *it);
+
+/// @memberof cpe_notes_iterator
+void cpe_notes_iterator_remove(struct cpe_notes_iterator *it);
+/// @memberof cpe_notes_iterator
+void cpe_notes_iterator_reset(struct cpe_notes_iterator *it);
 
 /**
  * @struct cpe_reference_iterator

--- a/src/OVAL/oval_definitions_impl.h
+++ b/src/OVAL/oval_definitions_impl.h
@@ -111,8 +111,6 @@ xmlNode *oval_filter_to_dom(struct oval_filter *, xmlDoc *, xmlNode *);
 typedef void (*oval_object_content_consumer) (struct oval_object_content *, void *);
 xmlNode *oval_object_content_to_dom(struct oval_object_content *, xmlDoc *, xmlNode *);
 int oval_object_content_parse_tag(xmlTextReaderPtr, struct oval_parser_context *, oval_object_content_consumer, void *);
-struct oval_filter *oval_object_content_get_filter(struct oval_object_content *);
-void oval_object_content_set_filter(struct oval_object_content *, struct oval_filter *);
 
 int oval_state_content_parse_tag(xmlTextReaderPtr, struct oval_parser_context *, oscap_consumer_func, void *);
 xmlNode *oval_state_content_to_dom(struct oval_state_content *, xmlDoc *, xmlNode *);

--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -2290,6 +2290,10 @@ void oval_object_content_set_varCheck(struct oval_object_content *, oval_check_t
  * @memberof oval_object_content
  */
 void oval_object_content_set_setobject(struct oval_object_content *, struct oval_setobject *);	//type == OVAL_OBJECTCONTENT_SET
+/**
+ * @memberof oval_object_content
+ */
+void oval_object_content_set_filter(struct oval_object_content *, struct oval_filter *);	//type == OVAL_OBJECTCONTENT_FILTER
 /** @} */
 
 /**
@@ -2324,6 +2328,12 @@ oval_check_t oval_object_content_get_varCheck(struct oval_object_content *);	//t
  * @memberof oval_object_content
  */
 struct oval_setobject *oval_object_content_get_setobject(struct oval_object_content *);	//type == OVAL_OBJECTCONTENT_SET
+/**
+ * Get filter of a set object content.
+ * @return A pointer to the filter attribute of the specified @ref oval_object_content.
+ * @memberof oval_object_content
+ */
+struct oval_filter *oval_object_content_get_filter(struct oval_object_content *content); //type == OVAL_OBJECTCONTENT_FILTER
 /** @} */
 
 /**

--- a/src/XCCDF/benchmark.c
+++ b/src/XCCDF/benchmark.c
@@ -642,6 +642,11 @@ const char * xccdf_benchmark_supported(void)
     return XCCDF_SUPPORTED;
 }
 
+const struct xccdf_version_info *xccdf_benchmark_supported_schema_version(void)
+{
+	return xccdf_version_info_find(xccdf_benchmark_supported());
+}
+
 struct xccdf_group *xccdf_benchmark_append_new_group(struct xccdf_benchmark *benchmark, const char *id)
 {
 	if (benchmark == NULL) return NULL;

--- a/src/XCCDF/elements.c
+++ b/src/XCCDF/elements.c
@@ -78,6 +78,16 @@ static const struct xccdf_version_info XCCDF_VERSION_MAP[] = {
 	{NULL, NULL, NULL}
 };
 
+const struct xccdf_version_info *xccdf_version_info_find(const char *version)
+{
+	const struct xccdf_version_info *mapptr;
+	for (mapptr = XCCDF_VERSION_MAP; mapptr->version != 0; ++mapptr) {
+		if (!strcmp(mapptr->version, version))
+			return mapptr;
+	}
+	return NULL;
+}
+
 static const struct xccdf_version_info *_namespace_get_xccdf_version_info(const char *namespace_uri)
 {
 	const struct xccdf_version_info *mapptr;

--- a/src/XCCDF/elements.h
+++ b/src/XCCDF/elements.h
@@ -217,6 +217,8 @@ void xccdf_print_textlist(struct oscap_text_iterator *txt, int depth, int max, c
 
 xmlNs *lookup_xccdf_ns(xmlDoc *doc, xmlNode *parent, const struct xccdf_version_info *version_info);
 
+const struct xccdf_version_info *xccdf_version_info_find(const char *version);
+
 OSCAP_HIDDEN_END;
 
 #endif

--- a/src/XCCDF/public/xccdf_benchmark.h
+++ b/src/XCCDF/public/xccdf_benchmark.h
@@ -780,6 +780,9 @@ struct xccdf_benchmark * xccdf_benchmark_clone( const struct  xccdf_benchmark * 
  */
 const char * xccdf_benchmark_supported(void);
 
+/// @memberof xccdf_benchmark
+const struct xccdf_version_info *xccdf_benchmark_supported_schema_version(void);
+
 /// @memberof xccdf_profile
 struct xccdf_profile *xccdf_profile_new(void);
 /// @memberof xccdf_profile


### PR DESCRIPTION
Some of the code was treating the notes in a cpe_item as a list of oscap_texts, and some of the code was treating it as a cpe_notes object.  As a result cpe_item_get_notes() was returning garbage because it was trying to cast the memory for the cpe_notes struct as the first string in the list of note texts.
I fixed it, but it breaks the API a little bit because the return value of cpe_item_get_notes() is different now.  I don't feel bad because it was returning garbage before, so anyone who was using it was just getting garbage.  I bet nobody was using it.