### PR TITLE
Improve documentation of --tailoring-file and --tailoring-id options

### DIFF
--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -262,6 +262,10 @@ static struct oscap_module XCCDF_GEN_FIX = {
 		"   --benchmark-id <id> \r\t\t\t\t - ID of XCCDF Benchmark in some component in the datastream that should be used.\n"
 		"                   \r\t\t\t\t   (only applicable for source datastreams)\n"
 		"   --xccdf-id <id> \r\t\t\t\t - ID of component-ref with XCCDF in the datastream that should be evaluated.\n"
+		"                   \r\t\t\t\t   (only applicable for source datastreams)\n"
+		"   --tailoring-file <file>\r\t\t\t\t - Use given XCCDF Tailoring file.\n"
+		"                   \r\t\t\t\t   (only applicable for source datastreams)\n"
+		"   --tailoring-id <component-id>\r\t\t\t\t - Use given DS component as XCCDF Tailoring file.\n"
 		"                   \r\t\t\t\t   (only applicable for source datastreams)\n",
     .opt_parser = getopt_xccdf,
     .user = "legacy-fix.xsl",

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -203,7 +203,7 @@ static struct oscap_module XCCDF_REMEDIATE = {
 
 #define GEN_OPTS \
         "Generate options:\n" \
-        "   --profile <profile-id>\r\t\t\t\t - Tailor XCCDF file with respect to a profile.\n"
+        "   --profile <profile-id>\r\t\t\t\t - Apply profile with given ID to the Benchmark before further processing takes place.\n"
 
 static struct oscap_module XCCDF_GENERATE = {
     .name = "generate",

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -82,12 +82,12 @@ Select a particular rule from XCCDF document. Only this rule will be evaluated. 
 .TP
 \fB\-\-tailoring-file TAILORING_FILE\fR
 .RS
-Use given file for XCCDF tailoring. Needs to specify customized profile ID using --profile to take effect. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
+Use given file for XCCDF tailoring. Select profile from tailoring file to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .RE
 .TP
 \fB\-\-tailoring-id COMPONENT_ID\fR
 .RS
-Use component of given ID (in input source datastream) for XCCDF tailoring. Needs to specify customized profile ID using --profile to take effect. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
+Use component of given ID (in input source datastream) for XCCDF tailoring. Select profile from tailoring component to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .RE
 .TP
 \fB\-\-cpe CPE_FILE\fR
@@ -350,10 +350,10 @@ Takes component ref with given ID from checklists. This allows to select a parti
 Selects a component ref from any datastream that references a component with XCCDF Benchmark such that its @id attribute matches given string exactly.
 .TP
 \fB\-\-tailoring-file TAILORING_FILE\fR
-Use given file for XCCDF tailoring. Needs to specify customized profile ID using --profile to take effect. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
+Use given file for XCCDF tailoring. Select profile from tailoring file to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .TP
 \fB\-\-tailoring-id COMPONENT_ID\fR
-Use component of given ID (in input source datastream) for XCCDF tailoring. Needs to specify customized profile ID using --profile to take effect. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
+Use component of given ID (in input source datastream) for XCCDF tailoring. Select profile from tailoring component to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .RE
 .TP
 .B \fBcustom\fR  --stylesheet xslt-file [\fIoptions\fR] xccdf-file

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -348,6 +348,12 @@ Takes component ref with given ID from checklists. This allows to select a parti
 .TP
 \fB\-\-benchmark-id ID\fR
 Selects a component ref from any datastream that references a component with XCCDF Benchmark such that its @id attribute matches given string exactly.
+.TP
+\fB\-\-tailoring-file TAILORING_FILE\fR
+Use given file for XCCDF tailoring. Needs to specify customized profile ID using --profile to take effect. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
+.TP
+\fB\-\-tailoring-id COMPONENT_ID\fR
+Use component of given ID (in input source datastream) for XCCDF tailoring. Needs to specify customized profile ID using --profile to take effect. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .RE
 .TP
 .B \fBcustom\fR  --stylesheet xslt-file [\fIoptions\fR] xccdf-file

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -85,9 +85,9 @@ Select a particular rule from XCCDF document. Only this rule will be evaluated. 
 Use given file for XCCDF tailoring. Select profile from tailoring file to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .RE
 .TP
-\fB\-\-tailoring-id COMPONENT_ID\fR
+\fB\-\-tailoring-id COMPONENT_REF_ID\fR
 .RS
-Use component of given ID (in input source datastream) for XCCDF tailoring. Select profile from tailoring component to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
+Use tailoring component in input source datastream for XCCDF tailoring. The tailoring component must be specified by its Ref-ID (value of component-ref/@id attribute in input source datastream). Select profile from tailoring component to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .RE
 .TP
 \fB\-\-cpe CPE_FILE\fR
@@ -352,8 +352,8 @@ Selects a component ref from any datastream that references a component with XCC
 \fB\-\-tailoring-file TAILORING_FILE\fR
 Use given file for XCCDF tailoring. Select profile from tailoring file to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .TP
-\fB\-\-tailoring-id COMPONENT_ID\fR
-Use component of given ID (in input source datastream) for XCCDF tailoring. Select profile from tailoring component to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
+\fB\-\-tailoring-id COMPONENT_REF_ID\fR
+Use tailoring component in input source datastream for XCCDF tailoring. The tailoring component must be specified by its Ref-ID (value of component-ref/@id attribute in input source datastream). Select profile from tailoring component to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .RE
 .TP
 .B \fBcustom\fR  --stylesheet xslt-file [\fIoptions\fR] xccdf-file

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -82,12 +82,12 @@ Select a particular rule from XCCDF document. Only this rule will be evaluated. 
 .TP
 \fB\-\-tailoring-file TAILORING_FILE\fR
 .RS
-Use given file for XCCDF tailoring. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority!
+Use given file for XCCDF tailoring. Needs to specify customized profile ID using --profile to take effect. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .RE
 .TP
 \fB\-\-tailoring-id COMPONENT_ID\fR
 .RS
-Use component of given ID (in input source datastream) for XCCDF tailoring. If both --tailoring-file and --tailoring-id are specified, --tailoring files takes priority!
+Use component of given ID (in input source datastream) for XCCDF tailoring. Needs to specify customized profile ID using --profile to take effect. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .RE
 .TP
 \fB\-\-cpe CPE_FILE\fR


### PR DESCRIPTION
This PR makes tailoring options in "oscap xccdf generate fix" visible in help and man page.  I basically fixed issue #894 but I also tried to clarify tailoring in "oscap xccdf eval" when I touched it.