### PR TITLE
Type-specific oval variable iterators

### DIFF
--- a/src/OVAL/oval_variable.c
+++ b/src/OVAL/oval_variable.c
@@ -121,6 +121,20 @@ void oval_variable_possible_value_free(struct oval_variable_possible_value *pv)
 	}
 }
 
+char* oval_variable_possible_value_get_hint(struct oval_variable_possible_value* pv)
+{
+    __attribute__nonnull__(pv);
+
+    return pv->hint;
+}
+
+char* oval_variable_possible_value_get_value(struct oval_variable_possible_value* pv)
+{
+    __attribute__nonnull__(pv);
+
+    return pv->value;
+}
+
 bool oval_variable_possible_value_iterator_has_more(struct oval_variable_possible_value_iterator* iter)
 {
 	return oval_collection_iterator_has_more((struct oval_iterator*)iter);
@@ -174,7 +188,16 @@ struct oval_variable_restriction_iterator *oval_variable_possible_restriction_ge
 
 oval_operator_t oval_variable_possible_restriction_get_operator(struct oval_variable_possible_restriction *possible_restriction)
 {
+	__attribute__nonnull__(possible_restriction);
+
 	return possible_restriction->operator;
+}
+
+char* oval_variable_possible_restriction_get_hint(struct oval_variable_possible_restriction* possible_restriction)
+{
+	__attribute__nonnull__(possible_restriction);
+
+	return possible_restriction->hint;
 }
 
 
@@ -216,6 +239,19 @@ void oval_variable_restriction_free(struct oval_variable_restriction *r)
 	}
 }
 
+oval_operation_t oval_variable_restriction_get_operation(struct oval_variable_restriction* restriction)
+{
+    __attribute__nonnull__(restriction);
+
+    return restriction->operation;
+}
+
+char* oval_variable_restriction_get_value(struct oval_variable_restriction* restriction)
+{
+    __attribute__nonnull__(restriction);
+
+    return restriction->value;
+}
 
 bool oval_variable_restriction_iterator_has_more(struct oval_variable_restriction_iterator* iter)
 {

--- a/src/OVAL/oval_variable.c
+++ b/src/OVAL/oval_variable.c
@@ -181,7 +181,12 @@ void oval_variable_possible_restriction_add_restriction(struct oval_variable_pos
 	oval_collection_add(pr->restrictions, r);
 }
 
-struct oval_variable_restriction_iterator *oval_variable_possible_restriction_get_restrictions(struct oval_variable_possible_restriction *possible_restriction)
+struct oval_iterator *oval_variable_possible_restriction_get_restrictions(struct oval_variable_possible_restriction *possible_restriction)
+{
+	return oval_collection_iterator(possible_restriction->restrictions);
+}
+
+struct oval_variable_restriction_iterator *oval_variable_possible_restriction_get_restrictions2(struct oval_variable_possible_restriction *possible_restriction)
 {
 	return (struct oval_variable_restriction_iterator*)oval_collection_iterator(possible_restriction->restrictions);
 }
@@ -372,7 +377,17 @@ struct oval_value_iterator *oval_variable_get_values(struct oval_variable *varia
 		(struct oval_value_iterator *) oval_collection_iterator_new();
 }
 
-struct oval_variable_possible_value_iterator *oval_variable_get_possible_values(struct oval_variable *variable)
+struct oval_iterator *oval_variable_get_possible_values(struct oval_variable *variable)
+{
+	if (variable->type == OVAL_VARIABLE_EXTERNAL) {
+		oval_variable_EXTERNAL_t *var = (oval_variable_EXTERNAL_t *) variable;
+		return oval_collection_iterator(var->possible_values);
+	} else {
+		return oval_collection_iterator_new();
+	}
+}
+
+struct oval_variable_possible_value_iterator *oval_variable_get_possible_values2(struct oval_variable *variable)
 {
 	if (variable->type == OVAL_VARIABLE_EXTERNAL) {
 		oval_variable_EXTERNAL_t *var = (oval_variable_EXTERNAL_t *) variable;
@@ -382,7 +397,17 @@ struct oval_variable_possible_value_iterator *oval_variable_get_possible_values(
 	}
 }
 
-struct oval_variable_possible_restriction_iterator *oval_variable_get_possible_restrictions(struct oval_variable *variable)
+struct oval_iterator *oval_variable_get_possible_restrictions(struct oval_variable *variable)
+{
+	if (variable->type == OVAL_VARIABLE_EXTERNAL) {
+		oval_variable_EXTERNAL_t *var = (oval_variable_EXTERNAL_t *) variable;
+		return oval_collection_iterator(var->possible_restrictions);
+	} else {
+		return oval_collection_iterator_new();
+	}
+}
+
+struct oval_variable_possible_restriction_iterator *oval_variable_get_possible_restrictions2(struct oval_variable *variable)
 {
 	if (variable->type == OVAL_VARIABLE_EXTERNAL) {
 		oval_variable_EXTERNAL_t *var = (oval_variable_EXTERNAL_t *) variable;

--- a/src/OVAL/oval_variable.c
+++ b/src/OVAL/oval_variable.c
@@ -121,6 +121,26 @@ void oval_variable_possible_value_free(struct oval_variable_possible_value *pv)
 	}
 }
 
+bool oval_variable_possible_value_iterator_has_more(struct oval_variable_possible_value_iterator* iter)
+{
+	return oval_collection_iterator_has_more((struct oval_iterator*)iter);
+}
+
+struct oval_variable_possible_value* oval_variable_possible_value_iterator_next(struct oval_variable_possible_value_iterator* iter)
+{
+	return (struct oval_variable_possible_value*)oval_collection_iterator_next((struct oval_iterator*)iter);
+}
+
+void oval_variable_possible_value_iterator_free(struct oval_variable_possible_value_iterator* iter)
+{
+	oval_collection_iterator_free((struct oval_iterator*)iter);
+}
+
+int oval_variable_possible_value_iterator_remaining(struct oval_variable_possible_value_iterator* iter)
+{
+	return oval_collection_iterator_remaining((struct oval_iterator*)iter);
+}
+
 struct oval_variable_possible_restriction *oval_variable_possible_restriction_new(oval_operator_t operator, const char *hint)
 {
 	struct oval_variable_possible_restriction *pr;
@@ -147,15 +167,37 @@ void oval_variable_possible_restriction_add_restriction(struct oval_variable_pos
 	oval_collection_add(pr->restrictions, r);
 }
 
-struct oval_iterator *oval_variable_possible_restriction_get_restrictions(struct oval_variable_possible_restriction *possible_restriction)
+struct oval_variable_restriction_iterator *oval_variable_possible_restriction_get_restrictions(struct oval_variable_possible_restriction *possible_restriction)
 {
-	return oval_collection_iterator(possible_restriction->restrictions);
+	return (struct oval_variable_restriction_iterator*)oval_collection_iterator(possible_restriction->restrictions);
 }
 
 oval_operator_t oval_variable_possible_restriction_get_operator(struct oval_variable_possible_restriction *possible_restriction)
 {
 	return possible_restriction->operator;
 }
+
+
+bool oval_variable_possible_restriction_iterator_has_more(struct oval_variable_possible_restriction_iterator* iter)
+{
+	return oval_collection_iterator_has_more((struct oval_iterator*)iter);
+}
+
+struct oval_variable_possible_restriction* oval_variable_possible_restriction_iterator_next(struct oval_variable_possible_restriction_iterator* iter)
+{
+	return (struct oval_variable_possible_restriction*)oval_collection_iterator_next((struct oval_iterator*)iter);
+}
+
+void oval_variable_possible_restriction_iterator_free(struct oval_variable_possible_restriction_iterator* iter)
+{
+	oval_collection_iterator_free((struct oval_iterator*)iter);
+}
+
+int oval_variable_possible_restriction_iterator_remaining(struct oval_variable_possible_restriction_iterator* iter)
+{
+	return oval_collection_iterator_remaining((struct oval_iterator*)iter);
+}
+
 
 struct oval_variable_restriction *oval_variable_restriction_new(oval_operation_t operation, const char *value)
 {
@@ -173,6 +215,28 @@ void oval_variable_restriction_free(struct oval_variable_restriction *r)
 		oscap_free(r);
 	}
 }
+
+
+bool oval_variable_restriction_iterator_has_more(struct oval_variable_restriction_iterator* iter)
+{
+	return oval_collection_iterator_has_more((struct oval_iterator*)iter);
+}
+
+struct oval_variable_restriction* oval_variable_restriction_iterator_next(struct oval_variable_restriction_iterator* iter)
+{
+	return (struct oval_variable_restriction*)oval_collection_iterator_next((struct oval_iterator*)iter);
+}
+
+void oval_variable_restriction_iterator_free(struct oval_variable_restriction_iterator* iter)
+{
+	oval_collection_iterator_free((struct oval_iterator*)iter);
+}
+
+int oval_variable_restriction_iterator_remaining(struct oval_variable_restriction_iterator* iter)
+{
+	return oval_collection_iterator_remaining((struct oval_iterator*)iter);
+}
+
 
 bool oval_variable_iterator_has_more(struct oval_variable_iterator
 				     *oc_variable)
@@ -272,23 +336,23 @@ struct oval_value_iterator *oval_variable_get_values(struct oval_variable *varia
 		(struct oval_value_iterator *) oval_collection_iterator_new();
 }
 
-struct oval_iterator *oval_variable_get_possible_values(struct oval_variable *variable)
+struct oval_variable_possible_value_iterator *oval_variable_get_possible_values(struct oval_variable *variable)
 {
 	if (variable->type == OVAL_VARIABLE_EXTERNAL) {
 		oval_variable_EXTERNAL_t *var = (oval_variable_EXTERNAL_t *) variable;
-		return oval_collection_iterator(var->possible_values);
+		return (struct oval_variable_possible_value_iterator*)oval_collection_iterator(var->possible_values);
 	} else {
-		return oval_collection_iterator_new();
+		return (struct oval_variable_possible_value_iterator*)oval_collection_iterator_new();
 	}
 }
 
-struct oval_iterator *oval_variable_get_possible_restrictions(struct oval_variable *variable)
+struct oval_variable_possible_restriction_iterator *oval_variable_get_possible_restrictions(struct oval_variable *variable)
 {
 	if (variable->type == OVAL_VARIABLE_EXTERNAL) {
 		oval_variable_EXTERNAL_t *var = (oval_variable_EXTERNAL_t *) variable;
-		return oval_collection_iterator(var->possible_restrictions);
+		return (struct oval_variable_possible_restriction_iterator*)oval_collection_iterator(var->possible_restrictions);
 	} else {
-		return oval_collection_iterator_new();
+		return (struct oval_variable_possible_restriction_iterator*)oval_collection_iterator_new();
 	}
 }
 
@@ -546,34 +610,34 @@ struct oval_variable *oval_variable_clone(struct oval_definition_model *new_mode
 			evar = (oval_variable_EXTERNAL_t *) new_variable;
 			old_evar = (oval_variable_EXTERNAL_t *) old_variable;
 
-			struct oval_iterator *old_pv_itr;
+			struct oval_variable_possible_value_iterator *old_pv_itr;
 			old_pv_itr = oval_variable_get_possible_values(old_variable);
-			while (oval_collection_iterator_has_more(old_pv_itr)) {
+			while (oval_variable_possible_value_iterator_has_more(old_pv_itr)) {
 				struct oval_variable_possible_value *old_pv, *new_pv;
-				old_pv = oval_collection_iterator_next(old_pv_itr);
+				old_pv = oval_variable_possible_value_iterator_next(old_pv_itr);
 				new_pv = oval_variable_possible_value_new(old_pv->hint, old_pv->value);
 				oval_variable_add_possible_value(new_variable, new_pv);
 			}
-			oval_collection_iterator_free(old_pv_itr);
+			oval_variable_possible_value_iterator_free(old_pv_itr);
 
-			struct oval_iterator *old_pr_itr;
+			struct oval_variable_possible_restriction_iterator *old_pr_itr;
 			old_pr_itr = oval_variable_get_possible_restrictions(old_variable);
-			while (oval_collection_iterator_has_more(old_pr_itr)) {
+			while (oval_variable_possible_restriction_iterator_has_more(old_pr_itr)) {
 				struct oval_variable_possible_restriction *old_pr, *new_pr;
-				old_pr = oval_collection_iterator_next(old_pr_itr);
+				old_pr = oval_variable_possible_restriction_iterator_next(old_pr_itr);
 				new_pr = oval_variable_possible_restriction_new(old_pr->operator, old_pr->hint);
-				struct oval_iterator *old_r_itr;
+				struct oval_variable_restriction_iterator *old_r_itr;
 				old_r_itr = oval_variable_possible_restriction_get_restrictions(old_pr);
-				while (oval_collection_iterator_has_more(old_r_itr)) {
+				while (oval_variable_restriction_iterator_has_more(old_r_itr)) {
 					struct oval_variable_restriction *old_r, *new_r;
-					old_r = oval_collection_iterator_next(old_r_itr);
+					old_r = oval_variable_restriction_iterator_next(old_r_itr);
 					new_r = oval_variable_restriction_new(old_r->operation, old_r->value);
 					oval_variable_possible_restriction_add_restriction(new_pr, new_r);
 				}
-				oval_collection_iterator_free(old_r_itr);
+				oval_variable_restriction_iterator_free(old_r_itr);
 				oval_variable_add_possible_restriction(new_variable, new_pr);
 			}
-			oval_collection_iterator_free(old_pr_itr);
+			oval_variable_possible_restriction_iterator_free(old_pr_itr);
 
 			evar->values_ref = old_evar->values_ref;
 
@@ -804,13 +868,13 @@ static int oval_value_satisfies_possible_restriction(struct oval_value *value, s
 	oval_operator_t operator = pr->operator;
 	struct oresults results;
 	ores_clear(&results);
-	struct oval_iterator *restrictions = oval_variable_possible_restriction_get_restrictions(pr);
-	while (oval_collection_iterator_has_more(restrictions)) {
-		struct oval_variable_restriction *r = oval_collection_iterator_next(restrictions);
+	struct oval_variable_restriction_iterator *restrictions = oval_variable_possible_restriction_get_restrictions(pr);
+	while (oval_variable_restriction_iterator_has_more(restrictions)) {
+		struct oval_variable_restriction *r = oval_variable_restriction_iterator_next(restrictions);
 		oval_result_t result = oval_str_cmp_str(r->value, datatype, text, r->operation);
 		ores_add_res(&results, result);
 	}
-	oval_collection_iterator_free(restrictions);
+	oval_variable_restriction_iterator_free(restrictions);
 	return (ores_get_result_byopr(&results, operator) == OVAL_RESULT_TRUE);
 }
 
@@ -1072,40 +1136,40 @@ static xmlNode *_oval_VARIABLE_EXTERNAL_to_dom(struct oval_variable *variable, x
 	xmlNs *ns_definitions = xmlSearchNsByHref(doc, parent, OVAL_DEFINITIONS_NAMESPACE);
 	xmlNode *variable_node = xmlNewTextChild(parent, ns_definitions, BAD_CAST "external_variable", NULL);
 
-	struct oval_iterator *possible_values = oval_variable_get_possible_values(variable);
-	while (oval_collection_iterator_has_more(possible_values)) {
-		struct oval_variable_possible_value *pv = oval_collection_iterator_next(possible_values);
+	struct oval_variable_possible_value_iterator *possible_values = oval_variable_get_possible_values(variable);
+	while (oval_variable_possible_value_iterator_has_more(possible_values)) {
+		struct oval_variable_possible_value *pv = oval_variable_possible_value_iterator_next(possible_values);
 		xmlNode *possible_value_node = xmlNewTextChild(variable_node, ns_definitions, BAD_CAST "possible_value", BAD_CAST pv->value);
 		xmlNewProp(possible_value_node, BAD_CAST "hint", BAD_CAST pv->hint);
 	}
-	oval_collection_iterator_free(possible_values);
+	oval_variable_possible_value_iterator_free(possible_values);
 
 	oval_schema_version_t schema_version = oval_definition_model_get_core_schema_version(variable->model);
 	bool serialize_operator = oval_schema_version_cmp(schema_version, OVAL_SCHEMA_VERSION(5.11)) >= 0;
-	struct oval_iterator *possible_restrictions = oval_variable_get_possible_restrictions(variable);
-	while (oval_collection_iterator_has_more(possible_restrictions)) {
-		struct oval_variable_possible_restriction *pr = oval_collection_iterator_next(possible_restrictions);
-		struct oval_iterator *restrictions = oval_variable_possible_restriction_get_restrictions(pr);
+	struct oval_variable_possible_restriction_iterator *possible_restrictions = oval_variable_get_possible_restrictions(variable);
+	while (oval_variable_possible_restriction_iterator_has_more(possible_restrictions)) {
+		struct oval_variable_possible_restriction *pr = oval_variable_possible_restriction_iterator_next(possible_restrictions);
+		struct oval_variable_restriction_iterator *restrictions = oval_variable_possible_restriction_get_restrictions(pr);
 		/* Create "possible_restriction" node only if there will be some
 		 * "restriction" children, because each "possible_restriction"
 		 * node must have at least one "restriction" child.
 		 */
-		if (oval_collection_iterator_has_more(restrictions)) {
+		if (oval_variable_restriction_iterator_has_more(restrictions)) {
 			xmlNode *possible_restriction_node = xmlNewTextChild(variable_node, ns_definitions, BAD_CAST "possible_restriction", NULL);
 			/* Attribute "operator" is new in OVAL 5.11, we don't serialize it in older OVAL versions */
 			if (serialize_operator) {
 				xmlNewProp(possible_restriction_node, BAD_CAST "operator", BAD_CAST oval_operator_get_text(pr->operator));
 			}
 			xmlNewProp(possible_restriction_node, BAD_CAST "hint", BAD_CAST pr->hint);
-			while (oval_collection_iterator_has_more(restrictions)) {
-				struct oval_variable_restriction *r = oval_collection_iterator_next(restrictions);
+			while (oval_variable_restriction_iterator_has_more(restrictions)) {
+				struct oval_variable_restriction *r = oval_variable_restriction_iterator_next(restrictions);
 				xmlNode *restriction_node = xmlNewTextChild(possible_restriction_node, ns_definitions, BAD_CAST "restriction", BAD_CAST r->value);
 				xmlNewProp(restriction_node, BAD_CAST "operation", BAD_CAST oval_operation_get_text(r->operation));
 			}
 		}
-		oval_collection_iterator_free(restrictions);
+		oval_variable_restriction_iterator_free(restrictions);
 	}
-	oval_collection_iterator_free(possible_restrictions);
+	oval_variable_possible_restriction_iterator_free(possible_restrictions);
 
 	return variable_node;
 }

--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -338,14 +338,17 @@ struct oval_variable;
  * @struct oval_variable_possible_value
  */
 struct oval_variable_possible_value;
+struct oval_variable_possible_value_iterator;
 /**
  * @struct oval_variable_possible_restriction
  */
 struct oval_variable_possible_restriction;
+struct oval_variable_possible_restriction_iterator;
 /**
  * @struct oval_variable_restriction
  */
 struct oval_variable_restriction;
+struct oval_variable_restriction_iterator;
 /**
  * @struct oval_variable_iterator
  * @see oval_definition_model_get_variables
@@ -1652,6 +1655,29 @@ struct oval_variable_possible_value *oval_variable_possible_value_new(const char
 void oval_variable_possible_value_free(struct oval_variable_possible_value *pv);
 
 /**
+ * @name Iterators
+ * @{
+ */
+/**
+ * @memberof oval_variable_possible_value_iterator
+ */
+bool oval_variable_possible_value_iterator_has_more(struct oval_variable_possible_value_iterator*);
+/**
+ * @memberof oval_variable_possible_value_iterator
+ */
+struct oval_variable_possible_value *oval_variable_possible_value_iterator_next(struct oval_variable_possible_value_iterator*);
+/**
+ * @memberof oval_variable_possible_value_iterator
+ */
+int oval_variable_possible_value_iterator_remaining(struct oval_variable_possible_value_iterator*);
+/**
+ * @memberof oval_variable_possible_value_iterator
+ */
+void oval_variable_possible_value_iterator_free(struct oval_variable_possible_value_iterator*);
+/** @} */
+
+
+/**
  * Construct new instance of possible_restriction element.
  * @param operator Operator to evaluation
  * @param hint A short description of what the value means or represents.
@@ -1666,6 +1692,30 @@ struct oval_variable_possible_restriction *oval_variable_possible_restriction_ne
  */
 void oval_variable_possible_restriction_free(struct oval_variable_possible_restriction *pr);
 
+
+/**
+ * @name Iterators
+ * @{
+ */
+/**
+ * @memberof oval_variable_possible_restriction_iterator
+ */
+bool oval_variable_possible_restriction_iterator_has_more(struct oval_variable_possible_restriction_iterator* iter);
+/**
+ * @memberof oval_variable_possible_restriction_iterator
+ */
+struct oval_variable_possible_restriction *oval_variable_possible_restriction_iterator_next(struct oval_variable_possible_restriction_iterator* iter);
+/**
+ * @memberof oval_variable_possible_restriction_iterator
+ */
+int oval_variable_possible_restriction_iterator_remaining(struct oval_variable_possible_restriction_iterator* iter);
+/**
+ * @memberof oval_variable_possible_restriction_iterator
+ */
+void oval_variable_possible_restriction_iterator_free(struct oval_variable_possible_restriction_iterator* iter);
+/** @} */
+
+
 /**
  * Construct new instance of restriction element.
  * @param operation Operation of restriction.
@@ -1679,6 +1729,29 @@ struct oval_variable_restriction *oval_variable_restriction_new(oval_operation_t
  * @memberof oval_variable_restriction
  */
 void oval_variable_restriction_free(struct oval_variable_restriction *r);
+
+/**
+ * @name Iterators
+ * @{
+ */
+/**
+ * @memberof oval_variable_restriction_iterator
+ */
+bool oval_variable_restriction_iterator_has_more(struct oval_variable_restriction_iterator*);
+/**
+ * @memberof oval_variable_restriction_iterator
+ */
+struct oval_variable_restriction *oval_variable_restriction_iterator_next(struct oval_variable_restriction_iterator*);
+/**
+ * @memberof oval_variable_restriction_iterator
+ */
+int oval_variable_restriction_iterator_remaining(struct oval_variable_restriction_iterator*);
+/**
+ * @memberof oval_variable_restriction_iterator
+ */
+void oval_variable_restriction_iterator_free(struct oval_variable_restriction_iterator*);
+/** @} */
+
 
 /**
  * @name Setters
@@ -1828,7 +1901,7 @@ struct oval_component *oval_variable_get_component(struct oval_variable *);	//ty
  * It should be freed after use by the calling application.
  * @memberof oval_variable
  */
-struct oval_iterator *oval_variable_get_possible_values(struct oval_variable *variable);
+struct oval_variable_possible_value_iterator *oval_variable_get_possible_values(struct oval_variable *variable);
 
 /**
  * Get list of constraints for an external variable.
@@ -1836,7 +1909,7 @@ struct oval_iterator *oval_variable_get_possible_values(struct oval_variable *va
  * It should be freed after use by the calling application.
  * @memberof oval_variable
  */
-struct oval_iterator *oval_variable_get_possible_restrictions(struct oval_variable *variable);
+struct oval_variable_possible_restriction_iterator *oval_variable_get_possible_restrictions(struct oval_variable *variable);
 
 
 /**
@@ -1845,7 +1918,7 @@ struct oval_iterator *oval_variable_get_possible_restrictions(struct oval_variab
  * It should be freed after use by the calling application.
  * @memberof oval_variable_possible_restriction
  */
-struct oval_iterator *oval_variable_possible_restriction_get_restrictions(struct oval_variable_possible_restriction *possible_restriction);
+struct oval_variable_restriction_iterator *oval_variable_possible_restriction_get_restrictions(struct oval_variable_possible_restriction *possible_restriction);
 
 /**
  * Get operator of possible_restriction element

--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -1925,7 +1925,8 @@ struct oval_component *oval_variable_get_component(struct oval_variable *);	//ty
  * It should be freed after use by the calling application.
  * @memberof oval_variable
  */
-struct oval_variable_possible_value_iterator *oval_variable_get_possible_values(struct oval_variable *variable);
+OSCAP_DEPRECATED(struct oval_iterator *oval_variable_get_possible_values(struct oval_variable *variable));
+struct oval_variable_possible_value_iterator *oval_variable_get_possible_values2(struct oval_variable *variable);
 
 /**
  * Get list of constraints for an external variable.
@@ -1933,7 +1934,8 @@ struct oval_variable_possible_value_iterator *oval_variable_get_possible_values(
  * It should be freed after use by the calling application.
  * @memberof oval_variable
  */
-struct oval_variable_possible_restriction_iterator *oval_variable_get_possible_restrictions(struct oval_variable *variable);
+OSCAP_DEPRECATED(struct oval_iterator *oval_variable_get_possible_restrictions(struct oval_variable *variable));
+struct oval_variable_possible_restriction_iterator *oval_variable_get_possible_restrictions2(struct oval_variable *variable);
 
 
 /**
@@ -1942,7 +1944,8 @@ struct oval_variable_possible_restriction_iterator *oval_variable_get_possible_r
  * It should be freed after use by the calling application.
  * @memberof oval_variable_possible_restriction
  */
-struct oval_variable_restriction_iterator *oval_variable_possible_restriction_get_restrictions(struct oval_variable_possible_restriction *possible_restriction);
+OSCAP_DEPRECATED(struct oval_iterator *oval_variable_possible_restriction_get_restrictions(struct oval_variable_possible_restriction *possible_restriction));
+struct oval_variable_restriction_iterator *oval_variable_possible_restriction_get_restrictions2(struct oval_variable_possible_restriction *possible_restriction);
 
 /**
  * Get operator of possible_restriction element

--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -1655,6 +1655,18 @@ struct oval_variable_possible_value *oval_variable_possible_value_new(const char
 void oval_variable_possible_value_free(struct oval_variable_possible_value *pv);
 
 /**
+ * Get the hint of the possible_value
+ * @memberof oval_variable_possible_value
+ */
+char* oval_variable_possible_value_get_hint(struct oval_variable_possible_value* pv);
+
+/**
+ * Get the value of the possible value
+ * @memberof oval_variable_possible_value
+ */
+char* oval_variable_possible_value_get_value(struct oval_variable_possible_value* pv);
+
+/**
  * @name Iterators
  * @{
  */
@@ -1729,6 +1741,18 @@ struct oval_variable_restriction *oval_variable_restriction_new(oval_operation_t
  * @memberof oval_variable_restriction
  */
 void oval_variable_restriction_free(struct oval_variable_restriction *r);
+
+/**
+ * Get the operation of a restriction element.
+ * @memberof oval_variable_restriction
+ */
+oval_operation_t oval_variable_restriction_get_operation(struct oval_variable_restriction* restriction);
+
+/**
+ * Get the value of a restriction element.
+ * @memberof oval_variable_restriction
+ */
+char* oval_variable_restriction_get_value(struct oval_variable_restriction* restriction);
 
 /**
  * @name Iterators
@@ -1926,6 +1950,13 @@ struct oval_variable_restriction_iterator *oval_variable_possible_restriction_ge
  * @memberof oval_variable_possible_restriction
  */
 oval_operator_t oval_variable_possible_restriction_get_operator(struct oval_variable_possible_restriction *possible_restriction);
+
+/**
+ * Get hint of possible_restriction element
+ * @return hint
+ * @memberof oval_variable_possible_restriction
+ */
+char* oval_variable_possible_restriction_get_hint(struct oval_variable_possible_restriction* possible_restriction);
 
 /**
  * Returns attribute @ref Oval_component_type->text.


### PR DESCRIPTION
These functions were previously returning the generic oscap_iterators, which are not available publicly, and there are no python swig interfaces for them.