### PR TITLE
pass session->checklist_id to oscap_htable_get in get_html_guide

### DIFF
--- a/src/DS/ds_sds_session.c
+++ b/src/DS/ds_sds_session.c
@@ -352,9 +352,9 @@ char *ds_sds_session_get_html_guide(struct ds_sds_session *session, const char *
 		"profile_id", profile_id,
 		NULL
 	};
-	struct oscap_source *xccdf = oscap_htable_get(session->component_sources, "xccdf.xml");
+	struct oscap_source *xccdf = oscap_htable_get(session->component_sources, session->checklist_id);
 	if (xccdf == NULL) {
-		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Internal error: Could not acquire handle to xccdf.xml source.");
+		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Internal error: Could not acquire handle to '%s' source.", session->checklist_id);
 		return NULL;
 	}
 	return oscap_source_apply_xslt_path_mem(xccdf, "xccdf-guide.xsl", params, oscap_path_to_xslt());


### PR DESCRIPTION
In b8defed we moved to using `s->checklist_id` instead of hard coding `xccdf.xml`. However, this change was forgotten in `ds_sds_session_get_html_guide` which leads to the following error when trying to get the HTML guide:

    Internal error: Could not acquire handle to xccdf.xml source.

This change migrates `ds_sds_session_get_html_guide` to also use `s->checklist_id` and thus fixes the issue.

Tests missing and are left to the more knowledgeable maintainer ;)

Fixes: #744