### PR TITLE
Add path specification to wildcard function arguments.

### DIFF
--- a/schemas/Makefile.am
+++ b/schemas/Makefile.am
@@ -24,37 +24,37 @@ cpe23dir = $(pkgdatadir)/schemas/cpe/2.3/
 cvedir = $(pkgdatadir)/schemas/cve/
 commondir = $(pkgdatadir)/schemas/common/
 
-oval53_DATA = $(wildcard oval/5.3/*.xsd oval/5.3/*.xsl)
-oval54_DATA = $(wildcard oval/5.4/*.xsd oval/5.4/*.xsl)
-oval55_DATA = $(wildcard oval/5.5/*.xsd oval/5.5/*.xsl)
-oval56_DATA = $(wildcard oval/5.6/*.xsd oval/5.6/*.xsl)
-oval57_DATA = $(wildcard oval/5.7/*.xsd oval/5.7/*.xsl)
-oval58_DATA = $(wildcard oval/5.8/*.xsd oval/5.8/*.xsl)
-oval59_DATA = $(wildcard oval/5.9/*.xsd oval/5.9/*.xsl)
-oval510_DATA = $(wildcard oval/5.10/*.xsd oval/5.10/*.xsl)
-oval5101_DATA = $(wildcard oval/5.10.1/*.xsd oval/5.10.1/*.xsl)
-oval511_DATA = $(wildcard oval/5.11/*.xsd oval/5.11/*.xsl)
-oval5111_DATA = $(wildcard oval/5.11.1/*.xsd oval/5.11.1/*.xsl)
-oval5112_DATA = $(wildcard oval/5.11.2/*.xsd oval/5.11.2/*.xsl)
+oval53_DATA = $(wildcard $(srcdir)/oval/5.3/*.xsd $(srcdir)/oval/5.3/*.xsl)
+oval54_DATA = $(wildcard $(srcdir)/oval/5.4/*.xsd $(srcdir)/oval/5.4/*.xsl)
+oval55_DATA = $(wildcard $(srcdir)/oval/5.5/*.xsd $(srcdir)/oval/5.5/*.xsl)
+oval56_DATA = $(wildcard $(srcdir)/oval/5.6/*.xsd $(srcdir)/oval/5.6/*.xsl)
+oval57_DATA = $(wildcard $(srcdir)/oval/5.7/*.xsd $(srcdir)/oval/5.7/*.xsl)
+oval58_DATA = $(wildcard $(srcdir)/oval/5.8/*.xsd $(srcdir)/oval/5.8/*.xsl)
+oval59_DATA = $(wildcard $(srcdir)/oval/5.9/*.xsd $(srcdir)/oval/5.9/*.xsl)
+oval510_DATA = $(wildcard $(srcdir)/oval/5.10/*.xsd $(srcdir)/oval/5.10/*.xsl)
+oval5101_DATA = $(wildcard $(srcdir)/oval/5.10.1/*.xsd $(srcdir)/oval/5.10.1/*.xsl)
+oval511_DATA = $(wildcard $(srcdir)/oval/5.11/*.xsd $(srcdir)/oval/5.11/*.xsl)
+oval5111_DATA = $(wildcard $(srcdir)/oval/5.11.1/*.xsd $(srcdir)/oval/5.11.1/*.xsl)
+oval5112_DATA = $(wildcard $(srcdir)/oval/5.11.2/*.xsd $(srcdir)/oval/5.11.2/*.xsl)
 
 sce10_DATA = sce/1.0/sce-result-schema.xsd
 
-xccdf11_DATA = $(wildcard xccdf/1.1/*.xsd xccdf/1.1/*.dtd)
-xccdf11tailoring_DATA = $(wildcard xccdf/1.1-tailoring/*.xsd xccdf/1.1-tailoring/*.dtd)
-xccdf12_DATA = $(wildcard xccdf/1.2/*.xsd xccdf/1.2/*.dtd xccdf/1.2/*.xsl)
+xccdf11_DATA = $(wildcard $(srcdir)/xccdf/1.1/*.xsd $(srcdir)/xccdf/1.1/*.dtd)
+xccdf11tailoring_DATA = $(wildcard $(srcdir)/xccdf/1.1-tailoring/*.xsd $(srcdir)/xccdf/1.1-tailoring/*.dtd)
+xccdf12_DATA = $(wildcard $(srcdir)/xccdf/1.2/*.xsd $(srcdir)/xccdf/1.2/*.dtd $(srcdir)/xccdf/1.2/*.xsl)
 
-sds12_DATA = $(wildcard sds/1.2/*.xsd sds/1.2/*.dtd)
-arf11_DATA = $(wildcard arf/1.1/*.xsd)
+sds12_DATA = $(wildcard $(srcdir)/sds/1.2/*.xsd $(srcdir)/sds/1.2/*.dtd)
+arf11_DATA = $(wildcard $(srcdir)/arf/1.1/*.xsd)
 
-ocil20_DATA = $(wildcard ocil/2.0/*.xsd sds/2.0/*.dtd)
+ocil20_DATA = $(wildcard $(srcdir)/ocil/2.0/*.xsd $(srcdir)/sds/2.0/*.dtd)
 
-cpe20_DATA = $(wildcard cpe/2.0/*.xsd cpe/2.0/*.dtd)
-cpe21_DATA = $(wildcard cpe/2.1/*.xsd cpe/2.1/*.dtd)
-cpe22_DATA = $(wildcard cpe/2.2/*.xsd cpe/2.2/*.dtd)
-cpe23_DATA = $(wildcard cpe/2.3/*.xsd cpe/2.3/*.dtd)
+cpe20_DATA = $(wildcard $(srcdir)/cpe/2.0/*.xsd $(srcdir)/cpe/2.0/*.dtd)
+cpe21_DATA = $(wildcard $(srcdir)/cpe/2.1/*.xsd $(srcdir)/cpe/2.1/*.dtd)
+cpe22_DATA = $(wildcard $(srcdir)/cpe/2.2/*.xsd $(srcdir)/cpe/2.2/*.dtd)
+cpe23_DATA = $(wildcard $(srcdir)/cpe/2.3/*.xsd $(srcdir)/cpe/2.3/*.dtd)
 
-cve_DATA = $(wildcard cve/*.xsd)
-common_DATA = $(wildcard common/*.xsd)
+cve_DATA = $(wildcard $(srcdir)/cve/*.xsd)
+common_DATA = $(wildcard $(srcdir)/common/*.xsd)
 
 EXTRA_DIST = \
 	$(oval53_DATA) \


### PR DESCRIPTION
Automake doesn't understand the wildcard function which is evaluated
at install-time. Therefore, one has to make manually sure that the wildcard
argument corresponds to the intended filesystem location even when the build
happens outside the source tree.

This fixes #871 . The 100% clean solution would be to [remove the wildcards](https://www.gnu.org/software/automake/manual/html_node/Wildcards.html), but I can imagine we don't want to go for it.