### PR TITLE
Run sql57 probe tests only if sql57 probe is build

### DIFF
--- a/tests/probes/sql57/CMakeLists.txt
+++ b/tests/probes/sql57/CMakeLists.txt
@@ -1,3 +1,3 @@
-if(ENABLE_PROBES_INDEPENDENT)
+if(ENABLE_PROBES_INDEPENDENT AND TARGET sql57_probe)
 	add_oscap_test("all.sh")
 endif()


### PR DESCRIPTION
The test should be skipped if the probe is not build.