### PR TITLE
Added functionality for single rule evaluation

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -463,6 +463,16 @@ Where *scap-xccdf.xml* is the XCCDF document, *Desktop* is the selected
 profile from the XCCDF document, *xccdf-results.xml* is a file storing
 the scan results, and *cpe-dictionary.xml* is the CPE dictionary.
 
+* You can additionaly add ```--rule``` option to the above command to evaluate
+a specific rule:
+
+----
+$ oscap xccdf eval --profile Desktop --rule ensure_gpgcheck_globally_activated  --results xccdf-results.xml --cpe cpe-dictionary.xml scap-xccdf.xml
+----
+
+Where *ensure_gpgcheck_globally_activated* is the only rule from the *Desktop*
+profile which will be evaluated.
+
 ==== Source DataStream
 Commonly, all required input files are bundled together in Source DataStream.
 Scanning using Source DataStream is also handled by ```oscap xccdf eval``` command,

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -81,6 +81,15 @@ const char *xccdf_session_get_filename(const struct xccdf_session *session);
 bool xccdf_session_is_sds(const struct xccdf_session *session);
 
 /**
+ * Set rule for session - if rule is not NULL, session will use only this
+ * one rule.
+ * @memberof xccdf_session
+ * @param session XCCDF Session
+ * @param rule If not NULL, session will use only this rule
+ */
+void xccdf_session_set_rule(struct xccdf_session *session, const char *rule);
+
+/**
  * Set XSD validation level to one of three possibilities:
  *	- None: 	All XSD validations will be skipped.
  *	- Default:	Partial (input) XSD validations will be done.

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -63,6 +63,7 @@ struct oval_content_resource {
 
 struct xccdf_session {
 	const char *filename;				///< File name of SCAP (SDS or XCCDF) file for this session.
+	const char *rule;				///< Single-rule feature: if not NULL, the session will work only with this one rule.
 	struct oscap_source *source;                    ///< Main source assigned with the main file (SDS or XCCDF)
 	char *temp_dir;					///< Temp directory used for decomposed component files.
 	struct {
@@ -287,6 +288,11 @@ const char *xccdf_session_get_filename(const struct xccdf_session *session)
 bool xccdf_session_is_sds(const struct xccdf_session *session)
 {
 	return oscap_source_get_scap_type(session->source) == OSCAP_DOCUMENT_SDS;
+}
+
+void xccdf_session_set_rule(struct xccdf_session *session, const char *rule)
+{
+	session->rule = rule;
 }
 
 void xccdf_session_set_validation(struct xccdf_session *session, bool validate, bool full_validation)
@@ -1074,6 +1080,7 @@ int xccdf_session_evaluate(struct xccdf_session *session)
 		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Cannot build xccdf_policy.");
 		return 1;
 	}
+	policy->rule = session->rule;
 
 	session->xccdf.result = xccdf_policy_evaluate(policy);
 	if (session->xccdf.result == NULL)

--- a/src/XCCDF_POLICY/xccdf_policy_priv.h
+++ b/src/XCCDF_POLICY/xccdf_policy_priv.h
@@ -60,6 +60,8 @@ struct xccdf_policy {
 	struct xccdf_policy_model   * model;    ///< XCCDF Policy model
 	struct xccdf_profile        * profile;  ///< Profile structure (from benchmark)
 	/** A list of all selects. Either from profile or later added through API. */
+	const char *rule;			///< Single-rule feature: if not NULL, only this one rule will be selected.
+	int rule_found;				///< Single-rule feature: flag for rule - if rule is found it is set to 1 otherwise 0.
 	struct oscap_list           * selects;
 	struct oscap_list           * values;   ///< Bound values of profile
 	struct oscap_list           * results;  ///< List of XCCDF results

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -131,6 +131,11 @@ EXTRA_DIST += \
 	test_report_without_oval_poses_no_errors.sh \
 	test_report_without_oval_poses_no_errors.xccdf.xml.result.xml \
 	test_report_without_xsl_fails_gracefully.sh \
+	test_single_rule.sh \
+	test_single_rule.ds.xml \
+	test_single_rule.oval.xml \
+	test_single_rule-tailoring.xml \
+	test_single_rule.xccdf.xml \
 	test_xccdf_fix_attr_export.sh \
 	test_xccdf_fix_attr_export.xccdf.xml \
 	test_xccdf_complex_check_and_notchecked.sh \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -60,9 +60,9 @@ test_run "test xccdf resolve" $srcdir/test_xccdf_resolve.sh
 test_run "Exported arf results from xccdf without reference to oval" $srcdir/test_xccdf_results_arf_no_oval.sh
 test_run "XCCDF Substitute within Title" $srcdir/test_xccdf_sub_title.sh
 test_run "TestResult element should contain test-system attribute" $srcdir/test_xccdf_test_system.sh
-
 test_run "libxml errors handled correctly" $srcdir/test_unfinished.sh
 test_run "XCCDF 1.1 to 1.2 transformation" $srcdir/test_xccdf_transformation.sh
+test_run "Test single-rule evaluation" $srcdir/test_single_rule.sh
 
 #
 # Tests for 'oscap xccdf eval --remediate' and substitution

--- a/tests/API/XCCDF/unittests/test_single_rule-tailoring.xml
+++ b/tests/API/XCCDF/unittests/test_single_rule-tailoring.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xccdf:Tailoring xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
+  <xccdf:benchmark href="test_single_rule.ds.xml"/>
+  <xccdf:version time="2017-06-09T16:42:18">1</xccdf:version>
+  <xccdf:Profile id="xccdf_com.example.www_profile_test_single_rule_customized" extends="xccdf_com.example.www_profile_test_single_rule">
+    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">xccdf_test_profile [CUSTOMIZED]</xccdf:title>
+    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This profile is for testing.</xccdf:description>
+    <xccdf:select idref="xccdf_com.example.www_rule_test-fail" selected="false"/>
+  </xccdf:Profile>
+</xccdf:Tailoring>

--- a/tests/API/XCCDF/unittests/test_single_rule.ds.xml
+++ b/tests/API/XCCDF/unittests/test_single_rule.ds.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ds:data-stream-collection xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" id="scap_org.open-scap_collection_from_xccdf_test_single_rule.xccdf.xml" schematron-version="1.2"><ds:data-stream id="scap_org.open-scap_datastream_from_xccdf_test_single_rule.xccdf.xml" scap-version="1.2" use-case="OTHER"><ds:checklists><ds:component-ref id="scap_org.open-scap_cref_test_single_rule.xccdf.xml" xlink:href="#scap_org.open-scap_comp_test_single_rule.xccdf.xml"><cat:catalog><cat:uri name="test_single_rule.oval.xml" uri="#scap_org.open-scap_cref_test_single_rule.oval.xml"/></cat:catalog></ds:component-ref></ds:checklists><ds:checks><ds:component-ref id="scap_org.open-scap_cref_test_single_rule.oval.xml" xlink:href="#scap_org.open-scap_comp_test_single_rule.oval.xml"/></ds:checks></ds:data-stream><ds:component id="scap_org.open-scap_comp_test_single_rule.oval.xml" timestamp="2017-06-09T07:07:38"><oval_definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:win-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd    http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#windows windows-definitions-schema.xsd">
+  <generator>
+    <oval:schema_version>5.11</oval:schema_version>
+    <oval:timestamp>2009-01-12T10:41:00-05:00</oval:timestamp>
+  </generator>
+
+  <definitions>
+    <definition class="compliance" id="oval:test-pass:def:1" version="1">
+      <metadata>
+        <title>PASS</title>
+	<description>pass</description>
+      </metadata>
+      <criteria>
+        <criterion comment="PASS test" test_ref="oval:x:tst:1"/>
+      </criteria>
+    </definition>
+    <definition class="compliance" id="oval:test-fail:def:2" version="1">
+      <metadata>
+        <title>FAIL</title>
+	<description>conditional fail</description>
+      </metadata>
+      <criteria>
+        <criterion comment="FAIL test" test_ref="oval:x:tst:2"/>
+      </criteria>
+    </definition>
+  </definitions>
+
+    <tests>
+    <variable_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:tst:1" check="all" comment="always pass" version="1">
+      <object object_ref="oval:x:obj:1"/>
+    </variable_test>
+
+    <variable_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:tst:2" check="all" comment="always fail" version="1">
+      <object object_ref="oval:x:obj:1"/>
+      <state state_ref="oval:x:ste:1"/>
+    </variable_test>
+    </tests>
+
+    <objects>
+    <variable_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:obj:1" version="1" comment="x">
+      <var_ref>oval:x:var:1</var_ref>
+    </variable_object>
+    </objects>
+
+    <states>
+        <variable_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:ste:1" version="1">
+            <value datatype="int" operation="equals" var_ref="oval:ssg:var:1"/>
+        </variable_state>
+    </states>
+
+    <variables>
+      <constant_variable id="oval:x:var:1" version="1" comment="x" datatype="int">
+        <value>100</value>
+      </constant_variable>
+      <external_variable comment="default1" datatype="int" id="oval:ssg:var:1" version="1"/>
+    </variables>
+
+</oval_definitions></ds:component><ds:component id="scap_org.open-scap_comp_test_single_rule.xccdf.xml" timestamp="2017-06-09T09:15:45"><Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_com.example.www_benchmark_dummy" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="false" xml:lang="en-US">
+  <status>accepted</status>
+  <version>1.0</version>
+
+  <Profile id="xccdf_com.example.www_profile_test_single_rule">
+    <title>xccdf_test_profile</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_test-pass" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_test-fail" selected="true"/>
+    <!-- If value of val1 is bar_2, rule xccdf_test-fail_rule_2 will pass -->
+    <refine-value idref="xccdf_com.example.www_value_val1" selector="bar_2"/>
+  </Profile>
+  <Profile id="xccdf_com.example.www_profile_test_single_rule_2">
+    <title>xccdf_test_profile 2</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_test-pass" selected="false"/>
+    <select idref="xccdf_com.example.www_rule_test-fail" selected="true"/>
+  </Profile>
+
+  <Value id="xccdf_com.example.www_value_val1" type="number" operator="equals" interactive="0">
+    <title>test value</title>
+    <description>foo</description>
+    <value selector="bar_1">50</value>
+    <value selector="bar_2">100</value>
+  </Value>
+  <Rule selected="true" id="xccdf_com.example.www_rule_test-pass">
+    <title>This rule always pass</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_single_rule.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+  <Rule selected="true" id="xccdf_com.example.www_rule_test-fail">
+    <title>This rule fails if profile test_single_rule is not selected</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-export export-name="oval:ssg:var:1" value-id="xccdf_com.example.www_value_val1"/>
+      <check-content-ref href="test_single_rule.oval.xml" name="oval:test-fail:def:2"/>
+    </check>
+  </Rule>
+</Benchmark></ds:component></ds:data-stream-collection>

--- a/tests/API/XCCDF/unittests/test_single_rule.oval.xml
+++ b/tests/API/XCCDF/unittests/test_single_rule.oval.xml
@@ -1,0 +1,58 @@
+<oval_definitions xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd    http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#windows windows-definitions-schema.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:win-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+  <generator>
+    <oval:schema_version>5.11</oval:schema_version>
+    <oval:timestamp>2009-01-12T10:41:00-05:00</oval:timestamp>
+  </generator>
+
+  <definitions>
+    <definition class="compliance" id="oval:test-pass:def:1" version="1">
+      <metadata>
+        <title>PASS</title>
+	<description>pass</description>
+      </metadata>
+      <criteria>
+        <criterion comment="PASS test" test_ref="oval:x:tst:1"/>
+      </criteria>
+    </definition>
+    <definition class="compliance" id="oval:test-fail:def:2" version="1">
+      <metadata>
+        <title>FAIL</title>
+	<description>conditional fail</description>
+      </metadata>
+      <criteria>
+        <criterion comment="FAIL test" test_ref="oval:x:tst:2"/>
+      </criteria>
+    </definition>
+  </definitions>
+
+    <tests>
+    <variable_test id="oval:x:tst:1" check="all" comment="always pass" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+      <object object_ref="oval:x:obj:1"/>
+    </variable_test>
+
+    <variable_test id="oval:x:tst:2" check="all" comment="always fail" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+      <object object_ref="oval:x:obj:1"/>
+      <state state_ref="oval:x:ste:1"/>
+    </variable_test>
+    </tests>
+
+    <objects>
+    <variable_object id="oval:x:obj:1" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+      <var_ref>oval:x:var:1</var_ref>
+    </variable_object>
+    </objects>
+
+    <states>
+        <variable_state id="oval:x:ste:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <value datatype="int" operation="equals" var_ref="oval:ssg:var:1" />
+        </variable_state>
+    </states>
+
+    <variables>
+      <constant_variable id="oval:x:var:1" version="1" comment="x" datatype="int">
+        <value>100</value>
+      </constant_variable>
+      <external_variable comment="default1" datatype="int" id="oval:ssg:var:1" version="1"/>
+    </variables>
+
+</oval_definitions>

--- a/tests/API/XCCDF/unittests/test_single_rule.sh
+++ b/tests/API/XCCDF/unittests/test_single_rule.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+name=$(basename $0 .sh)
+prof1="xccdf_com.example.www_profile_test_single_rule"
+prof2="xccdf_com.example.www_profile_test_single_rule_2"
+rule_pass="xccdf_com.example.www_rule_test-pass"
+rule_fail="xccdf_com.example.www_rule_test-fail"
+result=$(mktemp -t ${name}.out.XXXXXX)
+stderr=$(mktemp -t ${name}.out.XXXXXX)
+ret=0
+echo "Stderr file = $stderr"
+echo "Result file = $result"
+
+
+#### XCCDF test cases ####
+
+# Tests that all rules from profile $prof1 (profile contains only 2 rules) are
+# evaluated when '--rule' option is not specified.
+$OSCAP xccdf eval --results $result --profile $prof1 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
+assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"pass\"]"
+:> $result
+
+# Tests that only selected passing rule from profile $prof1 is evaluated from
+# XCCDF document.
+$OSCAP xccdf eval --results $result --profile $prof1 \
+	--rule $rule_pass $srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
+assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"
+:> $result
+
+# Tests that only selected rule from XCCDF document is evaluated without
+# specifying a profile name -- this is possible as both rules in the XCCDF
+# document are selected by default.
+$OSCAP xccdf eval --results $result --rule $rule_pass \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
+assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"
+:> $result
+
+# Tests <Value> in XCCDF document which should cause a failure in evaluation
+# of the rule $rule_fail when profile $prof1 is not selected.
+$OSCAP xccdf eval --results $result --rule $rule_fail \
+	$srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
+[ $ret -eq 2 ]
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"notselected\"]"
+assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"fail\"]"
+:> $result
+
+# Tests <Value> in XCCDF document with profile $prof1 selected which should
+# cause that the rule $rule_fail will pass on its evaluation.
+$OSCAP xccdf eval --results $result --profile $prof1 \
+	--rule $rule_fail $srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"notselected\"]"
+assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"pass\"]"
+:> $result
+
+# Tests evaluation of a rule which is notselected in profile $prof2.
+$OSCAP xccdf eval --profile $prof2 \
+	--rule $rule_pass $srcdir/${name}.xccdf.xml \
+	2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+# Tests that error is printed when a non-existent rule is selected from XCCDF
+# document.
+$OSCAP xccdf eval --rule xccdf_non_existent $srcdir/${name}.xccdf.xml \
+	2> $stderr || ret=$?
+[ $ret -eq 1 ]
+[ -f $stderr ]; [ -s $stderr ]; cat $stderr; :> $stderr
+
+
+#### DS test cases ####
+
+# Tests that only selected passing rule from profile $prof1 is evaluated from
+# DS document.
+$OSCAP xccdf eval --results $result --profile $prof1 \
+	--rule $rule_pass $srcdir/${name}.ds.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
+assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"
+:> $result
+
+# Tests that only selected passing rule from profile ${prof1}_customized from
+# the tailoring file is evaluated (tailoring file was created using SCAP
+# Workbench.
+$OSCAP xccdf eval --tailoring-file $srcdir/${name}-tailoring.xml \
+	--results $result --profile ${prof1}_customized \
+	--rule $rule_pass $srcdir/${name}.ds.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
+assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"
+rm $result

--- a/tests/API/XCCDF/unittests/test_single_rule.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_single_rule.xccdf.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_com.example.www_benchmark_dummy" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="false" xml:lang="en-US">
+  <status>accepted</status>
+  <version>1.0</version>
+
+  <Profile id="xccdf_com.example.www_profile_test_single_rule">
+    <title>xccdf_test_profile</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_test-pass" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_test-fail" selected="true"/>
+    <!-- If value of val1 is bar_2, rule xccdf_test-fail_rule_2 will pass -->
+    <refine-value idref="xccdf_com.example.www_value_val1" selector="bar_2"/>
+  </Profile>
+  <Profile id="xccdf_com.example.www_profile_test_single_rule_2">
+    <title>xccdf_test_profile 2</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_test-pass" selected="false"/>
+    <select idref="xccdf_com.example.www_rule_test-fail" selected="true"/>
+  </Profile>
+
+  <Value id="xccdf_com.example.www_value_val1" type="number" operator="equals" interactive="0">
+    <title>test value</title>
+    <description>foo</description>
+    <value selector="bar_1">50</value>
+    <value selector="bar_2">100</value>
+  </Value>
+  <Rule selected="true" id="xccdf_com.example.www_rule_test-pass">
+    <title>This rule always pass</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_single_rule.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+  <Rule selected="true" id="xccdf_com.example.www_rule_test-fail">
+    <title>This rule fails if profile test_single_rule is not selected</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-export export-name="oval:ssg:var:1" value-id="xccdf_com.example.www_value_val1"/>
+      <check-content-ref href="test_single_rule.oval.xml" name="oval:test-fail:def:2"/>
+    </check>
+  </Rule>
+</Benchmark>

--- a/utils/oscap-tool.h
+++ b/utils/oscap-tool.h
@@ -118,6 +118,7 @@ struct oscap_action {
 	char *f_verbose_log;
 	/* others */
         char *profile;
+	const char *rule;
         char *show;
         char *format;
         const char *tmpl;

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -139,6 +139,7 @@ static struct oscap_module XCCDF_EVAL = {
 		"INPUT_FILE - XCCDF file or a source data stream file\n\n"
         "Options:\n"
         "   --profile <name>\r\t\t\t\t - The name of Profile to be evaluated.\n"
+	"   --rule <name>\r\t\t\t\t - The name of a single rule to be evaluated.\n"
         "   --tailoring-file <file>\r\t\t\t\t - Use given XCCDF Tailoring file.\n"
         "   --tailoring-id <component-id>\r\t\t\t\t - Use given DS component as XCCDF Tailoring file.\n"
         "   --cpe <name>\r\t\t\t\t - Use given CPE dictionary or language (autodetected)\n"
@@ -482,6 +483,7 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 	xccdf_session_set_remote_resources(session, action->remote_resources, download_reporting_callback);
 	xccdf_session_set_custom_oval_files(session, action->f_ovals);
 	xccdf_session_set_product_cpe(session, OSCAP_PRODUCTNAME);
+	xccdf_session_set_rule(session, action->rule);
 
 	if (xccdf_session_load(session) != 0)
 		goto cleanup;
@@ -915,6 +917,7 @@ enum oval_opt {
     XCCDF_OPT_XCCDF_ID,
     XCCDF_OPT_BENCHMARK_ID,
     XCCDF_OPT_PROFILE,
+    XCCDF_OPT_RULE,
     XCCDF_OPT_REPORT_FILE,
     XCCDF_OPT_SHOW,
     XCCDF_OPT_TEMPLATE,
@@ -949,6 +952,7 @@ bool getopt_xccdf(int argc, char **argv, struct oscap_action *action)
 		{"xccdf-id",		required_argument, NULL, XCCDF_OPT_XCCDF_ID},
 		{"benchmark-id",		required_argument, NULL, XCCDF_OPT_BENCHMARK_ID},
 		{"profile", 		required_argument, NULL, XCCDF_OPT_PROFILE},
+		{"rule", 		required_argument, NULL, XCCDF_OPT_RULE},
 		{"result-id",		required_argument, NULL, XCCDF_OPT_RESULT_ID},
 		{"report", 		required_argument, NULL, XCCDF_OPT_REPORT_FILE},
 		{"show", 		required_argument, NULL, XCCDF_OPT_SHOW},
@@ -991,6 +995,7 @@ bool getopt_xccdf(int argc, char **argv, struct oscap_action *action)
 		case XCCDF_OPT_XCCDF_ID:	action->f_xccdf_id = optarg; break;
 		case XCCDF_OPT_BENCHMARK_ID:	action->f_benchmark_id = optarg; break;
 		case XCCDF_OPT_PROFILE:		action->profile = optarg;	break;
+		case XCCDF_OPT_RULE:		action->rule = optarg;		break;
 		case XCCDF_OPT_RESULT_ID:	action->id = optarg;		break;
 		case XCCDF_OPT_REPORT_FILE:	action->f_report = optarg; 	break;
 		case XCCDF_OPT_SHOW:		action->show = optarg;		break;

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -75,6 +75,11 @@ You may specify OVAL Definition files as the last parameter, XCCDF evaluation wi
 Select a particular profile from XCCDF document.
 .RE
 .TP
+\fB\-\-rule RULE\fR
+.RS
+Select a particular rule from XCCDF document. Only this rule will be evaluated. Rule will use values according to the selected profile. If no profile is selected, default values are used.
+.RE
+.TP
 \fB\-\-tailoring-file TAILORING_FILE\fR
 .RS
 Use given file for XCCDF tailoring. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority!


### PR DESCRIPTION
* added '--rule' cmd option for xccdf eval
* usage:
    oscap xccdf eval [--remediate] --profile PROFILE --rule RULE INPUT_FILE