### PR TITLE
Cross compilation for Windows using CMake and MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,11 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -std=c99 -W -Wall -Wvla -Wnonnull -Wsh
 if(${CMAKE_SYSTEM_NAME} EQUAL "Solaris")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__EXTENSIONS__")
 endif()
+if(WIN32)
+	# expose new WinAPI function appearing on Windows 7
+	# eg. inet_pton
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_WIN32_WINNT=0x0600")
+endif()
 
 include_directories(
 	"compat/"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ check_library_exists(rt clock_gettime "" HAVE_CLOCK_GETTIME)
 check_function_exists(posix_memalign HAVE_POSIX_MEMALIGN)
 check_function_exists(memalign HAVE_MEMALIGN)
 check_function_exists(fts_open HAVE_FTS_OPEN)
+check_function_exists(strsep HAVE_STRSEP)
 
 # HAVE HEADERS
 check_include_file(syslog.h HAVE_SYSLOG_H)
@@ -257,6 +258,7 @@ if(${CMAKE_SYSTEM_NAME} EQUAL "Solaris")
 endif()
 
 include_directories(
+	"compat/"
 	"src/"
 	"src/common/"
 	"src/common/public/"
@@ -279,6 +281,7 @@ include_directories(
 	${LIBXML2_INCLUDE_DIR}
 )
 
+add_subdirectory("compat")
 add_subdirectory("src")
 add_subdirectory("utils")
 add_subdirectory("docs")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,9 +216,14 @@ set(ENABLE_OSCAP_UTIL_VM TRUE CACHE BOOL "enables oscap util VM utility")
 set(ENABLE_OSCAP_UTIL_CHROOT TRUE CACHE BOOL "enables oscap util chroot")
 
 # ENABLES TESTS
-# Tests will be turned on only on Linux, because the test suite uses bash
+# Tests will be turned off on Windows, because the test suite uses bash
 # and other Linux-specific tools.
-set(ENABLE_TESTS ${IS_LINUX} CACHE BOOL "enables tests")
+if(WIN32)
+	set(ENABLE_TESTS FALSE CACHE BOOL "enables tests")
+else()
+	set(ENABLE_TESTS TRUE CACHE BOOL "enables tests")
+endif()
+
 
 # SEAP_MSGID_BITS
 set(SEAP_MSGID_BITS 32 CACHE STRING "Size of SEAP_msgid_t in bits [32|64]")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ check_function_exists(memalign HAVE_MEMALIGN)
 check_function_exists(fts_open HAVE_FTS_OPEN)
 check_function_exists(strsep HAVE_STRSEP)
 check_function_exists(flock HAVE_FLOCK)
+check_function_exists(strptime HAVE_STRPTIME)
 
 # HAVE HEADERS
 check_include_file(syslog.h HAVE_SYSLOG_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,11 @@ set(ENABLE_OSCAP_UTIL_VM TRUE CACHE BOOL "enables oscap util VM utility")
 # ENABLES OSCAP UTIL CHROOT
 set(ENABLE_OSCAP_UTIL_CHROOT TRUE CACHE BOOL "enables oscap util chroot")
 
+# ENABLES TESTS
+# Tests will be turned on only on Linux, because the test suite uses bash
+# and other Linux-specific tools.
+set(ENABLE_TESTS ${IS_LINUX} CACHE BOOL "enables tests")
+
 # SEAP_MSGID_BITS
 set(SEAP_MSGID_BITS 32 CACHE STRING "Size of SEAP_msgid_t in bits [32|64]")
 
@@ -307,8 +312,10 @@ install(FILES
 )
 
 # Ctest
-enable_testing()
-add_subdirectory("tests")
+if(ENABLE_TESTS)
+	enable_testing()
+	add_subdirectory("tests")
+endif()
 
 # CPack
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "openscap-${OPENSCAP_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ check_function_exists(posix_memalign HAVE_POSIX_MEMALIGN)
 check_function_exists(memalign HAVE_MEMALIGN)
 check_function_exists(fts_open HAVE_FTS_OPEN)
 check_function_exists(strsep HAVE_STRSEP)
+check_function_exists(flock HAVE_FLOCK)
 
 # HAVE HEADERS
 check_include_file(syslog.h HAVE_SYSLOG_H)

--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -1,5 +1,9 @@
 file(GLOB_RECURSE COMPAT_SOURCES "*.h")
 
+if(NOT HAVE_FLOCK)
+	list(APPEND COMPAT_SOURCES "flock.c")
+endif()
+
 if(NOT HAVE_STRSEP)
 	list(APPEND COMPAT_SOURCES "strsep.c")
 endif()

--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -8,4 +8,8 @@ if(NOT HAVE_STRSEP)
 	list(APPEND COMPAT_SOURCES "strsep.c")
 endif()
 
+if(NOT HAVE_STRPTIME)
+	list(APPEND COMPAT_SOURCES "strptime.c")
+endif()
+
 add_library(compat_object OBJECT ${COMPAT_SOURCES})

--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB_RECURSE COMPAT_SOURCES "*.h")
+
+if(NOT HAVE_STRSEP)
+	list(APPEND COMPAT_SOURCES "strsep.c")
+endif()
+
+add_library(compat_object OBJECT ${COMPAT_SOURCES})

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -37,6 +37,11 @@ char *strsep(char **stringp, const char *delim);
 int flock (int fd, int operation);
 #endif
 
+#ifndef HAVE_STRPTIME
+#include <time.h>
+char *strptime(const char *buf, const char *format, struct tm *tm);
+#endif
+
 #if defined(unix) || defined(__unix__) || defined(__unix)
 #define OSCAP_UNIX
 #endif

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -29,4 +29,8 @@
 char *strsep(char **stringp, const char *delim);
 #endif
 
+#if defined(unix) || defined(__unix__) || defined(__unix)
+#define OSCAP_UNIX
+#endif
+
 #endif

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -46,4 +46,8 @@ char *strptime(const char *buf, const char *format, struct tm *tm);
 #define OSCAP_UNIX
 #endif
 
+#ifdef _WIN32
+#define PATH_MAX _MAX_PATH
+#endif
+
 #endif

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors:
+ *      Jan Černý <jcerny@redhat.com>
+ */
+
+#ifndef OSCAP_COMPAT_H_
+#define OSCAP_COMPAT_H_
+
+/* Fallback functions fixing portability issues */
+
+#ifndef HAVE_STRSEP
+char *strsep(char **stringp, const char *delim);
+#endif
+
+#endif

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -29,6 +29,14 @@
 char *strsep(char **stringp, const char *delim);
 #endif
 
+#ifndef HAVE_FLOCK
+#define LOCK_SH 1   /* Shared lock.  */
+#define LOCK_EX 2   /* Exclusive lock.  */
+#define LOCK_UN 8   /* Unlock.  */
+#define LOCK_NB 4   /* Don't block when locking.  */
+int flock (int fd, int operation);
+#endif
+
 #if defined(unix) || defined(__unix__) || defined(__unix)
 #define OSCAP_UNIX
 #endif

--- a/compat/flock.c
+++ b/compat/flock.c
@@ -1,0 +1,220 @@
+/* Emulate flock on platforms that lack it, primarily Windows and MinGW.
+
+   This is derived from sqlite3 sources.
+   http://www.sqlite.org/cvstrac/rlog?f=sqlite/src/os_win.c
+   http://www.sqlite.org/copyright.html
+
+   Written by Richard W.M. Jones <rjones.at.redhat.com>
+
+   Copyright (C) 2008-2016 Free Software Foundation, Inc.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <config.h>
+#include <sys/file.h>
+
+#if (defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__
+
+/* LockFileEx */
+# define WIN32_LEAN_AND_MEAN
+# include <windows.h>
+
+# include <errno.h>
+
+/* _get_osfhandle */
+# include <io.h>
+
+/* Determine the current size of a file.  Because the other braindead
+ * APIs we'll call need lower/upper 32 bit pairs, keep the file size
+ * like that too.
+ */
+static BOOL
+file_size (HANDLE h, DWORD * lower, DWORD * upper)
+{
+  *lower = GetFileSize (h, upper);
+  return 1;
+}
+
+/* LOCKFILE_FAIL_IMMEDIATELY is undefined on some Windows systems. */
+# ifndef LOCKFILE_FAIL_IMMEDIATELY
+#  define LOCKFILE_FAIL_IMMEDIATELY 1
+# endif
+
+/* Acquire a lock. */
+static BOOL
+do_lock (HANDLE h, int non_blocking, int exclusive)
+{
+  BOOL res;
+  DWORD size_lower, size_upper;
+  OVERLAPPED ovlp;
+  int flags = 0;
+
+  /* We're going to lock the whole file, so get the file size. */
+  res = file_size (h, &size_lower, &size_upper);
+  if (!res)
+    return 0;
+
+  /* Start offset is 0, and also zero the remaining members of this struct. */
+  memset (&ovlp, 0, sizeof ovlp);
+
+  if (non_blocking)
+    flags |= LOCKFILE_FAIL_IMMEDIATELY;
+  if (exclusive)
+    flags |= LOCKFILE_EXCLUSIVE_LOCK;
+
+  return LockFileEx (h, flags, 0, size_lower, size_upper, &ovlp);
+}
+
+/* Unlock reader or exclusive lock. */
+static BOOL
+do_unlock (HANDLE h)
+{
+  int res;
+  DWORD size_lower, size_upper;
+
+  res = file_size (h, &size_lower, &size_upper);
+  if (!res)
+    return 0;
+
+  return UnlockFile (h, 0, 0, size_lower, size_upper);
+}
+
+/* Now our BSD-like flock operation. */
+int
+flock (int fd, int operation)
+{
+  HANDLE h = (HANDLE) _get_osfhandle (fd);
+  DWORD res;
+  int non_blocking;
+
+  if (h == INVALID_HANDLE_VALUE)
+    {
+      errno = EBADF;
+      return -1;
+    }
+
+  non_blocking = operation & LOCK_NB;
+  operation &= ~LOCK_NB;
+
+  switch (operation)
+    {
+    case LOCK_SH:
+      res = do_lock (h, non_blocking, 0);
+      break;
+    case LOCK_EX:
+      res = do_lock (h, non_blocking, 1);
+      break;
+    case LOCK_UN:
+      res = do_unlock (h);
+      break;
+    default:
+      errno = EINVAL;
+      return -1;
+    }
+
+  /* Map Windows errors into Unix errnos.  As usual MSDN fails to
+   * document the permissible error codes.
+   */
+  if (!res)
+    {
+      DWORD err = GetLastError ();
+      switch (err)
+        {
+          /* This means someone else is holding a lock. */
+        case ERROR_LOCK_VIOLATION:
+          errno = EAGAIN;
+          break;
+
+          /* Out of memory. */
+        case ERROR_NOT_ENOUGH_MEMORY:
+          errno = ENOMEM;
+          break;
+
+        case ERROR_BAD_COMMAND:
+          errno = EINVAL;
+          break;
+
+          /* Unlikely to be other errors, but at least don't lose the
+           * error code.
+           */
+        default:
+          errno = err;
+        }
+
+      return -1;
+    }
+
+  return 0;
+}
+
+#else /* !Windows */
+
+# ifdef HAVE_STRUCT_FLOCK_L_TYPE
+/* We know how to implement flock in terms of fcntl. */
+
+#  include <fcntl.h>
+
+#  ifdef HAVE_UNISTD_H
+#   include <unistd.h>
+#  endif
+
+#  include <errno.h>
+#  include <string.h>
+
+int
+flock (int fd, int operation)
+{
+  int cmd, r;
+  struct flock fl;
+
+  if (operation & LOCK_NB)
+    cmd = F_SETLK;
+  else
+    cmd = F_SETLKW;
+  operation &= ~LOCK_NB;
+
+  memset (&fl, 0, sizeof fl);
+  fl.l_whence = SEEK_SET;
+  /* l_start & l_len are 0, which as a special case means "whole file". */
+
+  switch (operation)
+    {
+    case LOCK_SH:
+      fl.l_type = F_RDLCK;
+      break;
+    case LOCK_EX:
+      fl.l_type = F_WRLCK;
+      break;
+    case LOCK_UN:
+      fl.l_type = F_UNLCK;
+      break;
+    default:
+      errno = EINVAL;
+      return -1;
+    }
+
+  r = fcntl (fd, cmd, &fl);
+  if (r == -1 && errno == EACCES)
+    errno = EAGAIN;
+
+  return r;
+}
+
+# else /* !HAVE_STRUCT_FLOCK_L_TYPE */
+
+#  error "This platform lacks flock function, and Gnulib doesn't provide a replacement. This is a bug in Gnulib."
+
+# endif /* !HAVE_STRUCT_FLOCK_L_TYPE */
+
+#endif /* !Windows */

--- a/compat/strptime.c
+++ b/compat/strptime.c
@@ -1,0 +1,992 @@
+/* Convert a string representation of time to a time value.
+   Copyright (C) 1996, 1997, 1998, 1999, 2000 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@cygnus.com>, 1996.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 3 of the
+   License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; see the file COPYING.LIB.  If not, 
+   see <http://www.gnu.org/licenses/>.  */
+
+/* XXX This version of the implementation is not really complete.
+   Some of the fields cannot add information alone.  But if seeing
+   some of them in the same format (such as year, week and weekday)
+   this is enough information for determining the date.  */
+
+#include <string.h>
+#include "compat.h"
+
+#ifndef __P
+# if defined (__GNUC__) || (defined (__STDC__) && __STDC__)
+#  define __P(args) args
+# else
+#  define __P(args) ()
+# endif  /* GCC.  */
+#endif  /* Not __P.  */
+
+#if ! HAVE_LOCALTIME_R && ! defined localtime_r
+# ifdef _LIBC
+#  define localtime_r __localtime_r
+# else
+/* Approximate localtime_r as best we can in its absence.  */
+#  define localtime_r my_localtime_r
+static struct tm *localtime_r __P ((const time_t *, struct tm *));
+static struct tm *
+localtime_r (t, tp)
+     const time_t *t;
+     struct tm *tp;
+{
+  struct tm *l = localtime (t);
+  if (! l)
+    return 0;
+  *tp = *l;
+  return tp;
+}
+# endif /* ! _LIBC */
+#endif /* ! HAVE_LOCALTIME_R && ! defined (localtime_r) */
+
+
+#define match_char(ch1, ch2) if (ch1 != ch2) return NULL
+#if defined __GNUC__ && __GNUC__ >= 2
+# define match_string(cs1, s2) \
+  ({ size_t len = strlen (cs1);						      \
+     int result = strncasecmp ((cs1), (s2), len) == 0;			      \
+     if (result) (s2) += len;						      \
+     result; })
+#else
+/* Oh come on.  Get a reasonable compiler.  */
+# define match_string(cs1, s2) \
+  (strncasecmp ((cs1), (s2), strlen (cs1)) ? 0 : ((s2) += strlen (cs1), 1))
+#endif
+/* We intentionally do not use isdigit() for testing because this will
+   lead to problems with the wide character version.  */
+#define get_number(from, to, n) \
+  do {									      \
+    int __n = n;							      \
+    val = 0;								      \
+    while (*rp == ' ')							      \
+      ++rp;								      \
+    if (*rp < '0' || *rp > '9')						      \
+      return NULL;							      \
+    do {								      \
+      val *= 10;							      \
+      val += *rp++ - '0';						      \
+    } while (--__n > 0 && val * 10 <= to && *rp >= '0' && *rp <= '9');	      \
+    if (val < from || val > to)						      \
+      return NULL;							      \
+  } while (0)
+#ifdef _NL_CURRENT
+# define get_alt_number(from, to, n) \
+  ({									      \
+    __label__ do_normal;						      \
+    if (*decided != raw)						      \
+      {									      \
+	const char *alts = _NL_CURRENT (LC_TIME, ALT_DIGITS);		      \
+	int __n = n;							      \
+	int any = 0;							      \
+	while (*rp == ' ')						      \
+	  ++rp;								      \
+	val = 0;							      \
+	do {								      \
+	  val *= 10;							      \
+	  while (*alts != '\0')						      \
+	    {								      \
+	      size_t len = strlen (alts);				      \
+	      if (strncasecmp (alts, rp, len) == 0)			      \
+	        break;							      \
+	      alts += len + 1;						      \
+	      ++val;							      \
+	    }								      \
+	  if (*alts == '\0')						      \
+	    {								      \
+	      if (*decided == not && ! any)				      \
+		goto do_normal;						      \
+	      /* If we haven't read anything it's an error.  */		      \
+	      if (! any)						      \
+		return NULL;						      \
+	      /* Correct the premature multiplication.  */		      \
+	      val /= 10;						      \
+	      break;							      \
+	    }								      \
+	  else								      \
+	    *decided = loc;						      \
+	} while (--__n > 0 && val * 10 <= to);				      \
+	if (val < from || val > to)					      \
+	  return NULL;							      \
+      }									      \
+    else								      \
+      {									      \
+       do_normal:							      \
+        get_number (from, to, n);					      \
+      }									      \
+    0;									      \
+  })
+#else
+# define get_alt_number(from, to, n) \
+  /* We don't have the alternate representation.  */			      \
+  get_number(from, to, n)
+#endif
+#define recursive(new_fmt) \
+  (*(new_fmt) != '\0'							      \
+   && (rp = strptime_internal (rp, (new_fmt), tm, decided, era_cnt)) != NULL)
+
+
+#ifdef _LIBC
+/* This is defined in locale/C-time.c in the GNU libc.  */
+extern const struct locale_data _nl_C_LC_TIME;
+extern const unsigned short int __mon_yday[2][13];
+
+# define weekday_name (&_nl_C_LC_TIME.values[_NL_ITEM_INDEX (DAY_1)].string)
+# define ab_weekday_name \
+  (&_nl_C_LC_TIME.values[_NL_ITEM_INDEX (ABDAY_1)].string)
+# define month_name (&_nl_C_LC_TIME.values[_NL_ITEM_INDEX (MON_1)].string)
+# define ab_month_name (&_nl_C_LC_TIME.values[_NL_ITEM_INDEX (ABMON_1)].string)
+# define HERE_D_T_FMT (_nl_C_LC_TIME.values[_NL_ITEM_INDEX (D_T_FMT)].string)
+# define HERE_D_FMT (_nl_C_LC_TIME.values[_NL_ITEM_INDEX (D_FMT)].string)
+# define HERE_AM_STR (_nl_C_LC_TIME.values[_NL_ITEM_INDEX (AM_STR)].string)
+# define HERE_PM_STR (_nl_C_LC_TIME.values[_NL_ITEM_INDEX (PM_STR)].string)
+# define HERE_T_FMT_AMPM \
+  (_nl_C_LC_TIME.values[_NL_ITEM_INDEX (T_FMT_AMPM)].string)
+# define HERE_T_FMT (_nl_C_LC_TIME.values[_NL_ITEM_INDEX (T_FMT)].string)
+
+# define strncasecmp(s1, s2, n) __strncasecmp (s1, s2, n)
+#else
+static char const weekday_name[][10] =
+  {
+    "Sunday", "Monday", "Tuesday", "Wednesday",
+    "Thursday", "Friday", "Saturday"
+  };
+static char const ab_weekday_name[][4] =
+  {
+    "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+  };
+static char const month_name[][10] =
+  {
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+  };
+static char const ab_month_name[][4] =
+  {
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+  };
+# define HERE_D_T_FMT "%a %b %e %H:%M:%S %Y"
+# define HERE_D_FMT "%m/%d/%y"
+# define HERE_AM_STR "AM"
+# define HERE_PM_STR "PM"
+# define HERE_T_FMT_AMPM "%I:%M:%S %p"
+# define HERE_T_FMT "%H:%M:%S"
+
+static const unsigned short int __mon_yday[2][13] =
+  {
+    /* Normal years.  */
+    { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 },
+    /* Leap years.  */
+    { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 }
+  };
+#endif
+
+/* Status of lookup: do we use the locale data or the raw data?  */
+enum locale_status { not, loc, raw };
+
+
+#ifndef __isleap
+/* Nonzero if YEAR is a leap year (every 4 years,
+   except every 100th isn't, and every 400th is).  */
+# define __isleap(year)	\
+  ((year) % 4 == 0 && ((year) % 100 != 0 || (year) % 400 == 0))
+#endif
+
+/* Compute the day of the week.  */
+static void
+day_of_the_week (struct tm *tm)
+{
+  /* We know that January 1st 1970 was a Thursday (= 4).  Compute the
+     the difference between this data in the one on TM and so determine
+     the weekday.  */
+  int corr_year = 1900 + tm->tm_year - (tm->tm_mon < 2);
+  int wday = (-473
+	      + (365 * (tm->tm_year - 70))
+	      + (corr_year / 4)
+	      - ((corr_year / 4) / 25) + ((corr_year / 4) % 25 < 0)
+	      + (((corr_year / 4) / 25) / 4)
+	      + __mon_yday[0][tm->tm_mon]
+	      + tm->tm_mday - 1);
+  tm->tm_wday = ((wday % 7) + 7) % 7;
+}
+
+/* Compute the day of the year.  */
+static void
+day_of_the_year (struct tm *tm)
+{
+  tm->tm_yday = (__mon_yday[__isleap (1900 + tm->tm_year)][tm->tm_mon]
+		 + (tm->tm_mday - 1));
+}
+
+static char *
+#ifdef _LIBC
+internal_function
+#endif
+strptime_internal __P ((const char *rp, const char *fmt, struct tm *tm,
+			enum locale_status *decided, int era_cnt));
+
+static char *
+#ifdef _LIBC
+internal_function
+#endif
+strptime_internal (rp, fmt, tm, decided, era_cnt)
+     const char *rp;
+     const char *fmt;
+     struct tm *tm;
+     enum locale_status *decided;
+     int era_cnt;
+{
+  int cnt;
+  size_t val;
+  int have_I, is_pm;
+  int century, want_century;
+  int want_era;
+  int have_wday, want_xday;
+  int have_yday;
+  int have_mon, have_mday;
+#ifdef _NL_CURRENT
+  const char *rp_backup;
+  size_t num_eras;
+  struct era_entry *era;
+
+  era = NULL;
+#endif
+
+  have_I = is_pm = 0;
+  century = -1;
+  want_century = 0;
+  want_era = 0;
+
+  have_wday = want_xday = have_yday = have_mon = have_mday = 0;
+
+  while (*fmt != '\0')
+    {
+      /* A white space in the format string matches 0 more or white
+	 space in the input string.  */
+      if (isspace (*fmt))
+	{
+	  while (isspace (*rp))
+	    ++rp;
+	  ++fmt;
+	  continue;
+	}
+
+      /* Any character but `%' must be matched by the same character
+	 in the iput string.  */
+      if (*fmt != '%')
+	{
+	  match_char (*fmt++, *rp++);
+	  continue;
+	}
+
+      ++fmt;
+#ifndef _NL_CURRENT
+      /* We need this for handling the `E' modifier.  */
+    start_over:
+#endif
+
+#ifdef _NL_CURRENT
+      /* Make back up of current processing pointer.  */
+      rp_backup = rp;
+#endif
+
+      switch (*fmt++)
+	{
+	case '%':
+	  /* Match the `%' character itself.  */
+	  match_char ('%', *rp++);
+	  break;
+	case 'a':
+	case 'A':
+	  /* Match day of week.  */
+	  for (cnt = 0; cnt < 7; ++cnt)
+	    {
+#ifdef _NL_CURRENT
+	      if (*decided !=raw)
+		{
+		  if (match_string (_NL_CURRENT (LC_TIME, DAY_1 + cnt), rp))
+		    {
+		      if (*decided == not
+			  && strcmp (_NL_CURRENT (LC_TIME, DAY_1 + cnt),
+				     weekday_name[cnt]))
+			*decided = loc;
+		      break;
+		    }
+		  if (match_string (_NL_CURRENT (LC_TIME, ABDAY_1 + cnt), rp))
+		    {
+		      if (*decided == not
+			  && strcmp (_NL_CURRENT (LC_TIME, ABDAY_1 + cnt),
+				     ab_weekday_name[cnt]))
+			*decided = loc;
+		      break;
+		    }
+		}
+#endif
+	      if (*decided != loc
+		  && (match_string (weekday_name[cnt], rp)
+		      || match_string (ab_weekday_name[cnt], rp)))
+		{
+		  *decided = raw;
+		  break;
+		}
+	    }
+	  if (cnt == 7)
+	    /* Does not match a weekday name.  */
+	    return NULL;
+	  tm->tm_wday = cnt;
+	  have_wday = 1;
+	  break;
+	case 'b':
+	case 'B':
+	case 'h':
+	  /* Match month name.  */
+	  for (cnt = 0; cnt < 12; ++cnt)
+	    {
+#ifdef _NL_CURRENT
+	      if (*decided !=raw)
+		{
+		  if (match_string (_NL_CURRENT (LC_TIME, MON_1 + cnt), rp))
+		    {
+		      if (*decided == not
+			  && strcmp (_NL_CURRENT (LC_TIME, MON_1 + cnt),
+				     month_name[cnt]))
+			*decided = loc;
+		      break;
+		    }
+		  if (match_string (_NL_CURRENT (LC_TIME, ABMON_1 + cnt), rp))
+		    {
+		      if (*decided == not
+			  && strcmp (_NL_CURRENT (LC_TIME, ABMON_1 + cnt),
+				     ab_month_name[cnt]))
+			*decided = loc;
+		      break;
+		    }
+		}
+#endif
+	      if (match_string (month_name[cnt], rp)
+		  || match_string (ab_month_name[cnt], rp))
+		{
+		  *decided = raw;
+		  break;
+		}
+	    }
+	  if (cnt == 12)
+	    /* Does not match a month name.  */
+	    return NULL;
+	  tm->tm_mon = cnt;
+	  want_xday = 1;
+	  break;
+	case 'c':
+	  /* Match locale's date and time format.  */
+#ifdef _NL_CURRENT
+	  if (*decided != raw)
+	    {
+	      if (!recursive (_NL_CURRENT (LC_TIME, D_T_FMT)))
+		{
+		  if (*decided == loc)
+		    return NULL;
+		  else
+		    rp = rp_backup;
+		}
+	      else
+		{
+		  if (*decided == not &&
+		      strcmp (_NL_CURRENT (LC_TIME, D_T_FMT), HERE_D_T_FMT))
+		    *decided = loc;
+		  want_xday = 1;
+		  break;
+		}
+	      *decided = raw;
+	    }
+#endif
+	  if (!recursive (HERE_D_T_FMT))
+	    return NULL;
+	  want_xday = 1;
+	  break;
+	case 'C':
+	  /* Match century number.  */
+#ifdef _NL_CURRENT
+	match_century:
+#endif
+	  get_number (0, 99, 2);
+	  century = val;
+	  want_xday = 1;
+	  break;
+	case 'd':
+	case 'e':
+	  /* Match day of month.  */
+	  get_number (1, 31, 2);
+	  tm->tm_mday = val;
+	  have_mday = 1;
+	  want_xday = 1;
+	  break;
+	case 'F':
+	  if (!recursive ("%Y-%m-%d"))
+	    return NULL;
+	  want_xday = 1;
+	  break;
+	case 'x':
+#ifdef _NL_CURRENT
+	  if (*decided != raw)
+	    {
+	      if (!recursive (_NL_CURRENT (LC_TIME, D_FMT)))
+		{
+		  if (*decided == loc)
+		    return NULL;
+		  else
+		    rp = rp_backup;
+		}
+	      else
+		{
+		  if (*decided == not
+		      && strcmp (_NL_CURRENT (LC_TIME, D_FMT), HERE_D_FMT))
+		    *decided = loc;
+		  want_xday = 1;
+		  break;
+		}
+	      *decided = raw;
+	    }
+#endif
+	  /* Fall through.  */
+	case 'D':
+	  /* Match standard day format.  */
+	  if (!recursive (HERE_D_FMT))
+	    return NULL;
+	  want_xday = 1;
+	  break;
+	case 'k':
+	case 'H':
+	  /* Match hour in 24-hour clock.  */
+	  get_number (0, 23, 2);
+	  tm->tm_hour = val;
+	  have_I = 0;
+	  break;
+	case 'I':
+	  /* Match hour in 12-hour clock.  */
+	  get_number (1, 12, 2);
+	  tm->tm_hour = val % 12;
+	  have_I = 1;
+	  break;
+	case 'j':
+	  /* Match day number of year.  */
+	  get_number (1, 366, 3);
+	  tm->tm_yday = val - 1;
+	  have_yday = 1;
+	  break;
+	case 'm':
+	  /* Match number of month.  */
+	  get_number (1, 12, 2);
+	  tm->tm_mon = val - 1;
+	  have_mon = 1;
+	  want_xday = 1;
+	  break;
+	case 'M':
+	  /* Match minute.  */
+	  get_number (0, 59, 2);
+	  tm->tm_min = val;
+	  break;
+	case 'n':
+	case 't':
+	  /* Match any white space.  */
+	  while (isspace (*rp))
+	    ++rp;
+	  break;
+	case 'p':
+	  /* Match locale's equivalent of AM/PM.  */
+#ifdef _NL_CURRENT
+	  if (*decided != raw)
+	    {
+	      if (match_string (_NL_CURRENT (LC_TIME, AM_STR), rp))
+		{
+		  if (strcmp (_NL_CURRENT (LC_TIME, AM_STR), HERE_AM_STR))
+		    *decided = loc;
+		  break;
+		}
+	      if (match_string (_NL_CURRENT (LC_TIME, PM_STR), rp))
+		{
+		  if (strcmp (_NL_CURRENT (LC_TIME, PM_STR), HERE_PM_STR))
+		    *decided = loc;
+		  is_pm = 1;
+		  break;
+		}
+	      *decided = raw;
+	    }
+#endif
+	  if (!match_string (HERE_AM_STR, rp)) {
+	    if (match_string (HERE_PM_STR, rp)) {
+	      is_pm = 1;
+	    } else {
+	      return NULL;
+	    }
+	  }
+	  break;
+	case 'r':
+#ifdef _NL_CURRENT
+	  if (*decided != raw)
+	    {
+	      if (!recursive (_NL_CURRENT (LC_TIME, T_FMT_AMPM)))
+		{
+		  if (*decided == loc)
+		    return NULL;
+		  else
+		    rp = rp_backup;
+		}
+	      else
+		{
+		  if (*decided == not &&
+		      strcmp (_NL_CURRENT (LC_TIME, T_FMT_AMPM),
+			      HERE_T_FMT_AMPM))
+		    *decided = loc;
+		  break;
+		}
+	      *decided = raw;
+	    }
+#endif
+	  if (!recursive (HERE_T_FMT_AMPM))
+	    return NULL;
+	  break;
+	case 'R':
+	  if (!recursive ("%H:%M"))
+	    return NULL;
+	  break;
+	case 's':
+	  {
+	    /* The number of seconds may be very high so we cannot use
+	       the `get_number' macro.  Instead read the number
+	       character for character and construct the result while
+	       doing this.  */
+	    time_t secs = 0;
+	    if (*rp < '0' || *rp > '9')
+	      /* We need at least one digit.  */
+	      return NULL;
+
+	    do
+	      {
+		secs *= 10;
+		secs += *rp++ - '0';
+	      }
+	    while (*rp >= '0' && *rp <= '9');
+
+	    if (localtime_r (&secs, tm) == NULL)
+	      /* Error in function.  */
+	      return NULL;
+	  }
+	  break;
+	case 'S':
+	  get_number (0, 61, 2);
+	  tm->tm_sec = val;
+	  break;
+	case 'X':
+#ifdef _NL_CURRENT
+	  if (*decided != raw)
+	    {
+	      if (!recursive (_NL_CURRENT (LC_TIME, T_FMT)))
+		{
+		  if (*decided == loc)
+		    return NULL;
+		  else
+		    rp = rp_backup;
+		}
+	      else
+		{
+		  if (strcmp (_NL_CURRENT (LC_TIME, T_FMT), HERE_T_FMT))
+		    *decided = loc;
+		  break;
+		}
+	      *decided = raw;
+	    }
+#endif
+	  /* Fall through.  */
+	case 'T':
+	  if (!recursive (HERE_T_FMT))
+	    return NULL;
+	  break;
+	case 'u':
+	  get_number (1, 7, 1);
+	  tm->tm_wday = val % 7;
+	  have_wday = 1;
+	  break;
+	case 'g':
+	  get_number (0, 99, 2);
+	  /* XXX This cannot determine any field in TM.  */
+	  break;
+	case 'G':
+	  if (*rp < '0' || *rp > '9')
+	    return NULL;
+	  /* XXX Ignore the number since we would need some more
+	     information to compute a real date.  */
+	  do
+	    ++rp;
+	  while (*rp >= '0' && *rp <= '9');
+	  break;
+	case 'U':
+	case 'V':
+	case 'W':
+	  get_number (0, 53, 2);
+	  /* XXX This cannot determine any field in TM without some
+	     information.  */
+	  break;
+	case 'w':
+	  /* Match number of weekday.  */
+	  get_number (0, 6, 1);
+	  tm->tm_wday = val;
+	  have_wday = 1;
+	  break;
+	case 'y':
+#ifdef _NL_CURRENT
+	match_year_in_century:
+#endif
+	  /* Match year within century.  */
+	  get_number (0, 99, 2);
+	  /* The "Year 2000: The Millennium Rollover" paper suggests that
+	     values in the range 69-99 refer to the twentieth century.  */
+	  tm->tm_year = val >= 69 ? val : val + 100;
+	  /* Indicate that we want to use the century, if specified.  */
+	  want_century = 1;
+	  want_xday = 1;
+	  break;
+	case 'Y':
+	  /* Match year including century number.  */
+	  get_number (0, 9999, 4);
+	  tm->tm_year = val - 1900;
+	  want_century = 0;
+	  want_xday = 1;
+	  break;
+	case 'Z':
+	  /* XXX How to handle this?  */
+	  break;
+	case 'E':
+#ifdef _NL_CURRENT
+	  switch (*fmt++)
+	    {
+	    case 'c':
+	      /* Match locale's alternate date and time format.  */
+	      if (*decided != raw)
+		{
+		  const char *fmt = _NL_CURRENT (LC_TIME, ERA_D_T_FMT);
+
+		  if (*fmt == '\0')
+		    fmt = _NL_CURRENT (LC_TIME, D_T_FMT);
+
+		  if (!recursive (fmt))
+		    {
+		      if (*decided == loc)
+			return NULL;
+		      else
+			rp = rp_backup;
+		    }
+		  else
+		    {
+		      if (strcmp (fmt, HERE_D_T_FMT))
+			*decided = loc;
+		      want_xday = 1;
+		      break;
+		    }
+		  *decided = raw;
+		}
+	      /* The C locale has no era information, so use the
+		 normal representation.  */
+	      if (!recursive (HERE_D_T_FMT))
+		return NULL;
+	      want_xday = 1;
+	      break;
+	    case 'C':
+	      if (*decided != raw)
+		{
+		  if (era_cnt >= 0)
+		    {
+		      era = _nl_select_era_entry (era_cnt);
+		      if (match_string (era->era_name, rp))
+			{
+			  *decided = loc;
+			  break;
+			}
+		      else
+			return NULL;
+		    }
+		  else
+		    {
+		      num_eras = _NL_CURRENT_WORD (LC_TIME,
+						   _NL_TIME_ERA_NUM_ENTRIES);
+		      for (era_cnt = 0; era_cnt < (int) num_eras;
+			   ++era_cnt, rp = rp_backup)
+			{
+			  era = _nl_select_era_entry (era_cnt);
+			  if (match_string (era->era_name, rp))
+			    {
+			      *decided = loc;
+			      break;
+			    }
+			}
+		      if (era_cnt == (int) num_eras)
+			{
+			  era_cnt = -1;
+			  if (*decided == loc)
+			    return NULL;
+			}
+		      else
+			break;
+		    }
+
+		  *decided = raw;
+		}
+	      /* The C locale has no era information, so use the
+		 normal representation.  */
+	      goto match_century;
+ 	    case 'y':
+	      if (*decided == raw)
+		goto match_year_in_century;
+
+	      get_number(0, 9999, 4);
+	      tm->tm_year = val;
+	      want_era = 1;
+	      want_xday = 1;
+	      break;
+	    case 'Y':
+	      if (*decided != raw)
+		{
+		  num_eras = _NL_CURRENT_WORD (LC_TIME,
+					       _NL_TIME_ERA_NUM_ENTRIES);
+		  for (era_cnt = 0; era_cnt < (int) num_eras;
+		       ++era_cnt, rp = rp_backup)
+		    {
+		      era = _nl_select_era_entry (era_cnt);
+		      if (recursive (era->era_format))
+			break;
+		    }
+		  if (era_cnt == (int) num_eras)
+		    {
+		      era_cnt = -1;
+		      if (*decided == loc)
+			return NULL;
+		      else
+			rp = rp_backup;
+		    }
+		  else
+		    {
+		      *decided = loc;
+		      era_cnt = -1;
+		      break;
+		    }
+
+		  *decided = raw;
+		}
+	      get_number (0, 9999, 4);
+	      tm->tm_year = val - 1900;
+	      want_century = 0;
+	      want_xday = 1;
+	      break;
+	    case 'x':
+	      if (*decided != raw)
+		{
+		  const char *fmt = _NL_CURRENT (LC_TIME, ERA_D_FMT);
+
+		  if (*fmt == '\0')
+		    fmt = _NL_CURRENT (LC_TIME, D_FMT);
+
+		  if (!recursive (fmt))
+		    {
+		      if (*decided == loc)
+			return NULL;
+		      else
+			rp = rp_backup;
+		    }
+		  else
+		    {
+		      if (strcmp (fmt, HERE_D_FMT))
+			*decided = loc;
+		      break;
+		    }
+		  *decided = raw;
+		}
+	      if (!recursive (HERE_D_FMT))
+		return NULL;
+	      break;
+	    case 'X':
+	      if (*decided != raw)
+		{
+		  const char *fmt = _NL_CURRENT (LC_TIME, ERA_T_FMT);
+
+		  if (*fmt == '\0')
+		    fmt = _NL_CURRENT (LC_TIME, T_FMT);
+
+		  if (!recursive (fmt))
+		    {
+		      if (*decided == loc)
+			return NULL;
+		      else
+			rp = rp_backup;
+		    }
+		  else
+		    {
+		      if (strcmp (fmt, HERE_T_FMT))
+			*decided = loc;
+		      break;
+		    }
+		  *decided = raw;
+		}
+	      if (!recursive (HERE_T_FMT))
+		return NULL;
+	      break;
+	    default:
+	      return NULL;
+	    }
+	  break;
+#else
+	  /* We have no information about the era format.  Just use
+	     the normal format.  */
+	  if (*fmt != 'c' && *fmt != 'C' && *fmt != 'y' && *fmt != 'Y'
+	      && *fmt != 'x' && *fmt != 'X')
+	    /* This is an illegal format.  */
+	    return NULL;
+
+	  goto start_over;
+#endif
+	case 'O':
+	  switch (*fmt++)
+	    {
+	    case 'd':
+	    case 'e':
+	      /* Match day of month using alternate numeric symbols.  */
+	      get_alt_number (1, 31, 2);
+	      tm->tm_mday = val;
+	      have_mday = 1;
+	      want_xday = 1;
+	      break;
+	    case 'H':
+	      /* Match hour in 24-hour clock using alternate numeric
+		 symbols.  */
+	      get_alt_number (0, 23, 2);
+	      tm->tm_hour = val;
+	      have_I = 0;
+	      break;
+	    case 'I':
+	      /* Match hour in 12-hour clock using alternate numeric
+		 symbols.  */
+	      get_alt_number (1, 12, 2);
+	      tm->tm_hour = val - 1;
+	      have_I = 1;
+	      break;
+	    case 'm':
+	      /* Match month using alternate numeric symbols.  */
+	      get_alt_number (1, 12, 2);
+	      tm->tm_mon = val - 1;
+	      have_mon = 1;
+	      want_xday = 1;
+	      break;
+	    case 'M':
+	      /* Match minutes using alternate numeric symbols.  */
+	      get_alt_number (0, 59, 2);
+	      tm->tm_min = val;
+	      break;
+	    case 'S':
+	      /* Match seconds using alternate numeric symbols.  */
+	      get_alt_number (0, 61, 2);
+	      tm->tm_sec = val;
+	      break;
+	    case 'U':
+	    case 'V':
+	    case 'W':
+	      get_alt_number (0, 53, 2);
+	      /* XXX This cannot determine any field in TM without
+		 further information.  */
+	      break;
+	    case 'w':
+	      /* Match number of weekday using alternate numeric symbols.  */
+	      get_alt_number (0, 6, 1);
+	      tm->tm_wday = val;
+	      have_wday = 1;
+	      break;
+	    case 'y':
+	      /* Match year within century using alternate numeric symbols.  */
+	      get_alt_number (0, 99, 2);
+	      tm->tm_year = val >= 69 ? val : val + 100;
+	      want_xday = 1;
+	      break;
+	    default:
+	      return NULL;
+	    }
+	  break;
+	default:
+	  return NULL;
+	}
+    }
+
+  if (have_I && is_pm)
+    tm->tm_hour += 12;
+
+  if (century != -1)
+    {
+      if (want_century)
+	tm->tm_year = tm->tm_year % 100 + (century - 19) * 100;
+      else
+	/* Only the century, but not the year.  Strange, but so be it.  */
+	tm->tm_year = (century - 19) * 100;
+    }
+
+#ifdef _NL_CURRENT
+  if (era_cnt != -1)
+    {
+      era = _nl_select_era_entry(era_cnt);
+      if (want_era)
+	tm->tm_year = (era->start_date[0]
+		       + ((tm->tm_year - era->offset)
+			  * era->absolute_direction));
+      else
+	/* Era start year assumed.  */
+	tm->tm_year = era->start_date[0];
+    }
+  else
+#endif
+    if (want_era)
+      return NULL;
+
+  if (want_xday && !have_wday)
+    {
+      if ( !(have_mon && have_mday) && have_yday)
+	{
+	  /* We don't have tm_mon and/or tm_mday, compute them.  */
+	  int t_mon = 0;
+	  while (__mon_yday[__isleap(1900 + tm->tm_year)][t_mon] <= tm->tm_yday)
+	      t_mon++;
+	  if (!have_mon)
+	      tm->tm_mon = t_mon - 1;
+	  if (!have_mday)
+	      tm->tm_mday =
+		(tm->tm_yday
+		 - __mon_yday[__isleap(1900 + tm->tm_year)][t_mon - 1] + 1);
+	}
+      day_of_the_week (tm);
+    }
+  if (want_xday && !have_yday)
+    day_of_the_year (tm);
+
+  return rp;
+}
+
+
+char *strptime(const char *buf, const char *format, struct tm *tm)
+{
+  enum locale_status decided;
+
+#ifdef _NL_CURRENT
+  decided = not;
+#else
+  decided = raw;
+#endif
+  return strptime_internal (buf, format, tm, &decided, -1);
+}

--- a/compat/strsep.c
+++ b/compat/strsep.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors:
+ *      Jan Černý <jcerny@redhat.com>
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <string.h>
+
+char *strsep(char **stringp, const char *delim)
+{
+	char *str = *stringp;
+	char *found = NULL;
+	if (str == NULL) {
+		return NULL;
+	}
+	const size_t delim_cnt = strlen(delim);
+	for (size_t i = 0; i < delim_cnt && found == NULL; i++) {
+		found = strchr(str, delim[i]);
+	}
+	if (found != NULL) {
+		*found = '\0';
+		*stringp = str + 1;
+	} else {
+		*stringp = NULL;
+	}
+	return str;
+}

--- a/config.h.in
+++ b/config.h.in
@@ -80,6 +80,7 @@
 
 #cmakedefine HAVE_STRSEP
 #cmakedefine HAVE_FLOCK
+#cmakedefine HAVE_STRPTIME
 
 #include "compat.h"
 

--- a/config.h.in
+++ b/config.h.in
@@ -79,6 +79,7 @@
 #cmakedefine HAVE_SYS_ACL_H
 
 #cmakedefine HAVE_STRSEP
+#cmakedefine HAVE_FLOCK
 
 #include "compat.h"
 

--- a/config.h.in
+++ b/config.h.in
@@ -78,5 +78,8 @@
 #cmakedefine HAVE_ACL_LIBACL_H
 #cmakedefine HAVE_SYS_ACL_H
 
+#cmakedefine HAVE_STRSEP
+
+#include "compat.h"
 
 #endif

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -2006,18 +2006,8 @@ NOTE: mingw32-pthreads needs to be version 5.0 or greater.
 4) Build!
 
 ------------------------------
- $ make -k 2> build-errors.log
+ $ make
 ------------------------------
-
-5) Inspect build-errors.log for problems
-
------------------------------------------------
- $ grep -E '(error:|implicit)' build-errors.log
------------------------------------------------
-
------------------------------------------------------------------------------
-oval_resModel.c:70:28: error: conflicting types for 'oval_results_model_new_with_probe_session'
------------------------------------------------------------------------------
 
 If you would like to send us a patch fixing any Windows
 compiling issues, please consult the page about

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1985,7 +1985,7 @@ NOTE: mingw32-pthreads needs to be version 5.0 or greater.
  # yum install mingw32-gcc mingw32-binutils mingw32-libxml2 \
  mingw32-libgcrypt mingw32-pthreads mingw32-libxslt \
  mingw32-curl mingw32-pcre \
- automake autoconf libtool
+ mingw32-filesystem
 -------------------------------------------------------------
 
 2) Checkout the master branch of the OpenSCAP repository

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1971,11 +1971,10 @@ If we want to generate new statistics, we should remove the old ones.
  $ lcov --directory ./ --zerocounters ; find ./ -name "*.gcno" | xargs rm
  $ rm -rf ./coverage
 
-=== Building OpenSCAP for Windows (cross-compilation)
-Building OpenSCAP for Windows without a POSIX emulation layer is currently not
-possible. However, we are close to a native port of OpenSCAP for Windows. If you
-want to help us solve the remaining problems. Instructions for cross-compiling
-OpenSCAP for Windows:
+=== Building OpenSCAP for Windows on a Linux box (cross-compilation)
+Currently it is possible to build OpenSCAP for Windows only without probes.
+The resulting binary is not able to perform scanning.
+Instructions for cross-compiling OpenSCAP for Windows:
 
 1) Install the cross-compiler & dependencies
 

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1985,7 +1985,7 @@ NOTE: mingw32-pthreads needs to be version 5.0 or greater.
  # yum install mingw32-gcc mingw32-binutils mingw32-libxml2 \
  mingw32-libgcrypt mingw32-pthreads mingw32-libxslt \
  mingw32-curl mingw32-pcre \
- mingw32-filesystem
+ mingw32-filesystem mingw32-bzip2
 -------------------------------------------------------------
 
 2) Checkout the master branch of the OpenSCAP repository

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -2008,6 +2008,8 @@ NOTE: mingw32-pthreads needs to be version 5.0 or greater.
  $ make
 ------------------------------
 
+Resulting ```oscap.exe``` can be found in the ```utils/``` directory.
+
 If you would like to send us a patch fixing any Windows
 compiling issues, please consult the page about
 http://open-scap.org/page/Contribute[contributing to the OpenSCAP

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1998,8 +1998,9 @@ NOTE: mingw32-pthreads needs to be version 5.0 or greater.
 3) Prepare the build
 
 ----------------------------------------------------------------------------------
- $ ./autogen.sh
- $ mingw32-configure --disable-probes --disable-python --disable-util-oscap-docker
+ $ mkdir build-win32
+ $ cd build-win32
+ $ mingw32-cmake -D ENABLE_PYTHON2=FALSE -D ENABLE_PROBES=FALSE -D ENABLE_OSCAP_UTIL_DOCKER=FALSE ../
 ----------------------------------------------------------------------------------
 
 4) Build!

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,7 @@ set(OBJECTS_TO_LINK_AGAINST
 	$<TARGET_OBJECTS:ovaladt_object>
 	$<TARGET_OBJECTS:ovalcmp_object>
 	$<TARGET_OBJECTS:ovalresults_object>
+	$<TARGET_OBJECTS:rbt_object>
 	$<TARGET_OBJECTS:xccdf_object>
 	$<TARGET_OBJECTS:xccdfPolicy_object>
 )
@@ -63,7 +64,6 @@ endif()
 if (ENABLE_PROBES)
 	list(APPEND OBJECTS_TO_LINK_AGAINST
 		$<TARGET_OBJECTS:probe_object>
-		$<TARGET_OBJECTS:rbt_object>
 		$<TARGET_OBJECTS:seap_object>
 	)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,5 +78,8 @@ if(RPM_FOUND)
 	# just because of rpmvercmp
 	target_link_libraries(openscap ${RPM_LIBRARIES})
 endif()
+if(WIN32)
+	target_link_libraries(openscap wsock32 ws2_32)
+endif()
 
 install(TARGETS openscap DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ add_subdirectory("XCCDF")
 add_subdirectory("XCCDF_POLICY")
 
 set(OBJECTS_TO_LINK_AGAINST
+	$<TARGET_OBJECTS:compat_object>
 	$<TARGET_OBJECTS:common_object>
 	$<TARGET_OBJECTS:cpe_object>
 	$<TARGET_OBJECTS:cve_object>

--- a/src/OVAL/CMakeLists.txt
+++ b/src/OVAL/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory("results")
 add_subdirectory("adt")
+add_subdirectory("probes")
 file(GLOB_RECURSE PUBLIC_HEADERS "public/*.h")
 
 set (OVAL_SOURCES
@@ -53,8 +54,6 @@ set (OVAL_SOURCES
 )
 
 if (ENABLE_PROBES)
-    add_subdirectory("probes")
-    
     list(APPEND OVAL_SOURCES
 	"oval_probe.c"
 	"oval_probe_hint.c"

--- a/src/OVAL/probes/CMakeLists.txt
+++ b/src/OVAL/probes/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_subdirectory("crapi")
-add_subdirectory("probe")
 add_subdirectory("SEAP")
 
 function(add_oscap_probe PROBE_NAME PROBE_SOURCE_FILE)
@@ -9,144 +7,150 @@ function(add_oscap_probe PROBE_NAME PROBE_SOURCE_FILE)
 	install(TARGETS ${PROBE_NAME} DESTINATION ${OVAL_PROBE_DIR})
 endfunction()
 
-if(ENABLE_PROBES_INDEPENDENT)
-	add_oscap_probe(probe_system_info "independent/system_info.c")
+if(ENABLE_PROBES)
+	add_subdirectory("crapi")
+	add_subdirectory("probe")
 
-	add_oscap_probe(probe_family "independent/family.c")
+	if(ENABLE_PROBES_INDEPENDENT)
+		add_oscap_probe(probe_system_info "independent/system_info.c")
 
-	add_oscap_probe(probe_textfilecontent "independent/textfilecontent.c")
+		add_oscap_probe(probe_family "independent/family.c")
 
-	add_oscap_probe(probe_textfilecontent54 "independent/textfilecontent54.c")
+		add_oscap_probe(probe_textfilecontent "independent/textfilecontent.c")
 
-	add_oscap_probe(probe_variable "independent/variable.c")
+		add_oscap_probe(probe_textfilecontent54 "independent/textfilecontent54.c")
 
-	add_oscap_probe(probe_xmlfilecontent "independent/xmlfilecontent.c")
-	target_link_libraries(probe_xmlfilecontent ${LIBXML2_LIBRARIES})
+		add_oscap_probe(probe_variable "independent/variable.c")
 
-	add_oscap_probe(probe_filehash "independent/filehash.c")
-	target_link_libraries(probe_filehash crapi)
+		add_oscap_probe(probe_xmlfilecontent "independent/xmlfilecontent.c")
+		target_link_libraries(probe_xmlfilecontent ${LIBXML2_LIBRARIES})
 
-	add_oscap_probe(probe_filehash58 "independent/filehash58.c")
-	target_link_libraries(probe_filehash58 crapi)
+		add_oscap_probe(probe_filehash "independent/filehash.c")
+		target_link_libraries(probe_filehash crapi)
 
-	add_oscap_probe(probe_environmentvariable "independent/environmentvariable.c")
+		add_oscap_probe(probe_filehash58 "independent/filehash58.c")
+		target_link_libraries(probe_filehash58 crapi)
 
-	add_oscap_probe(probe_environmentvariable58 "independent/environmentvariable58.c")
+		add_oscap_probe(probe_environmentvariable "independent/environmentvariable.c")
 
-	if(OPENDBX_FOUND)
-		add_oscap_probe(probe_sql "independent/sql.c")
-		target_include_directories(probe_sql PRIVATE ${OPENDBX_INCLUDE_DIRS})
-		target_link_libraries(probe_sql ${OPENDBX_LIBRARIES})
+		add_oscap_probe(probe_environmentvariable58 "independent/environmentvariable58.c")
 
-		add_oscap_probe(probe_sql57 "independent/sql57.c")
-		target_include_directories(probe_sql57 PRIVATE ${OPENDBX_INCLUDE_DIRS})
-		target_link_libraries(probe_sql57 ${OPENDBX_LIBRARIES})
+		if(OPENDBX_FOUND)
+			add_oscap_probe(probe_sql "independent/sql.c")
+			target_include_directories(probe_sql PRIVATE ${OPENDBX_INCLUDE_DIRS})
+			target_link_libraries(probe_sql ${OPENDBX_LIBRARIES})
+
+			add_oscap_probe(probe_sql57 "independent/sql57.c")
+			target_include_directories(probe_sql57 PRIVATE ${OPENDBX_INCLUDE_DIRS})
+			target_link_libraries(probe_sql57 ${OPENDBX_LIBRARIES})
+		endif()
+
+		if(LDAP_FOUND)
+			add_oscap_probe(probe_ldap57 "independent/ldap57.c")
+			target_include_directories(probe_ldap57 PRIVATE ${LDAP_INCLUDE_DIRS})
+			target_link_libraries(probe_ldap57 ${LDAP_LIBRARIES})
+		endif()
 	endif()
 
-	if(LDAP_FOUND)
-		add_oscap_probe(probe_ldap57 "independent/ldap57.c")
-		target_include_directories(probe_ldap57 PRIVATE ${LDAP_INCLUDE_DIRS})
-		target_link_libraries(probe_ldap57 ${LDAP_LIBRARIES})
-	endif()
-endif()
+	if(ENABLE_PROBES_UNIX)
+		add_oscap_probe(probe_dnscache "unix/dnscache.c")
 
-if(ENABLE_PROBES_UNIX)
-	add_oscap_probe(probe_dnscache "unix/dnscache.c")
+		add_oscap_probe(probe_runlevel "unix/runlevel.c")
 
-	add_oscap_probe(probe_runlevel "unix/runlevel.c")
+		add_oscap_probe(probe_file "unix/file.c")
+		target_link_libraries(probe_file ${ACL_LIBRARIES})
 
-	add_oscap_probe(probe_file "unix/file.c")
-	target_link_libraries(probe_file ${ACL_LIBRARIES})
+		add_oscap_probe(probe_fileextendedattribute "unix/fileextendedattribute.c")
 
-	add_oscap_probe(probe_fileextendedattribute "unix/fileextendedattribute.c")
+		add_oscap_probe(probe_password "unix/password.c")
 
-	add_oscap_probe(probe_password "unix/password.c")
+		add_oscap_probe(probe_process "unix/process.c" "unix/process58-devname.c" "unix/process58-devname.h")
+		target_link_libraries(probe_process ${SELINUX_LIBRARIES} ${PROCPS_LIBRARIES})
 
-	add_oscap_probe(probe_process "unix/process.c" "unix/process58-devname.c" "unix/process58-devname.h")
-	target_link_libraries(probe_process ${SELINUX_LIBRARIES} ${PROCPS_LIBRARIES})
+		if(CAP_FOUND)
+			add_oscap_probe(probe_process58 "unix/process58.c" "unix/process58-capability.h" "unix/process58-devname.c" "unix/process58-devname.h")
+			target_include_directories(probe_process58 PRIVATE ${CAP_INCLUDE_DIR})
+			target_link_libraries(probe_process58 ${CAP_LIBRARIES} ${SELINUX_LIBRARIES} ${PROCPS_LIBRARIES})
+		endif()
 
-	if(CAP_FOUND)
-		add_oscap_probe(probe_process58 "unix/process58.c" "unix/process58-capability.h" "unix/process58-devname.c" "unix/process58-devname.h")
-		target_include_directories(probe_process58 PRIVATE ${CAP_INCLUDE_DIR})
-		target_link_libraries(probe_process58 ${CAP_LIBRARIES} ${SELINUX_LIBRARIES} ${PROCPS_LIBRARIES})
-	endif()
+		add_oscap_probe(probe_shadow "unix/shadow.c")
 
-	add_oscap_probe(probe_shadow "unix/shadow.c")
+		add_oscap_probe(probe_uname "unix/uname.c")
 
-	add_oscap_probe(probe_uname "unix/uname.c")
+		add_oscap_probe(probe_interface "unix/interface.c")
 
-	add_oscap_probe(probe_interface "unix/interface.c")
+		add_oscap_probe(probe_xinetd "unix/xinetd.c")
 
-	add_oscap_probe(probe_xinetd "unix/xinetd.c")
+		add_oscap_probe(probe_sysctl "unix/sysctl.c")
 
-	add_oscap_probe(probe_sysctl "unix/sysctl.c")
+		add_oscap_probe(probe_routingtable "unix/routingtable.c")
 
-	add_oscap_probe(probe_routingtable "unix/routingtable.c")
+		add_oscap_probe(probe_symlink "unix/symlink.c")
 
-	add_oscap_probe(probe_symlink "unix/symlink.c")
-
-	if(GCONF_FOUND)
-		add_oscap_probe(probe_gconf "unix/gconf.c")
-		target_include_directories(probe_gconf PRIVATE ${GCONF_INCLUDE_DIRS})
-		target_link_libraries(probe_gconf ${GCONF_LIBRARIES})
-	endif()
-endif()
-
-if(ENABLE_PROBES_SOLARIS)
-	add_oscap_probe(probe_isainfo "unix/solaris/isainfo.c")
-
-	add_oscap_probe(probe_package "unix/solaris/package.c")
-
-	add_oscap_probe(probe_patch "unix/solaris/patch.c")
-
-	add_oscap_probe(probe_smf "unix/solaris/smf.c")
-endif()
-
-if(ENABLE_PROBES_LINUX)
-	add_oscap_probe(probe_partition "unix/linux/partition.c")
-	target_link_libraries(probe_partition ${BLKID_LIBRARIES})
-
-	add_oscap_probe(probe_inetlisteningservers "unix/linux/inetlisteningservers.c")
-
-	add_oscap_probe(probe_iflisteners "unix/linux/iflisteners.c" "unix/linux/iflisteners-proto.h")
-
-	if(SELINUX_FOUND)
-		add_oscap_probe(probe_selinuxboolean "unix/linux/selinuxboolean.c")
-		target_include_directories(probe_selinuxboolean PRIVATE ${SELINUX_INCLUDE_DIR})
-		target_link_libraries(probe_selinuxboolean ${SELINUX_LIBRARIES})
-
-		add_oscap_probe(probe_selinuxsecuritycontext "unix/linux/selinuxsecuritycontext.c")
-		target_include_directories(probe_selinuxsecuritycontext PRIVATE ${SELINUX_INCLUDE_DIR})
-		target_link_libraries(probe_selinuxsecuritycontext ${SELINUX_LIBRARIES})
+		if(GCONF_FOUND)
+			add_oscap_probe(probe_gconf "unix/gconf.c")
+			target_include_directories(probe_gconf PRIVATE ${GCONF_INCLUDE_DIRS})
+			target_link_libraries(probe_gconf ${GCONF_LIBRARIES})
+		endif()
 	endif()
 
-	if(RPM_FOUND)
-		add_oscap_probe(probe_rpminfo "unix/linux/rpminfo.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c")
-		target_link_libraries(probe_rpminfo ${RPM_LIBRARIES})
+	if(ENABLE_PROBES_SOLARIS)
+		add_oscap_probe(probe_isainfo "unix/solaris/isainfo.c")
 
-		add_oscap_probe(probe_rpmverify "unix/linux/rpmverify.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c")
-		target_link_libraries(probe_rpmverify ${RPM_LIBRARIES})
+		add_oscap_probe(probe_package "unix/solaris/package.c")
 
-		add_oscap_probe(probe_rpmverifyfile "unix/linux/rpmverifyfile.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c")
-		target_link_libraries(probe_rpmverifyfile ${RPM_LIBRARIES})
+		add_oscap_probe(probe_patch "unix/solaris/patch.c")
 
-		add_oscap_probe(probe_rpmverifypackage "unix/linux/rpmverifypackage.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c" "unix/linux/probe-chroot.h" "unix/linux/probe-chroot.c")
-		target_link_libraries(probe_rpmverifypackage ${RPM_LIBRARIES} ${POPT_LIBRARIES})
+		add_oscap_probe(probe_smf "unix/solaris/smf.c")
 	endif()
 
-	if (APTPKG_FOUND)
-		add_oscap_probe(probe_dpkginfo "unix/linux/dpkginfo.c" "unix/linux/dpkginfo-helper.cxx" "unix/linux/dpkginfo-helper.h")
-		target_include_directories(probe_dpkginfo PRIVATE ${APTPKG_INCLUDE_DIR})
-		target_link_libraries(probe_dpkginfo ${APTPKG_LIBRARIES})
+	if(ENABLE_PROBES_LINUX)
+		add_oscap_probe(probe_partition "unix/linux/partition.c")
+		target_link_libraries(probe_partition ${BLKID_LIBRARIES})
+
+		add_oscap_probe(probe_inetlisteningservers "unix/linux/inetlisteningservers.c")
+
+		add_oscap_probe(probe_iflisteners "unix/linux/iflisteners.c" "unix/linux/iflisteners-proto.h")
+
+		if(SELINUX_FOUND)
+			add_oscap_probe(probe_selinuxboolean "unix/linux/selinuxboolean.c")
+			target_include_directories(probe_selinuxboolean PRIVATE ${SELINUX_INCLUDE_DIR})
+			target_link_libraries(probe_selinuxboolean ${SELINUX_LIBRARIES})
+
+			add_oscap_probe(probe_selinuxsecuritycontext "unix/linux/selinuxsecuritycontext.c")
+			target_include_directories(probe_selinuxsecuritycontext PRIVATE ${SELINUX_INCLUDE_DIR})
+			target_link_libraries(probe_selinuxsecuritycontext ${SELINUX_LIBRARIES})
+		endif()
+
+		if(RPM_FOUND)
+			add_oscap_probe(probe_rpminfo "unix/linux/rpminfo.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c")
+			target_link_libraries(probe_rpminfo ${RPM_LIBRARIES})
+
+			add_oscap_probe(probe_rpmverify "unix/linux/rpmverify.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c")
+			target_link_libraries(probe_rpmverify ${RPM_LIBRARIES})
+
+			add_oscap_probe(probe_rpmverifyfile "unix/linux/rpmverifyfile.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c")
+			target_link_libraries(probe_rpmverifyfile ${RPM_LIBRARIES})
+
+			add_oscap_probe(probe_rpmverifypackage "unix/linux/rpmverifypackage.c" "unix/linux/rpm-helper.h" "unix/linux/rpm-helper.c" "unix/linux/probe-chroot.h" "unix/linux/probe-chroot.c")
+			target_link_libraries(probe_rpmverifypackage ${RPM_LIBRARIES} ${POPT_LIBRARIES})
+		endif()
+
+		if (APTPKG_FOUND)
+			add_oscap_probe(probe_dpkginfo "unix/linux/dpkginfo.c" "unix/linux/dpkginfo-helper.cxx" "unix/linux/dpkginfo-helper.h")
+			target_include_directories(probe_dpkginfo PRIVATE ${APTPKG_INCLUDE_DIR})
+			target_link_libraries(probe_dpkginfo ${APTPKG_LIBRARIES})
+		endif()
+
+		if(DBUS_FOUND)
+			add_oscap_probe(probe_systemdunitproperty "unix/linux/systemdunitproperty.c" "unix/linux/systemdshared.h")
+			target_include_directories(probe_systemdunitproperty PRIVATE ${DBUS_INCLUDE_DIRS})
+			target_link_libraries(probe_systemdunitproperty ${DBUS_LIBRARIES})
+
+			add_oscap_probe(probe_systemdunitdependency "unix/linux/systemdunitdependency.c" "unix/linux/systemdshared.h")
+			target_include_directories(probe_systemdunitdependency PRIVATE ${DBUS_INCLUDE_DIRS})
+			target_link_libraries(probe_systemdunitdependency ${DBUS_LIBRARIES})
+		endif()
 	endif()
 
-	if(DBUS_FOUND)
-		add_oscap_probe(probe_systemdunitproperty "unix/linux/systemdunitproperty.c" "unix/linux/systemdshared.h")
-		target_include_directories(probe_systemdunitproperty PRIVATE ${DBUS_INCLUDE_DIRS})
-		target_link_libraries(probe_systemdunitproperty ${DBUS_LIBRARIES})
-
-		add_oscap_probe(probe_systemdunitdependency "unix/linux/systemdunitdependency.c" "unix/linux/systemdshared.h")
-		target_include_directories(probe_systemdunitdependency PRIVATE ${DBUS_INCLUDE_DIRS})
-		target_link_libraries(probe_systemdunitdependency ${DBUS_LIBRARIES})
-	endif()
 endif()

--- a/src/OVAL/probes/SEAP/CMakeLists.txt
+++ b/src/OVAL/probes/SEAP/CMakeLists.txt
@@ -9,10 +9,11 @@ file(GLOB_RECURSE RBT_HEADERS "generic/rbt/*.h")
 file(GLOB_RECURSE SEAP_SOURCES_TO_REMOVE "sexp-handler.c" "sexp-template.c")
 list(REMOVE_ITEM SEAP_SOURCES ${SEAP_SOURCES_TO_REMOVE} ${RBT_SOURCES} ${RBT_HEADERS})
 
-add_library(seap_object OBJECT ${SEAP_SOURCES} ${SEAP_HEADERS})
-target_include_directories(seap_object PRIVATE
-	${CMAKE_SOURCE_DIR}
-	"public"
-)
-
-set_oscap_generic_properties(seap_object)
+if(ENABLE_PROBES)
+	add_library(seap_object OBJECT ${SEAP_SOURCES} ${SEAP_HEADERS})
+	target_include_directories(seap_object PRIVATE
+		${CMAKE_SOURCE_DIR}
+		"public"
+	)
+	set_oscap_generic_properties(seap_object)
+endif()

--- a/src/OVAL/probes/independent/family.c
+++ b/src/OVAL/probes/independent/family.c
@@ -72,7 +72,7 @@ int probe_main(probe_ctx *ctx, void *arg)
         "windows";
 #elif defined(Macintosh) || defined(macintosh) || (defined(__APPLE__) && defined(__MACH__))
         "macos";
-#elif defined(__unix__) || defined(__unix)
+#elif defined(OSCAP_UNIX)
         "unix";
 #elif defined(CISCO_IOS) /* XXX: how to detect IOS? */
         "ios";

--- a/src/OVAL/results/oval_cmp.c
+++ b/src/OVAL/results/oval_cmp.c
@@ -30,8 +30,13 @@
 
 #include <string.h>
 #include <inttypes.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#endif
 
 #include "oval_types.h"
 #include "oval_system_characteristics.h"

--- a/src/OVAL/results/oval_cmp_evr_string.c
+++ b/src/OVAL/results/oval_cmp_evr_string.c
@@ -39,7 +39,9 @@
 #ifdef HAVE_RPMVERCMP
 #include <rpm/rpmlib.h>
 #else
-#if !defined(__FreeBSD__)
+#ifdef _WIN32
+#include <malloc.h>
+#elif !defined(__FreeBSD__)
 #include <alloca.h>
 #endif
 static int rpmvercmp(const char *a, const char *b);

--- a/src/OVAL/results/oval_cmp_ip_address.c
+++ b/src/OVAL/results/oval_cmp_ip_address.c
@@ -35,8 +35,13 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#endif
 
 #include "oval_definitions.h"
 #include "oval_types.h"

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -24,7 +24,11 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/stat.h>
+
+#ifdef OSCAP_UNIX
 #include <sys/wait.h>
+#endif
+
 #include <unistd.h>
 
 #include <libxml/tree.h>

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -35,6 +35,7 @@
 # include <time.h>
 # include <errno.h>
 # include <fcntl.h>
+# include <sys/stat.h>
 
 #if defined(OVAL_PROBES_ENABLED)
 # include <sexp.h>

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -88,7 +88,7 @@ oscap_verbosity_levels __debuglog_level = DBG_UNKNOWN;
 #if defined(_WIN32)
 static char * get_program_name()
 {
-        char path[MAX_PATH + 1];
+        char path[PATH_MAX + 1];
         int path_size = GetModuleFileName(NULL, path, sizeof(path) - 1);
 
         if(path_size < 0)

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -52,7 +52,7 @@
 #endif
 
 #if defined(_WIN32)
-# include "flock.h"
+# include <windows.h>
 # define GET_PROGRAM_NAME get_program_name()
 #elif defined(__APPLE__)
 # define GET_PROGRAM_NAME getprogname()

--- a/src/common/elements.c
+++ b/src/common/elements.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/stat.h>
 
 #include "public/oscap.h"
 #include "util.h"

--- a/src/common/err_queue.c
+++ b/src/common/err_queue.c
@@ -127,10 +127,14 @@ int err_queue_to_string(struct err_queue *q, char **result)
 	char *pos = *result;
 	pos[0] = '\0';
 	err = q->first;
+	size_t desc_len;
 	while (err != NULL) {
 		if (err->desc != NULL) {
-			pos = stpcpy(pos, err->desc);
-			pos = stpcpy(pos, "\n");
+			desc_len = strlen(err->desc);
+			strncpy(pos, err->desc, desc_len);
+			pos += desc_len;
+			*pos = '\n';
+			pos++;
 		}
 		err = err->next;
 	}

--- a/src/common/err_queue.c
+++ b/src/common/err_queue.c
@@ -127,10 +127,9 @@ int err_queue_to_string(struct err_queue *q, char **result)
 	char *pos = *result;
 	pos[0] = '\0';
 	err = q->first;
-	size_t desc_len;
 	while (err != NULL) {
 		if (err->desc != NULL) {
-			desc_len = strlen(err->desc);
+			const size_t desc_len = strlen(err->desc);
 			strncpy(pos, err->desc, desc_len);
 			pos += desc_len;
 			*pos = '\n';

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -57,11 +57,11 @@ oscap_acquire_temp_dir()
 #ifdef _WIN32
 	DWORD dwRetVal = 0;
 	UINT uRetVal = 0;
-	TCHAR lpTempPathBuffer[MAX_PATH];
-	TCHAR szTempFileName[MAX_PATH];
+	TCHAR lpTempPathBuffer[PATH_MAX];
+	TCHAR szTempFileName[PATH_MAX];
 
-	dwRetVal = GetTempPath(MAX_PATH, lpTempPathBuffer);
-	if (dwRetVal > MAX_PATH || dwRetVal == 0) {
+	dwRetVal = GetTempPath(PATH_MAX, lpTempPathBuffer);
+	if (dwRetVal > PATH_MAX || dwRetVal == 0) {
 		oscap_seterr(OSCAP_EFAMILY_WINDOWS, "Could not retrieve the path of the directory for temporary files.");
 		return NULL;
 	}

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <limits.h>
+#include <sys/stat.h>
 
 #include <curl/curl.h>
 #include <curl/easy.h>

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -74,7 +74,7 @@ oscap_acquire_temp_dir()
 		oscap_seterr(OSCAP_EFAMILY_WINDOWS, "Could not create temp directory '%s'.", szTempFileName);
 		return NULL;
 	}
-	return strdup(szTempFileName);
+	return oscap_strdup(szTempFileName);
 #else
 	char *temp_dir = strdup(TEMP_DIR_TEMPLATE);
 	if (mkdtemp(temp_dir) == NULL) {

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -54,6 +54,28 @@
 char *
 oscap_acquire_temp_dir()
 {
+#ifdef _WIN32
+	DWORD dwRetVal = 0;
+	UINT uRetVal = 0;
+	TCHAR lpTempPathBuffer[MAX_PATH];
+	TCHAR szTempFileName[MAX_PATH];
+
+	dwRetVal = GetTempPath(MAX_PATH, lpTempPathBuffer);
+	if (dwRetVal > MAX_PATH || dwRetVal == 0) {
+		oscap_seterr(OSCAP_EFAMILY_WINDOWS, "Could not retrieve the path of the directory for temporary files.");
+		return NULL;
+	}
+	uRetVal = GetTempFileName(lpTempPathBuffer, TEXT("oscap"), 0, szTempFileName);
+	if (uRetVal == 0) {
+		oscap_seterr(OSCAP_EFAMILY_WINDOWS, "Could not get a name for new temporary directory.");
+		return NULL;
+	}
+	if (!CreateDirectory(szTempFileName, NULL)) {
+		oscap_seterr(OSCAP_EFAMILY_WINDOWS, "Could not create temp directory '%s'.", szTempFileName);
+		return NULL;
+	}
+	return strdup(szTempFileName);
+#else
 	char *temp_dir = strdup(TEMP_DIR_TEMPLATE);
 	if (mkdtemp(temp_dir) == NULL) {
 		free(temp_dir);
@@ -61,6 +83,7 @@ oscap_acquire_temp_dir()
 		return NULL;
 	}
 	return temp_dir;
+#endif
 }
 
 #ifndef _WIN32

--- a/src/common/public/oscap_error.h
+++ b/src/common/public/oscap_error.h
@@ -60,6 +60,7 @@ typedef uint16_t oscap_errfamily_t;
 #define OSCAP_EFAMILY_XCCDF    5	/**< XCCDF errors */
 #define OSCAP_EFAMILY_SCE      6	/**< SCE errors */
 #define OSCAP_EFAMILY_NET	7	/**< Errors from network communication. Presumably from libcurl. */
+#define OSCAP_EFAMILY_WINDOWS	8	/**< Windows API Errors */
 /** @} */
 
 /**

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -237,7 +237,7 @@ char *oscap_expand_ipv6(const char *input)
 char *oscap_realpath(const char *path, char *resolved_path)
 {
 #ifdef _WIN32
-	return _fullpath(resolved_path, path, MAX_PATH);
+	return _fullpath(resolved_path, path, PATH_MAX);
 #else
 	return realpath(path, resolved_path);
 #endif
@@ -248,7 +248,7 @@ char *oscap_basename(char *path)
 #ifdef _WIN32
 	char fname[_MAX_FNAME];
 	char ext[_MAX_EXT];
-	_splitpath_s(path_buffer, NULL, 0, NULL, 0, fname, _MAX_FNAME, ext, _MAX_EXT);
+	_splitpath_s(path, NULL, 0, NULL, 0, fname, _MAX_FNAME, ext, _MAX_EXT);
 	size_t base_len = strlen(fname) + strlen(ext) + 1;
 	char *base = malloc(base_len);
 	strncpy(base, fname, base_len);

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -213,8 +213,8 @@ static struct oscap_module* OVAL_GEN_SUBMODULES[OVAL_GEN_SUBMODULES_NUM] = {
     NULL
 };
 
-#if defined(OVAL_PROBES_ENABLED)
 static struct oscap_module* OVAL_SUBMODULES[OVAL_SUBMODULES_NUM] = {
+#if defined(OVAL_PROBES_ENABLED)
     &OVAL_COLLECT,
     &OVAL_EVAL,
 #endif


### PR DESCRIPTION
This pull request brings a set of changes that enable us to cross compile OpenSCAP for Windows on Fedora. It uses MinGW together with CMake. The build is **without probes**.

Suddenly it turns out that autotools handled some portability issues. However we can't use it because it was strongly dependent  on automake, GNUlib, m4, AC_ macros and other stuff that we got rid of. Therefore I solved some of the portability issues again.

I created a new directory called `compat` where we will put implementations of functions that we use but are available only in Linux. I have seen a similar directory in famous projects Git (https://github.com/git/git/tree/master/compat) and VLC (https://github.com/videolan/vlc/tree/master/compat). I don't know if there can be a better solution. Any suggestions and ideas are welcome.

I have downloaded some of the functions from GNUlib again :smiley:  Others are replaced by either standard functions or Windows API calls. For details please see the respective commit messages.

I had to change some of the object dependencies to be able to build without probes. I also had to fix the problem that ENABLE_PROBES=FALSE didn't turn off probes completely.

The patches proposed in this PR build an `oscap.exe` and a `libopenscap.dll`.

Use the following commands:

```
sudo dnf install mingw32-gcc mingw32-binutils mingw32-libxml2 mingw32-libgcrypt mingw32-pthreads mingw32-libxslt mingw32-curl mingw32-pcre mingw32-filesystem mingw32-bzip2
mkdir build-win32
cd build-win32
mingw32-cmake -D ENABLE_PYTHON2=FALSE -D ENABLE_PROBES=FALSE -D ENABLE_OSCAP_UTIL_DOCKER=FALSE ../
make
```

The procedure is described in User Manual at the *Building OpenSCAP for Windows on a Linux box (cross-compilation)* section, which is also updated by this PR.

I tried to used this PR as a part of SCAP Workbench for windows.
I follow the Windows Release Guide in https://github.com/OpenSCAP/scap-workbench/wiki/Windows-build-and-installer-guide, but I replace configure commands in step "1.  Install OpenSCAP from master" by CMake commands that are described above. Rest of the Workbench release remains the same.
I was able to run SCAP Workbench on Windows successfully.

However I wasn't able to produce the MSI installer due to this issue: https://github.com/OpenSCAP/scap-workbench/issues/153

A huge problem is that issue that `oscap.exe` can't find where schemas and XSLTs are located. This problem is beacuse CMake on Linux produces paths into `config.h`  eg.
```
#define OSCAP_DEFAULT_SCHEMA_PATH "/usr/i686-w64-mingw32/sys-root/mingw/share/openscap/schemas"`
```
, but obviously no such path exists on Windows. I have found this issue was there with autotools as well. I think we must fix that in a separate PR.