### PR TITLE
Removed line that overwrites the original result start time that is s…

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1684,7 +1684,7 @@ int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, co
 	struct xccdf_policy *xccdf_policy = xccdf_session_get_xccdf_policy(session);
 	if (xccdf_policy == NULL)
 		return 1;
-	xccdf_result_set_start_time_current(session->xccdf.result);
+
 	xccdf_policy_add_result(xccdf_policy, session->xccdf.result);
 	return 0;
 }


### PR DESCRIPTION
…et at the beginning of evaluation