### PR TITLE
OVAL Textfilecontent54 multiline behavior default bugfix

### DIFF
--- a/src/OVAL/probes/independent/textfilecontent54.c
+++ b/src/OVAL/probes/independent/textfilecontent54.c
@@ -411,17 +411,32 @@ int probe_main(probe_ctx *ctx, void *arg)
 	/* reset filebehavior attributes if 'filepath' entity is used */
 	if (filepath_ent != NULL && bh_ent != NULL) {
 		SEXP_t *r1, *r2, *r3;
-
-		r1 = probe_ent_getattrval(bh_ent, "ignore_case");
-		r2 = probe_ent_getattrval(bh_ent, "multiline");
-		r3 = probe_ent_getattrval(bh_ent, "singleline");
-		r0 = probe_attr_creat("ignore_case", r1,
-				      "multiline", r2,
-				      "singleline", r3,
-				      NULL);
+		r1 = r2 = r3 = NULL;
+		if (probe_ent_attrexists(bh_ent, "ignore_case")) {
+			r1 = probe_ent_getattrval(bh_ent, "ignore_case");
+		}
+		if (probe_ent_attrexists(bh_ent, "multiline")) {
+			r2 = probe_ent_getattrval(bh_ent, "multiline");
+		}
+		if (probe_ent_attrexists(bh_ent, "singleline")) {
+			r3 = probe_ent_getattrval(bh_ent, "singleline");
+		}
+		r0 = SEXP_list_new(NULL);
 		SEXP_free(bh_ent);
 		bh_ent = probe_ent_creat1("behaviors", r0, NULL);
-		SEXP_vfree(r0, r1, r2, r3, NULL);
+		SEXP_free(r0);
+		if (r1) {
+			probe_ent_attr_add(bh_ent, "ignore_case", r1);
+			SEXP_free(r1);
+		}
+		if (r2) {
+			probe_ent_attr_add(bh_ent, "multiline", r2);
+			SEXP_free(r2);
+		}
+		if (r3) {
+			probe_ent_attr_add(bh_ent, "singleline", r3);
+			SEXP_free(r3);
+		}
 	}
 
 	probe_tfc54behaviors_canonicalize(&bh_ent);

--- a/tests/probes/textfilecontent54/Makefile.am
+++ b/tests/probes/textfilecontent54/Makefile.am
@@ -21,6 +21,8 @@ EXTRA_DIST = \
 	test_validation_of_various_oval_versions.sh \
 	test_symlinks.sh \
 	test_symlinks.xml.tpl \
+	test_behavior_multiline.sh \
+	test_behavior_multiline.xml.tpl \
 	tfc54-def-5.4-invalid.xml \
 	tfc54-def-5.4-valid.xml \
 	tfc54-def-5.5-valid.xml \

--- a/tests/probes/textfilecontent54/all.sh
+++ b/tests/probes/textfilecontent54/all.sh
@@ -6,4 +6,5 @@ test_init "test_probes_textfilecontent54.log"
 test_run "textfilecontent54 general functionality" $srcdir/test_probes_textfilecontent54.sh
 test_run "validate OVAL definitions of various schema versions" $srcdir/test_validation_of_various_oval_versions.sh
 test_run "test behavior on symlinks" $srcdir/test_symlinks.sh
+test_run "test multiline behavior" $srcdir/test_behavior_multiline.sh
 test_exit

--- a/tests/probes/textfilecontent54/test_behavior_multiline.sh
+++ b/tests/probes/textfilecontent54/test_behavior_multiline.sh
@@ -46,4 +46,4 @@ echo "Testing syschar values."
 [ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filepath:obj:4"]/@flag)')" == "does not exist" ]
 [ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filepath:obj:5"]/@flag)')" == "complete" ]
 
-#rm -rf $tmpdir
+rm -rf $tmpdir

--- a/tests/probes/textfilecontent54/test_behavior_multiline.sh
+++ b/tests/probes/textfilecontent54/test_behavior_multiline.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+name=$(basename $0 .sh)
+tmpdir=$(mktemp -t -d "${name}.XXXXXX")
+tpl=${srcdir}/${name}.xml.tpl
+input=${tmpdir}/${name}.xml
+result=${tmpdir}/${name}.results.xml
+echo "Temp dir: $tmpdir"
+
+# prepare the environment
+sed "s@%PATH%@${tmpdir}@" $tpl > $input
+echo "line1" > "${tmpdir}/textfile"
+echo "line2" >> "${tmpdir}/textfile"
+echo "line3" >> "${tmpdir}/textfile"
+
+echo "Evaluating content."
+$OSCAP oval eval --results $result $input || [ $? == 2 ]
+echo "Validating results."
+$OSCAP oval validate-xml --results $result
+echo "Testing syschar values."
+# filename
+[ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:filename:tst:1"]/@result)')" == "true" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:filename:tst:2"]/@result)')" == "true" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:filename:tst:3"]/@result)')" == "true" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:filename:tst:4"]/@result)')" == "false" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:filename:tst:5"]/@result)')" == "true" ]
+# filepath
+[ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:filepath:tst:1"]/@result)')" == "true" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:filepath:tst:2"]/@result)')" == "true" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:filepath:tst:3"]/@result)')" == "true" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:filepath:tst:4"]/@result)')" == "false" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:filepath:tst:5"]/@result)')" == "true" ]
+echo "Testing syschar values."
+# filename
+[ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filename:obj:1"]/@flag)')" == "complete" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filename:obj:2"]/@flag)')" == "complete" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filename:obj:3"]/@flag)')" == "complete" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filename:obj:4"]/@flag)')" == "does not exist" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filename:obj:5"]/@flag)')" == "complete" ]
+#filepath
+[ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filepath:obj:1"]/@flag)')" == "complete" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filepath:obj:2"]/@flag)')" == "complete" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filepath:obj:3"]/@flag)')" == "complete" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filepath:obj:4"]/@flag)')" == "does not exist" ]
+[ "$($XPATH $result 'string(/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:filepath:obj:5"]/@flag)')" == "complete" ]
+
+#rm -rf $tmpdir

--- a/tests/probes/textfilecontent54/test_behavior_multiline.xml.tpl
+++ b/tests/probes/textfilecontent54/test_behavior_multiline.xml.tpl
@@ -1,0 +1,130 @@
+<?xml version="1.0"?>
+<oval_definitions xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
+    <generator>
+        <oval:schema_version>5.10.1</oval:schema_version>
+        <oval:timestamp>0001-01-01T00:00:00+00:00</oval:timestamp>
+    </generator>
+
+    <definitions>
+        <definition class="compliance" version="1" id="oval:x:def:1">
+            <metadata>
+                <title>x</title>
+                <description>x</description>
+                <affected family="unix">
+                    <platform>x</platform>
+                </affected>
+            </metadata>
+            <criteria comment="x">
+                <criterion test_ref="oval:filename:tst:1"/>
+                <criterion test_ref="oval:filename:tst:2"/>
+                <criterion test_ref="oval:filename:tst:3"/>
+                <criterion test_ref="oval:filename:tst:4"/>
+                <criterion test_ref="oval:filename:tst:5"/>
+                <criterion test_ref="oval:filepath:tst:1"/>
+                <criterion test_ref="oval:filepath:tst:2"/>
+                <criterion test_ref="oval:filepath:tst:3"/>
+                <criterion test_ref="oval:filepath:tst:4"/>
+                <criterion test_ref="oval:filepath:tst:5"/>
+            </criteria>
+        </definition>
+    </definitions>
+
+    <tests>
+        <textfilecontent54_test id="oval:filename:tst:1" check="all" comment="x" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <object object_ref="oval:filename:obj:1"/>
+        </textfilecontent54_test>
+        <textfilecontent54_test id="oval:filename:tst:2" check="all" comment="x" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <object object_ref="oval:filename:obj:2"/>
+        </textfilecontent54_test>
+        <textfilecontent54_test id="oval:filename:tst:3" check="all" comment="x" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <object object_ref="oval:filename:obj:3"/>
+        </textfilecontent54_test>
+        <textfilecontent54_test id="oval:filename:tst:4" check="all" comment="x" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <object object_ref="oval:filename:obj:4"/>
+        </textfilecontent54_test>
+        <textfilecontent54_test id="oval:filename:tst:5" check="all" comment="x" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <object object_ref="oval:filename:obj:5"/>
+        </textfilecontent54_test>
+        <textfilecontent54_test id="oval:filepath:tst:1" check="all" comment="x" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <object object_ref="oval:filepath:obj:1"/>
+        </textfilecontent54_test>
+        <textfilecontent54_test id="oval:filepath:tst:2" check="all" comment="x" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <object object_ref="oval:filepath:obj:2"/>
+        </textfilecontent54_test>
+        <textfilecontent54_test id="oval:filepath:tst:3" check="all" comment="x" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <object object_ref="oval:filepath:obj:3"/>
+        </textfilecontent54_test>
+        <textfilecontent54_test id="oval:filepath:tst:4" check="all" comment="x" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <object object_ref="oval:filepath:obj:4"/>
+        </textfilecontent54_test>
+        <textfilecontent54_test id="oval:filepath:tst:5" check="all" comment="x" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <object object_ref="oval:filepath:obj:5"/>
+        </textfilecontent54_test>
+    </tests>
+
+    <objects>
+        <textfilecontent54_object id="oval:filename:obj:1" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <path datatype="string" operation="equals">%PATH%</path>
+            <filename datatype="string" operation="equals">textfile</filename>
+            <pattern datatype="string" operation="pattern match">^line2$</pattern>
+            <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object id="oval:filename:obj:2" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <behaviors />
+            <path datatype="string" operation="equals">%PATH%</path>
+            <filename datatype="string" operation="equals">textfile</filename>
+            <pattern datatype="string" operation="pattern match">^line2$</pattern>
+            <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object id="oval:filename:obj:3" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <behaviors multiline="true"/>
+            <path datatype="string" operation="equals">%PATH%</path>
+            <filename datatype="string" operation="equals">textfile</filename>
+            <pattern datatype="string" operation="pattern match">^line2$</pattern>
+            <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object id="oval:filename:obj:4" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <behaviors multiline="false"/>
+            <path datatype="string" operation="equals">%PATH%</path>
+            <filename datatype="string" operation="equals">textfile</filename>
+            <pattern datatype="string" operation="pattern match">^line2$</pattern>
+            <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object id="oval:filename:obj:5" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <behaviors ignore_case="false"/>
+            <path datatype="string" operation="equals">%PATH%</path>
+            <filename datatype="string" operation="equals">textfile</filename>
+            <pattern datatype="string" operation="pattern match">^line2$</pattern>
+            <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object id="oval:filepath:obj:1" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <filepath datatype="string" operation="equals">%PATH%/textfile</filepath>
+            <pattern datatype="string" operation="pattern match">^line2$</pattern>
+            <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object id="oval:filepath:obj:2" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <behaviors />
+            <filepath datatype="string" operation="equals">%PATH%/textfile</filepath>
+            <pattern datatype="string" operation="pattern match">^line2$</pattern>
+            <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object id="oval:filepath:obj:3" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <behaviors multiline="true"/>
+            <filepath datatype="string" operation="equals">%PATH%/textfile</filepath>
+            <pattern datatype="string" operation="pattern match">^line2$</pattern>
+            <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object id="oval:filepath:obj:4" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <behaviors multiline="false"/>
+            <filepath datatype="string" operation="equals">%PATH%/textfile</filepath>
+            <pattern datatype="string" operation="pattern match">^line2$</pattern>
+            <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object id="oval:filepath:obj:5" version="1" comment="x" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+            <behaviors ignore_case="false"/>
+            <filepath datatype="string" operation="equals">%PATH%/textfile</filepath>
+            <pattern datatype="string" operation="pattern match">^line2$</pattern>
+            <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+    </objects>
+</oval_definitions>


### PR DESCRIPTION
This PR attempts to fix issue #792 by changing the "reset filebehavior attributes if 'filepath' entity is used" block to only set attributes if they exist, allowing the defaults in the probe_tfc54behaviors_canonicalize() function to be effective.

Test cases are also added to check some permutations of behaviors.  The checks for oval:filepath:tst:5 fail without the changes to the textfilecontent54 probe.

I'm more confident in the bug than the fix; feel free to point out problems in the fix or better approaches.