### PR TITLE
Implement xccdf requires

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -1001,11 +1001,11 @@ _xccdf_policy_rule_evaluate(struct xccdf_policy * policy, const struct xccdf_rul
 		// One requires element has no idref met
 		if (!any_require_selected) {
 			all_requires_met = false;
-			dI("A requires element from Rule '%s' requires that any of the following XCCDF Items is also selected.", rule_id);
+			dW("A requires element from Rule '%s' requires that any of the following XCCDF Items is also selected.", rule_id);
 			requires_ids = oscap_stringlist_get_strings(requires_element);
 			while (oscap_string_iterator_has_more(requires_ids)) {
 				const char *requires_id = oscap_string_iterator_next(requires_ids);
-				dI("%s", requires_id);
+				dW("%s", requires_id);
 			}
 			oscap_string_iterator_free(requires_ids);
 		}
@@ -1013,7 +1013,7 @@ _xccdf_policy_rule_evaluate(struct xccdf_policy * policy, const struct xccdf_rul
 	oscap_stringlist_iterator_free(requires_elements);
 
 	if (!all_requires_met) {
-		dI("Rule '%s' will be unselected because one of its requires element was not met.", rule_id);
+		dW("Rule '%s' will be unselected because one of its requires element was not met.", rule_id);
 
 		// We need to report result before unselecting rule
 		// This is necessary for the callback to know if a rule result is notselected

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -1015,9 +1015,14 @@ _xccdf_policy_rule_evaluate(struct xccdf_policy * policy, const struct xccdf_rul
 	if (!all_requires_met) {
 		dI("Rule '%s' will be unselected because one of its requires element was not met.", rule_id);
 
+		// We need to report result before unselecting rule
+		// This is necessary for the callback to know if a rule result is notselected
+		// because its @selected is false or any requires elemant was not met
+		int report_rule_result = _xccdf_policy_report_rule_result(policy, result, rule, NULL, XCCDF_RESULT_NOT_SELECTED, "At least one requires element was not met.");
+
 		// Remove rule from hash table
 		oscap_htable_detach(policy->selected_final, rule_id);
-		return _xccdf_policy_report_rule_result(policy, result, rule, NULL, XCCDF_RESULT_NOT_SELECTED, "At least one requires element was not met.");
+		return report_rule_result;
 	}
 
 	if (role == XCCDF_ROLE_UNCHECKED)

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -590,10 +590,8 @@ xccdf_policy_is_item_selected(struct xccdf_policy *policy, const char *id)
 {
 	const bool *tmp = (const bool*) oscap_htable_get(policy->selected_final, id);
 	if (tmp	== NULL) {
-		/* This shall really never happen. All valid IDs of any
-		 * xccdf:Item shall be stored in the dictionery. However,
-		 * we shall not to segfault. */
-		assert(false);
+		// This can happen when a Rule is changed to 'notselected' because it contains
+		// requires or conflicts elements not met.
 		return false;
 	}
 	return *tmp;

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -65,6 +65,7 @@ test_run "Profile suffix matching" $srcdir/test_profile_selection_by_suffix.sh
 test_run "libxml errors handled correctly" $srcdir/test_unfinished.sh
 test_run "XCCDF 1.1 to 1.2 transformation" $srcdir/test_xccdf_transformation.sh
 test_run "Test single-rule evaluation" $srcdir/test_single_rule.sh
+test_run "Test XCCDF requires" $srcdir/test_requires.sh
 
 #
 # Tests for 'oscap xccdf eval --remediate' and substitution

--- a/tests/API/XCCDF/unittests/test_requires.oval.xml
+++ b/tests/API/XCCDF/unittests/test_requires.oval.xml
@@ -1,0 +1,38 @@
+<oval_definitions xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd    http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#windows windows-definitions-schema.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:win-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+  <generator>
+    <oval:schema_version>5.11</oval:schema_version>
+    <oval:timestamp>2009-01-12T10:41:00-05:00</oval:timestamp>
+  </generator>
+
+  <definitions>
+    <definition class="compliance" id="oval:test-pass:def:1" version="1">
+      <metadata>
+        <title>PASS</title>
+        <description>pass</description>
+      </metadata>
+      <criteria>
+        <criterion comment="PASS test" test_ref="oval:x:tst:1"/>
+      </criteria>
+    </definition>
+  </definitions>
+
+    <tests>
+    <variable_test id="oval:x:tst:1" check="all" comment="always pass" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+      <object object_ref="oval:x:obj:1"/>
+    </variable_test>
+    </tests>
+
+    <objects>
+    <variable_object id="oval:x:obj:1" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+      <var_ref>oval:x:var:1</var_ref>
+    </variable_object>
+    </objects>
+
+    <variables>
+      <constant_variable id="oval:x:var:1" version="1" comment="x" datatype="int">
+        <value>100</value>
+      </constant_variable>
+      <external_variable comment="default1" datatype="int" id="oval:ssg:var:1" version="1"/>
+    </variables>
+
+</oval_definitions>

--- a/tests/API/XCCDF/unittests/test_requires.sh
+++ b/tests/API/XCCDF/unittests/test_requires.sh
@@ -23,9 +23,9 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 
 
-#### XCCDF test cases ####
+#### XCCDF requires test cases ####
 
-# Tests that all rules from profile $prof1 are selected and evaluated when
+# Tests requires from profile $prof1
 $OSCAP xccdf eval --results $result --profile $prof1 \
 	$srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
@@ -37,7 +37,7 @@ assert_exists 6 "//rule-result/result[text()=\"notselected\"]"
 assert_exists 0 "//rule-result/result[text()=\"fail\"]"
 :> $result
 
-# Tests that all rules from profile $prof1 are selected and evaluated when
+# Tests requires from profile $prof2
 $OSCAP xccdf eval --results $result --profile $prof2 \
 	$srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
@@ -47,52 +47,62 @@ $OSCAP xccdf validate-xml $result
 assert_exists 3 "//rule-result/result[text()=\"pass\"]"
 assert_exists 7 "//rule-result/result[text()=\"notselected\"]"
 assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+:> $result
 
-# Tests that all rules from profile $prof1 are selected and evaluated when
+# Tests requires from profile $prof3
 $OSCAP xccdf eval --results $result --profile $prof3 \
 	$srcdir/${name}.xccdf.xml 2> $stderr
-[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+grep -q "'xccdf_com.example.www_rule_2' will be unselected" $stderr
+:> $stderr
 
 $OSCAP xccdf validate-xml $result
 
 assert_exists 2 "//rule-result/result[text()=\"pass\"]"
 assert_exists 8 "//rule-result/result[text()=\"notselected\"]"
 assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+:> $result
 
-# Tests that all rules from profile $prof1 are selected and evaluated when
+# Tests requires from profile $prof4
 $OSCAP xccdf eval --results $result --profile $prof4 \
 	$srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
 $OSCAP xccdf validate-xml $result
 
+assert_exists 4 "//rule-result/result[text()=\"pass\"]"
+assert_exists 6 "//rule-result/result[text()=\"notselected\"]"
+assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+:> $result
+
+# Tests requires from profile $prof5
+$OSCAP xccdf eval --results $result --profile $prof5 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+grep -q "'xccdf_com.example.www_rule_6' will be unselected" $stderr
+grep -q "'xccdf_com.example.www_rule_7' will be unselected" $stderr
+grep -q "'xccdf_com.example.www_rule_8' will be unselected" $stderr
+:> $stderr
+
+$OSCAP xccdf validate-xml $result
+
 assert_exists 0 "//rule-result/result[text()=\"pass\"]"
 assert_exists 10 "//rule-result/result[text()=\"notselected\"]"
 assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+:> $result
 
-# Tests that all rules from profile $prof1 are selected and evaluated when
-$OSCAP xccdf eval --results $result --profile $prof5 \
+# Tests requires from profile $prof6
+$OSCAP xccdf eval --results $result --profile $prof6 \
 	$srcdir/${name}.xccdf.xml 2> $stderr
-[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+grep -q "'xccdf_com.example.www_rule_8' will be unselected" $stderr
+:> $stderr
 
 $OSCAP xccdf validate-xml $result
 
 assert_exists 2 "//rule-result/result[text()=\"pass\"]"
 assert_exists 8 "//rule-result/result[text()=\"notselected\"]"
 assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+:> $result
 
-# Tests that all rules from profile $prof1 are selected and evaluated when
-$OSCAP xccdf eval --results $result --profile $prof6 \
-	$srcdir/${name}.xccdf.xml 2> $stderr
-[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
-
-$OSCAP xccdf validate-xml $result
-
-assert_exists 3 "//rule-result/result[text()=\"pass\"]"
-assert_exists 7 "//rule-result/result[text()=\"notselected\"]"
-assert_exists 0 "//rule-result/result[text()=\"fail\"]"
-
-# Tests that all rules from profile $prof1 are selected and evaluated when
+# Tests requires from profile $prof7
 $OSCAP xccdf eval --results $result --profile $prof7 \
 	$srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
@@ -102,19 +112,22 @@ $OSCAP xccdf validate-xml $result
 assert_exists 3 "//rule-result/result[text()=\"pass\"]"
 assert_exists 7 "//rule-result/result[text()=\"notselected\"]"
 assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+:> $result
 
-# Tests that all rules from profile $prof1 are selected and evaluated when
+# Tests requires from profile $prof8
 $OSCAP xccdf eval --results $result --profile $prof8 \
 	$srcdir/${name}.xccdf.xml 2> $stderr
-[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+grep -q "'xccdf_com.example.www_rule_9' will be unselected" $stderr
+:> $stderr
 
 $OSCAP xccdf validate-xml $result
 
 assert_exists 1 "//rule-result/result[text()=\"pass\"]"
 assert_exists 9 "//rule-result/result[text()=\"notselected\"]"
 assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+:> $result
 
-# Tests that all rules from profile $prof1 are selected and evaluated when
+# Tests requires from profile $prof9
 $OSCAP xccdf eval --results $result --profile $prof9 \
 	$srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
@@ -124,11 +137,13 @@ $OSCAP xccdf validate-xml $result
 assert_exists 3 "//rule-result/result[text()=\"pass\"]"
 assert_exists 7 "//rule-result/result[text()=\"notselected\"]"
 assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+:> $result
 
-# Tests that all rules from profile $prof1 are selected and evaluated when
+# Tests requires from profile $prof10
 $OSCAP xccdf eval --results $result --profile $prof10 \
 	$srcdir/${name}.xccdf.xml 2> $stderr
-[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+grep -q "'xccdf_com.example.www_rule_10' will be unselected" $stderr
+:> $stderr
 
 $OSCAP xccdf validate-xml $result
 

--- a/tests/API/XCCDF/unittests/test_requires.sh
+++ b/tests/API/XCCDF/unittests/test_requires.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+name=$(basename $0 .sh)
+prof1="xccdf_com.example.www_profile_test_requires_1"
+prof2="xccdf_com.example.www_profile_test_requires_2"
+prof3="xccdf_com.example.www_profile_test_requires_3"
+prof4="xccdf_com.example.www_profile_test_requires_4"
+prof5="xccdf_com.example.www_profile_test_requires_5"
+prof6="xccdf_com.example.www_profile_test_requires_6"
+prof7="xccdf_com.example.www_profile_test_requires_7"
+prof8="xccdf_com.example.www_profile_test_requires_8"
+prof9="xccdf_com.example.www_profile_test_requires_9"
+prof10="xccdf_com.example.www_profile_test_requires_10"
+rule_pass="xccdf_com.example.www_rule_test-pass"
+rule_fail="xccdf_com.example.www_rule_test-fail"
+result=$(mktemp -t ${name}.out.XXXXXX)
+stderr=$(mktemp -t ${name}.out.XXXXXX)
+ret=0
+echo "Stderr file = $stderr"
+echo "Result file = $result"
+
+
+#### XCCDF test cases ####
+
+# Tests that all rules from profile $prof1 are selected and evaluated when
+$OSCAP xccdf eval --results $result --profile $prof1 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 4 "//rule-result/result[text()=\"pass\"]"
+assert_exists 6 "//rule-result/result[text()=\"notselected\"]"
+assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+:> $result
+
+# Tests that all rules from profile $prof1 are selected and evaluated when
+$OSCAP xccdf eval --results $result --profile $prof2 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 3 "//rule-result/result[text()=\"pass\"]"
+assert_exists 7 "//rule-result/result[text()=\"notselected\"]"
+assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+
+# Tests that all rules from profile $prof1 are selected and evaluated when
+$OSCAP xccdf eval --results $result --profile $prof3 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 2 "//rule-result/result[text()=\"pass\"]"
+assert_exists 8 "//rule-result/result[text()=\"notselected\"]"
+assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+
+# Tests that all rules from profile $prof1 are selected and evaluated when
+$OSCAP xccdf eval --results $result --profile $prof4 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 0 "//rule-result/result[text()=\"pass\"]"
+assert_exists 10 "//rule-result/result[text()=\"notselected\"]"
+assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+
+# Tests that all rules from profile $prof1 are selected and evaluated when
+$OSCAP xccdf eval --results $result --profile $prof5 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 2 "//rule-result/result[text()=\"pass\"]"
+assert_exists 8 "//rule-result/result[text()=\"notselected\"]"
+assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+
+# Tests that all rules from profile $prof1 are selected and evaluated when
+$OSCAP xccdf eval --results $result --profile $prof6 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 3 "//rule-result/result[text()=\"pass\"]"
+assert_exists 7 "//rule-result/result[text()=\"notselected\"]"
+assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+
+# Tests that all rules from profile $prof1 are selected and evaluated when
+$OSCAP xccdf eval --results $result --profile $prof7 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 3 "//rule-result/result[text()=\"pass\"]"
+assert_exists 7 "//rule-result/result[text()=\"notselected\"]"
+assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+
+# Tests that all rules from profile $prof1 are selected and evaluated when
+$OSCAP xccdf eval --results $result --profile $prof8 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 1 "//rule-result/result[text()=\"pass\"]"
+assert_exists 9 "//rule-result/result[text()=\"notselected\"]"
+assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+
+# Tests that all rules from profile $prof1 are selected and evaluated when
+$OSCAP xccdf eval --results $result --profile $prof9 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 3 "//rule-result/result[text()=\"pass\"]"
+assert_exists 7 "//rule-result/result[text()=\"notselected\"]"
+assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+
+# Tests that all rules from profile $prof1 are selected and evaluated when
+$OSCAP xccdf eval --results $result --profile $prof10 \
+	$srcdir/${name}.xccdf.xml 2> $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+$OSCAP xccdf validate-xml $result
+
+assert_exists 2 "//rule-result/result[text()=\"pass\"]"
+assert_exists 8 "//rule-result/result[text()=\"notselected\"]"
+assert_exists 0 "//rule-result/result[text()=\"fail\"]"
+
+rm $result

--- a/tests/API/XCCDF/unittests/test_requires.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_requires.xccdf.xml
@@ -5,7 +5,7 @@
 
   <Profile id="xccdf_com.example.www_profile_test_requires_1">
     <title>xccdf_test_requires_1</title>
-    <description>This profile is for testing requires.</description>
+    <description>Tests a forward chain of requires.</description>
     <select idref="xccdf_com.example.www_rule_1" selected="true"/>
     <select idref="xccdf_com.example.www_rule_2" selected="true"/>
     <select idref="xccdf_com.example.www_rule_3" selected="true"/>
@@ -14,7 +14,7 @@
 
   <Profile id="xccdf_com.example.www_profile_test_requires_2">
     <title>xccdf_test_requires 2</title>
-    <description>This profile is for testing.</description>
+    <description>Tests a forward chain of requires with first rule unselected.</description>
     <select idref="xccdf_com.example.www_rule_1" selected="false"/>
     <select idref="xccdf_com.example.www_rule_2" selected="true"/>
     <select idref="xccdf_com.example.www_rule_3" selected="true"/>
@@ -23,7 +23,7 @@
 
   <Profile id="xccdf_com.example.www_profile_test_requires_3">
     <title>xccdf_test_requires 3</title>
-    <description>This profile is for testing.</description>
+    <description>Tests a forward chain of requires with third rule unselected.</description>
     <select idref="xccdf_com.example.www_rule_1" selected="true"/>
     <select idref="xccdf_com.example.www_rule_2" selected="true"/>
     <select idref="xccdf_com.example.www_rule_3" selected="false"/>
@@ -32,8 +32,8 @@
 
   <Profile id="xccdf_com.example.www_profile_test_requires_4">
     <title>xccdf_test_requires_4</title>
-    <description>This profile is for testing requires.</description>
-    <select idref="xccdf_com.example.www_rule_5" selected="false"/>
+    <description>Tests a backward chain of requires.</description>
+    <select idref="xccdf_com.example.www_rule_5" selected="true"/>
     <select idref="xccdf_com.example.www_rule_6" selected="true"/>
     <select idref="xccdf_com.example.www_rule_7" selected="true"/>
     <select idref="xccdf_com.example.www_rule_8" selected="true"/>
@@ -41,25 +41,25 @@
 
   <Profile id="xccdf_com.example.www_profile_test_requires_5">
     <title>xccdf_test_requires 5</title>
-    <description>This profile is for testing.</description>
+    <description>Tests a backward chain of requires with first rule unselected.</description>
+    <select idref="xccdf_com.example.www_rule_5" selected="false"/>
+    <select idref="xccdf_com.example.www_rule_6" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_7" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_8" selected="true"/>
+  </Profile>
+
+  <Profile id="xccdf_com.example.www_profile_test_requires_6">
+    <title>xccdf_test_requires 6</title>
+    <description>Tests a backward chain of requires with third rule unselected.</description>
     <select idref="xccdf_com.example.www_rule_5" selected="true"/>
     <select idref="xccdf_com.example.www_rule_6" selected="true"/>
     <select idref="xccdf_com.example.www_rule_7" selected="false"/>
     <select idref="xccdf_com.example.www_rule_8" selected="true"/>
   </Profile>
 
-  <Profile id="xccdf_com.example.www_profile_test_requires_6">
-    <title>xccdf_test_requires 6</title>
-    <description>This profile is for testing.</description>
-    <select idref="xccdf_com.example.www_rule_5" selected="true"/>
-    <select idref="xccdf_com.example.www_rule_6" selected="true"/>
-    <select idref="xccdf_com.example.www_rule_7" selected="true"/>
-    <select idref="xccdf_com.example.www_rule_8" selected="false"/>
-  </Profile>
-
   <Profile id="xccdf_com.example.www_profile_test_requires_7">
     <title>xccdf_test_requires 7</title>
-    <description>This profile is for testing.</description>
+    <description>Tests a rule with two requires met.</description>
     <select idref="xccdf_com.example.www_rule_5" selected="true"/>
     <select idref="xccdf_com.example.www_rule_6" selected="true"/>
     <select idref="xccdf_com.example.www_rule_9" selected="true"/>
@@ -67,7 +67,7 @@
 
   <Profile id="xccdf_com.example.www_profile_test_requires_8">
     <title>xccdf_test_requires 8</title>
-    <description>This profile is for testing.</description>
+    <description>Tests a rule with two requires, one met and the other not.</description>
     <select idref="xccdf_com.example.www_rule_5" selected="true"/>
     <select idref="xccdf_com.example.www_rule_6" selected="false"/>
     <select idref="xccdf_com.example.www_rule_9" selected="true"/>
@@ -75,17 +75,21 @@
 
   <Profile id="xccdf_com.example.www_profile_test_requires_9">
     <title>xccdf_test_requires 9</title>
-    <description>This profile is for testing.</description>
+    <description>Tests a rule with two lists of requires.</description>
+    <select idref="xccdf_com.example.www_rule_3" selected="false"/>
     <select idref="xccdf_com.example.www_rule_4" selected="true"/>
     <select idref="xccdf_com.example.www_rule_5" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_6" selected="false"/>
     <select idref="xccdf_com.example.www_rule_10" selected="true"/>
   </Profile>
 
   <Profile id="xccdf_com.example.www_profile_test_requires_10">
     <title>xccdf_test_requires 10</title>
-    <description>This profile is for testing.</description>
+    <description>Tests a rule with two lists of requires, one met and the other not.</description>
     <select idref="xccdf_com.example.www_rule_3" selected="true"/>
     <select idref="xccdf_com.example.www_rule_4" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_5" selected="false"/>
+    <select idref="xccdf_com.example.www_rule_6" selected="false"/>
     <select idref="xccdf_com.example.www_rule_10" selected="true"/>
   </Profile>
 

--- a/tests/API/XCCDF/unittests/test_requires.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_requires.xccdf.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_com.example.www_benchmark_dummy" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="false" xml:lang="en-US">
+  <status>accepted</status>
+  <version>1.0</version>
+
+  <Profile id="xccdf_com.example.www_profile_test_requires_1">
+    <title>xccdf_test_requires_1</title>
+    <description>This profile is for testing requires.</description>
+    <select idref="xccdf_com.example.www_rule_1" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_2" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_3" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_4" selected="true"/>
+  </Profile>
+
+  <Profile id="xccdf_com.example.www_profile_test_requires_2">
+    <title>xccdf_test_requires 2</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_1" selected="false"/>
+    <select idref="xccdf_com.example.www_rule_2" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_3" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_4" selected="true"/>
+  </Profile>
+
+  <Profile id="xccdf_com.example.www_profile_test_requires_3">
+    <title>xccdf_test_requires 3</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_1" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_2" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_3" selected="false"/>
+    <select idref="xccdf_com.example.www_rule_4" selected="true"/>
+  </Profile>
+
+  <Profile id="xccdf_com.example.www_profile_test_requires_4">
+    <title>xccdf_test_requires_4</title>
+    <description>This profile is for testing requires.</description>
+    <select idref="xccdf_com.example.www_rule_5" selected="false"/>
+    <select idref="xccdf_com.example.www_rule_6" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_7" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_8" selected="true"/>
+  </Profile>
+
+  <Profile id="xccdf_com.example.www_profile_test_requires_5">
+    <title>xccdf_test_requires 5</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_5" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_6" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_7" selected="false"/>
+    <select idref="xccdf_com.example.www_rule_8" selected="true"/>
+  </Profile>
+
+  <Profile id="xccdf_com.example.www_profile_test_requires_6">
+    <title>xccdf_test_requires 6</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_5" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_6" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_7" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_8" selected="false"/>
+  </Profile>
+
+  <Profile id="xccdf_com.example.www_profile_test_requires_7">
+    <title>xccdf_test_requires 7</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_5" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_6" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_9" selected="true"/>
+  </Profile>
+
+  <Profile id="xccdf_com.example.www_profile_test_requires_8">
+    <title>xccdf_test_requires 8</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_5" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_6" selected="false"/>
+    <select idref="xccdf_com.example.www_rule_9" selected="true"/>
+  </Profile>
+
+  <Profile id="xccdf_com.example.www_profile_test_requires_9">
+    <title>xccdf_test_requires 9</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_4" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_5" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_10" selected="true"/>
+  </Profile>
+
+  <Profile id="xccdf_com.example.www_profile_test_requires_10">
+    <title>xccdf_test_requires 10</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_3" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_4" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_10" selected="true"/>
+  </Profile>
+
+  <Rule selected="false" id="xccdf_com.example.www_rule_1">
+    <title>Rule number 1</title>
+    <requires idref="xccdf_com.example.www_rule_2"/>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_requires.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+  <Rule selected="false" id="xccdf_com.example.www_rule_2">
+    <title>Rule number 2</title>
+    <requires idref="xccdf_com.example.www_rule_3"/>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_requires.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+  <Rule selected="false" id="xccdf_com.example.www_rule_3">
+    <title>Rule number 3</title>
+    <requires idref="xccdf_com.example.www_rule_4"/>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_requires.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+  <Rule selected="false" id="xccdf_com.example.www_rule_4">
+    <title>Rule number 4</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_requires.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+
+  <Rule selected="false" id="xccdf_com.example.www_rule_5">
+    <title>Rule number 5</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_requires.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+  <Rule selected="false" id="xccdf_com.example.www_rule_6">
+    <title>Rule number 6</title>
+    <requires idref="xccdf_com.example.www_rule_5"/>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_requires.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+  <Rule selected="false" id="xccdf_com.example.www_rule_7">
+    <title>Rule number 7</title>
+    <requires idref="xccdf_com.example.www_rule_6"/>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_requires.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+  <Rule selected="false" id="xccdf_com.example.www_rule_8">
+    <title>Rule number 8</title>
+    <requires idref="xccdf_com.example.www_rule_7"/>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_requires.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+
+  <Rule selected="false" id="xccdf_com.example.www_rule_9">
+    <title>Rule number 9</title>
+    <requires idref="xccdf_com.example.www_rule_5"/>
+    <requires idref="xccdf_com.example.www_rule_6"/>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_requires.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+  
+  <Rule selected="false" id="xccdf_com.example.www_rule_10">
+    <title>Rule number 10</title>
+    <requires idref="xccdf_com.example.www_rule_3 xccdf_com.example.www_rule_4"/>
+    <requires idref="xccdf_com.example.www_rule_5 xccdf_com.example.www_rule_6"/>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_requires.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+
+</Benchmark>

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -345,8 +345,10 @@ static int callback_scr_result(struct xccdf_rule_result *rule_result, void *arg)
 {
 	xccdf_test_result_type_t result = xccdf_rule_result_get_result(rule_result);
 
-	/* is result from selected rule? we print only selected rules */
-	if (result == XCCDF_RESULT_NOT_SELECTED)
+	const bool selected = xccdf_policy_is_item_selected((struct xccdf_policy *) arg, xccdf_rule_result_get_idref(rule_result));
+	// Is result from selected rule? We print only selected rules
+	// Even when result from a selected rule is 'notselected'
+	if (!selected)
 		return 0;
 
 	/* print result */
@@ -379,8 +381,10 @@ static int callback_scr_result_progress(struct xccdf_rule_result *rule_result, v
 {
 	xccdf_test_result_type_t result = xccdf_rule_result_get_result(rule_result);
 
-	/* is result from selected rule? we print only selected rules */
-	if (result == XCCDF_RESULT_NOT_SELECTED)
+	const bool selected = xccdf_policy_is_item_selected((struct xccdf_policy *) arg, xccdf_rule_result_get_idref(rule_result));
+	// Is result from selected rule? We print only selected rules
+	// Even when result from a selected rule is 'notselected'
+	if (!selected)
 		return 0;
 
 	/* print result */
@@ -430,12 +434,14 @@ static void _register_progress_callback(struct xccdf_session *session, bool prog
 	if (progress) {
 		xccdf_policy_model_register_start_callback(policy_model, callback_scr_rule_progress,
 				(void *) xccdf_session_get_xccdf_policy(session));
-		xccdf_policy_model_register_output_callback(policy_model, callback_scr_result_progress, NULL);
+		xccdf_policy_model_register_output_callback(policy_model, callback_scr_result_progress,
+				(void *) xccdf_session_get_xccdf_policy(session));
 	}
 	else {
 		xccdf_policy_model_register_start_callback(policy_model, callback_scr_rule,
 				(void *) xccdf_session_get_xccdf_policy(session));
-		xccdf_policy_model_register_output_callback(policy_model, callback_scr_result, NULL);
+		xccdf_policy_model_register_output_callback(policy_model, callback_scr_result,
+				(void *) xccdf_session_get_xccdf_policy(session));
 	}
 	/* xccdf_policy_model_register_output_callback(policy_model, callback_syslog_result, NULL); */
 }


### PR DESCRIPTION
Parse XCCDF `requires` element and check if their `idrefs` are selected.
Rule results in 'notselected' if any `requires` element is not met.