### PR TITLE
Issue #773: Ensure that bash fixes are always selected

### DIFF
--- a/tests/API/XCCDF/fix/results-xccdf11.xml
+++ b/tests/API/XCCDF/fix/results-xccdf11.xml
@@ -4,7 +4,7 @@
   <version>1.0</version>
   <model system="urn:xccdf:scoring:default"/>
   <Rule id="xccdf_moc.elpmaxe.www_rule_1" selected="true">
-    <fix>
+    <fix system="urn:xccdf:fix:script:sh">
 echo
     </fix>
     <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -12,7 +12,7 @@ echo
     </check>
   </Rule>
   <Rule id="xccdf_moc.elpmaxe.www_rule_2" selected="true">
-    <fix>
+    <fix system="urn:xccdf:fix:script:sh">
 bad
     </fix>
     <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">

--- a/tests/API/XCCDF/fix/results-xccdf12.xml
+++ b/tests/API/XCCDF/fix/results-xccdf12.xml
@@ -4,7 +4,7 @@
   <version>1.0</version>
   <model system="urn:xccdf:scoring:default"/>
   <Rule id="xccdf_moc.elpmaxe.www_rule_1" selected="true">
-    <fix>
+    <fix system="urn:xccdf:fix:script:sh">
 echo
     </fix>
     <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -12,7 +12,7 @@ echo
     </check>
   </Rule>
   <Rule id="xccdf_moc.elpmaxe.www_rule_2" selected="true">
-    <fix>
+    <fix system="urn:xccdf:fix:script:sh">
 bad
     </fix>
     <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">

--- a/utils/oscap-tool.h
+++ b/utils/oscap-tool.h
@@ -154,6 +154,7 @@ struct oscap_action {
         int list_dynamic;
 	char *probe_root;
 	char *verbosity_level;
+	char *fix_type;
 };
 
 int app_xslt(const char *infile, const char *xsltfile, const char *outfile, const char **params);

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -846,6 +846,7 @@ int app_generate_fix(const struct oscap_action *action)
 		}
 	}
 
+	const char *template = action->tmpl == NULL ? "urn:xccdf:fix:script:sh" : action->tmpl;
 	if (action->id != NULL) {
 		/* Result-oriented fixes */
 		if (xccdf_session_build_policy_from_testresult(session, action->id) != 0)
@@ -853,7 +854,7 @@ int app_generate_fix(const struct oscap_action *action)
 
 		struct xccdf_policy *policy = xccdf_session_get_xccdf_policy(session);
 		struct xccdf_result *result = xccdf_policy_get_result_by_id(policy, xccdf_session_get_result_id(session));
-		if (xccdf_policy_generate_fix(policy, result, action->tmpl, output_fd) == 0)
+		if (xccdf_policy_generate_fix(policy, result, template, output_fd) == 0)
 			ret = OSCAP_OK;
 	} else { // Fallback to profile if result id is missing
 		/* Profile-oriented fixes */
@@ -873,7 +874,7 @@ int app_generate_fix(const struct oscap_action *action)
 			}
 		}
 		struct xccdf_policy *policy = xccdf_session_get_xccdf_policy(session);
-		if (xccdf_policy_generate_fix(policy, NULL, action->tmpl, output_fd) == 0)
+		if (xccdf_policy_generate_fix(policy, NULL, template, output_fd) == 0)
 			ret = OSCAP_OK;
 	}
 cleanup2:

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -331,6 +331,9 @@ Result-oriented fixes are generated using result-id provided to select only the 
 .TP
 Profile-oriented fixes are generated using all rules within the provided profile. If no result-id/profile are provided, (default) profile will be used to generate fixes.
 .TP
+\fB\-\-fix-type TYPE\fR
+Specify fix type. There are multiple programming languages in which the fix script can be generated. TYPE should be one of: bash, ansible, puppet, anaconda. Default is bash. This option is mutually exclusive with --template, because fix type already determines the template URN.
+.TP
 \fB\-\-output FILE\fR
 Write the report to this file instead of standard output.
 .TP


### PR DESCRIPTION
Bash is a default language for remediation scripts. If we don't
provide a template explicitely, the result script shouldn't
contain Ansible or other snippets.