### PR TITLE
Remove unnecessary linking

### DIFF
--- a/cmake/FindRPM.cmake
+++ b/cmake/FindRPM.cmake
@@ -27,8 +27,10 @@ find_library(RPMIO_LIBRARY
 )
 
 set(RPM_VERSION ${RPM_PKGCONF_VERSION})
-string(COMPARE GREATER "4.6" ${RPM_VERSION} RPM46_FOUND)
-string(COMPARE GREATER "4.7" ${RPM_VERSION} RPM47_FOUND)
+if(RPM_VERSION)
+	string(COMPARE GREATER "4.6" ${RPM_VERSION} RPM46_FOUND)
+	string(COMPARE GREATER "4.7" ${RPM_VERSION} RPM47_FOUND)
+endif()
 
 # Set the include dir variables and the libraries and let libfind_process do the rest.
 # NOTE: Singular variables for this library, plural for libraries this this lib depends on.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,14 +53,18 @@ set(OBJECTS_TO_LINK_AGAINST
 	$<TARGET_OBJECTS:ovaladt_object>
 	$<TARGET_OBJECTS:ovalcmp_object>
 	$<TARGET_OBJECTS:ovalresults_object>
-	$<TARGET_OBJECTS:probe_object>
-	$<TARGET_OBJECTS:rbt_object>
-	$<TARGET_OBJECTS:seap_object>
 	$<TARGET_OBJECTS:xccdf_object>
 	$<TARGET_OBJECTS:xccdfPolicy_object>
 )
 if (ENABLE_CCE)
 	list(APPEND OBJECTS_TO_LINK_AGAINST $<TARGET_OBJECTS:cce_object>)
+endif()
+if (ENABLE_PROBES)
+	list(APPEND OBJECTS_TO_LINK_AGAINST
+		$<TARGET_OBJECTS:probe_object>
+		$<TARGET_OBJECTS:rbt_object>
+		$<TARGET_OBJECTS:seap_object>
+	)
 endif()
 
 add_library(openscap SHARED ${OBJECTS_TO_LINK_AGAINST})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,4 +74,4 @@ if(RPM_FOUND)
 	target_link_libraries(openscap ${RPM_LIBRARIES})
 endif()
 
-install(TARGETS openscap LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS openscap DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,5 +65,13 @@ endif()
 
 add_library(openscap SHARED ${OBJECTS_TO_LINK_AGAINST})
 set_target_properties(openscap PROPERTIES VERSION ${SONAME} SOVERSION ${SOVERSION})
+target_link_libraries(openscap ${LIBXML2_LIBRARIES} ${LIBXSLT_LIBRARIES} ${LIBXSLT_EXSLT_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES})
+if (BZIP2_FOUND)
+	target_link_libraries(openscap ${BZIP2_LIBRARIES})
+endif()
+if(RPM_FOUND)
+	# just because of rpmvercmp
+	target_link_libraries(openscap ${RPM_LIBRARIES})
+endif()
 
 install(TARGETS openscap LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/OVAL/probes/CMakeLists.txt
+++ b/src/OVAL/probes/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory("SEAP")
 function(add_oscap_probe PROBE_NAME PROBE_SOURCE_FILE)
 	add_executable(${PROBE_NAME} ${PROBE_SOURCE_FILE} ${ARGN})
 	target_include_directories(${PROBE_NAME} PRIVATE "." "public")
-	target_link_libraries(${PROBE_NAME} openscap ${LIBXML2_LIBRARIES} ${LIBXSLT_LIBRARIES} ${LIBXSLT_EXSLT_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES})
+	target_link_libraries(${PROBE_NAME} openscap ${LIBXML2_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES})
 	install(TARGETS ${PROBE_NAME} DESTINATION ${OVAL_PROBE_DIR})
 endfunction()
 

--- a/src/OVAL/probes/CMakeLists.txt
+++ b/src/OVAL/probes/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory("SEAP")
 function(add_oscap_probe PROBE_NAME PROBE_SOURCE_FILE)
 	add_executable(${PROBE_NAME} ${PROBE_SOURCE_FILE} ${ARGN})
 	target_include_directories(${PROBE_NAME} PRIVATE "." "public")
-	target_link_libraries(${PROBE_NAME} openscap ${LIBXML2_LIBRARIES} ${LIBXSLT_LIBRARIES} ${LIBXSLT_EXSLT_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES} ${RPM_LIBRARIES} ${BZIP2_LIBRARIES})
+	target_link_libraries(${PROBE_NAME} openscap ${LIBXML2_LIBRARIES} ${LIBXSLT_LIBRARIES} ${LIBXSLT_EXSLT_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES} ${RPM_LIBRARIES})
 	install(TARGETS ${PROBE_NAME} DESTINATION ${OVAL_PROBE_DIR})
 endfunction()
 

--- a/src/OVAL/probes/CMakeLists.txt
+++ b/src/OVAL/probes/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory("SEAP")
 function(add_oscap_probe PROBE_NAME PROBE_SOURCE_FILE)
 	add_executable(${PROBE_NAME} ${PROBE_SOURCE_FILE} ${ARGN})
 	target_include_directories(${PROBE_NAME} PRIVATE "." "public")
-	target_link_libraries(${PROBE_NAME} openscap ${LIBXML2_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES})
+	target_link_libraries(${PROBE_NAME} openscap ${LIBXML2_LIBRARIES} ${PCRE_LIBRARIES})
 	install(TARGETS ${PROBE_NAME} DESTINATION ${OVAL_PROBE_DIR})
 endfunction()
 

--- a/src/OVAL/probes/CMakeLists.txt
+++ b/src/OVAL/probes/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory("SEAP")
 function(add_oscap_probe PROBE_NAME PROBE_SOURCE_FILE)
 	add_executable(${PROBE_NAME} ${PROBE_SOURCE_FILE} ${ARGN})
 	target_include_directories(${PROBE_NAME} PRIVATE "." "public")
-	target_link_libraries(${PROBE_NAME} openscap ${LIBXML2_LIBRARIES} ${PCRE_LIBRARIES})
+	target_link_libraries(${PROBE_NAME} openscap ${PCRE_LIBRARIES})
 	install(TARGETS ${PROBE_NAME} DESTINATION ${OVAL_PROBE_DIR})
 endfunction()
 
@@ -21,6 +21,7 @@ if(ENABLE_PROBES_INDEPENDENT)
 	add_oscap_probe(probe_variable "independent/variable.c")
 
 	add_oscap_probe(probe_xmlfilecontent "independent/xmlfilecontent.c")
+	target_link_libraries(probe_xmlfilecontent ${LIBXML2_LIBRARIES})
 
 	add_oscap_probe(probe_filehash "independent/filehash.c")
 	target_link_libraries(probe_filehash crapi)

--- a/src/OVAL/probes/CMakeLists.txt
+++ b/src/OVAL/probes/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory("SEAP")
 function(add_oscap_probe PROBE_NAME PROBE_SOURCE_FILE)
 	add_executable(${PROBE_NAME} ${PROBE_SOURCE_FILE} ${ARGN})
 	target_include_directories(${PROBE_NAME} PRIVATE "." "public")
-	target_link_libraries(${PROBE_NAME} openscap ${LIBXML2_LIBRARIES} ${LIBXSLT_LIBRARIES} ${LIBXSLT_EXSLT_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES} ${RPM_LIBRARIES})
+	target_link_libraries(${PROBE_NAME} openscap ${LIBXML2_LIBRARIES} ${LIBXSLT_LIBRARIES} ${LIBXSLT_EXSLT_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES})
 	install(TARGETS ${PROBE_NAME} DESTINATION ${OVAL_PROBE_DIR})
 endfunction()
 
@@ -121,13 +121,16 @@ if(ENABLE_PROBES_LINUX)
 
 	if(RPM_FOUND)
 		add_oscap_probe(probe_rpminfo "unix/linux/rpminfo.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c")
+		target_link_libraries(probe_rpminfo ${RPM_LIBRARIES})
 
 		add_oscap_probe(probe_rpmverify "unix/linux/rpmverify.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c")
+		target_link_libraries(probe_rpmverify ${RPM_LIBRARIES})
 
 		add_oscap_probe(probe_rpmverifyfile "unix/linux/rpmverifyfile.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c")
+		target_link_libraries(probe_rpmverifyfile ${RPM_LIBRARIES})
 
 		add_oscap_probe(probe_rpmverifypackage "unix/linux/rpmverifypackage.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c" "unix/linux/probe-chroot.h" "unix/linux/probe-chroot.c")
-		target_link_libraries(probe_rpmverifypackage ${POPT_LIBRARIES})
+		target_link_libraries(probe_rpmverifypackage ${RPM_LIBRARIES} ${POPT_LIBRARIES})
 	endif()
 
 	if (APTPKG_FOUND)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(ENABLE_OSCAP_UTIL)
 	file(GLOB UTILS_SOURCES "*.c")
 	add_executable(oscap ${UTILS_SOURCES})
-	target_link_libraries(oscap openscap ${LIBXML2_LIBRARIES} ${LIBXSLT_LIBRARIES} ${LIBXSLT_EXSLT_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES} ${RPM_LIBRARIES})
+	target_link_libraries(oscap openscap)
 	install(TARGETS "oscap"
 		DESTINATION ${CMAKE_INSTALL_BINDIR}
 	)


### PR DESCRIPTION
For reasons I can't figure out we were linking to all sorts of libraries for every single probe. This seems weird and excessive. Why not link to the libraries in libopenscap.so? Maybe I am missing something?