### PR TITLE
Added stig viewer tests

### DIFF
--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -139,6 +139,7 @@ EXTRA_DIST += \
 	test_report_without_oval_poses_no_errors.xccdf.xml.result.xml \
 	test_report_without_xsl_fails_gracefully.sh \
 	test_single_rule.sh \
+	test_single_rule_stigw.sh correct_stigw_result.xml stig-viewer-equivalence.py \
 	test_single_rule.ds.xml \
 	test_single_rule.oval.xml \
 	test_single_rule-tailoring.xml \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -66,6 +66,7 @@ test_run "Profile suffix matching" $srcdir/test_profile_selection_by_suffix.sh
 test_run "libxml errors handled correctly" $srcdir/test_unfinished.sh
 test_run "XCCDF 1.1 to 1.2 transformation" $srcdir/test_xccdf_transformation.sh
 test_run "Test single-rule evaluation" $srcdir/test_single_rule.sh
+test_run "Test STIG viewer output for single-rule evaluation" $srcdir/test_single_rule_stigw.sh
 
 #
 # Tests for 'oscap xccdf eval --remediate' and substitution

--- a/tests/API/XCCDF/unittests/correct_stigw_result.xml
+++ b/tests/API/XCCDF/unittests/correct_stigw_result.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestResult xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_org.open-scap_testresult_default-profile" start-time="2017-12-01T17:40:39" end-time="2017-12-01T17:40:39" version="1.0" test-system="cpe:/a:redhat:openscap:1.2.17">
+  <benchmark href="unittests/test_single_rule.xccdf.xml" id="xccdf_com.example.www_benchmark_dummy"/>
+  <title>OSCAP Scan Result</title>
+  <identity authenticated="false" privileged="false">matyc</identity>
+  <target>matyc-laptop</target>
+  <target-address>127.0.0.1</target-address>
+  <target-address>10.43.21.229</target-address>
+  <target-address>10.200.159.53</target-address>
+  <target-address>192.168.124.1</target-address>
+  <target-address>0:0:0:0:0:0:0:1</target-address>
+  <target-address>2620:52:0:2b15:96e5:dd14:dcb:de8d</target-address>
+  <target-address>fe80:0:0:0:533:83a6:d471:8f80</target-address>
+  <target-address>fe80:0:0:0:9963:7041:aab3:2a17</target-address>
+  <target-facts>
+    <fact name="urn:xccdf:fact:scanner:name" type="string">OpenSCAP</fact>
+    <fact name="urn:xccdf:fact:scanner:version" type="string">1.2.17</fact>
+    <fact name="urn:xccdf:fact:ethernet:MAC" type="string">00:00:00:00:00:00</fact>
+    <fact name="urn:xccdf:fact:ethernet:MAC" type="string">54:E1:AD:72:81:54</fact>
+    <fact name="urn:xccdf:fact:ethernet:MAC" type="string">CC:2F:71:30:C6:22</fact>
+    <fact name="urn:xccdf:fact:ethernet:MAC" type="string">52:54:00:06:FE:61</fact>
+    <fact name="urn:xccdf:fact:ethernet:MAC" type="string">00:00:00:00:00:00</fact>
+    <fact name="urn:xccdf:fact:ethernet:MAC" type="string">54:E1:AD:72:81:54</fact>
+    <fact name="urn:xccdf:fact:ethernet:MAC" type="string">54:E1:AD:72:81:54</fact>
+    <fact name="urn:xccdf:fact:ethernet:MAC" type="string">CC:2F:71:30:C6:22</fact>
+  </target-facts>
+  <set-value idref="xccdf_com.example.www_value_val1">50</set-value>
+  <rule-result idref="SV-86937r1_rule" time="2017-12-01T17:40:39" weight="1.000000">
+    <result>pass</result>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref name="oval:test-pass:def:1" href="test_single_rule.oval.xml"/>
+    </check>
+  </rule-result>
+  <rule-result idref="SV-86601r1_rule" time="2017-12-01T17:40:39" weight="1.000000">
+    <result>fail</result>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-export export-name="oval:ssg:var:1" value-id="xccdf_com.example.www_value_val1"/>
+      <check-content-ref name="oval:test-fail:def:2" href="test_single_rule.oval.xml"/>
+    </check>
+  </rule-result>
+  <score system="urn:xccdf:scoring:default" maximum="100.000000">50.000000</score>
+</TestResult>

--- a/tests/API/XCCDF/unittests/stig-viewer-equivalence.py
+++ b/tests/API/XCCDF/unittests/stig-viewer-equivalence.py
@@ -14,15 +14,19 @@ class RuleResult(object):
     def __init__(self, element):
         self.idref = element.attrib["idref"]
         self.weight = element.attrib["weight"]
+
         result_element = element.find("{%s}result" % NAMESPACES["profile_ns"])
         self.result_text = result_element.text
+
         check_element = element.find("{%s}check" % NAMESPACES["profile_ns"])
         self.check_system = check_element.attrib["system"]
         self.check_system = check_element.attrib["system"]
+
         check_content_ref_element = check_element.find(
             "{%s}check-content-ref" % NAMESPACES["profile_ns"])
         self.content_ref_href = check_content_ref_element.attrib["href"]
         self.content_ref_name = check_content_ref_element.attrib["name"]
+
         check_export_element = check_element.find(
             "{%s}check-export" % NAMESPACES["profile_ns"])
         self.check_export_name = None
@@ -43,7 +47,7 @@ def fname_to_etree(fname):
     return input_tree
 
 
-def query_something(tree):
+def get_rule_results_from_etree(tree):
     xpath_expr =  ".//{%s}rule-result" % NAMESPACES["profile_ns"]
     xccdfs = tree.findall(xpath_expr)
     return xccdfs
@@ -51,7 +55,7 @@ def query_something(tree):
 
 def extract_results_from_file(fname):
     tree = fname_to_etree(fname)
-    results = query_something(tree)
+    results = get_rule_results_from_etree(tree)
     results = {RuleResult(r) for r in results}
     return results
 

--- a/tests/API/XCCDF/unittests/stig-viewer-equivalence.py
+++ b/tests/API/XCCDF/unittests/stig-viewer-equivalence.py
@@ -1,0 +1,75 @@
+from __future__ import print_function
+
+import argparse as ap
+from xml.etree import ElementTree
+
+
+NAMESPACES = dict(
+    xccdf_ns="http://scap.nist.gov/schema/scap/source/1.2",
+    profile_ns="http://checklists.nist.gov/xccdf/1.2",
+)
+
+
+class RuleResult(object):
+    def __init__(self, element):
+        self.idref = element.attrib["idref"]
+        self.weight = element.attrib["weight"]
+        result_element = element.find("{%s}result" % NAMESPACES["profile_ns"])
+        self.result_text = result_element.text
+        check_element = element.find("{%s}check" % NAMESPACES["profile_ns"])
+        self.check_system = check_element.attrib["system"]
+        self.check_system = check_element.attrib["system"]
+        check_content_ref_element = check_element.find(
+            "{%s}check-content-ref" % NAMESPACES["profile_ns"])
+        self.content_ref_href = check_content_ref_element.attrib["href"]
+        self.content_ref_name = check_content_ref_element.attrib["name"]
+        check_export_element = check_element.find(
+            "{%s}check-export" % NAMESPACES["profile_ns"])
+        self.check_export_name = None
+        self.check_export_value_id = None
+        if check_export_element is not None:
+            self.check_export_name = check_export_element.attrib["export-name"]
+            self.check_export_value_id = check_export_element.attrib["value-id"]
+
+    def __hash__(self):
+        return hash(frozenset(self.__dict__.items()))
+
+    def __eq__(self, rhs):
+        return hash(self) == hash(rhs)
+
+
+def fname_to_etree(fname):
+    input_tree = ElementTree.parse(fname)
+    return input_tree
+
+
+def query_something(tree):
+    xpath_expr =  ".//{%s}rule-result" % NAMESPACES["profile_ns"]
+    xccdfs = tree.findall(xpath_expr)
+    return xccdfs
+
+
+def extract_results_from_file(fname):
+    tree = fname_to_etree(fname)
+    results = query_something(tree)
+    results = {RuleResult(r) for r in results}
+    return results
+
+
+def make_parser():
+    parser = ap.ArgumentParser()
+    parser.add_argument("first")
+    parser.add_argument("second")
+    return parser
+
+
+if __name__ == "__main__":
+    parser = make_parser()
+    args = parser.parse_args()
+    first_results = extract_results_from_file(args.first)
+    second_results = extract_results_from_file(args.second)
+    assert len(first_results) == len(second_results), \
+        "There is not the same number of results in the two input files"
+    for result in first_results:
+        assert result in second_results, \
+            "There is a result in the first file that isn't in the second file"

--- a/tests/API/XCCDF/unittests/test_single_rule.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_single_rule.xccdf.xml
@@ -26,12 +26,16 @@
   </Value>
   <Rule selected="true" id="xccdf_com.example.www_rule_test-pass">
     <title>This rule always pass</title>
+    <reference href="http://iase.disa.mil/stigs/os/unix-linux/Pages/index.aspx">RHEL-07-040800</reference>
+    <reference href="http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx">SV-86937r1_rule</reference>
     <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
       <check-content-ref href="test_single_rule.oval.xml" name="oval:test-pass:def:1"/>
     </check>
   </Rule>
   <Rule selected="true" id="xccdf_com.example.www_rule_test-fail">
     <title>This rule fails if profile test_single_rule is not selected</title>
+    <reference href="http://iase.disa.mil/stigs/os/unix-linux/Pages/index.aspx">RHEL-07-020050</reference>
+    <reference href="http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx">SV-86601r1_rule</reference>
     <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
       <check-export export-name="oval:ssg:var:1" value-id="xccdf_com.example.www_value_val1"/>
       <check-content-ref href="test_single_rule.oval.xml" name="oval:test-fail:def:2"/>

--- a/tests/API/XCCDF/unittests/test_single_rule_stigw.sh
+++ b/tests/API/XCCDF/unittests/test_single_rule_stigw.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 name=$(basename $0 .sh)
 name="${name%_stigw}"
-result=$(mktemp -t ${name}.out.XXXXXX)
+result="$(mktemp -t ${name}.out.XXXXXX)"
 stderr=$(mktemp -t ${name}.out.XXXXXX)
 ret=0
 echo "Stderr file = $stderr"
@@ -17,9 +17,9 @@ echo "Result file = $result"
 # Tests that all rules from profile $prof1 (profile contains only 2 rules) are
 # evaluated when '--rule' option is not specified.
 
-# One of the rules is supposed to fail, so the return code of this line has to be 0
+# One of the rules is supposed to fail, so the return code of this line has to be 0 so the test can continue
 $OSCAP xccdf eval --stig-viewer "$result" "$srcdir/${name}.xccdf.xml" 2> "$stderr" || true
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-"${PYTHON:-python}" "$srcdir/stig-viewer-equivalence.py" "$result" "$srcdir/correct_stigw_result.xml" 2> "$stderr"
-rm $result
+"${PYTHON:-python}" "$srcdir/stig-viewer-equivalence.py" "$result" "$srcdir/correct_stigw_result.xml" 2> "$stderr" || ret=$?
+rm "$result"

--- a/tests/API/XCCDF/unittests/test_single_rule_stigw.sh
+++ b/tests/API/XCCDF/unittests/test_single_rule_stigw.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+name=$(basename $0 .sh)
+name="${name%_stigw}"
+result=$(mktemp -t ${name}.out.XXXXXX)
+stderr=$(mktemp -t ${name}.out.XXXXXX)
+ret=0
+echo "Stderr file = $stderr"
+echo "Result file = $result"
+
+
+#### XCCDF test cases ####
+
+# Tests that all rules from profile $prof1 (profile contains only 2 rules) are
+# evaluated when '--rule' option is not specified.
+
+# One of the rules is supposed to fail, so the return code of this line has to be 0
+$OSCAP xccdf eval --stig-viewer "$result" "$srcdir/${name}.xccdf.xml" 2> "$stderr" || true
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+
+"${PYTHON:-python}" "$srcdir/stig-viewer-equivalence.py" "$result" "$srcdir/correct_stigw_result.xml" 2> "$stderr"
+rm $result


### PR DESCRIPTION
The `--stig-viewer` option got its test case - the output is compared to a known output that is OK by a Python script.