### PR TITLE
Update oval_fts.c

### DIFF
--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -134,6 +134,9 @@ static void OVAL_FTSENT_free(OVAL_FTSENT *ofts_ent)
 #ifndef MNTTYPE_SMB
 #define MNTTYPE_SMB	"smb"
 #endif
+#ifndef MNTTYPE_SMBFS
+#define MNTTYPE_SMBFS	"smbfs"
+#endif
 #ifndef MNTTYPE_PROC
 #define MNTTYPE_PROC	"proc"
 #endif
@@ -233,7 +236,7 @@ static void free_zones_path_list()
 	avl_destroy(&avl_tree_list);
 }
 
-static bool valid_local_zone(char *path)
+static bool valid_local_zone(const char *path)
 {
 	zone_path_t temp;
 	avl_index_t where;


### PR DESCRIPTION
path argument of valid_local_zone() function should be const char* since this function is called by OVAL_FTS_localp() which declared path as const char*.