### PR TITLE
Fix Memory leak for dpkginfo-helper found by clang analyzer

### DIFF
--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
+++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
@@ -19,6 +19,7 @@ using namespace std;
 
 static int _init_done = 0;
 static pkgCache *cgCache = NULL;
+static MMap *map = NULL;
 
 static int opencache (void) {
         if (pkgInitConfig (*_config) == false) return 0;
@@ -27,7 +28,7 @@ static int opencache (void) {
         FileFd *fd = new FileFd (_config->FindFile ("Dir::Cache::pkgcache"),
                         FileFd::ReadOnly);
 
-        MMap *map = new MMap (*fd, MMap::Public|MMap::ReadOnly);
+        map = new MMap (*fd, MMap::Public|MMap::ReadOnly);
         if (_error->PendingError () == true) {
                 _error->DumpErrors ();
                 return 0;
@@ -130,6 +131,9 @@ int dpkginfo_fini()
 {
         delete cgCache;
         cgCache = NULL;
+
+        delete map;
+        map = NULL;
 
         return 0;
 }


### PR DESCRIPTION
Hi openscap developers,

MMap *map will not be free https://github.com/OpenSCAP/openscap/blob/maint-1.2/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx#L33

Please review my patch, thanks a lot!

Regards,
Leslie Zhai - https://reviews.llvm.org/p/xiangzhai/