### PR TITLE
Remove posix regex leftovers from master branch

### DIFF
--- a/src/OVAL/probes/independent/system_info.c
+++ b/src/OVAL/probes/independent/system_info.c
@@ -99,7 +99,6 @@
 #include <arpa/inet.h>
 #include <sys/types.h>
 
-#if defined USE_REGEX_PCRE
 #include <pcre.h>
 #define _REGEX_RES_VECSIZE     3
 #define _REGEX_MENUENTRY       "(?<=menuentry ').*?(?=')"
@@ -107,13 +106,6 @@
 #define _REGEX_SAVED_ENTRY     "(?<=saved_entry=).*"
 #define _REGEX_ARCH            "(?<=\\.)i386|i686|x86_64|ia64|alpha|amd64|arm|armeb|armel|hppa|m32r" \
 		               "|m68k|mips|mipsel|powerpc|ppc64|s390|s390x|sh3|sh3eb|sh4|sh4eb|sparc"
-#elif defined USE_REGEX_POSIX
-#include <regex.h>
-#define _REGEX_MENUENTRY       "^menuentry '.*'"
-#define _REGEX_SAVED_ENTRY     "^saved_entry=.*"
-#define _REGEX_ARCH            "\\.(i386|i686|x86_64|ia64|alpha|amd64|arm|armeb|armel|hppa|m32r" \
-		               "|m68k|mips|mipsel|powerpc|ppc64|s390|s390x|sh3|sh3eb|sh4|sh4eb|sparc)"
-#endif
 #define MAX_BUFFER_SIZE        4096
 
 static int fd=-1;
@@ -364,7 +356,6 @@ static char * _offline_chroot_get_menuentry(int entry_num)
 	if (fp == NULL)
 		goto fail;
 
-#ifdef USE_REGEX_PCRE
 	int rc = PCRE_ERROR_NOMATCH;
 	int erroffset, ovec[_REGEX_RES_VECSIZE];
 	const char *error;
@@ -397,40 +388,6 @@ static char * _offline_chroot_get_menuentry(int entry_num)
 
 	grubcfg[ovec[1]] = '\0';
 	ret = strdup(grubcfg + ovec[0]);
-#elif defined USE_REGEX_POSIX
-	regex_t preg;
-	regmatch_t pmatch[1];
-
-	int rc = regcomp(&preg, _REGEX_MENUENTRY, REG_EXTENDED|REG_NEWLINE);
-	if (rc)
-		goto fail2;
-
-	while ((len = fread(grubcfg, 1, MAX_BUFFER_SIZE, fp)) > 0) {
-		if (ferror(fp)) {
-			regfree(&preg);
-			goto fail2;
-		}
-
-		do {
-			rc = regexec(&preg, grubcfg, 1, pmatch, 0);
-			if (rc == 0)
-				entry_num--;
-		} while (rc == 0 && entry_num > 0);
-
-		if (entry_num == 0)
-			break;
-	}
-	regfree(&preg);
-
-	/* End string at first ' character ocurrance or matched string end  */
-	char *ptr = grubcfg + pmatch->rm_so + sizeof("menuentry '") - 1;
-	char *replace = strstr(ptr, "'");
-	if (replace)
-		*replace = '\0';
-	grubcfg[pmatch->rm_eo] = '\0';
-
-	ret = strdup(ptr);
-#endif
 fail2:
 	fclose(fp);
 fail:
@@ -459,7 +416,6 @@ static char * _offline_chroot_get_arch(const char *os)
 	if (os == NULL)
 		return NULL;
 
-#ifdef USE_REGEX_PCRE
 	int erroffset, ovec[_REGEX_RES_VECSIZE] = { 0 };
 	const char *error;
 	pcre *re;
@@ -481,30 +437,6 @@ static char * _offline_chroot_get_arch(const char *os)
 fail:
 	pcre_free(re);
 	return ptr;
-#elif defined USE_REGEX_POSIX
-	regex_t preg;
-	regmatch_t pmatch[1];
-
-	rc = regcomp(&preg, _REGEX_ARCH, REG_EXTENDED|REG_NEWLINE);
-	if (rc)
-		goto fail2;
-
-	rc = regexec(&preg, os, 1, pmatch, 0);
-	if (rc) {
-		regfree(&preg);
-		goto fail2;
-	}
-
-	size_t len = pmatch->rm_eo - pmatch->rm_so - 1; // Skip '.' char
-	ptr = malloc(sizeof(char) * len + 1);
-	if (ptr == NULL)
-		goto fail2;
-	ptr = strncpy(ptr, os + pmatch->rm_so+1, len);
-	ptr[len] = '\0';
-fail2:
-	regfree(&preg);
-	return ptr;
-#endif
 }
 
 static char * _offline_chroot_get_os_name(void)
@@ -523,7 +455,6 @@ static char * _offline_chroot_get_os_name(void)
 		goto finish;
 	saved_entry[rc] = '\0';
 
-#ifdef USE_REGEX_PCRE
 	size_t len;
 	int erroffset, ovec[_REGEX_RES_VECSIZE] = { 0 };
 	const char *error;
@@ -557,38 +488,6 @@ static char * _offline_chroot_get_os_name(void)
 		pcre_free(re);
 		goto finish;
 	}
-#elif defined USE_REGEX_POSIX
-	regex_t preg;
-	regmatch_t pmatch[1];
-
-	rc = regcomp(&preg, _REGEX_SAVED_ENTRY, REG_EXTENDED|REG_NEWLINE);
-	if (rc)
-		goto finish;
-
-	rc = regexec(&preg, saved_entry, 1, pmatch, 0);
-	if (rc) {
-		regfree(&preg);
-		goto finish;
-	}
-
-	ptr = saved_entry + pmatch->rm_so + sizeof("saved_entry=")-1;
-	saved_entry[pmatch->rm_eo] = '\0';
-
-	/* Check if we got an entry # in grub.cfg or a name we can use */
-	for (char *tmp = ptr; *tmp; tmp++) {
-		if (!isdigit(*tmp)) {
-			ret = strdup(ptr);
-			break;
-		}
-	}
-
-	if (ret == NULL) { // Saved entry is all digits, so we need to inspect grub.cfg
-		int nr = atoi(ptr);
-		ret = _offline_chroot_get_menuentry(nr);
-	}
-
-	regfree(&preg);
-#endif
 finish:
 	fclose(fp);
 fail:

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -28,11 +28,7 @@
 #include <unistd.h>
 
 #include <libxml/tree.h>
-
-
-#if defined USE_REGEX_PCRE
 #include <pcre.h>
-#endif
 
 #include "XCCDF/item.h"
 #include "common/_error.h"
@@ -594,7 +590,6 @@ static int _write_fix_missing_warning_to_fd(const char *sys, int output_fd, stru
 
 static inline int _xccdf_policy_rule_generate_fix_ansible(const char *template, int output_fd, const char *fix_text, bool ansible_variable_mode)
 {
-#if defined USE_REGEX_PCRE
 	// TODO: Tolerate different indentation styles in this regex
 	const char *pattern =
 		"- name: XCCDF Value [^ ]+ # promote to variable\n  set_fact:\n"
@@ -679,15 +674,6 @@ static inline int _xccdf_policy_rule_generate_fix_ansible(const char *template, 
 
 	pcre_free(re);
 	return 0;
-#else
-	// TODO: Implement the post-process for posix regex as well
-	if (ansible_variable_mode) {
-		// this is not implemented so we don't write anything out for variables
-		return 0;
-	}
-	else
-		return _write_remediation_to_fd_and_free(output_fd, template, fix_text);
-#endif
 }
 
 static inline int _xccdf_policy_rule_generate_fix(struct xccdf_policy *policy, struct xccdf_rule *rule, const char *template, int output_fd, unsigned int current, unsigned int total, bool ansible_variable_mode)


### PR DESCRIPTION
Support for posix regular expression in master branch was removed long
time ago in 8bcad0850db80d379ca70a3daf293108af78c91e.
Bbut some code appeared again in master, probably by merging maint-1.2
branch. We need to be more careful when we merge maint-1.2 into master.