### PR TITLE
Added and implemented the xccdf_session_set_profile_id_by_suffix meth…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Makefile.in
 *.lo
 *.a
 *.la
+*.cproject
+*.project
+.settings/language.settings.xml
 
 oscap_debug.log.*
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ Makefile.in
 *.lo
 *.a
 *.la
-*.cproject
-*.project
+.cproject
+.project
 .settings/language.settings.xml
 
 oscap_debug.log.*

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -302,6 +302,15 @@ bool xccdf_session_set_report_export(struct xccdf_session *session, const char *
 bool xccdf_session_set_profile_id(struct xccdf_session *session, const char *profile_id);
 
 /**
+ *Select XCCDF Profile for evaluation with only profile suffix as input
+ *@memberof xccdf_session
+ *@param session XCCDF Session
+ *@param profile_suffix unique profile ID or suffix of the ID of the profile to set
+ *@returns true on success
+ */
+bool xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const char *profile_suffix);
+
+/**
  * Retrieves ID of the profile that we will evaluate with, or NULL.
  * @memberof xccdf_session
  * @param session XCCDF Session

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -302,13 +302,14 @@ bool xccdf_session_set_report_export(struct xccdf_session *session, const char *
 bool xccdf_session_set_profile_id(struct xccdf_session *session, const char *profile_id);
 
 /**
- *Select XCCDF Profile for evaluation with only profile suffix as input
+ *Select XCCDF Profile for evaluation with only profile suffix as input. Reports error
+ *if multiple profiles match the suffix.
  *@memberof xccdf_session
  *@param session XCCDF Session
  *@param profile_suffix unique profile ID or suffix of the ID of the profile to set
- *@returns true on success
+ *@returns 0 on success, 1 if profile is not found, and 2 if multiple matches are found.
  */
-bool xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const char *profile_suffix);
+int xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const char *profile_suffix);
 
 /**
  * Retrieves ID of the profile that we will evaluate with, or NULL.

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -486,7 +486,8 @@ int xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const 
 	} else if (multiple) {
 		return 2;
 	} else {
-		assert(xccdf_session_set_profile_id(session, full_profile_id)==0);
+		const bool search_result = xccdf_session_set_profile_id(session, full_profile_id);
+		assert(search_result);
 		return 0;
 	}
 }

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -491,7 +491,7 @@ int xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const 
 		return 2;
 	}
 	else {
-		xccdf_session_set_profile_id(session, full_profile_id);
+		assert(xccdf_session_set_profile_id(session, full_profile_id)==0);
 		return 0;
 	}
 }

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -469,7 +469,10 @@ bool xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const
 		xccdf_profile_iterator_free(profit_bench);
 	}
 
-	return xccdf_session_set_profile_id(session, full_profile_id);
+	if (full_profile_id == NULL)
+		return false;
+	else
+		return xccdf_session_set_profile_id(session, full_profile_id);
 }
 
 const char *xccdf_session_get_profile_id(struct xccdf_session *session)

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -452,12 +452,10 @@ int xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const 
 						full_profile_id, tailoring_profile_id);
 					multiple = true;
 					break;
-				}
-				else {
+				} else {
 					full_profile_id = tailoring_profile_id;
 				}
 			}
-
 		}
 		xccdf_profile_iterator_free(profit_tailoring);
 	}
@@ -475,8 +473,7 @@ int xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const 
 						full_profile_id, bench_profile_id);
 					multiple = true;
 					break;
-				}
-				else {
+				} else {
 					full_profile_id = bench_profile_id;
 				}
 			}
@@ -486,11 +483,9 @@ int xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const 
 
 	if (full_profile_id == NULL) {
 		return 1;
-	}
-	else if (multiple) {
+	} else if (multiple) {
 		return 2;
-	}
-	else {
+	} else {
 		assert(xccdf_session_set_profile_id(session, full_profile_id)==0);
 		return 0;
 	}

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -431,6 +431,47 @@ bool xccdf_session_set_profile_id(struct xccdf_session *session, const char *pro
 	return true;
 }
 
+bool xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const char *profile_suffix)
+{
+	const char *full_profile_id = NULL;
+	struct xccdf_benchmark *bench = xccdf_policy_model_get_benchmark(session->xccdf.policy_model);
+
+	// Tailoring Profiles
+	struct xccdf_tailoring *tailoring = xccdf_policy_model_get_tailoring(session->xccdf.policy_model);
+	if (tailoring != NULL)   {
+		struct xccdf_profile_iterator *profit_tailoring = xccdf_tailoring_get_profiles(tailoring);
+		while (xccdf_profile_iterator_has_more(profit_tailoring)) {
+			struct xccdf_profile *tailoring_profile = xccdf_profile_iterator_next(profit_tailoring);
+			const char *tailoring_profile_id = xccdf_profile_get_id(tailoring_profile);
+
+			if(oscap_str_endswith(tailoring_profile_id, profile_suffix)) {
+				full_profile_id = tailoring_profile_id;
+				break;
+			}
+
+		}
+		xccdf_profile_iterator_free(profit_tailoring);
+	}
+
+	// Benchmark Profiles
+	if (full_profile_id == NULL) {
+		struct xccdf_profile_iterator *profit_bench = xccdf_benchmark_get_profiles(bench);
+		while (xccdf_profile_iterator_has_more(profit_bench)) {
+			struct xccdf_profile *bench_profile = xccdf_profile_iterator_next(profit_bench);
+			const char *bench_profile_id = xccdf_profile_get_id(bench_profile);
+
+			if(oscap_str_endswith(bench_profile_id, profile_suffix)) {
+				full_profile_id = bench_profile_id;
+				break;
+			}
+		}
+
+		xccdf_profile_iterator_free(profit_bench);
+	}
+
+	return xccdf_session_set_profile_id(session, full_profile_id);
+}
+
 const char *xccdf_session_get_profile_id(struct xccdf_session *session)
 {
 	return session->xccdf.profile_id;

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -431,10 +431,12 @@ bool xccdf_session_set_profile_id(struct xccdf_session *session, const char *pro
 	return true;
 }
 
-bool xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const char *profile_suffix)
+// 0 = no error, 1 = no matches, 2 = multiple matches
+int xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const char *profile_suffix)
 {
 	const char *full_profile_id = NULL;
 	struct xccdf_benchmark *bench = xccdf_policy_model_get_benchmark(session->xccdf.policy_model);
+	bool multiple = false;
 
 	// Tailoring Profiles
 	struct xccdf_tailoring *tailoring = xccdf_policy_model_get_tailoring(session->xccdf.policy_model);
@@ -444,9 +446,16 @@ bool xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const
 			struct xccdf_profile *tailoring_profile = xccdf_profile_iterator_next(profit_tailoring);
 			const char *tailoring_profile_id = xccdf_profile_get_id(tailoring_profile);
 
-			if(oscap_str_endswith(tailoring_profile_id, profile_suffix)) {
-				full_profile_id = tailoring_profile_id;
-				break;
+			if (oscap_str_endswith(tailoring_profile_id, profile_suffix)) {
+				if (full_profile_id != NULL) {
+					oscap_seterr(OSCAP_EFAMILY_OSCAP, "Multiple matches found:\n%s\n%s\n",
+						full_profile_id, tailoring_profile_id);
+					multiple = true;
+					break;
+				}
+				else {
+					full_profile_id = tailoring_profile_id;
+				}
 			}
 
 		}
@@ -461,18 +470,30 @@ bool xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const
 			const char *bench_profile_id = xccdf_profile_get_id(bench_profile);
 
 			if(oscap_str_endswith(bench_profile_id, profile_suffix)) {
-				full_profile_id = bench_profile_id;
-				break;
+				if (full_profile_id != NULL) {
+					oscap_seterr(OSCAP_EFAMILY_OSCAP, "Multiple matches found:\n%s\n%s\n",
+						full_profile_id, bench_profile_id);
+					multiple = true;
+					break;
+				}
+				else {
+					full_profile_id = bench_profile_id;
+				}
 			}
 		}
-
 		xccdf_profile_iterator_free(profit_bench);
 	}
 
-	if (full_profile_id == NULL)
-		return false;
-	else
-		return xccdf_session_set_profile_id(session, full_profile_id);
+	if (full_profile_id == NULL) {
+		return 1;
+	}
+	else if (multiple) {
+		return 2;
+	}
+	else {
+		xccdf_session_set_profile_id(session, full_profile_id);
+		return 0;
+	}
 }
 
 const char *xccdf_session_get_profile_id(struct xccdf_session *session)

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -84,6 +84,7 @@ EXTRA_DIST += \
 	test_oval_without_definition.xccdf.xml \
 	test_profile_selection_by_suffix.sh \
 	test_profile_selection_by_suffix.xccdf.xml \
+	test_profile_selection_by_suffix_tailoring.xccdf.xml \
 	test_remediate_perl.sh \
 	test_remediate_perl.xccdf.xml \
 	test_remediate_python.sh \

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -82,6 +82,8 @@ EXTRA_DIST += \
 	test_oval_without_definition.oval.xml \
 	test_oval_without_definition.sh \
 	test_oval_without_definition.xccdf.xml \
+	test_profile_selection_by_suffix.sh \
+	test_profile_selection_by_suffix.xccdf.xml \
 	test_remediate_perl.sh \
 	test_remediate_perl.xccdf.xml \
 	test_remediate_python.sh \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -60,6 +60,8 @@ test_run "test xccdf resolve" $srcdir/test_xccdf_resolve.sh
 test_run "Exported arf results from xccdf without reference to oval" $srcdir/test_xccdf_results_arf_no_oval.sh
 test_run "XCCDF Substitute within Title" $srcdir/test_xccdf_sub_title.sh
 test_run "TestResult element should contain test-system attribute" $srcdir/test_xccdf_test_system.sh
+test_run "Profile suffix matching" $srcdir/test_profile_selection_by_suffix.sh
+
 test_run "libxml errors handled correctly" $srcdir/test_unfinished.sh
 test_run "XCCDF 1.1 to 1.2 transformation" $srcdir/test_xccdf_transformation.sh
 test_run "Test single-rule evaluation" $srcdir/test_single_rule.sh

--- a/tests/API/XCCDF/unittests/test_profile_selection_by_suffix.sh
+++ b/tests/API/XCCDF/unittests/test_profile_selection_by_suffix.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+name=$(basename $0 .sh)
+stderr=$(mktemp -t ${name}.out.XXXXXX)
+ret=0
+
+# Multiple matches should result in failure
+$OSCAP xccdf eval --profile common $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
+[ $ret -eq 1 ]
+
+# Should pass, because underscore creates unique suffix
+$OSCAP xccdf eval --profile _common $srcdir/${name}.xccdf.xml 2> $stderr
+
+# Should fail, because a profile with this suffix does not exist
+$OSCAP xccdf eval --profile xcommon $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
+[ $ret -eq 1 ]
+ 

--- a/tests/API/XCCDF/unittests/test_profile_selection_by_suffix.sh
+++ b/tests/API/XCCDF/unittests/test_profile_selection_by_suffix.sh
@@ -5,16 +5,27 @@ set -o pipefail
 
 name=$(basename $0 .sh)
 stderr=$(mktemp -t ${name}.out.XXXXXX)
+result=$(mktemp -t ${name}.out.XXXXXX)
+echo "Stderr file = $stderr"
+echo "Result file = $result"
 ret=0
 
 # Multiple matches should result in failure
 $OSCAP xccdf eval --profile common $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
 [ $ret -eq 1 ]
+# Checks that first test does result in multiple match error
+grep -Fq "Multiple matches found" $stderr
 
 # Should pass, because underscore creates unique suffix
-$OSCAP xccdf eval --profile _common $srcdir/${name}.xccdf.xml 2> $stderr
+$OSCAP xccdf eval --profile _common --results $result $srcdir/${name}.xccdf.xml 2> $stderr
+# Checks that full profile name is used in rule evaluation
+grep -Fq xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_common $result
 
 # Should fail, because a profile with this suffix does not exist
 $OSCAP xccdf eval --profile xcommon $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
 [ $ret -eq 1 ]
- 
+# Checks that last test does result in no match error
+grep -Fq "No profile matching suffix \"xcommon\" was found" $stderr
+
+[ -f $stderr ]; rm $stderr
+rm $result

--- a/tests/API/XCCDF/unittests/test_profile_selection_by_suffix.sh
+++ b/tests/API/XCCDF/unittests/test_profile_selection_by_suffix.sh
@@ -6,26 +6,51 @@ set -o pipefail
 name=$(basename $0 .sh)
 stderr=$(mktemp -t ${name}.out.XXXXXX)
 result=$(mktemp -t ${name}.out.XXXXXX)
+benchmark=$srcdir/${name}.xccdf.xml
+tailoring=$srcdir/${name}_tailoring.xccdf.xml
 echo "Stderr file = $stderr"
 echo "Result file = $result"
 ret=0
 
 # Multiple matches should result in failure
-$OSCAP xccdf eval --profile common $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
+$OSCAP xccdf eval --profile common $benchmark 2> $stderr || ret=$?
 [ $ret -eq 1 ]
 # Checks that first test does result in multiple match error
 grep -Fq "Multiple matches found" $stderr
 
 # Should pass, because underscore creates unique suffix
-$OSCAP xccdf eval --profile _common --results $result $srcdir/${name}.xccdf.xml 2> $stderr
+$OSCAP xccdf eval --profile _common --results $result $benchmark 2> $stderr
 # Checks that full profile name is used in rule evaluation
 grep -Fq xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_common $result
 
 # Should fail, because a profile with this suffix does not exist
-$OSCAP xccdf eval --profile xcommon $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
+$OSCAP xccdf eval --profile xcommon $benchmark 2> $stderr || ret=$?
 [ $ret -eq 1 ]
 # Checks that last test does result in no match error
 grep -Fq "No profile matching suffix \"xcommon\" was found" $stderr
+
+
+# Should pass, because only one match is in tailoring file, which takes precedence
+$OSCAP xccdf eval --tailoring-file $tailoring --profile common $benchmark 2> $stderr
+# Checks that full profile name is used in rule evaluation
+grep -Fq xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_common $result
+
+# Should fail, because there will be multiple suffix matches
+$OSCAP xccdf eval --tailoring-file $tailoring --profile her $benchmark 2> $stderr || ret=$?
+[ $ret -eq 1 ]
+# Checks that multiple match error does result
+grep -Fq "Multiple matches found" $stderr
+
+# Should pass, because underscore creates unique suffix
+$OSCAP xccdf eval --tailoring-file $tailoring --profile _her --results $result $benchmark 2> $stderr
+# Checks that full profile name is used in rule evaluation
+grep -Fq xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_her $result
+
+# Should fail, because a profile with this suffix does not exist
+$OSCAP xccdf eval --tailoring-file $tailoring --profile another $benchmark 2> $stderr || ret=$?
+[ $ret -eq 1 ]
+# Checks that last test does result in no match error
+grep -Fq "No profile matching suffix \"another\" was found" $stderr
 
 [ -f $stderr ]; rm $stderr
 rm $result

--- a/tests/API/XCCDF/unittests/test_profile_selection_by_suffix.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_profile_selection_by_suffix.xccdf.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+  <status>accepted</status>
+  <version>1.0</version>
+  <Profile id="xccdf_moc.elpmaxe.www_profile_common">
+    <title>is kinda compulsory</title>
+    <select idref="xccdf_moc.elpmaxe.www_rule_1" selected="false"/>
+  </Profile>
+  <Profile id="xccdf_moc.elpmaxe.www_profile_uncommon">
+    <title>is kinda not compulsory</title>
+    <select idref="xccdf_moc.elpmaxe.www_rule_1" selected="true"/>
+  </Profile>
+  <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_1">
+    <title>Ensure that file exists and it is not executable</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_remediation_simple.oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
+    </check>
+  </Rule>
+</Benchmark>

--- a/tests/API/XCCDF/unittests/test_profile_selection_by_suffix_tailoring.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_profile_selection_by_suffix_tailoring.xccdf.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xccdf:Tailoring xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
+  <xccdf:version time="2017-06-15T12:08:06">1.0</xccdf:version>
+ <xccdf:Profile id="xccdf_org.ssgproject.content_profile_verycommon" extends="xccdf_org.ssgproject.content_profile_common">
+    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">Common Profile for General-Purpose Fedora Systems </xccdf:title>
+    <xccdf:select  idref="xccdf_moc.elpmaxe.www_rule_1" selected="true"/>
+  </xccdf:Profile>
+  <xccdf:Profile id="xccdf_org.ssgproject.content_profile_other" extends="xccdf_org.ssgproject.content_profile_common">
+    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">Other Common Profile for General-Purpose Fedora Systems</xccdf:title>
+    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This profile contains items common to general-purpose Fedora installations.</xccdf:description>
+    <xccdf:select  idref="xccdf_moc.elpmaxe.www_rule_1" selected="true"/>
+  </xccdf:Profile>
+ <xccdf:Profile id="xccdf_org.ssgproject.content_profile_her" extends="xccdf_org.ssgproject.content_profile_common">
+    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">Common Profile for General-Purpose Fedora Systems [CUSTOMIZED]</xccdf:title>
+    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This profile contains items common to general-purpose Fedora installations.</xccdf:description>
+    <xccdf:select  idref="xccdf_moc.elpmaxe.www_rule_1" selected="false"/>
+  </xccdf:Profile>
+</xccdf:Tailoring>

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -507,13 +507,11 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 			if (suffix_match_result == 1) {
 				report_missing_profile(action);
 				goto cleanup;
-			}
-			else if (suffix_match_result == 2) {
+			} else if (suffix_match_result == 2) {
 				report_multiple_profile_matches(action);
 				goto cleanup;
 			}
-		}
-		else {
+		} else {
 			fprintf(stderr, "No Policy was found for default profile.\n");
 			goto cleanup;
 		}

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -494,11 +494,16 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 
 	/* Select profile */
 	if (!xccdf_session_set_profile_id(session, action->profile)) {
-		if (action->profile != NULL)
-			report_missing_profile(action);
-		else
+		if (action->profile != NULL) {
+			if (!xccdf_session_set_profile_id_by_suffix(session, action->profile)) {
+				report_missing_profile(action);
+				goto cleanup;
+			}
+		}
+		else {
 			fprintf(stderr, "No Policy was found for default profile.\n");
-		goto cleanup;
+			goto cleanup;
+		}
 	}
 
 	_register_progress_callback(session, action->progress);

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -443,7 +443,7 @@ static void _register_progress_callback(struct xccdf_session *session, bool prog
 static void report_missing_profile(const struct oscap_action *action)
 {
 	fprintf(stderr,
-		"Profile \"%s\" was not found. Get available profiles using:\n"
+		"No profile matching suffix \"%s\" was found. Get available profiles using:\n"
 		"$ oscap info \"%s\"\n", action->profile, action->f_xccdf);
 }
 


### PR DESCRIPTION
…od to xccdf_session.c to improve command line interface for the user: instead of requiring the full extended profile id, the user only needs to give the profile suffix as an argument. Later commits will make sure that only one profile matches the suffix.