### PR TITLE
Issue #715: Fix resource leaks reported by Coverity

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -783,11 +783,11 @@ int xccdf_policy_generate_fix(struct xccdf_policy *policy, struct xccdf_result *
 	}
 	else {
 		dI("Generating result-oriented fixes for policy(result/@id=%s)", xccdf_result_get_id(result));
-		struct xccdf_rule_result_iterator *rr_it = xccdf_result_get_rule_results(result);
 
 		if (_write_script_header_to_fd(policy, result, sys, output_fd) != 0)
 			return 1;
 
+		struct xccdf_rule_result_iterator *rr_it = xccdf_result_get_rule_results(result);
 		while (xccdf_rule_result_iterator_has_more(rr_it)) {
 			struct xccdf_rule_result *rr = xccdf_rule_result_iterator_next(rr_it);
 			if (xccdf_rule_result_get_result(rr) != XCCDF_RESULT_FAIL)

--- a/utils/oscap-info.c
+++ b/utils/oscap-info.c
@@ -391,15 +391,24 @@ static int app_info(const struct oscap_action *action)
 
 				struct oscap_source *report_source = ds_rds_session_select_report(session, report_id);
 				if (report_source == NULL) {
+					rds_report_index_iterator_free(report_it);
+					rds_asset_index_iterator_free(asset_it);
+					ds_rds_session_free(session);
 					goto cleanup;
 				}
 				oscap_document_type_t report_source_type = oscap_source_get_scap_type(report_source);
 				if (report_source_type != OSCAP_DOCUMENT_XCCDF) {
+					rds_report_index_iterator_free(report_it);
+					rds_asset_index_iterator_free(asset_it);
+					ds_rds_session_free(session);
 					oscap_source_free(report_source);
 					goto cleanup;
 				}
 				struct xccdf_result *xccdf_result = xccdf_result_import_source(report_source);
 				if (xccdf_result == NULL) {
+					rds_report_index_iterator_free(report_it);
+					rds_asset_index_iterator_free(asset_it);
+					ds_rds_session_free(session);
 					oscap_source_free(report_source);
 					goto cleanup;
 				}


### PR DESCRIPTION
Addressing:
openscap-1.2.14/utils/oscap-info.c:399: leaked_storage: Variable "report_it" going out of scope leaks the storage it points to.
openscap-1.2.14/utils/oscap-info.c:399: leaked_storage: Variable "asset_it" going out of scope leaks the storage it points to.
openscap-1.2.14/utils/oscap-info.c:394: leaked_storage: Variable "session" going out of scope leaks the storage it points to.
openscap-1.2.14/utils/oscap-info.c:394: leaked_storage: Variable "report_it" going out of scope leaks the storage it points to.
openscap-1.2.14/utils/oscap-info.c:394: leaked_storage: Variable "asset_it" going out of scope leaks the storage it points to.
openscap-1.2.14/src/XCCDF_POLICY/xccdf_policy_remediate.c:647: leaked_storage: Variable "rr_it" going out of scope leaks the storage it points to.