### PR TITLE
Extend 'oscap info'

### DIFF
--- a/utils/oscap-tool.h
+++ b/utils/oscap-tool.h
@@ -138,7 +138,8 @@ struct oscap_action {
 	char *file;
 
 	int verbosity;
-        int doctype;
+	int show_profiles_only;
+	int doctype;
 	int force;
 	int validate;
 	int schematron;


### PR DESCRIPTION
This PR aims to address #685 by parametrizing the `info` module of the `oscap` binary.