### PR TITLE
Ansible variables to come first before tasks

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -598,10 +598,17 @@ static inline int _xccdf_policy_rule_generate_fix_ansible(const char *template, 
 		return 1;
 	}
 
+	// ovector sizing:
+	// 2 elements are used for the whole needle,
+	// 4 elements are used for the 2 capture groups
+	// pcre documentation says we should allocate a third extra for additional
+	// workspace.
+	// (3 * 2) * (3 / 2) = 9
+	int ovector[9];
+
 	const size_t fix_text_len = strlen(fix_text);
 	int start_offset = 0;
 	while (true) {
-		int ovector[30];
 		const int match = pcre_exec(re, NULL, fix_text, fix_text_len, start_offset,
 				0, ovector, sizeof(ovector) / sizeof(ovector[0]));
 		if (match == -1)

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -696,6 +696,7 @@ static inline int _xccdf_policy_rule_generate_fix(struct xccdf_policy *policy, s
 			_write_remediation_to_fd_and_free(output_fd, template, remediation_part);
 		}
 
+		free(fix_text);
 		pcre_free(re);
 #else
 		// TODO: Implement the post-process for posix regex as well

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -704,7 +704,7 @@ static inline int _xccdf_policy_rule_generate_fix(struct xccdf_policy *policy, s
 		// TODO: Implement the post-process for posix regex as well
 		if (ansible_variable_mode) {
 			free(fix_text);
-			fix_text = strdup("");
+			fix_text = oscap_strdup("");
 		}
 #endif
 	}

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -603,7 +603,7 @@ static inline int _xccdf_policy_rule_generate_fix_ansible(const char *template, 
 	// 4 elements are used for the 2 capture groups
 	// pcre documentation says we should allocate a third extra for additional
 	// workspace.
-	// (3 * 2) * (3 / 2) = 9
+	// (2 + 4) * (3 / 2) = 9
 	int ovector[9];
 
 	const size_t fix_text_len = strlen(fix_text);

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -665,16 +665,20 @@ static inline int _xccdf_policy_rule_generate_fix(struct xccdf_policy *policy, s
 				return 1;
 			}
 
-			char *variable_name = malloc((ovector[3] - ovector[2] + 1) * sizeof(char));
-			memcpy(variable_name, &fix_text[ovector[2]], ovector[3] - ovector[2]);
-			variable_name[ovector[3] - ovector[2]] = '\0';
-
-			char *variable_value = malloc((ovector[5] - ovector[4] + 1) * sizeof(char));
-			memcpy(variable_value, &fix_text[ovector[4]], ovector[5] - ovector[4]);
-			variable_value[ovector[5] - ovector[4]] = '\0';
-
 			if (ansible_variable_mode) {
+				char *variable_name = malloc((ovector[3] - ovector[2] + 1) * sizeof(char));
+				memcpy(variable_name, &fix_text[ovector[2]], ovector[3] - ovector[2]);
+				variable_name[ovector[3] - ovector[2]] = '\0';
+
+				char *variable_value = malloc((ovector[5] - ovector[4] + 1) * sizeof(char));
+				memcpy(variable_value, &fix_text[ovector[4]], ovector[5] - ovector[4]);
+				variable_value[ovector[5] - ovector[4]] = '\0';
+
 				char *var_line = oscap_sprintf("  %s: %s", variable_name, variable_value);
+
+				free(variable_name);
+				free(variable_value);
+
 				_write_remediation_to_fd_and_free(output_fd, template, var_line);
 			}
 			else {
@@ -685,8 +689,6 @@ static inline int _xccdf_policy_rule_generate_fix(struct xccdf_policy *policy, s
 			}
 
 			start_offset = ovector[1]; // next time start after the entire pattern
-			free(variable_name);
-			free(variable_value);
 		}
 
 		if (!ansible_variable_mode && fix_text_len - start_offset > 0) {

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -614,6 +614,9 @@ static inline int _xccdf_policy_rule_generate_fix_ansible(const char *template, 
 		}
 
 		if (ansible_variable_mode) {
+			// ovector[0] and [1] hold the start and end of the whole needle match
+			// ovector[2] and [3] hold the start and end of the first capture group
+			// ovector[4] and [5] hold the start and end of the second capture group
 			char *variable_name = malloc((ovector[3] - ovector[2] + 1) * sizeof(char));
 			memcpy(variable_name, &fix_text[ovector[2]], ovector[3] - ovector[2]);
 			variable_name[ovector[3] - ovector[2]] = '\0';

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -660,9 +660,12 @@ static inline int _xccdf_policy_rule_generate_fix_ansible(const char *template, 
 	return 0;
 #else
 	// TODO: Implement the post-process for posix regex as well
-	if (!ansible_variable_mode) {
-		return _write_remediation_to_fd_and_free(output_fd, template, fix_text);
+	if (ansible_variable_mode) {
+		// this is not implemented so we don't write anything out for variables
+		return 0;
 	}
+	else
+		return _write_remediation_to_fd_and_free(output_fd, template, fix_text);
 #endif
 }
 

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -637,13 +637,19 @@ static inline int _xccdf_policy_rule_generate_fix_ansible(const char *template, 
 			free(variable_name);
 			free(variable_value);
 
-			_write_remediation_to_fd_and_free(output_fd, template, var_line);
+			if (_write_remediation_to_fd_and_free(output_fd, template, var_line) != 0) {
+				pcre_free(re);
+				return 1;
+			}
 		}
 		else {
 			char *remediation_part = malloc((ovector[0] + 1) * sizeof(char));
 			memcpy(remediation_part, &fix_text[start_offset], ovector[0]);
 			remediation_part[ovector[0]] = '\0';
-			_write_remediation_to_fd_and_free(output_fd, template, remediation_part);
+			if (_write_remediation_to_fd_and_free(output_fd, template, remediation_part) != 0) {
+				pcre_free(re);
+				return 1;
+			}
 		}
 
 		start_offset = ovector[1]; // next time start after the entire pattern
@@ -653,7 +659,11 @@ static inline int _xccdf_policy_rule_generate_fix_ansible(const char *template, 
 		char *remediation_part = malloc((fix_text_len - start_offset + 1) * sizeof(char));
 		memcpy(remediation_part, &fix_text[start_offset], fix_text_len - start_offset);
 		remediation_part[fix_text_len - start_offset] = '\0';
-		_write_remediation_to_fd_and_free(output_fd, template, remediation_part);
+
+		if (_write_remediation_to_fd_and_free(output_fd, template, remediation_part) != 0) {
+			pcre_free(re);
+			return 1;
+		}
 	}
 
 	pcre_free(re);

--- a/tests/API/XCCDF/unittests/test_fix_arf.playbook1.yml
+++ b/tests/API/XCCDF/unittests/test_fix_arf.playbook1.yml
@@ -1,5 +1,6 @@
 ---
  - hosts: all
+   vars:
    tasks:
     - name: ensure everything passes
         shell: /bin/true

--- a/tests/API/XCCDF/unittests/test_fix_arf.playbook2.yml
+++ b/tests/API/XCCDF/unittests/test_fix_arf.playbook2.yml
@@ -1,5 +1,6 @@
 ---
  - hosts: all
+   vars:
    tasks:
     - name: correct the failing case
         shell: /bin/false


### PR DESCRIPTION
In ansible playbooks it is customary for variables to be specified in a list separate from tasks. That way Ansible users can tailor the playbooks without any external tools:

Playbook after this change:
```
---
###############################################################################
#
# Ansible remediation role for profile xccdf_org.ssgproject.content_profile_pci-dss
# Profile Title:  PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7
# Profile Description:
# This is a *draft* profile for PCI-DSS v3.
#
# Benchmark ID:  xccdf_org.ssgproject.content_benchmark_RHEL-7
# Benchmark Version:  0.1.36
#
# XCCDF Version:  1.2
#
# This file was generated by OpenSCAP 1.2.16 using:
# 	$ oscap xccdf generate fix --profile xccdf_org.ssgproject.content_profile_pci-dss --template urn:xccdf:fix:script:ansible sds.xml 
#
# This script is generated from an OpenSCAP profile without preliminary evaluation.
# It attempts to fix every selected rule, even if the system is already compliant.
#
# How to apply this remediation role:
# $ ansible-playbook -i "192.168.1.155," playbook.yml
# $ ansible-playbook -i inventory.ini playbook.yml
#
###############################################################################


 - hosts: all
   vars:
      inactivity_timeout_value: 900
      var_accounts_maximum_age_login_defs: 90
      var_account_disable_post_pw_expiration: 90
      var_password_pam_dcredit: -1
      var_password_pam_minlen: 7
      var_password_pam_ucredit: -1
      var_password_pam_lcredit: -1
      var_auditd_max_log_file: 6
      var_auditd_max_log_file_action: rotate
      var_auditd_space_left_action: email
      var_auditd_admin_space_left_action: single
      var_auditd_action_mail_acct: root
      sshd_idle_timeout_value: 900
   tasks:
    - name: "Read permission of GPG key directory"
      stat:
        path: /etc/pki/rpm-gpg/
      register: gpg_key_directory_permission
      check_mode: no
      tags:
        - ensure_redhat_gpgkey_installed
        - high_severity
        - restrict_strategy
        - medium_complexity
        - medium_disruption
...
```