### PR TITLE
Add support for AIX

### DIFF
--- a/src/OVAL/probes/probe/entcmp.c
+++ b/src/OVAL/probes/probe/entcmp.c
@@ -42,6 +42,7 @@
 #include <regex.h>
 #endif
 #include <arpa/inet.h>
+#include <sys/socket.h>
 
 #include "common/debug_priv.h"
 #include "entcmp.h"


### PR DESCRIPTION
AIX requires <sys/socket.h> for AF_INET and AF_INET6