### PR TITLE
Added line that assigns default bash template when template argument …

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -91,7 +91,6 @@ static int _write_remediation_to_fd_and_free(int output_fd, const char* template
 {
 	if (oscap_streq(template, "urn:xccdf:fix:script:ansible")) {
 		// Add required indentation in front of every single line
-
 		const char delim = '\n';
 		const char *indentation = "    ";
 
@@ -579,6 +578,9 @@ static int _write_fix_missing_warning_to_fd(const char *sys, int output_fd, stru
 
 static inline int _xccdf_policy_rule_generate_fix(struct xccdf_policy *policy, struct xccdf_rule *rule, const char *template, int output_fd, unsigned int current, unsigned int total)
 {
+	if (template == NULL)
+		template = "urn:xccdf:fix:script:sh";
+
 	// Ensure that given Rule is selected and applicable (CPE).
 	const bool is_selected = xccdf_policy_is_item_selected(policy, xccdf_rule_get_id(rule));
 	if (!is_selected) {


### PR DESCRIPTION
…is missing from generate fix. Ensures that both bash and ansible scripts don't appear in same file

In function _find_fix_for_template in xccdf_policy_remediate.c, fixes for rules are only filtered by template if template is not null. Thus if template is null, no filtering occurs, and both bash and ansible scripts will be printed, but a missing template argument should default to bash script only. This fix assigns a null template to a bash template. 