### PR TITLE
Update oscap-oval.c

### DIFF
--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -358,7 +358,7 @@ int app_evaluate_oval(const struct oscap_action *action)
 	}
 
 	/* set validation level */
-	oval_session_set_validation(session, action->validate, getenv("OSCAP_FULL_VALIDATION"));
+	oval_session_set_validation(session, action->validate, getenv("OSCAP_FULL_VALIDATION") != NULL);
 
 	/* set source DS related IDs */
 	oval_session_set_datastream_id(session, action->f_datastream_id);


### PR DESCRIPTION
Fix the following warning raised by Oracle Developer Studio 12.5:
  CC       oscap-oscap-oval.o
"oscap-oval.c", line 361: warning: improper pointer/integer combination: arg #3.