### PR TITLE
tests/mitre/test_mitre.sh: do not run SELinux test on systems without SELinux

### DIFF
--- a/tests/mitre/test_mitre.sh
+++ b/tests/mitre/test_mitre.sh
@@ -15,6 +15,8 @@ EXTVARFILE="${MITRE_FILES}/var/linux-external-variables.xml"
 DISTRO="$(cat /etc/*-release | head -n1)"
 DISTRO_NAME="$(cat /etc/*-release | awk '{print $1}' | head -n1)"
 DISTRO_RELEASE="$(cat /etc/*-release | sed -n 's|^[^0-9]*\([0-9]*\).*$|\1|p' | head -n1)"
+SELINUX_ENABLED=$(grep -iqE "(SELINUX=enforcing|SELINUX=permissive)" \
+	/etc/selinux/config 2>/dev/null; echo $?)
 
 function test_mitre {
 
@@ -105,7 +107,10 @@ if [[ ( ${DISTRO#Fedora} != "$DISTRO" && $DISTRO_RELEASE -lt 18 ) || \
 	test_run "linux-def_selinuxboolean_test.xml" test_mitre linux-def_selinuxboolean_test.xml "true"
 fi
 
-test_run "linux-def_selinuxsecuritycontext_test.xml" test_mitre linux-def_selinuxsecuritycontext_test.xml "true"
+if [ $SELINUX_ENABLED -eq 0 ]; then
+	test_run "linux-def_selinuxsecuritycontext_test.xml" test_mitre linux-def_selinuxsecuritycontext_test.xml "true"
+fi
+
 test_run "linux-def_inetlisteningservers_test.xml" test_mitre linux-def_inetlisteningservers_test.xml "true"
 
 test_run "oval_binary_datatype.xml" test_mitre oval_binary_datatype.xml "true"


### PR DESCRIPTION
* added check if SELinux is enabled and if it is not the test
  linux-def_selinuxsecuritycontext_test.xml is skipped