### PR TITLE
Fix oscap-docker with Docker newer than 2.0

### DIFF
--- a/utils/oscap-docker.in
+++ b/utils/oscap-docker.in
@@ -55,7 +55,12 @@ class OscapDocker(object):
 
 def ping_docker():
     ''' Simple check if the docker daemon is running '''
-    client = docker.Client()
+    # Class docker.Client was renamed to docker.APIClient in
+    # python-docker-py 2.0.0.
+    try:
+        client = docker.APIClient()
+    except AttributeError:
+        client = docker.Client()
     client.ping()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Class docker.Client was renamed to docker.APIClient in python-docker-py 2.0.0. See https://github.com/docker/docker-py/releases/tag/2.0.0

Unfortunately, this **doesn't fix** oscap-docker on Fedora 26. It just shows another, more serious issue:
See : https://github.com/OpenSCAP/openscap/issues/794



