### PR TITLE
Remove obsolete omp pragma

### DIFF
--- a/src/OVAL/probes/crapi/digest.c
+++ b/src/OVAL/probes/crapi/digest.c
@@ -145,7 +145,6 @@ int crapi_mdigest_fd (int fd, int num, ... /* crapi_alg_t alg, void *dst, size_t
         va_end (ap);
 
         while ((ret = read (fd, fd_buf, sizeof fd_buf)) == sizeof fd_buf) {
-#pragma omp parallel for
                 for (i = 0; i < num; ++i) {
 			if (ctbl[i].ctx == NULL)
 				continue;


### PR DESCRIPTION
IBM XLC fails with the following error on "pragma omp parallel for" statement:
>"digest.c", line 153.33: 1506-814 (S) Branching in or out of structured block and parallel/work-sharing loop is not allowed."