### PR TITLE
[WIP] Suffix/short id option for --result-id arguments 

### DIFF
--- a/src/XCCDF/benchmark.c
+++ b/src/XCCDF/benchmark.c
@@ -518,6 +518,10 @@ struct xccdf_result *xccdf_benchmark_get_result_by_id(struct xccdf_benchmark *be
 
 struct xccdf_result *xccdf_benchmark_get_result_by_id_suffix(struct xccdf_benchmark *benchmark, const char *testresult_suffix)
 {
+	struct xccdf_result *init_result = xccdf_benchmark_get_result_by_id(benchmark, testresult_suffix);
+	if (init_result != NULL)
+		return init_result;
+
 	const char *final_result_id = NULL;
 	struct xccdf_result_iterator *result_iterator = xccdf_benchmark_get_results(benchmark);
 
@@ -537,12 +541,7 @@ struct xccdf_result *xccdf_benchmark_get_result_by_id_suffix(struct xccdf_benchm
 	}
 	xccdf_result_iterator_free(result_iterator);
 
-	if (final_result_id == NULL) {
-		return NULL;
-	} else {
-		struct xccdf_result *final_result =  xccdf_benchmark_get_result_by_id(benchmark, final_result_id);
-		return final_result;
-	}
+	return xccdf_benchmark_get_result_by_id(benchmark, final_result_id);
 }
 
 bool xccdf_benchmark_add_content(struct xccdf_benchmark *bench, struct xccdf_item *item)

--- a/src/XCCDF/benchmark.c
+++ b/src/XCCDF/benchmark.c
@@ -516,6 +516,35 @@ struct xccdf_result *xccdf_benchmark_get_result_by_id(struct xccdf_benchmark *be
 	return result;
 }
 
+struct xccdf_result *xccdf_benchmark_get_result_by_id_suffix(struct xccdf_benchmark *benchmark, const char *testresult_suffix)
+{
+	const char *final_result_id = NULL;
+	struct xccdf_result_iterator *result_iterator = xccdf_benchmark_get_results(benchmark);
+
+	while (xccdf_result_iterator_has_more(result_iterator)) {
+		struct xccdf_result *result = xccdf_result_iterator_next(result_iterator);
+		const char *result_full_id = xccdf_result_get_id(result);
+
+		if (oscap_str_endswith(result_full_id, testresult_suffix)) {
+			if (final_result_id != NULL) {
+				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Multiple matches found:\n%s\n%s\n",
+					final_result_id, result_full_id);
+				break;
+			} else {
+				final_result_id = result_full_id;
+			}
+		}
+	}
+	xccdf_result_iterator_free(result_iterator);
+
+	if (final_result_id == NULL) {
+		return NULL;
+	} else {
+		struct xccdf_result *final_result =  xccdf_benchmark_get_result_by_id(benchmark, final_result_id);
+		return final_result;
+	}
+}
+
 bool xccdf_benchmark_add_content(struct xccdf_benchmark *bench, struct xccdf_item *item)
 {
 	if (item == NULL) return false;

--- a/src/XCCDF/benchmark.c
+++ b/src/XCCDF/benchmark.c
@@ -518,30 +518,28 @@ struct xccdf_result *xccdf_benchmark_get_result_by_id(struct xccdf_benchmark *be
 
 struct xccdf_result *xccdf_benchmark_get_result_by_id_suffix(struct xccdf_benchmark *benchmark, const char *testresult_suffix)
 {
-	struct xccdf_result *init_result = xccdf_benchmark_get_result_by_id(benchmark, testresult_suffix);
-	if (init_result != NULL)
-		return init_result;
+	struct xccdf_result *result = xccdf_benchmark_get_result_by_id(benchmark, testresult_suffix);
+	if (result != NULL)
+		return result;
 
-	const char *final_result_id = NULL;
 	struct xccdf_result_iterator *result_iterator = xccdf_benchmark_get_results(benchmark);
 
 	while (xccdf_result_iterator_has_more(result_iterator)) {
-		struct xccdf_result *result = xccdf_result_iterator_next(result_iterator);
-		const char *result_full_id = xccdf_result_get_id(result);
+		struct xccdf_result *temp_result = xccdf_result_iterator_next(result_iterator);
+		const char *result_full_id = xccdf_result_get_id(temp_result);
 
 		if (oscap_str_endswith(result_full_id, testresult_suffix)) {
-			if (final_result_id != NULL) {
+			if (result != NULL) {
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Multiple matches found:\n%s\n%s\n",
-					final_result_id, result_full_id);
+					xccdf_result_get_id(result), result_full_id);
 				break;
 			} else {
-				final_result_id = result_full_id;
+				result = temp_result;
 			}
 		}
 	}
 	xccdf_result_iterator_free(result_iterator);
-
-	return xccdf_benchmark_get_result_by_id(benchmark, final_result_id);
+	return result;
 }
 
 bool xccdf_benchmark_add_content(struct xccdf_benchmark *bench, struct xccdf_item *item)

--- a/src/XCCDF/item.h
+++ b/src/XCCDF/item.h
@@ -445,6 +445,7 @@ bool xccdf_benchmark_rename_item(struct xccdf_item *item, const char *newid);
 char *xccdf_benchmark_gen_id(struct xccdf_benchmark *benchmark, xccdf_type_t type, const char *prefix);
 struct xccdf_profile *xccdf_benchmark_get_profile_by_id(struct xccdf_benchmark *benchmark, const char *profile_id);
 struct xccdf_result *xccdf_benchmark_get_result_by_id(struct xccdf_benchmark *benchmark, const char *testresult_id);
+struct xccdf_result *xccdf_benchmark_get_result_by_id_suffix(struct xccdf_benchmark *benchmark, const char *testresult_suffix);
 bool xccdf_add_item(struct oscap_list *list, struct xccdf_item *parent, struct xccdf_item *item, const char *prefix);
 
 struct xccdf_tailoring *xccdf_tailoring_parse(xmlTextReaderPtr reader, struct xccdf_item* benchmark);

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -531,7 +531,7 @@ int xccdf_session_remediate(struct xccdf_session *session);
  * @memberof xccdf_session
  * @param session XCCDF Session
  * @param testresult_id ID of the TestResult element in the file (the NULL value stands
- * for the last TestResult).
+ * for the last TestResult). Suffix match is attempted if exact match is not found.
  * @returns zero on success.
  */
 int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, const char *testresult_id);

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -161,6 +161,12 @@ void xccdf_session_set_benchmark_id(struct xccdf_session *session, const char *b
 const char *xccdf_session_get_benchmark_id(struct xccdf_session *session);
 
 /**
+ * Retrieves the result id
+ * @memberof xccdf_session
+ */
+const char *xccdf_session_get_result_id(struct xccdf_session *session);
+
+/**
  * Set path to custom CPE dictionary for the session. This function is applicable
  * only before session loads. It has no effect if run afterwards.
  * @memberof xccdf_session

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1653,7 +1653,7 @@ int xccdf_session_remediate(struct xccdf_session *session)
 	return xccdf_policy_recalculate_score(xccdf_session_get_xccdf_policy(session), session->xccdf.result);
 }
 
-struct xccdf_result *xccdf_benchmark_get_result_by_id_prefix(struct xccdf_benchmark *benchmark, const char *testresult_suffix)
+struct xccdf_result *xccdf_benchmark_get_result_by_id_suffix(struct xccdf_benchmark *benchmark, const char *testresult_suffix)
 {
 	const char *final_result_id = NULL;
 	struct xccdf_result_iterator *result_iterator = xccdf_benchmark_get_results(benchmark);
@@ -1672,9 +1672,14 @@ struct xccdf_result *xccdf_benchmark_get_result_by_id_prefix(struct xccdf_benchm
 			}
 		}
 	}
-	oscap_result_iterator_free(result_iterator);
-	printf("Final id: %s\n", final_result_id);
-	return xccdf_benchmark_get_result_by_id(benchmark, final_result_id);
+	xccdf_result_iterator_free(result_iterator);
+
+	if (final_result_id == NULL) {
+		return NULL;
+	} else {
+		struct xccdf_result *final_result =  xccdf_benchmark_get_result_by_id(benchmark, final_result_id);
+		return final_result;
+	}
 }
 
 int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, const char *testresult_id)
@@ -1682,8 +1687,7 @@ int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, co
 	if (session->xccdf.result_source == NULL) {
 		session->xccdf.result = NULL;
 		struct xccdf_benchmark *benchmark = xccdf_policy_model_get_benchmark(session->xccdf.policy_model);
-		//struct xccdf_result *result = xccdf_benchmark_get_result_by_id(benchmark, testresult_id);
-		struct xccdf_result *result = xccdf_benchmark_get_result_by_id_prefix(benchmark, testresult_id);
+		struct xccdf_result *result = xccdf_benchmark_get_result_by_id_suffix(benchmark, testresult_id);
 		if (result == NULL) {
 			if (testresult_id == NULL)
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not find latest TestResult element.");

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -345,6 +345,11 @@ const char *xccdf_session_get_benchmark_id(struct xccdf_session *session)
 	return session->ds.user_benchmark_id;
 }
 
+const char *xccdf_session_get_result_id(struct xccdf_session *session)
+{
+	return xccdf_result_get_id(session->xccdf.result);
+}
+
 void xccdf_session_set_user_cpe(struct xccdf_session *session, const char *user_cpe)
 {
 	oscap_free(session->user_cpe);

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1653,12 +1653,37 @@ int xccdf_session_remediate(struct xccdf_session *session)
 	return xccdf_policy_recalculate_score(xccdf_session_get_xccdf_policy(session), session->xccdf.result);
 }
 
+struct xccdf_result *xccdf_benchmark_get_result_by_id_prefix(struct xccdf_benchmark *benchmark, const char *testresult_suffix)
+{
+	const char *final_result_id = NULL;
+	struct xccdf_result_iterator *result_iterator = xccdf_benchmark_get_results(benchmark);
+
+	while (xccdf_result_iterator_has_more(result_iterator)) {
+		struct xccdf_result *result = xccdf_result_iterator_next(result_iterator);
+		const char *result_full_id = xccdf_result_get_id(result);
+
+		if (oscap_str_endswith(result_full_id, testresult_suffix)) {
+			if (final_result_id != NULL) {
+				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Multiple matches found:\n%s\n%s\n",
+					final_result_id, result_full_id);
+				break;
+			} else {
+				final_result_id = result_full_id;
+			}
+		}
+	}
+	oscap_result_iterator_free(result_iterator);
+	printf("Final id: %s\n", final_result_id);
+	return xccdf_benchmark_get_result_by_id(benchmark, final_result_id);
+}
+
 int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, const char *testresult_id)
 {
 	if (session->xccdf.result_source == NULL) {
 		session->xccdf.result = NULL;
 		struct xccdf_benchmark *benchmark = xccdf_policy_model_get_benchmark(session->xccdf.policy_model);
-		struct xccdf_result *result = xccdf_benchmark_get_result_by_id(benchmark, testresult_id);
+		//struct xccdf_result *result = xccdf_benchmark_get_result_by_id(benchmark, testresult_id);
+		struct xccdf_result *result = xccdf_benchmark_get_result_by_id_prefix(benchmark, testresult_id);
 		if (result == NULL) {
 			if (testresult_id == NULL)
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not find latest TestResult element.");

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1653,35 +1653,6 @@ int xccdf_session_remediate(struct xccdf_session *session)
 	return xccdf_policy_recalculate_score(xccdf_session_get_xccdf_policy(session), session->xccdf.result);
 }
 
-struct xccdf_result *xccdf_benchmark_get_result_by_id_suffix(struct xccdf_benchmark *benchmark, const char *testresult_suffix)
-{
-	const char *final_result_id = NULL;
-	struct xccdf_result_iterator *result_iterator = xccdf_benchmark_get_results(benchmark);
-
-	while (xccdf_result_iterator_has_more(result_iterator)) {
-		struct xccdf_result *result = xccdf_result_iterator_next(result_iterator);
-		const char *result_full_id = xccdf_result_get_id(result);
-
-		if (oscap_str_endswith(result_full_id, testresult_suffix)) {
-			if (final_result_id != NULL) {
-				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Multiple matches found:\n%s\n%s\n",
-					final_result_id, result_full_id);
-				break;
-			} else {
-				final_result_id = result_full_id;
-			}
-		}
-	}
-	xccdf_result_iterator_free(result_iterator);
-
-	if (final_result_id == NULL) {
-		return NULL;
-	} else {
-		struct xccdf_result *final_result =  xccdf_benchmark_get_result_by_id(benchmark, final_result_id);
-		return final_result;
-	}
-}
-
 int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, const char *testresult_id)
 {
 	if (session->xccdf.result_source == NULL) {

--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -71,6 +71,8 @@ EXTRA_DIST += \
 	test_fix_instance.xccdf.xml \
 	test_fix_filtering.xccdf.xml \
 	test_fix_filtering.sh \
+	test_fix_resultid_by_suffix.sh \
+	test_fix_resultid_by_suffix.xml \
 	test_fix_script_header.sh \
 	test_fix_script_header.xccdf.xml \
 	test_inherit_selector.oval.xml \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -107,5 +107,6 @@ test_run "generate fix: ensure filtering drop fixes" $srcdir/test_fix_filtering.
 test_run "generate fix: generate header for bash script" $srcdir/test_fix_script_header.sh
 test_run "generate fix: from result DataStream" $srcdir/test_fix_arf.sh
 test_run "generate fix: result id selection by suffix" $srcdir/test_fix_resultid_by_suffix.sh
+test_run "generate fix: from result DataStream" $srcdir/test_fix_arf.sh
 
 test_exit

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -106,5 +106,6 @@ test_run "generate fix: just as the anaconda does + DataStream" $srcdir/test_rep
 test_run "generate fix: ensure filtering drop fixes" $srcdir/test_fix_filtering.sh
 test_run "generate fix: generate header for bash script" $srcdir/test_fix_script_header.sh
 test_run "generate fix: from result DataStream" $srcdir/test_fix_arf.sh
+test_run "generate fix: result id selection by suffix" $srcdir/test_fix_resultid_by_suffix.sh
 
 test_exit

--- a/tests/API/XCCDF/unittests/test_fix_resultid_by_suffix.sh
+++ b/tests/API/XCCDF/unittests/test_fix_resultid_by_suffix.sh
@@ -1,36 +1,33 @@
 #!/bin/bash
 
-set -x
 set -e
 set -o pipefail
 
 name=$(basename $0 .sh)
 stderr=$(mktemp -t ${name}.out.XXXXXX)
-stdout=$(mktemp -t ${name}.out.XXXXXX)
-result=$(mktemp -t ${name}.out.XXXXXX)
 script=$(mktemp -t ${name}.sh.XXXXXX)
-benchmark=$srcdir/${name}.xccdf.xml
-profile="xccdf_moc.elpmaxe.www_profile_standard"
-profile2="xccdf_moc.elpmaxe.www_profile_common"
+result=$srcdir/${name}.xml
 echo "Stderr file = $stderr"
 echo "Result file = $result"
 ret=0
 
-# First evaluate benchmark
-$OSCAP xccdf eval --profile $profile --profile $profile2 --results-arf $result $benchmark >$stdout 2>$stderr || [ $? == 2 ]
-[ -f $stdout ]; [ -s $stdout ]; rm $stdout
-[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+# Should pass, unique TestResult ID suffix
+$OSCAP xccdf generate fix --result-id standard --output $script $result 2> $stderr
+# Checks that full result id is used in rule evaluation
+# grep -Fq xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_standard $script
 
 # Should pass, because underscore creates unique suffix
 $OSCAP xccdf generate fix --result-id _common --output $script $result 2> $stderr
 # Checks that full result id is used in rule evaluation
+# Will work with script header generation 
 # grep -Fq xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_common $script
 
 # Should fail, because result with this id suffix does not exist
 $OSCAP xccdf generate fix --result-id rare --output $script $result 2> $stderr || ret=$?
 [ $ret -eq 1 ]
 # Checks that last test does result in no match error
-grep -Fq "No profile matching suffix \"rare\" was found" $stderr
+# Will work with script header generation 
+grep -Fq "Could not find TestResult/@id=\"rare\"" $stderr
 
 # Multiple matches should result in failure
 $OSCAP xccdf generate fix --result-id common --output $script $result 2> $stderr || ret=$?
@@ -39,5 +36,4 @@ $OSCAP xccdf generate fix --result-id common --output $script $result 2> $stderr
 grep -Fq "Multiple matches found" $stderr
 
 [ -f $stderr ]; rm $stderr
-rm $result
 rm $script

--- a/tests/API/XCCDF/unittests/test_fix_resultid_by_suffix.sh
+++ b/tests/API/XCCDF/unittests/test_fix_resultid_by_suffix.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -x
+set -e
+set -o pipefail
+
+name=$(basename $0 .sh)
+stderr=$(mktemp -t ${name}.out.XXXXXX)
+stdout=$(mktemp -t ${name}.out.XXXXXX)
+result=$(mktemp -t ${name}.out.XXXXXX)
+script=$(mktemp -t ${name}.sh.XXXXXX)
+benchmark=$srcdir/${name}.xccdf.xml
+profile="xccdf_moc.elpmaxe.www_profile_standard"
+profile2="xccdf_moc.elpmaxe.www_profile_common"
+echo "Stderr file = $stderr"
+echo "Result file = $result"
+ret=0
+
+# First evaluate benchmark
+$OSCAP xccdf eval --profile $profile --profile $profile2 --results-arf $result $benchmark >$stdout 2>$stderr || [ $? == 2 ]
+[ -f $stdout ]; [ -s $stdout ]; rm $stdout
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
+# Should pass, because underscore creates unique suffix
+$OSCAP xccdf generate fix --result-id _common --output $script $result 2> $stderr
+# Checks that full result id is used in rule evaluation
+# grep -Fq xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_common $script
+
+# Should fail, because result with this id suffix does not exist
+$OSCAP xccdf generate fix --result-id rare --output $script $result 2> $stderr || ret=$?
+[ $ret -eq 1 ]
+# Checks that last test does result in no match error
+grep -Fq "No profile matching suffix \"rare\" was found" $stderr
+
+# Multiple matches should result in failure
+$OSCAP xccdf generate fix --result-id common --output $script $result 2> $stderr || ret=$?
+[ $ret -eq 1 ]
+# Checks that first test does result in multiple match error
+grep -Fq "Multiple matches found" $stderr
+
+[ -f $stderr ]; rm $stderr
+rm $result
+rm $script

--- a/tests/API/XCCDF/unittests/test_fix_resultid_by_suffix.xml
+++ b/tests/API/XCCDF/unittests/test_fix_resultid_by_suffix.xml
@@ -1,0 +1,158 @@
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_moc.elpmaxe.www_benchmark_test" resolved="1">
+  <status>incomplete</status>
+  <title xmlns:xhtml="http://www.w3.org/1999/xhtml">Security Benchmark</title>
+  <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">A sample benchmark</description>
+  <version>1.0</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <model system="urn:xccdf:scoring:flat"/>
+  <model system="urn:xccdf:scoring:flat-unweighted"/>
+  <model system="urn:xccdf:scoring:absolute"/>
+  <Profile id="xccdf_moc.elpmaxe.www_profile_standard">
+    <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">Standard System Security Profile</title>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">This profile contains rules to ensure standard security baseline of your system.</description>
+    <select idref="xccdf_moc.elpmaxe.www_rule_1" selected="true"/>
+    <select idref="xccdf_moc.elpmaxe.www_rule_2" selected="true"/>
+  </Profile>
+  <Profile id="xccdf_moc.elpmaxe.www_profile_common">
+    <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">Common Security Profile</title>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">This profile contains rules to ensure standard security baseline of your system.</description>
+    <select idref="xccdf_moc.elpmaxe.www_rule_1" selected="true"/>
+    <select idref="xccdf_moc.elpmaxe.www_rule_2" selected="true"/>
+  </Profile>
+  <Profile id="xccdf_moc.elpmaxe.www_profile_uncommon">
+    <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">Uncommon Security Profile</title>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">This profile contains rules to ensure standard security baseline of your system.</description>
+    <select idref="xccdf_moc.elpmaxe.www_rule_1" selected="true"/>
+    <select idref="xccdf_moc.elpmaxe.www_rule_2" selected="true"/>
+  </Profile>
+  <Rule id="xccdf_moc.elpmaxe.www_rule_1" selected="false">
+    <title xmlns:xhtml="http://www.w3.org/1999/xhtml">Passing rule</title>
+    <fix xmlns:xhtml="http://www.w3.org/1999/xhtml" id="bash_fix_for_passing_rule" system="urn:xccdf:fix:script:sh">echo this_is_ok</fix>
+    <fix xmlns:xhtml="http://www.w3.org/1999/xhtml" id="ansible_fix_for_passing_rule" system="urn:xccdf:fix:script:ansible">- name: ensure everything passes
+    shell: /bin/true</fix>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref name="oval:moc.elpmaxe.www:def:1" href="oval/pass/oval.xml"/>
+    </check>
+  </Rule>
+  <Rule id="xccdf_moc.elpmaxe.www_rule_2" selected="false">
+    <title xmlns:xhtml="http://www.w3.org/1999/xhtml">Failing rule</title>
+    <fix xmlns:xhtml="http://www.w3.org/1999/xhtml" id="fix_for_failing_rule" system="urn:xccdf:fix:script:sh">echo fix_me_please</fix>
+    <fix xmlns:xhtml="http://www.w3.org/1999/xhtml" id="ansible_fix_for_failing_rule" system="urn:xccdf:fix:script:ansible">- name: correct the failing case
+    shell: /bin/false</fix>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref name="oval:moc.elpmaxe.www:def:1" href="oval/fail/oval.xml"/>
+    </check>
+  </Rule>
+  <TestResult id="xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_common" start-time="2017-06-30T14:04:25" end-time="2017-06-30T14:04:25" version="1.0" test-system="cpe:/a:redhat:openscap:1.2.15">
+    <benchmark href="./test_fix_resultid_by_suffix.xccdf.xml" id="xccdf_moc.elpmaxe.www_benchmark_test"/>
+    <title>OSCAP Scan Result</title>
+    <identity authenticated="false" privileged="false">kjankov</identity>
+    <profile idref="xccdf_moc.elpmaxe.www_profile_common"/>
+    <target>localhost.localdomain</target>
+    <target-address>127.0.0.1</target-address>
+    <target-address>10.18.57.26</target-address>
+    <target-address>0:0:0:0:0:0:0:1</target-address>
+    <target-address>2620:52:0:1238:a5a3:450:3839:6fb3</target-address>
+    <target-address>fe80:0:0:0:942a:b1b:9eb7:cd74</target-address>
+    <target-facts>
+      <fact name="urn:xccdf:fact:scanner:name" type="string">OpenSCAP</fact>
+      <fact name="urn:xccdf:fact:scanner:version" type="string">1.2.15</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">00:00:00:00:00:00</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">28:D2:44:EA:54:01</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">00:00:00:00:00:00</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">28:D2:44:EA:54:01</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">28:D2:44:EA:54:01</fact>
+    </target-facts>
+    <rule-result idref="xccdf_moc.elpmaxe.www_rule_1" time="2017-06-30T14:04:25" weight="1.000000">
+      <result>pass</result>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:moc.elpmaxe.www:def:1" href="oval/pass/oval.xml"/>
+      </check>
+    </rule-result>
+    <rule-result idref="xccdf_moc.elpmaxe.www_rule_2" time="2017-06-30T14:04:25" weight="1.000000">
+      <result>fail</result>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:moc.elpmaxe.www:def:1" href="oval/fail/oval.xml"/>
+      </check>
+    </rule-result>
+    <score system="urn:xccdf:scoring:default" maximum="100.000000">50.000000</score>
+    <score system="urn:xccdf:scoring:flat" maximum="2.000000">1.000000</score>
+    <score system="urn:xccdf:scoring:flat-unweighted" maximum="2.000000">1.000000</score>
+    <score system="urn:xccdf:scoring:absolute" maximum="2.000000">0.000000</score>
+  </TestResult>
+  <TestResult id="xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_uncommon" start-time="2017-06-30T14:04:25" end-time="2017-06-30T14:04:25" version="1.0" test-system="cpe:/a:redhat:openscap:1.2.15">
+    <benchmark href="./test_fix_resultid_by_suffix.xccdf.xml" id="xccdf_moc.elpmaxe.www_benchmark_test"/>
+    <title>OSCAP Scan Result</title>
+    <identity authenticated="false" privileged="false">kjankov</identity>
+    <profile idref="xccdf_moc.elpmaxe.www_profile_uncommon"/>
+    <target>localhost.localdomain</target>
+    <target-address>127.0.0.1</target-address>
+    <target-address>10.18.57.26</target-address>
+    <target-address>0:0:0:0:0:0:0:1</target-address>
+    <target-address>2620:52:0:1238:a5a3:450:3839:6fb3</target-address>
+    <target-address>fe80:0:0:0:942a:b1b:9eb7:cd74</target-address>
+    <target-facts>
+      <fact name="urn:xccdf:fact:scanner:name" type="string">OpenSCAP</fact>
+      <fact name="urn:xccdf:fact:scanner:version" type="string">1.2.15</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">00:00:00:00:00:00</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">28:D2:44:EA:54:01</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">00:00:00:00:00:00</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">28:D2:44:EA:54:01</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">28:D2:44:EA:54:01</fact>
+    </target-facts>
+    <rule-result idref="xccdf_moc.elpmaxe.www_rule_1" time="2017-06-30T14:04:25" weight="1.000000">
+      <result>pass</result>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:moc.elpmaxe.www:def:1" href="oval/pass/oval.xml"/>
+      </check>
+    </rule-result>
+    <rule-result idref="xccdf_moc.elpmaxe.www_rule_2" time="2017-06-30T14:04:25" weight="1.000000">
+      <result>fail</result>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:moc.elpmaxe.www:def:1" href="oval/fail/oval.xml"/>
+      </check>
+    </rule-result>
+    <score system="urn:xccdf:scoring:default" maximum="100.000000">50.000000</score>
+    <score system="urn:xccdf:scoring:flat" maximum="2.000000">1.000000</score>
+    <score system="urn:xccdf:scoring:flat-unweighted" maximum="2.000000">1.000000</score>
+    <score system="urn:xccdf:scoring:absolute" maximum="2.000000">0.000000</score>
+  </TestResult>
+  <TestResult id="xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_standard" start-time="2017-06-30T14:04:25" end-time="2017-06-30T14:04:25" version="1.0" test-system="cpe:/a:redhat:openscap:1.2.15">
+    <benchmark href="./test_fix_resultid_by_suffix.xccdf.xml" id="xccdf_moc.elpmaxe.www_benchmark_test"/>
+    <title>OSCAP Scan Result</title>
+    <identity authenticated="false" privileged="false">kjankov</identity>
+    <profile idref="xccdf_moc.elpmaxe.www_profile_standard"/>
+    <target>localhost.localdomain</target>
+    <target-address>127.0.0.1</target-address>
+    <target-address>10.18.57.26</target-address>
+    <target-address>0:0:0:0:0:0:0:1</target-address>
+    <target-address>2620:52:0:1238:a5a3:450:3839:6fb3</target-address>
+    <target-address>fe80:0:0:0:942a:b1b:9eb7:cd74</target-address>
+    <target-facts>
+      <fact name="urn:xccdf:fact:scanner:name" type="string">OpenSCAP</fact>
+      <fact name="urn:xccdf:fact:scanner:version" type="string">1.2.15</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">00:00:00:00:00:00</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">28:D2:44:EA:54:01</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">00:00:00:00:00:00</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">28:D2:44:EA:54:01</fact>
+      <fact name="urn:xccdf:fact:ethernet:MAC" type="string">28:D2:44:EA:54:01</fact>
+    </target-facts>
+    <rule-result idref="xccdf_moc.elpmaxe.www_rule_1" time="2017-06-30T14:04:25" weight="1.000000">
+      <result>pass</result>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:moc.elpmaxe.www:def:1" href="oval/pass/oval.xml"/>
+      </check>
+    </rule-result>
+    <rule-result idref="xccdf_moc.elpmaxe.www_rule_2" time="2017-06-30T14:04:25" weight="1.000000">
+      <result>fail</result>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:moc.elpmaxe.www:def:1" href="oval/fail/oval.xml"/>
+      </check>
+    </rule-result>
+    <score system="urn:xccdf:scoring:default" maximum="100.000000">50.000000</score>
+    <score system="urn:xccdf:scoring:flat" maximum="2.000000">1.000000</score>
+    <score system="urn:xccdf:scoring:flat-unweighted" maximum="2.000000">1.000000</score>
+    <score system="urn:xccdf:scoring:absolute" maximum="2.000000">0.000000</score>
+  </TestResult>
+</Benchmark>
+

--- a/tests/API/XCCDF/unittests/test_fix_resultid_by_suffix.xml
+++ b/tests/API/XCCDF/unittests/test_fix_resultid_by_suffix.xml
@@ -155,4 +155,3 @@
     <score system="urn:xccdf:scoring:absolute" maximum="2.000000">0.000000</score>
   </TestResult>
 </Benchmark>
-

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -852,7 +852,7 @@ int app_generate_fix(const struct oscap_action *action)
 			goto cleanup2;
 
 		struct xccdf_policy *policy = xccdf_session_get_xccdf_policy(session);
-		struct xccdf_result *result = xccdf_policy_get_result_by_id(policy, action->id);
+		struct xccdf_result *result = xccdf_policy_get_result_by_id(policy, xccdf_session_get_result_id(session));
 		if (xccdf_policy_generate_fix(policy, result, action->tmpl, output_fd) == 0)
 			ret = OSCAP_OK;
 	} else { // Fallback to profile if result id is missing


### PR DESCRIPTION
Allows for user to input suffix for the result id; i.e., common instead of xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_common 
Works for xccdf generate fix --result-id and xccdf generate report --result-id