### PR TITLE
RHBZ#1446451: Allow to identify problems with external variables

### DIFF
--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1462,12 +1462,21 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_VARREF(oval_argu_
 		return flag;
 	}
 
+	dIndent(1);
+	dI("Variable component references %s '%s'",
+		oval_variable_type_get_text(oval_variable_get_type(variable)),
+		oval_variable_get_id(variable));
+
 	if (argu->mode == OVAL_MODE_QUERY) {
-		if (oval_probe_query_variable(argu->u.sess, variable) != 0)
+		if (oval_probe_query_variable(argu->u.sess, variable) != 0) {
+			dIndent(-1);
 			return flag;
+		}
 	} else {
-		if (oval_syschar_model_compute_variable(argu->u.sysmod, variable) != 0)
+		if (oval_syschar_model_compute_variable(argu->u.sysmod, variable) != 0) {
+			dIndent(-1);
 			return flag;
+		}
 	}
 
 	flag = oval_variable_get_collection_flag(variable);
@@ -1480,6 +1489,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_VARREF(oval_argu_
 		oval_value_iterator_free(values);
 	}
 
+	dIndent(-1);
 	return flag;
 }
 

--- a/src/OVAL/oval_variable.c
+++ b/src/OVAL/oval_variable.c
@@ -481,6 +481,11 @@ int oval_syschar_model_compute_variable(struct oval_syschar_model *sysmod, struc
 
 static int _dump_variable_values(struct oval_variable *variable)
 {
+	if (variable->flag != SYSCHAR_FLAG_COMPLETE && variable->flag != SYSCHAR_FLAG_INCOMPLETE) {
+		dI("Variable '%s' has no values.", variable->id);
+		return 0;
+	}
+
 	struct oval_value_iterator *val_itr = oval_variable_get_values(variable);
 	if (!oval_value_iterator_has_more(val_itr)) {
 		oval_value_iterator_free(val_itr);
@@ -536,15 +541,6 @@ int oval_probe_query_variable(oval_probe_session_t *sess, struct oval_variable *
 		dW("NULL component bound to a variable, id: %s.", var->id);
 		return -1;
         }
-
-	switch (var->flag) {
-	case SYSCHAR_FLAG_COMPLETE:
-	case SYSCHAR_FLAG_INCOMPLETE:
-		break;
-	default:
-		dI("Variable '%s' has no values.", var->id);
-		return 0;
-	}
 
 	if (_dump_variable_values(variable) != 0) {
 		var->flag = SYSCHAR_FLAG_ERROR;

--- a/src/OVAL/oval_variable.c
+++ b/src/OVAL/oval_variable.c
@@ -524,14 +524,18 @@ int oval_probe_query_variable(oval_probe_session_t *sess, struct oval_variable *
 
 	__attribute__nonnull__(variable);
 
-	if (variable->type != OVAL_VARIABLE_LOCAL)
+	dI("Querying variable '%s'.", variable->id);
+
+	if (variable->type != OVAL_VARIABLE_LOCAL) {
+		dI("Variable '%s' is not local, skipping.", variable->id);
+		_dump_variable_values(variable);
 		return 0;
+	}
 
 	var = (oval_variable_LOCAL_t *) variable;
 	if (var->flag != SYSCHAR_FLAG_UNKNOWN)
 		return 0;
 
-	dI("Querying variable '%s'.", var->id);
 	component = var->component;
         if (component) {
 		if (!var->values)

--- a/src/OVAL/results/oval_resultTest.c
+++ b/src/OVAL/results/oval_resultTest.c
@@ -564,6 +564,12 @@ static oval_result_t eval_item(struct oval_syschar_model *syschar_model, struct 
 						oval_sysent_get_value(item_entity),
 						oval_sysitem_get_id(cur_sysitem), oval_state_get_id(state));
 			}
+			if (ent_val_res == OVAL_RESULT_ERROR) {
+				dI("Comparing entity '%s'='%s' of item '%s' to corresponding entity in state '%s' was not successful.",
+						oval_sysent_get_name(item_entity),
+						oval_sysent_get_value(item_entity),
+						oval_sysitem_get_id(cur_sysitem), oval_state_get_id(state));
+			}
 			if (((signed) ent_val_res) == -1) {
 				oval_sysent_iterator_free(item_entities_itr);
 				goto fail;


### PR DESCRIPTION
RHBZ#1446451 has discovered that we are unable to find reasons of errors caused by missing external variables. There was no chance that user could magically figure out that he needs to provide some external variables.

This PR wants to add a way to inform user about missing external variables by introducing some error messages.