### PR TITLE
Update seap.h

### DIFF
--- a/src/OVAL/probes/SEAP/public/seap.h
+++ b/src/OVAL/probes/SEAP/public/seap.h
@@ -33,6 +33,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <errno.h>
 #include <sexp.h>
 #include <seap-types.h>
 #include <seap-message.h>


### PR DESCRIPTION
Avoid redefining EOPNOTSUPP and ECANCELED if they are already defined in <errno.h>.