### PR TITLE
Fixes crash when deallocating rbt_node in windows

### DIFF
--- a/src/OVAL/probes/SEAP/generic/rbt/rbt_common.c
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt_common.c
@@ -92,7 +92,14 @@ void rbt_free(rbt_t *rbt, void (*callback)(void *))
                                         callback((void *)&(rbt_walk_top()->_node));
 
                                 n = rbt_node_ptr(rbt_walk_top()->_chld[RBT_NODE_SR]);
+#ifndef _WIN32
                                 free(rbt_walk_top());
+#else
+				// using free for memory allocated through _aligned_malloc is illegal
+				// rbt_str.c -> rbt_str_node_alloc
+				// https://msdn.microsoft.com/en-us/library/8z34s9c6.aspx
+				_aligned_free(rbt_walk_top());
+#endif
 
                                 if (n != NULL)
                                         rbt_walk_top() = n;
@@ -142,7 +149,14 @@ void rbt_free2(rbt_t *rbt, void (*callback)(void *, void *), void *user)
                                         callback((void *)&(rbt_walk_top()->_node), user);
 
                                 n = rbt_node_ptr(rbt_walk_top()->_chld[RBT_NODE_SR]);
+#ifndef _WIN32
                                 free(rbt_walk_top());
+#else
+				// using free for memory allocated through _aligned_malloc is illegal
+				// rbt_str.c -> rbt_str_node_alloc
+				// https://msdn.microsoft.com/en-us/library/8z34s9c6.aspx
+				_aligned_free(rbt_walk_top());
+#endif
 
                                 if (n != NULL)
                                         rbt_walk_top() = n;

--- a/src/OVAL/probes/SEAP/generic/rbt/rbt_i32.c
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt_i32.c
@@ -52,7 +52,16 @@ static struct rbt_node *rbt_i32_node_alloc(void)
 static void rbt_i32_node_free(struct rbt_node *n)
 {
         if (n != NULL)
+	{
+#ifndef _WIN32
                 free(rbt_node_ptr(n));
+#else
+		// using free for memory allocated through _aligned_malloc is illegal
+		// rbt_i32.c -> rbt_i32_node_alloc
+		// https://msdn.microsoft.com/en-us/library/8z34s9c6.aspx
+		_aligned_free(rbt_node_ptr(n));
+#endif
+	}
 }
 
 rbt_t *rbt_i32_new (void)

--- a/src/OVAL/probes/SEAP/generic/rbt/rbt_i64.c
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt_i64.c
@@ -51,7 +51,16 @@ static struct rbt_node *rbt_i64_node_alloc(void)
 static void rbt_i64_node_free(struct rbt_node *n)
 {
         if (n != NULL)
+	{
+#ifndef _WIN32
                 free(rbt_node_ptr(n));
+#else
+		// using free for memory allocated through _aligned_malloc is illegal
+		// rbt_i64.c -> rbt_i64_node_alloc
+		// https://msdn.microsoft.com/en-us/library/8z34s9c6.aspx
+		_aligned_free(rbt_node_ptr(n));
+#endif
+	}
 }
 
 rbt_t *rbt_i64_new (void)


### PR DESCRIPTION
Fixes OpenSCAP/scap-workbench#129 and OpenSCAP/scap-workbench#61

Signed-off-by: Wesley Ceraso Prudencio <wcerasop@redhat.com>