### PR TITLE
Enables make check to use a different oscap binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Note: If you want to run `make distcheck` you will also need to install
 on Fedora), or you can install `rubygems` package and then run
 `gem install asciidoctor`.
 
+It's also possible to use the make check to test any other oscap binary present in the system. You just have to set the path of the binary to the CUSTOM_OSCAP variable:
+```
+export CUSTOM_OSCAP=/usr/bin/oscap; make check
+```
+Not every check tests the oscap tool, however, when the CUSTOM_OSCAP variable is set, only the checks which do are executed.
+
+
 4) Run the installation procedure by executing the following command:
 ```
 make install

--- a/tests/API/CCE/test_api_cce.sh
+++ b/tests/API/CCE/test_api_cce.sh
@@ -46,15 +46,16 @@ function test_api_cce_search_non_existing {
 }
 
 # Testing.
-
 test_init "test_api_cce.log" 
 
-test_run "test_api_cce_smoke" test_api_cce_smoke
-test_run "test_api_cce_validate_valid_xml" test_api_cce_validate_valid_xml
-test_run "test_api_cce_validate_invalid_xml" test_api_cce_validate_invalid_xml
-test_run "test_api_cce_validate_damaged_xml" test_api_cce_validate_damaged_xml
-test_run "test_api_cce_parse_xml" test_api_cce_parse_xml
-test_run "test_api_cce_search_existing" test_api_cce_search_existing
-test_run "test_api_cce_search_non_existing" test_api_cce_search_non_existing
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_api_cce_smoke" test_api_cce_smoke
+    test_run "test_api_cce_validate_valid_xml" test_api_cce_validate_valid_xml
+    test_run "test_api_cce_validate_invalid_xml" test_api_cce_validate_invalid_xml
+    test_run "test_api_cce_validate_damaged_xml" test_api_cce_validate_damaged_xml
+    test_run "test_api_cce_parse_xml" test_api_cce_parse_xml
+    test_run "test_api_cce_search_existing" test_api_cce_search_existing
+    test_run "test_api_cce_search_non_existing" test_api_cce_search_non_existing
+fi
 
 test_exit

--- a/tests/API/CPE/dict/test_api_cpe_dict.sh
+++ b/tests/API/CPE/dict/test_api_cpe_dict.sh
@@ -117,19 +117,21 @@ function test_api_cpe_dict_import_official_v23(){
 
 test_init "test_api_cpe_dict.log"
 
-test_run "test_api_cpe_dict_smoke" test_api_cpe_dict_smoke    
-test_run "test_api_cpe_dict_remove_cpe" test_api_cpe_dict_remove_cpe
-test_run "test_api_cpe_dict_import_damaged_xml" \
-    test_api_cpe_dict_import_damaged_xml
-test_run "test_api_cpe_dict_match_non_existing_cpe" \
-    test_api_cpe_dict_match_non_existing_cpe   
-test_run "test_api_cpe_dict_match_existing_cpe" \
-    test_api_cpe_dict_match_existing_cpe
-test_run "test_api_cpe_dict_export_xml"  test_api_cpe_dict_export_xml
-#test_run "test_api_cpe_dict_import_cp1250_xml" \
-#    test_api_cpe_dict_import_cp1250_xml   
-test_run "test_api_cpe_dict_import_utf8_xml" test_api_cpe_dict_import_utf8_xml
-test_run "test_api_cpe_dict_import_official_v22" test_api_cpe_dict_import_official_v22
-test_run "test_api_cpe_dict_import_official_v23" test_api_cpe_dict_import_official_v23
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_api_cpe_dict_smoke" test_api_cpe_dict_smoke
+    test_run "test_api_cpe_dict_remove_cpe" test_api_cpe_dict_remove_cpe
+    test_run "test_api_cpe_dict_import_damaged_xml" \
+        test_api_cpe_dict_import_damaged_xml
+    test_run "test_api_cpe_dict_match_non_existing_cpe" \
+        test_api_cpe_dict_match_non_existing_cpe   
+    test_run "test_api_cpe_dict_match_existing_cpe" \
+        test_api_cpe_dict_match_existing_cpe
+    test_run "test_api_cpe_dict_export_xml"  test_api_cpe_dict_export_xml
+    #test_run "test_api_cpe_dict_import_cp1250_xml" \
+    #    test_api_cpe_dict_import_cp1250_xml   
+    test_run "test_api_cpe_dict_import_utf8_xml" test_api_cpe_dict_import_utf8_xml
+    test_run "test_api_cpe_dict_import_official_v22" test_api_cpe_dict_import_official_v22
+    test_run "test_api_cpe_dict_import_official_v23" test_api_cpe_dict_import_official_v23
+fi
 
 test_exit

--- a/tests/API/CPE/lang/test_api_cpe_lang.sh
+++ b/tests/API/CPE/lang/test_api_cpe_lang.sh
@@ -149,13 +149,15 @@ function test_api_cpe_lang_match {
 
 test_init "test_api_cpe_lang.log"
 
-test_run "test_api_cpe_lang_smoke" test_api_cpe_lang_smoke
-test_run "test_api_cpe_lang_import" test_api_cpe_lang_import
-test_run "test_api_cpe_lang_import_damaged" test_api_cpe_lang_import_damaged    
-test_run "test_api_cpe_lang_import_key" test_api_cpe_lang_import_key
-# test_run "test_api_cpe_lang_export_empty" test_api_cpe_lang_export_empty
-# test_run "test_api_cpe_lang_export_ecoding" test_api_cpe_lang_export_encoding
-# test_run "test_api_cpe_lang_export_namespace" test_api_cpe_lang_export_namespace
-test_run "test_api_cpe_lang_match" test_api_cpe_lang_match
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_api_cpe_lang_smoke" test_api_cpe_lang_smoke
+    test_run "test_api_cpe_lang_import" test_api_cpe_lang_import
+    test_run "test_api_cpe_lang_import_damaged" test_api_cpe_lang_import_damaged    
+    test_run "test_api_cpe_lang_import_key" test_api_cpe_lang_import_key
+    # test_run "test_api_cpe_lang_export_empty" test_api_cpe_lang_export_empty
+    # test_run "test_api_cpe_lang_export_ecoding" test_api_cpe_lang_export_encoding
+    # test_run "test_api_cpe_lang_export_namespace" test_api_cpe_lang_export_namespace
+    test_run "test_api_cpe_lang_match" test_api_cpe_lang_match
+fi
 
 test_exit 

--- a/tests/API/CPE/name/test_api_cpe_uri.sh
+++ b/tests/API/CPE/name/test_api_cpe_uri.sh
@@ -127,9 +127,11 @@ function test_api_cpe_uri_match {
 
 test_init "test_api_cpe_uri.log"
 
-test_run "test_api_cpe_uri_smoke"  test_api_cpe_uri_smoke
-test_run "test_api_cpe_uri_parse"  test_api_cpe_uri_parse
-test_run "test_api_cpe_uri_create" test_api_cpe_uri_create
-test_run "test_api_cpe_uri_match"  test_api_cpe_uri_match
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_api_cpe_uri_smoke"  test_api_cpe_uri_smoke
+    test_run "test_api_cpe_uri_parse"  test_api_cpe_uri_parse
+    test_run "test_api_cpe_uri_create" test_api_cpe_uri_create
+    test_run "test_api_cpe_uri_match"  test_api_cpe_uri_match
+fi
 
 test_exit

--- a/tests/API/CVE/test_api_cve.sh
+++ b/tests/API/CVE/test_api_cve.sh
@@ -32,7 +32,11 @@ function test_api_cve_export {
 }
 
 test_init "test_api_cve.log"
-test_run "test_api_cve_cvss" test_api_cve_cvss
-test_run "test_api_cve_export" test_api_cve_export
+
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_api_cve_cvss" test_api_cve_cvss
+    test_run "test_api_cve_export" test_api_cve_export
+fi
+
 test_exit
 

--- a/tests/API/CVSS/test_api_cvss.sh
+++ b/tests/API/CVSS/test_api_cvss.sh
@@ -35,7 +35,9 @@ function test_api_cvss_vector {
 
 test_init "test_api_cvss.log"
 
-test_run "test_api_cvss_vector" test_api_cvss_vector
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_api_cvss_vector" test_api_cvss_vector
+fi
 
 test_exit 
 

--- a/tests/API/OVAL/glob_to_regex/test_glob_to_regex.sh
+++ b/tests/API/OVAL/glob_to_regex/test_glob_to_regex.sh
@@ -19,5 +19,9 @@ function test_glob_to_regex {
 # Testing.
 
 test_init "test_glob_to_regex.log"
-test_run "test_glob_to_regex" test_glob_to_regex
+
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_glob_to_regex" test_glob_to_regex
+fi
+
 test_exit

--- a/tests/API/OVAL/schema_version/test_schema_version.sh
+++ b/tests/API/OVAL/schema_version/test_schema_version.sh
@@ -42,5 +42,9 @@ function test_comparing_schema_versions {
 # Testing.
 
 test_init "test_schema_version.log"
-test_run "test_comparing_schema_versions" test_comparing_schema_versions
+
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_comparing_schema_versions" test_comparing_schema_versions
+fi
+
 test_exit

--- a/tests/API/OVAL/test_api_oval.sh
+++ b/tests/API/OVAL/test_api_oval.sh
@@ -39,9 +39,11 @@ function test_api_oval_directives {
 
 test_init "test_api_oval.log"
 
-test_run "test_api_oval_definition" test_api_oval_definition
-test_run "test_api_oval_syschar" test_api_oval_syschar
-test_run "test_api_oval_results" test_api_oval_results
-test_run "test_api_oval_directives" test_api_oval_directives
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_api_oval_definition" test_api_oval_definition
+    test_run "test_api_oval_syschar" test_api_oval_syschar
+    test_run "test_api_oval_results" test_api_oval_results
+    test_run "test_api_oval_directives" test_api_oval_directives
+fi
 
 test_exit

--- a/tests/API/SEAP/test_api_seap.sh
+++ b/tests/API/SEAP/test_api_seap.sh
@@ -484,15 +484,17 @@ function test_api_strto {
 
 test_init "test_api_seap.log"
 
-test_run "test_api_seap_incorrect_expression"   test_api_seap_incorrect_expression
-test_run "test_api_seap_correct_expression"     test_api_seap_correct_expression
-test_run "test_api_seap_split"                  test_api_seap_split
-test_run "test_api_seap_concurency"             test_api_seap_concurency
-test_run "test_api_seap_spb"                  ./test_api_seap_spb
-test_run "test_api_seap_list"                 ./test_api_seap_list
-test_run "test_api_seap_number_expression"    ./test_api_seap_number
-test_run "test_api_seap_string_expression"    ./test_api_seap_string
-test_run "test_api_SEXP_deepcmp"              ./test_api_SEXP_deepcmp
-test_run "test_api_strto"                     ./test_api_strto
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_api_seap_incorrect_expression"   test_api_seap_incorrect_expression
+    test_run "test_api_seap_correct_expression"     test_api_seap_correct_expression
+    test_run "test_api_seap_split"                  test_api_seap_split
+    test_run "test_api_seap_concurency"             test_api_seap_concurency
+    test_run "test_api_seap_spb"                  ./test_api_seap_spb
+    test_run "test_api_seap_list"                 ./test_api_seap_list
+    test_run "test_api_seap_number_expression"    ./test_api_seap_number
+    test_run "test_api_seap_string_expression"    ./test_api_seap_string
+    test_run "test_api_SEXP_deepcmp"              ./test_api_SEXP_deepcmp
+    test_run "test_api_strto"                     ./test_api_strto
+fi
 
 test_exit

--- a/tests/API/XCCDF/parser/test_api_xccdf.sh
+++ b/tests/API/XCCDF/parser/test_api_xccdf.sh
@@ -49,10 +49,12 @@ function test_api_xccdf_validate {
 
 test_init "test_api_xccdf.log"
 
-test_run "export xccdf 1.1" test_api_xccdf_export xccdf11.xml
-test_run "validate xccdf 1.1" test_api_xccdf_validate xccdf11.xml "1.1"
-test_run "export xccdf 1.2" test_api_xccdf_export xccdf12.xml
-test_run "validate xccdf 1.2" test_api_xccdf_validate xccdf12.xml "1.2"
-test_run "export xccdf results 1.1" test_api_xccdf_export xccdf11-results.xml
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "export xccdf 1.1" test_api_xccdf_export xccdf11.xml
+    test_run "validate xccdf 1.1" test_api_xccdf_validate xccdf11.xml "1.1"
+    test_run "export xccdf 1.2" test_api_xccdf_export xccdf12.xml
+    test_run "validate xccdf 1.2" test_api_xccdf_validate xccdf12.xml "1.2"
+    test_run "export xccdf results 1.1" test_api_xccdf_export xccdf11-results.xml
+fi
 
 test_exit

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -8,15 +8,16 @@ test_init test_api_xccdf_unittests.log
 #
 # API C Tests
 #
-test_run "xccdf:complex-check -- NAND is working properly" ./test_xccdf_shall_pass $srcdir/test_xccdf_complex_check_nand.xccdf.xml
-test_run "xccdf:complex-check -- single negation" ./test_xccdf_shall_pass $srcdir/test_xccdf_complex_check_single_negate.xccdf.xml
-test_run "Certain id's of xccdf_items may overlap" ./test_xccdf_shall_pass $srcdir/test_xccdf_overlaping_IDs.xccdf.xml
-test_run "Test Abstract data types." ./test_oscap_common
-test_run "xccdf_rule_result_override" $srcdir/test_xccdf_overrides.sh
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "xccdf:complex-check -- NAND is working properly" ./test_xccdf_shall_pass $srcdir/test_xccdf_complex_check_nand.xccdf.xml
+    test_run "xccdf:complex-check -- single negation" ./test_xccdf_shall_pass $srcdir/test_xccdf_complex_check_single_negate.xccdf.xml
+    test_run "Certain id's of xccdf_items may overlap" ./test_xccdf_shall_pass $srcdir/test_xccdf_overlaping_IDs.xccdf.xml
+    test_run "Test Abstract data types." ./test_oscap_common
+    test_run "xccdf_rule_result_override" $srcdir/test_xccdf_overrides.sh
 
-test_run "Assert for environment" [ ! -x $srcdir/not_executable ]
-test_run "Assert for environment better" $OSCAP oval eval --id oval:moc.elpmaxe.www:def:1 $srcdir/test_xccdf_check_content_ref_without_name_attr.oval.xml
-
+    test_run "Assert for environment" [ ! -x $srcdir/not_executable ]
+    test_run "Assert for environment better" $OSCAP oval eval --id oval:moc.elpmaxe.www:def:1 $srcdir/test_xccdf_check_content_ref_without_name_attr.oval.xml
+fi
 #
 # General XCCDF Tests. (Mostly, oscap xccdf eval)
 #

--- a/tests/API/crypt/test_api_crypt.sh
+++ b/tests/API/crypt/test_api_crypt.sh
@@ -84,7 +84,9 @@ function test_crapi_mdigest {
 
 test_init "test_api_crypt.log"
 
-test_run "test_crapi_digest" test_crapi_digest
-test_run "test_crapi_mdigest" test_crapi_mdigest
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_crapi_digest" test_crapi_digest
+    test_run "test_crapi_mdigest" test_crapi_mdigest
+fi
 
 test_exit

--- a/tests/API/probes/all.sh
+++ b/tests/API/probes/all.sh
@@ -3,6 +3,10 @@
 . ../../test_common.sh
 
 test_init "test_api_probes.log"
-test_run "fts test" $srcdir/fts.sh
-test_run "probe api smoke test" ./test_api_probes_smoke
+
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "fts test" $srcdir/fts.sh
+    test_run "probe api smoke test" ./test_api_probes_smoke
+fi
+
 test_exit

--- a/tests/DS/ds_sds_index/all.sh
+++ b/tests/DS/ds_sds_index/all.sh
@@ -5,7 +5,11 @@ set -e -o pipefail
 . ../../test_common.sh
 
 test_init ds_sds_index.log
-test_run "ds_sds_index" ./test_ds_sds_index $srcdir/sds.xml
-test_run "ds_sds_index_multiple" ./test_ds_sds_index_multiple $srcdir/sds_multiple.xml
-test_run "ds_sds_index_invalid" ./test_ds_sds_index_invalid $srcdir/sds_invalid.xml
+
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "ds_sds_index" ./test_ds_sds_index $srcdir/sds.xml
+    test_run "ds_sds_index_multiple" ./test_ds_sds_index_multiple $srcdir/sds_multiple.xml
+    test_run "ds_sds_index_invalid" ./test_ds_sds_index_invalid $srcdir/sds_invalid.xml
+fi
+
 test_exit

--- a/tests/DS/signed/all.sh
+++ b/tests/DS/signed/all.sh
@@ -13,7 +13,12 @@ function test_verify {
 }
 
 test_init test_signed.log
+
 test_run "signed-sds-no-verification" test_eval_no_verify sds-signed.xml
-#test_run "signed-sds-verify" test_verify sds-signed.xml sds-signed-key.pub
 test_run "signed-sds-fake-x509-no-verification" test_eval_no_verify sds-signed-fake-x509.xml
+
+#if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    # test_run "signed-sds-verify" test_verify sds-signed.xml sds-signed-key.pub  
+#fi
+
 test_exit

--- a/tests/bindings/test_perl.sh
+++ b/tests/bindings/test_perl.sh
@@ -19,6 +19,8 @@ function test_perl_import {
 # Testing.
 test_init "test_perl.log"
 
-test_run "perl_import" test_perl_import
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "perl_import" test_perl_import
+fi
 
 test_exit

--- a/tests/bindings/test_python.sh
+++ b/tests/bindings/test_python.sh
@@ -14,6 +14,8 @@ function test_python_import {
 # Testing.
 test_init "test_python.log"
 
-test_run "python_import" test_python_import
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "python_import" test_python_import
+fi
 
 test_exit

--- a/tests/codestyle/all.sh
+++ b/tests/codestyle/all.sh
@@ -36,8 +36,10 @@ function shell_script_syntax(){
 
 test_init "test_codebase.log"
 
-test_run "illicit use of functions" test_illicit_function_use 0
-test_run "Check syntax of distributed shell scripts" shell_script_syntax \
-	utils/oscap-ssh
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "illicit use of functions" test_illicit_function_use 0
+    test_run "Check syntax of distributed shell scripts" shell_script_syntax \
+	    utils/oscap-ssh
+fi
 
 test_exit

--- a/tests/oscap_string/test_oscap_string.sh
+++ b/tests/oscap_string/test_oscap_string.sh
@@ -19,5 +19,9 @@ function test_oscap_string {
 # Testing.
 
 test_init "test_oscap_string.log"
-test_run "test_oscap_string" test_oscap_string
+
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_oscap_string" test_oscap_string
+fi
+
 test_exit

--- a/tests/probes/sysinfo/test_probes_sysinfo.sh
+++ b/tests/probes/sysinfo/test_probes_sysinfo.sh
@@ -72,6 +72,8 @@ function test_probes_sysinfo {
 
 test_init "test_probes_sysinfo.log"
 
-test_run "test_probes_sysinfo" test_probes_sysinfo
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_probes_sysinfo" test_probes_sysinfo
+fi
 
 test_exit

--- a/tests/probes/xinetd/test_xinetd_probe.sh
+++ b/tests/probes/xinetd/test_xinetd_probe.sh
@@ -84,8 +84,10 @@ function test_probe_xinetd_duplicates {
 
 test_init "test_probe_xinetd.log"
 
-test_run "test_probe_xinetd_parser" test_probe_xinetd_parser
-test_run "xinetd parser regression test: string list" test_probe_xinetd_regression_stringlist
-test_run "test_probe_xinetd_duplicates" test_probe_xinetd_duplicates
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "test_probe_xinetd_parser" test_probe_xinetd_parser
+    test_run "xinetd parser regression test: string list" test_probe_xinetd_regression_stringlist
+    test_run "test_probe_xinetd_duplicates" test_probe_xinetd_duplicates
+fi
 
 test_exit

--- a/tests/schemas/all.sh
+++ b/tests/schemas/all.sh
@@ -31,5 +31,9 @@ function test_no_external_imports {
 
 # Testing.
 test_init "test_schemas.log"
-test_run "no_external_imports" test_no_external_imports
+
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "no_external_imports" test_no_external_imports
+fi
+
 test_exit

--- a/tests/sources/all.sh
+++ b/tests/sources/all.sh
@@ -25,5 +25,8 @@ function test_config_h(){
 
 test_init "test_config_h.log"
 
-test_run "Check existence including config.h in every .c file" test_config_h
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "Check existence including config.h in every .c file" test_config_h
+fi
+
 test_exit

--- a/tests/test_common.sh.in
+++ b/tests/test_common.sh.in
@@ -15,13 +15,17 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 LC_ALL=C
 export LC_ALL
 
-enable_valgrind=@vgcheck@
-if [ $enable_valgrind = "yes" ] ; then
-  actualdir=@abs_top_srcdir@
-  export actualdir
-  [ -z "$builddir" ] || export OSCAP="@abs_top_srcdir@/tests/valgrind_test.sh"
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    enable_valgrind=@vgcheck@
+    if [ $enable_valgrind = "yes" ] ; then
+        actualdir=@abs_top_srcdir@
+        export actualdir
+        [ -z "$builddir" ] || export OSCAP="@abs_top_srcdir@/tests/valgrind_test.sh"
+    else
+        [ -z "$builddir" ] || export OSCAP=$(cd $builddir/utils/.libs; pwd)/oscap
+    fi
 else
-  [ -z "$builddir" ] || export OSCAP=$(cd $builddir/utils/.libs; pwd)/oscap
+    export OSCAP=${CUSTOM_OSCAP}
 fi
 
 export XMLDIFF="@abs_top_srcdir@/tests/xmldiff.pl"


### PR DESCRIPTION
This commit allows us to use any oscap tool in the system with the make check by setting the variable OSCAP.

However, the following tests link against libopenscap_testing.la and don't use the oscap tool:
./tests/probes/xinetd
./tests/probes/sysinfo
./tests/oscap_string
./tests/bz2
./tests/API/CVSS
./tests/API/XCCDF/parser
./tests/API/XCCDF/unittests
./tests/API/CCE
./tests/API/SEAP
./tests/API/crypt
./tests/API/probes
./tests/API/CPE/lang
./tests/API/CPE/name
./tests/API/CPE/dict
./tests/API/CVE
./tests/API/OVAL/schema_version
./tests/API/OVAL/glob_to_regex
./tests/API/OVAL
./tests/DS/ds_sds_index

I could turn these tests off in case the OSCAP variable is defined, does it make sense or is there a better alternative?