### PR TITLE
Fix several arrays declaration

### DIFF
--- a/utils/oscap-cve.c
+++ b/utils/oscap-cve.c
@@ -41,7 +41,9 @@ static bool getopt_cve(int argc, char **argv, struct oscap_action *action);
 static int app_cve_validate(const struct oscap_action *action);
 static int app_cve_find(const struct oscap_action *action);
 
-static struct oscap_module* CVE_SUBMODULES[];
+#define CVE_SUBMODULES_NUM 3 /* See actual CVE_SUBMODULES array
+				initialization below. */
+static struct oscap_module* CVE_SUBMODULES[CVE_SUBMODULES_NUM];
 
 struct oscap_module OSCAP_CVE_MODULE = {
     .name = "cve",
@@ -70,7 +72,7 @@ static struct oscap_module CVE_FIND_MODULE = {
     .func = app_cve_find
 };
 
-static struct oscap_module* CVE_SUBMODULES[] = {
+static struct oscap_module* CVE_SUBMODULES[CVE_SUBMODULES_NUM] = {
     &CVE_VALIDATE_MODULE,
     &CVE_FIND_MODULE,
     NULL

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -40,7 +40,9 @@
 #include "oscap-tool.h"
 #include <oscap_debug.h>
 
-static struct oscap_module* DS_SUBMODULES[];
+#define DS_SUBMODULES_NUM 8 /* See actual DS_SUBMODULES array
+				initialization below. */
+static struct oscap_module* DS_SUBMODULES[DS_SUBMODULES_NUM];
 bool getopt_ds(int argc, char **argv, struct oscap_action *action);
 int app_ds_sds_split(const struct oscap_action *action);
 int app_ds_sds_compose(const struct oscap_action *action);
@@ -143,7 +145,7 @@ static struct oscap_module DS_RDS_VALIDATE_MODULE = {
 	.func = app_ds_rds_validate
 };
 
-static struct oscap_module* DS_SUBMODULES[] = {
+static struct oscap_module* DS_SUBMODULES[DS_SUBMODULES_NUM] = {
 	&DS_SDS_SPLIT_MODULE,
 	&DS_SDS_COMPOSE_MODULE,
 	&DS_SDS_ADD_MODULE,

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -57,8 +57,11 @@ static bool getopt_oval_report(int argc, char **argv, struct oscap_action *actio
 
 static bool valid_inputs(const struct oscap_action *action);
 
-static struct oscap_module* OVAL_SUBMODULES[];
-static struct oscap_module* OVAL_GEN_SUBMODULES[];
+#define OVAL_SUBMODULES_NUM	8
+#define OVAL_GEN_SUBMODULES_NUM 2 /* See actual OVAL_GEN_SUBMODULES and
+				OVAL_SUBMODULES arrays initialization below. */
+static struct oscap_module* OVAL_SUBMODULES[OVAL_SUBMODULES_NUM];
+static struct oscap_module* OVAL_GEN_SUBMODULES[OVAL_GEN_SUBMODULES_NUM];
 
 struct oscap_module OSCAP_OVAL_MODULE = {
     .name = "oval",
@@ -191,11 +194,11 @@ static struct oscap_module OVAL_LIST_PROBES = {
     .func = app_oval_list_probes
 };
 
-static struct oscap_module* OVAL_GEN_SUBMODULES[] = {
+static struct oscap_module* OVAL_GEN_SUBMODULES[OVAL_GEN_SUBMODULES_NUM] = {
     &OVAL_REPORT,
     NULL
 };
-static struct oscap_module* OVAL_SUBMODULES[] = {
+static struct oscap_module* OVAL_SUBMODULES[OVAL_SUBMODULES_NUM] = {
     &OVAL_COLLECT,
     &OVAL_EVAL,
     &OVAL_ANALYSE,

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -64,8 +64,11 @@ static bool getopt_generate(int argc, char **argv, struct oscap_action *action);
 static int app_xccdf_xslt(const struct oscap_action *action);
 static int app_generate_fix(const struct oscap_action *action);
 
-static struct oscap_module* XCCDF_SUBMODULES[8];
-static struct oscap_module* XCCDF_GEN_SUBMODULES[5];
+#define XCCDF_SUBMODULES_NUM		8
+#define XCCDF_GEN_SUBMODULES_NUM	5 /* See actual arrays
+						initialization below. */
+static struct oscap_module* XCCDF_SUBMODULES[XCCDF_SUBMODULES_NUM];
+static struct oscap_module* XCCDF_GEN_SUBMODULES[XCCDF_GEN_SUBMODULES_NUM];
 
 struct oscap_module OSCAP_XCCDF_MODULE = {
     .name = "xccdf",
@@ -286,7 +289,7 @@ static struct oscap_module XCCDF_GEN_CUSTOM = {
     .func = app_xccdf_xslt
 };
 
-static struct oscap_module* XCCDF_GEN_SUBMODULES[] = {
+static struct oscap_module* XCCDF_GEN_SUBMODULES[XCCDF_GEN_SUBMODULES_NUM] = {
     &XCCDF_GEN_REPORT,
     &XCCDF_GEN_GUIDE,
     &XCCDF_GEN_FIX,
@@ -294,7 +297,7 @@ static struct oscap_module* XCCDF_GEN_SUBMODULES[] = {
     NULL
 };
 
-static struct oscap_module* XCCDF_SUBMODULES[] = {
+static struct oscap_module* XCCDF_SUBMODULES[XCCDF_SUBMODULES_NUM] = {
     &XCCDF_EVAL,
     &XCCDF_RESOLVE,
     &XCCDF_VALIDATE,


### PR DESCRIPTION
Get rid of warnings about missing array size reported by at least XLC and GCC compilers.
Also remove the use of magic numbers in a previous fix in ./utils/oscap-xccdf.c (#845).