### PR TITLE
Add missing includes

### DIFF
--- a/src/OVAL/oval_variable.c
+++ b/src/OVAL/oval_variable.c
@@ -45,6 +45,7 @@
 #include "common/oscap_string.h"
 #include "results/oval_cmp_impl.h"
 #include "results/oval_results_impl.h"
+#include "public/oval_probe.h"
 
 typedef struct oval_variable {
 #define VAR_BASE				\

--- a/src/OVAL/probes/SEAP/seap-command-backendS.c
+++ b/src/OVAL/probes/SEAP/seap-command-backendS.c
@@ -30,6 +30,7 @@
 #include "public/sm_alloc.h"
 #include "_seap-command.h"
 #include "seap-command-backendS.h"
+#include "seap-command-backendL.h"
 
 typedef struct {
         SEAP_cmdrec_t **c_recs;

--- a/tests/API/CVRF/Makefile.am
+++ b/tests/API/CVRF/Makefile.am
@@ -6,6 +6,7 @@ AM_CPPFLAGS =   -I$(top_srcdir)/tests/include \
 		-I$(top_srcdir)/src/CCE/public \
 		-I$(top_srcdir)/src/OVAL/public \
 		-I$(top_srcdir)/src/XCCDF/public \
+		-I$(top_srcdir)/src/XCCDF_POLICY/public \
 		-I$(top_srcdir)/src/common/public \
 		-I$(top_srcdir)/src/source/public \
 		-I$(top_srcdir)/src/OVAL/probes/public \

--- a/utils/oscap-cve.c
+++ b/utils/oscap-cve.c
@@ -34,6 +34,7 @@
 
 #include <cve_nvd.h>
 #include <oscap_source.h>
+#include <xccdf_session.h>
 
 #include "oscap-tool.h"
 

--- a/utils/oscap-cvss.c
+++ b/utils/oscap-cvss.c
@@ -33,6 +33,7 @@
 #include <math.h>
 
 #include <cvss_score.h>
+#include <xccdf_session.h>
 
 #include "oscap-tool.h"
 

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -36,6 +36,7 @@
 #include <oscap_source.h>
 #include <ds_rds_session.h>
 #include <ds_sds_session.h>
+#include <xccdf_session.h>
 
 #include "oscap-tool.h"
 #include <oscap_debug.h>

--- a/utils/oscap-info.c
+++ b/utils/oscap-info.c
@@ -46,6 +46,7 @@
 #include <scap_ds.h>
 #include <ds_rds_session.h>
 #include <ds_sds_session.h>
+#include <xccdf_session.h>
 
 #include "oscap-tool.h"
 

--- a/utils/oscap-tool.h
+++ b/utils/oscap-tool.h
@@ -37,6 +37,7 @@
 #include <oval_probe.h>
 #include <cvss_score.h>
 #include <xccdf_benchmark.h>
+#include <xccdf_session.h>
 #include <cpe_dict.h>
 #include <cpe_name.h>
 #include <cve_nvd.h>


### PR DESCRIPTION
Addressing many warnings like
```
/home/jcerny/openscap/utils/oscap-tool.h:174:47: warning: ‘struct
xccdf_session’ declared inside parameter list will not be visible
outside of this definition or declaration
 int xccdf_set_profile_or_report_bad_id(struct xccdf_session *session,
const char *profile_id, const char *source_file);
```