### PR TITLE
Use the versioned shebang in scap-as-rpm

### DIFF
--- a/utils/scap-as-rpm
+++ b/utils/scap-as-rpm
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2
+
 # Copyright 2013 Red Hat Inc., Durham, North Carolina.
 # All Rights Reserved.
 #


### PR DESCRIPTION
The world is moving to python3 and using just python is confusing.

Fixes #903

See also: https://taskotron.fedoraproject.org/artifacts/all/3de20448-c945-11e7-bbd3-525400817a8f/task_output/output.log