### PR TITLE
[WIP] Fast iterator

### DIFF
--- a/src/common/list.c
+++ b/src/common/list.c
@@ -189,17 +189,17 @@ void* oscap_list_find(struct oscap_list *list, void *what, oscap_cmp_func compar
 	if (list == NULL) return false;
 	if (compare == NULL) compare = oscap_ptr_cmp;
 
-	struct oscap_iterator *it = oscap_iterator_new(list);
+	struct oscap_fast_iterator *it = oscap_fast_iterator_new(list);
 
-	while (_oscap_iterator_has_more_internal(it)) {
-		void *item = oscap_iterator_next(it);
+	while (oscap_fast_iterator_has_more(it)) {
+		void *item = oscap_fast_iterator_next(it);
 		if (compare(item, what)) {
-			oscap_iterator_free(it);
+			oscap_fast_iterator_free(it);
 			return item;
 		}
 	}
 
-	oscap_iterator_free(it);
+	oscap_fast_iterator_free(it);
 	return NULL;
 }
 

--- a/src/common/list.h
+++ b/src/common/list.h
@@ -114,7 +114,7 @@ inline size_t oscap_fast_iterator_get_itemcount(const struct oscap_fast_iterator
 	return it->list->itemcount;
 }
 inline bool oscap_fast_iterator_has_more(struct oscap_fast_iterator *it) {
-	if (!it->list || !it->list->first)
+	if (!it->list->first)
 		return false;
 	if (it->cur == NULL)
 		return true;

--- a/src/common/list.h
+++ b/src/common/list.h
@@ -88,6 +88,11 @@ struct oscap_iterator {
 	void *user_data;
 };
 
+struct oscap_fast_iterator {
+	struct oscap_list_item *cur;
+	struct oscap_list *list;
+};
+
 // FIXME: SCE engine uses these
 OSCAP_HIDDEN_END;
 
@@ -99,6 +104,27 @@ bool oscap_iterator_has_more(struct oscap_iterator *it);
 void oscap_iterator_reset(struct oscap_iterator *it);
 void *oscap_iterator_detach(struct oscap_iterator *it);
 void oscap_iterator_free(struct oscap_iterator *it);
+
+void *oscap_fast_iterator_new(struct oscap_list *list);
+inline void *oscap_fast_iterator_next(struct oscap_fast_iterator *it) {
+	it->cur = (it->cur ? it->cur->next : it->list->first);
+	return it->cur->data;
+}
+inline size_t oscap_fast_iterator_get_itemcount(const struct oscap_fast_iterator *it) {
+	return it->list->itemcount;
+}
+inline bool oscap_fast_iterator_has_more(struct oscap_fast_iterator *it) {
+	if (!it->list || !it->list->first)
+		return false;
+	if (it->cur == NULL)
+		return true;
+	return it->cur->next != NULL;
+}
+inline void oscap_fast_iterator_reset(struct oscap_fast_iterator *it) {
+	it->cur = NULL;
+}
+void *oscap_fast_iterator_detach(struct oscap_fast_iterator *it);
+void oscap_fast_iterator_free(struct oscap_fast_iterator *it);
 
 OSCAP_HIDDEN_START;
 

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -124,19 +124,19 @@ typedef void (*oscap_consumer_func) (void *, void *);
 #define OSCAP_GETTER(RTYPE,SNAME,MNAME) \
 	OSCAP_GENERIC_GETTER(RTYPE,SNAME,MNAME,MNAME)
 
-#define ITERATOR_CAST(x) ((struct oscap_iterator*)(x))
+#define ITERATOR_CAST(x) ((struct oscap_fast_iterator*)(x))
 #define OSCAP_ITERATOR(n) struct n##_iterator*
 #define OSCAP_ITERATOR_FWD(n) struct n##_iterator;
-#define OSCAP_ITERATOR_HAS_MORE(n) bool n##_iterator_has_more(OSCAP_ITERATOR(n) it) { return oscap_iterator_has_more(ITERATOR_CAST(it)); }
-#define OSCAP_ITERATOR_NEXT(t,n) t n##_iterator_next(OSCAP_ITERATOR(n) it) { return oscap_iterator_next(ITERATOR_CAST(it)); }
-#define OSCAP_ITERATOR_FREE(n) void n##_iterator_free(OSCAP_ITERATOR(n) it) { oscap_iterator_free(ITERATOR_CAST(it)); }
-#define OSCAP_ITERATOR_RESET(n) void n##_iterator_reset(OSCAP_ITERATOR(n) it) { oscap_iterator_reset(ITERATOR_CAST(it)); }
-#define OSCAP_ITERATOR_DETACH(t,n) t n##_iterator_detach(OSCAP_ITERATOR(n) it) { return oscap_iterator_detach(ITERATOR_CAST(it)); }
+#define OSCAP_ITERATOR_HAS_MORE(n) bool n##_iterator_has_more(OSCAP_ITERATOR(n) it) { return oscap_fast_iterator_has_more(ITERATOR_CAST(it)); }
+#define OSCAP_ITERATOR_NEXT(t,n) t n##_iterator_next(OSCAP_ITERATOR(n) it) { return oscap_fast_iterator_next(ITERATOR_CAST(it)); }
+#define OSCAP_ITERATOR_FREE(n) void n##_iterator_free(OSCAP_ITERATOR(n) it) { oscap_fast_iterator_free(ITERATOR_CAST(it)); }
+#define OSCAP_ITERATOR_RESET(n) void n##_iterator_reset(OSCAP_ITERATOR(n) it) { oscap_fast_iterator_reset(ITERATOR_CAST(it)); }
+#define OSCAP_ITERATOR_DETACH(t,n) t n##_iterator_detach(OSCAP_ITERATOR(n) it) { return oscap_fast_iterator_detach(ITERATOR_CAST(it)); }
 #define OSCAP_ITERATOR_GEN_T(t,n) OSCAP_ITERATOR_FWD(n) OSCAP_ITERATOR_HAS_MORE(n) OSCAP_ITERATOR_RESET(n) OSCAP_ITERATOR_NEXT(t,n) OSCAP_ITERATOR_FREE(n)
 #define OSCAP_ITERATOR_GEN(n) OSCAP_ITERATOR_GEN_T(struct n*,n)
 
 #define OSCAP_ITERATOR_REMOVE_T(t,n,destructor) \
-		void n##_iterator_remove(OSCAP_ITERATOR(n) it) { destructor(oscap_iterator_detach(ITERATOR_CAST(it))); }
+		void n##_iterator_remove(OSCAP_ITERATOR(n) it) { destructor(oscap_fast_iterator_detach(ITERATOR_CAST(it))); }
 #define OSCAP_ITERATOR_REMOVE(n,destructor) OSCAP_ITERATOR_REMOVE_T(struct n*,n,destructor)
 #define OSCAP_ITERATOR_REMOVE_F(n) OSCAP_ITERATOR_REMOVE(n, n##_free)
 


### PR DESCRIPTION
In another episode of "wtf is this in our codebase", I found that we are doing a ton of jumps and use the filtering iterator for everything even though the filters are only used on 2 lines in the entire codebase.

```
fast-iterator make check: 13m48.488s
maint-1.2 make check: 15m22.458s
```

And I haven't gotten rid of the delegation jumps yet. For every "typed" iterator (the type is actually fake, just for readability) we do a jump that is not inlined. If I finish getting rid of the delegation jumps and fix up the iterators we save a bit more.

Example:
```
#define OSCAP_ITERATOR_HAS_MORE(n) bool n##_iterator_has_more(OSCAP_ITERATOR(n) it) { return oscap_fast_iterator_has_more(ITERATOR_CAST(it)); }
#define OSCAP_ITERATOR_NEXT(t,n) t n##_iterator_next(OSCAP_ITERATOR(n) it) { return oscap_fast_iterator_next(ITERATOR_CAST(it)); }
```

so for oscap_string_iterator_has_more we jump into the function which immediately loads the arguments and jumps into oscap_iterator_has_more which then loads the filter (if it's not used it's not NULL as you would expect, it's a "always true" function instead but because it's a function pointer we have to jump into it and can't inline it) and jumps at least twice into the filter.

Opening a PR for discussion. I think a part of this can be done in maint-1.2 but if we want to really make iteration blazing fast we can only do it in master. What do you think?

(by blazing fast I mean iterators on the stack, 128bits per iterator, everything inlined, no extra features like filtering, no delegation jumps, no safety - if you use it wrong we segfault)