### PR TITLE
Remove requires from pkgconfig file

### DIFF
--- a/libopenscap.pc.in
+++ b/libopenscap.pc.in
@@ -7,6 +7,5 @@ Name: libopenscap
 Description: An open source library enabling integration of the SCAP line of standards
 URL: http://www.open-scap.org
 Version: @VERSION@
-Requires: libxml-2.0 libxslt
 Libs: -L${libdir} -lopenscap
 Cflags: -I${includedir}

--- a/libopenscap.pc.in
+++ b/libopenscap.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@/openscap
 
 Name: libopenscap
 Description: An open source library enabling integration of the SCAP line of standards
-URL: http://www.open-scap.org
+URL: https://www.open-scap.org
 Version: @VERSION@
 Libs: -L${libdir} -lopenscap
 Cflags: -I${includedir}


### PR DESCRIPTION
See #796
See https://bugzilla.redhat.com/show_bug.cgi?id=1414777

All the 3 "Requires" are not actually required when using openscap public API.