### PR TITLE
Don't reinvent builtins in our codebase

### DIFF
--- a/src/XCCDF/value.c
+++ b/src/XCCDF/value.c
@@ -418,7 +418,7 @@ struct xccdf_value_instance *xccdf_value_new_instance(struct xccdf_value *val)
 	bool xccdf_value_instance_set_##WHAT##_string(struct xccdf_value_instance *inst, const char *newval) { \
 		oscap_free(inst->WHAT); inst->WHAT = oscap_strdup(newval); inst->flags.WHAT##_given = true; return true; }
 #define XCCDF_VALUE_INSTANCE_VALUE_ACCESSOR_NUM(WHAT) \
-	xccdf_numeric xccdf_value_instance_get_##WHAT##_number(const struct xccdf_value_instance *inst) { return oscap_strtol(inst->WHAT, NULL, 10); } \
+	xccdf_numeric xccdf_value_instance_get_##WHAT##_number(const struct xccdf_value_instance *inst) { return inst->WHAT == NULL ? NAN : strtol(inst->WHAT, NULL, 10); } \
 	bool xccdf_value_instance_set_##WHAT##_number(struct xccdf_value_instance *inst, xccdf_numeric newval) { \
 		oscap_free(inst->WHAT); inst->WHAT = oscap_sprintf("%f", newval); inst->flags.WHAT##_given = true; return true; }
 #define XCCDF_VALUE_INSTANCE_VALUE_ACCESSOR_BOOL(WHAT) \

--- a/src/XCCDF/value.c
+++ b/src/XCCDF/value.c
@@ -417,8 +417,9 @@ struct xccdf_value_instance *xccdf_value_new_instance(struct xccdf_value *val)
 	const char *xccdf_value_instance_get_##WHAT##_string(const struct xccdf_value_instance *inst) { return inst->WHAT; } \
 	bool xccdf_value_instance_set_##WHAT##_string(struct xccdf_value_instance *inst, const char *newval) { \
 		oscap_free(inst->WHAT); inst->WHAT = oscap_strdup(newval); inst->flags.WHAT##_given = true; return true; }
+// TODO: Parse floats correctly instead of converting long to float
 #define XCCDF_VALUE_INSTANCE_VALUE_ACCESSOR_NUM(WHAT) \
-	xccdf_numeric xccdf_value_instance_get_##WHAT##_number(const struct xccdf_value_instance *inst) { return inst->WHAT == NULL ? NAN : strtol(inst->WHAT, NULL, 10); } \
+	xccdf_numeric xccdf_value_instance_get_##WHAT##_number(const struct xccdf_value_instance *inst) { return inst->WHAT == NULL ? NAN : (float)strtol(inst->WHAT, NULL, 10); } \
 	bool xccdf_value_instance_set_##WHAT##_number(struct xccdf_value_instance *inst, xccdf_numeric newval) { \
 		oscap_free(inst->WHAT); inst->WHAT = oscap_sprintf("%f", newval); inst->flags.WHAT##_given = true; return true; }
 #define XCCDF_VALUE_INSTANCE_VALUE_ACCESSOR_BOOL(WHAT) \

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -54,22 +54,6 @@ const char *oscap_enum_to_string(const struct oscap_string_map *map, int val)
 	return map->string;
 }
 
-char *oscap_strdup(const char *str)
-{
-
-	char *m;
-
-	if (str == NULL)
-		return NULL;
-
-	m = strdup(str);
-
-	if (m == NULL)
-		oscap_seterr(OSCAP_EFAMILY_GLIBC, strerror(errno));
-
-	return m;
-}
-
 float oscap_strtol(const char *str, char **endptr, int base){
     if (str == NULL) {
         return NAN;

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -85,20 +85,6 @@ char **oscap_split(char *str, const char *delim)
 	return fields;
 }
 
-bool oscap_str_startswith(const char *str, const char *with)
-{
-	return !strncmp(str, with, strlen(with));
-}
-
-bool oscap_str_endswith(const char *str, const char *with)
-{
-	size_t str_len = strlen(str);
-	size_t with_len = strlen(with);
-	if (with_len > str_len)
-		return false;
-	return strncmp(str + str_len - with_len, with, with_len) == 0;
-}
-
 char *oscap_trim(char *str)
 {
 	int off, i = 0;

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -85,11 +85,6 @@ char **oscap_split(char *str, const char *delim)
 	return fields;
 }
 
-bool oscap_streq(const char *s1, const char *s2)
-{
-	return (oscap_strcmp(s1, s2) == 0);
-}
-
 bool oscap_str_startswith(const char *str, const char *with)
 {
 	return !strncmp(str, with, strlen(with));

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -85,14 +85,6 @@ char **oscap_split(char *str, const char *delim)
 	return fields;
 }
 
-
-int oscap_strcmp(const char *s1, const char *s2)
-{
-	if (s1 == NULL) s1 = "";
-	if (s2 == NULL) s2 = "";
-	return strcmp(s1, s2);
-}
-
 bool oscap_streq(const char *s1, const char *s2)
 {
 	return (oscap_strcmp(s1, s2) == 0);

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -54,14 +54,6 @@ const char *oscap_enum_to_string(const struct oscap_string_map *map, int val)
 	return map->string;
 }
 
-float oscap_strtol(const char *str, char **endptr, int base){
-    if (str == NULL) {
-        return NAN;
-    } else
-        return strtol(str, endptr, base);
-}
-
-
 static const size_t CPE_SPLIT_INIT_ALLOC = 8;
 
 char **oscap_split(char *str, const char *delim)

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -361,8 +361,11 @@ static inline int oscap_strcmp(const char *s1, const char *s2) {
 	return strcmp(s1, s2);
 }
 
-/// Check for string equality
-bool oscap_streq(const char *s1, const char *s2);
+/// Check for string equality. Use the standard strcmp directly if possible.
+static inline bool oscap_streq(const char *s1, const char *s2) {
+	return oscap_strcmp(s1, s2) == 0;
+}
+
 bool oscap_str_startswith(const char *str, const char *with);
 bool oscap_str_endswith(const char *str, const char *with);
 /// Trim whitespace (modifies its argument!)

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -366,8 +366,19 @@ static inline bool oscap_streq(const char *s1, const char *s2) {
 	return oscap_strcmp(s1, s2) == 0;
 }
 
-bool oscap_str_startswith(const char *str, const char *with);
-bool oscap_str_endswith(const char *str, const char *with);
+/// Check whether str starts with "prefix"
+static inline bool oscap_str_startswith(const char *str, const char *prefix) {
+	return !strncmp(str, prefix, strlen(prefix));
+}
+
+/// Check whether str ends with "suffix"
+static inline bool oscap_str_endswith(const char *str, const char *suffix) {
+	const size_t str_len = strlen(str);
+	const size_t suffix_len = strlen(suffix);
+	if (suffix_len > str_len)
+		return false;
+	return strncmp(str + str_len - suffix_len, suffix, suffix_len) == 0;
+}
 /// Trim whitespace (modifies its argument!)
 char *oscap_trim(char *str);
 /// Print to a newly allocated string using a va_list.

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -344,14 +344,6 @@ static inline char *oscap_strdup(const char *str) {
 }
 
 /**
- * Use strtol on string, if string is NULL, return NaN
- * @param str String we want to duplicate
- * @param endptr see man strtol
- * @param base see man strtol
- */
-float oscap_strtol(const char *str, char **endptr, int base);
-
-/**
  * Split a string.
  * Split string using given delimiter.
  * Produces NULL-terminated array of strings.

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -354,8 +354,13 @@ static inline char *oscap_strdup(const char *str) {
 char **oscap_split(char *str, const char *delim);
 
 
-/// Use strcmp on strings, NULL safe
-int oscap_strcmp(const char *s1, const char *s2);
+/// Just like strcmp except it's NULL-safe. Use the standard strcmp directly if possible.
+static inline int oscap_strcmp(const char *s1, const char *s2) {
+	if (s1 == NULL) s1 = "";
+	if (s2 == NULL) s2 = "";
+	return strcmp(s1, s2);
+}
+
 /// Check for string equality
 bool oscap_streq(const char *s1, const char *s2);
 bool oscap_str_startswith(const char *str, const char *with);

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -403,15 +403,6 @@ void oscap_strtoupper(char *str);
 bool oscap_ptr_cmp(void *node1, void *node2);
 
 /**
- * find file with given name and mode in given paths
- * @param filename filename to be found
- * @param mode desired file mode (e.g. R_OK for readable files)
- * @param pathvar environment variable to check for path, can be NULL
- * @param path path where to search the file
- */
-char *oscap_find_file(const char *filename, int mode, const char *pathvar, const char *path);
-
-/**
  * A helper function to expand given shorthand IPv6
  *
  * example:

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -368,7 +368,7 @@ static inline bool oscap_streq(const char *s1, const char *s2) {
 
 /// Check whether str starts with "prefix"
 static inline bool oscap_str_startswith(const char *str, const char *prefix) {
-	return !strncmp(str, prefix, strlen(prefix));
+	return strncmp(str, prefix, strlen(prefix)) == 0;
 }
 
 /// Check whether str ends with "suffix"

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -29,6 +29,7 @@
 #include "public/oscap.h"
 #include "alloc.h"
 #include <stdarg.h>
+#include <string.h>
 
 #ifndef __attribute__nonnull__
 #define __attribute__nonnull__(x) assert((x) != NULL)
@@ -331,7 +332,16 @@ const char *oscap_enum_to_string(const struct oscap_string_map *map, int val);
  * Use strdup on string, if string is NULL, return NULL
  * @param str String we want to duplicate
  */
-char *oscap_strdup(const char *str);
+static inline char *oscap_strdup(const char *str) {
+	if (str == NULL)
+		return NULL;
+
+#ifdef _MSC_VER
+	return _strdup(str);
+#else
+	return strdup(str);
+#endif
+}
 
 /**
  * Use strtol on string, if string is NULL, return NaN


### PR DESCRIPTION
I wanted to get rid of more of our reinvented builtins but in the end the best I could do was inline some of them. I was able to get rid of oscap_strtol though. Plus I discovered that oscap_find_file doesn't exist even though it's declared.

This is all just minor spring cleaning for fun, really. The performance gains are quite minimal.