### PR TITLE
Suggest users to install bzip2-devel instead of bzip2

### DIFF
--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -521,7 +521,7 @@ AC_SUBST([vgcheck])
 
 if test "x${util_oscap_docker}" = "xyes"; then
 	if test ! "x${HAVE_BZIP2}" = xyes; then
-		AC_MSG_FAILURE(oscap-docker requires bzip2! Either disable oscap-docker or install bzip2.)
+		AC_MSG_FAILURE(oscap-docker requires bzip2! Either disable oscap-docker or install bzip2 development support.)
 	fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1238,7 +1238,7 @@ AC_SUBST([vgcheck])
 
 if test "x${util_oscap_docker}" = "xyes"; then
 	if test ! "x${HAVE_BZIP2}" = xyes; then
-		AC_MSG_FAILURE(oscap-docker requires bzip2! Either disable oscap-docker or install bzip2.)
+		AC_MSG_FAILURE(oscap-docker requires bzip2! Either disable oscap-docker or install bzip2 development support.)
 	fi
 fi
 


### PR DESCRIPTION
We use this ('devel support') and similar language as a pattern across the build pipeline.

🐟 