### PR TITLE
The enum value in oscap_string_map elements can be const

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -308,8 +308,8 @@ typedef void (*oscap_consumer_func) (void *, void *);
  * the default value for strings not defined elsewhere.
  */
 struct oscap_string_map {
-	int value;		/* integer/enum value */
-	const char *string;	/* string representation of the value */
+	const int value;    /* integer/enum value */
+	const char *string; /* string representation of the value */
 };
 
 /**


### PR DESCRIPTION
And should be to avoid coding errors.

This is a pretty minor thing I noticed while working on the CVRF code. The assumption is that the elements of the oscap_string_map are const. We can make that clear by the const keyword on the int value.

Note fore reviewer: oscap_string_map is a bad name for what this is, it's actually one line/element of that map.