### PR TITLE
Use oscap_strdup instead of just strdup

### DIFF
--- a/src/CPE/cpename.c
+++ b/src/CPE/cpename.c
@@ -214,7 +214,7 @@ bool cpe_set_field(struct cpe_name * cpe, int idx, const char *newval)
 	if (newval && strcmp(newval, "") == 0)
 		newval = NULL;
 	if (newval != NULL)
-		*fieldptr = strdup(newval);
+		*fieldptr = oscap_strdup(newval);
 	else
 		*fieldptr = NULL;
 
@@ -241,7 +241,7 @@ struct cpe_name *cpe_name_new(const char *cpestr)
 
 	if (cpestr) {
 		if (format == CPE_FORMAT_URI) {
-			char *data_ = strdup(cpestr + 5);	// without 'cpe:/'
+			char *data_ = oscap_strdup(cpestr + 5); // without 'cpe:/'
 			char **fields_ = oscap_split(data_, ":");
 			for (i = 0; fields_[i]; ++i)
 			{
@@ -286,7 +286,7 @@ struct cpe_name *cpe_name_new(const char *cpestr)
 			free(fields_);
 		}
 		else if (format == CPE_FORMAT_STRING) {
-			char *data_ = strdup(cpestr + 8);	// without 'cpe:2.3:'
+			char *data_ = oscap_strdup(cpestr + 8); // without 'cpe:2.3:'
 			char **fields_ = oscap_split(data_, ":");
 			for (i = 0; fields_[i] && i < CPE_TOTAL_FIELDNUM; ++i)
 			{

--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -137,7 +137,7 @@ struct oval_definition_model* oval_agent_get_definition_model(oval_agent_session
 void oval_agent_set_product_name(oval_agent_session_t *ag_sess, char * product_name)
 {
 	struct oval_generator *generator;
-	ag_sess->product_name = strdup(product_name);
+	ag_sess->product_name = oscap_strdup(product_name);
 
 	generator = oval_syschar_model_get_generator(ag_sess->sys_models[0]);
 	oval_generator_set_product_name(generator, product_name);

--- a/src/OVAL/oval_defModel.c
+++ b/src/OVAL/oval_defModel.c
@@ -76,7 +76,7 @@ struct oval_definition_model *oval_definition_model_new()
 	newmodel->test_map = oval_string_map_new();
 	newmodel->variable_map = oval_string_map_new();
 	newmodel->bound_variable_models = NULL;
-        newmodel->schema = strdup(OVAL_DEF_SCHEMA_LOCATION);
+	newmodel->schema = oscap_strdup(OVAL_DEF_SCHEMA_LOCATION);
 	newmodel->vardef_map = NULL;
 
 	return newmodel;

--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -152,7 +152,7 @@ static int oval_pdtbl_add(oval_pdtbl_t *tbl, oval_subtype_t type, int sd, const 
 	pd = oscap_talloc(oval_pd_t);
 	pd->subtype = type;
 	pd->sd      = sd;
-	pd->uri     = strdup(uri);
+	pd->uri     = oscap_strdup(uri);
 
 	tbl->memb = realloc(tbl->memb, sizeof(oval_pd_t *) * (++tbl->count));
 

--- a/src/OVAL/oval_state.c
+++ b/src/OVAL/oval_state.c
@@ -154,7 +154,7 @@ struct oval_state *oval_state_new(struct oval_definition_model *model, const cha
 	state->operator = OVAL_OPERATOR_UNKNOWN;
 	state->subtype = OVAL_SUBTYPE_UNKNOWN;
 	state->comment = NULL;
-	state->id = strdup(id);
+	state->id = oscap_strdup(id);
 	state->notes = oval_collection_new();
 	state->contents = oval_collection_new();
 	state->model = model;
@@ -219,15 +219,14 @@ void oval_state_set_subtype(struct oval_state *state, oval_subtype_t subtype)
 void oval_state_add_note(struct oval_state *state, char *notes)
 {
 	__attribute__nonnull__(state);
-	oval_collection_add(state->notes, (void *)strdup(notes));
+	oval_collection_add(state->notes, (void *)oscap_strdup(notes));
 }
 
 void oval_state_set_comment(struct oval_state *state, char *comm)
 {
 	__attribute__nonnull__(state);
-	if (state->comment != NULL)
-		free(state->comment);
-	state->comment = comm == NULL ? NULL : strdup(comm);
+	free(state->comment);
+	state->comment = oscap_strdup(comm);
 }
 
 void oval_state_set_deprecated(struct oval_state *state, bool deprecated)

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -96,7 +96,7 @@ void sce_check_result_free(struct sce_check_result* v)
 void sce_check_result_set_href(struct sce_check_result* v, const char* href)
 {
 	free(v->href);
-	v->href = strdup(href);
+	v->href = oscap_strdup(href);
 }
 
 const char* sce_check_result_get_href(struct sce_check_result* v)
@@ -107,7 +107,7 @@ const char* sce_check_result_get_href(struct sce_check_result* v)
 void sce_check_result_set_basename(struct sce_check_result* v, const char* base_name)
 {
 	free(v->basename);
-	v->basename = strdup(base_name);
+	v->basename = oscap_strdup(base_name);
 }
 
 const char* sce_check_result_get_basename(struct sce_check_result* v)
@@ -118,7 +118,7 @@ const char* sce_check_result_get_basename(struct sce_check_result* v)
 void sce_check_result_set_stdout(struct sce_check_result* v, const char* _stdout)
 {
 	free(v->std_out);
-	v->std_out = strdup(_stdout);
+	v->std_out = oscap_strdup(_stdout);
 }
 
 const char* sce_check_result_get_stdout(struct sce_check_result* v)
@@ -129,7 +129,7 @@ const char* sce_check_result_get_stdout(struct sce_check_result* v)
 void sce_check_result_set_stderr(struct sce_check_result* v, const char* _stderr)
 {
 	free(v->std_err);
-	v->std_err = strdup(_stderr);
+	v->std_err = oscap_strdup(_stderr);
 }
 
 const char* sce_check_result_get_stderr(struct sce_check_result* v)
@@ -290,7 +290,7 @@ void sce_parameters_set_xccdf_directory(struct sce_parameters* v, const char* va
 	if (v->xccdf_directory)
 		free(v->xccdf_directory);
 
-	v->xccdf_directory = value == NULL ? NULL : strdup(value);
+	v->xccdf_directory = oscap_strdup(value);
 }
 
 const char* sce_parameters_get_xccdf_directory(struct sce_parameters* v)

--- a/src/XCCDF/elements.c
+++ b/src/XCCDF/elements.c
@@ -400,9 +400,7 @@ const char *xccdf_attribute_get(xmlTextReaderPtr reader, xccdf_attribute_t attr)
 char *xccdf_attribute_copy(xmlTextReaderPtr reader, xccdf_attribute_t attr)
 {
 	const char *ret = xccdf_attribute_get(reader, attr);
-	if (ret)
-		return strdup(ret);
-	return NULL;
+	return oscap_strdup(ret);
 }
 
 

--- a/src/XCCDF/rule.c
+++ b/src/XCCDF/rule.c
@@ -334,7 +334,7 @@ struct xccdf_item *xccdf_rule_parse(xmlTextReaderPtr reader, struct xccdf_item *
 				if (tag == NULL)
 					break;
 				struct xccdf_profile_note *note = xccdf_profile_note_new();
-				note->reftag = strdup(tag);
+				note->reftag = oscap_strdup(tag);
 				note->text = oscap_text_new_parse(XCCDF_TEXT_PROFNOTE, reader);
 				oscap_list_add(rule->sub.rule.profile_notes, note);
 				break;
@@ -453,8 +453,8 @@ struct xccdf_ident *xccdf_ident_new(void)
 struct xccdf_ident *xccdf_ident_new_fill(const char *id, const char *sys)
 {
 	struct xccdf_ident *ident = xccdf_ident_new();
-	ident->id = strdup(id);
-	ident->system = strdup(sys);
+	ident->id = oscap_strdup(id);
+	ident->system = oscap_strdup(sys);
 	return ident;
 }
 
@@ -608,7 +608,7 @@ struct xccdf_check *xccdf_check_parse(xmlTextReaderPtr reader)
 					break;
 				struct xccdf_check_content_ref *ref = xccdf_check_content_ref_new();
 				ref->name = xccdf_attribute_copy(reader, XCCDFA_NAME);
-				ref->href = strdup(href);
+				ref->href = oscap_strdup(href);
 				oscap_list_add(check->content_refs, ref);
 				break;
 			}
@@ -622,9 +622,9 @@ struct xccdf_check *xccdf_check_parse(xmlTextReaderPtr reader)
 				if (name == NULL) // @import-name is a required attribute
 					break;
 				struct xccdf_check_import *imp = xccdf_check_import_new();
-				imp->name = strdup(name);
+				imp->name = oscap_strdup(name);
 				if (xpath) // @import-xpath is just optional
-					imp->xpath = strdup(xpath);
+					imp->xpath = oscap_strdup(xpath);
 				imp->content = oscap_element_string_copy(reader);
 				oscap_list_add(check->imports, imp);
 				break;
@@ -634,7 +634,7 @@ struct xccdf_check *xccdf_check_parse(xmlTextReaderPtr reader)
 				if (name == NULL)
 					break;
 				struct xccdf_check_export *exp = xccdf_check_export_new();
-				exp->name = strdup(name);
+				exp->name = oscap_strdup(name);
 				exp->value = xccdf_attribute_copy(reader, XCCDFA_VALUE_ID);
 				oscap_list_add(check->exports, exp);
 				break;
@@ -821,7 +821,7 @@ struct xccdf_fixtext * xccdf_fixtext_clone(const struct xccdf_fixtext * fixtext)
 	clone->complexity = fixtext->complexity;
 	clone->fixref = oscap_strdup(fixtext->fixref);
 	clone->text = oscap_text_clone(fixtext->text);
-	return clone;	
+	return clone;
 }
 
 struct xccdf_fixtext *xccdf_fixtext_parse(xmlTextReaderPtr reader)

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -860,7 +860,7 @@ void xccdf_session_set_custom_oval_files(struct xccdf_session *session, char **o
 
 	for (int i = 0; oval_filenames[i];) {
 		resources[i] = malloc(sizeof(struct oval_content_resource));
-		resources[i]->href = strdup(basename(oval_filenames[i]));
+		resources[i]->href = oscap_strdup(basename(oval_filenames[i]));
 		resources[i]->source = oscap_source_new_from_file(oval_filenames[i]);
 		resources[i]->source_owned = true;
 		i++;
@@ -884,7 +884,7 @@ static int _xccdf_session_get_oval_from_model(struct xccdf_session *session)
 
 	_oval_content_resources_free(session->oval.resources);
 
-	xccdf_path_cpy = strdup(oscap_source_readable_origin(session->xccdf.source));
+	xccdf_path_cpy = oscap_strdup(oscap_source_readable_origin(session->xccdf.source));
 	dir_path = dirname(xccdf_path_cpy);
 
 	resources = malloc(sizeof(struct oval_content_resource *));
@@ -921,7 +921,7 @@ static int _xccdf_session_get_oval_from_model(struct xccdf_session *session)
 
 		if (source != NULL || stat(tmp_path, &sb) == 0) {
 			resources[idx] = malloc(sizeof(struct oval_content_resource));
-			resources[idx]->href = strdup(oscap_file_entry_get_file(file_entry));
+			resources[idx]->href = oscap_strdup(oscap_file_entry_get_file(file_entry));
 			if (source == NULL) {
 				source = oscap_source_new_from_file(tmp_path);
 				resources[idx]->source_owned = true;
@@ -950,7 +950,7 @@ static int _xccdf_session_get_oval_from_model(struct xccdf_session *session)
 						session->oval.progress(false, "ok\n");
 
 						resources[idx] = malloc(sizeof(struct oval_content_resource));
-						resources[idx]->href = strdup(printable_path);
+						resources[idx]->href = oscap_strdup(printable_path);
 						resources[idx]->source = oscap_source_new_take_memory(data, data_size, printable_path);
 						resources[idx]->source_owned = true;
 						idx++;

--- a/src/XCCDF_POLICY/xccdf_policy_substitute.c
+++ b/src/XCCDF_POLICY/xccdf_policy_substitute.c
@@ -84,7 +84,7 @@ static int _xccdf_text_substitution_cb(xmlNode **node, void *user_data)
 				// during Document Generation or Assessment, process the <xccdf:sub>
 				// element as if @use was set to "value".
 				free(sub_use);
-				sub_use = strdup((data->processing_type & _TAILORING_TYPE) ? "title" : "value");
+				sub_use = oscap_strdup((data->processing_type & _TAILORING_TYPE) ? "title" : "value");
 			}
 
 			if (oscap_streq(sub_use, "title")) {

--- a/src/common/list.c
+++ b/src/common/list.c
@@ -352,7 +352,7 @@ struct oscap_string_iterator *oscap_stringlist_get_strings(const struct oscap_st
 
 bool oscap_stringlist_add_string(struct oscap_stringlist* list, const char *str)
 {
-	return oscap_list_add((struct oscap_list *) list, strdup(str));
+	return oscap_list_add((struct oscap_list *) list, oscap_strdup(str));
 }
 
 struct oscap_stringlist * oscap_stringlist_new(void)
@@ -467,7 +467,7 @@ bool oscap_htable_add(struct oscap_htable * htable, const char *key, void *item)
 	unsigned int hashcode = oscap_htable_hash(key, htable->hsize);
 	struct oscap_htable_item *newhtitem;
 	newhtitem = malloc(sizeof(struct oscap_htable_item));
-	newhtitem->key = strdup(key);
+	newhtitem->key = oscap_strdup(key);
 	newhtitem->value = item;
 	newhtitem->next = htable->table[hashcode];
 	htable->table[hashcode] = newhtitem;

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -51,7 +51,7 @@
 char *
 oscap_acquire_temp_dir()
 {
-	char *temp_dir = strdup(TEMP_DIR_TEMPLATE);
+	char *temp_dir = oscap_strdup(TEMP_DIR_TEMPLATE);
 	if (mkdtemp(temp_dir) == NULL) {
 		free(temp_dir);
 		oscap_seterr(OSCAP_EFAMILY_GLIBC, "Could not create temp directory " TEMP_DIR_TEMPLATE ". %s", strerror(errno));
@@ -136,7 +136,7 @@ oscap_acquire_url_to_filename(const char *url)
 		oscap_seterr(OSCAP_EFAMILY_NET, "Failed to escape the given url %s", url);
 		return NULL;
 	}
-	filename = strdup(curl_filename);
+	filename = oscap_strdup(curl_filename);
 	curl_free(curl_filename);
 	curl_easy_cleanup(curl);
 	curl_global_cleanup();
@@ -208,11 +208,11 @@ char *oscap_acquire_guess_realpath(const char *filepath)
 
 	char *rpath = realpath(filepath, resolved_name);
 	if (rpath != NULL)
-		rpath = strdup(rpath);
+		rpath = oscap_strdup(rpath);
 	else {
 		// file does not exists, let's try to guess realpath
 		// this is not 100% correct, but it is good enough
-		char *copy = strdup(filepath);
+		char *copy = oscap_strdup(filepath);
 		if (copy == NULL) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Cannot guess realpath for %s, directory: cannot allocate memory!", filepath);
 			return NULL;

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -360,10 +360,10 @@ const char *oscap_source_get_schema_version(struct oscap_source *source)
 		}
 		switch (oscap_source_get_scap_type(source)) {
 			case OSCAP_DOCUMENT_SDS:
-				source->origin.version = strdup("1.2");
+				source->origin.version = oscap_strdup("1.2");
 				break;
 			case OSCAP_DOCUMENT_ARF:
-				source->origin.version = strdup("1.1");
+				source->origin.version = oscap_strdup("1.1");
 				break;
 			case OSCAP_DOCUMENT_OVAL_DEFINITIONS:
 			case OSCAP_DOCUMENT_OVAL_VARIABLES:
@@ -384,13 +384,13 @@ const char *oscap_source_get_schema_version(struct oscap_source *source)
 				source->origin.version = cpe_lang_model_detect_version_priv(reader);
 				break;
 			case OSCAP_DOCUMENT_CVE_FEED:
-				source->origin.version = strdup("2.0");
+				source->origin.version = oscap_strdup("2.0");
 				break;
 			case OSCAP_DOCUMENT_CVRF_FEED:
-				source->origin.version = strdup("1.1");
+				source->origin.version = oscap_strdup("1.1");
 				break;
 			case OSCAP_DOCUMENT_SCE_RESULT:
-				source->origin.version = strdup("1.0");
+				source->origin.version = oscap_strdup("1.0");
 				break;
 			default:
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not determine origin.version for document %s: Unknown type: %s",

--- a/src/source/xslt.c
+++ b/src/source/xslt.c
@@ -118,7 +118,7 @@ static xmlDoc *apply_xslt_path_internal(struct oscap_source *source, const char 
 	/* is it an absolute path? */
 	char *xsltpath;
 	if (strstr(xsltfile, "/") == xsltfile) {
-		xsltpath = strdup(xsltfile);
+		xsltpath = oscap_strdup(xsltfile);
 		if (access(xsltpath, R_OK)) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "XSLT file '%s' not found when trying to transform '%s'",
 				xsltfile, oscap_source_readable_origin(source));


### PR DESCRIPTION
strdup is not a C standard function, it is different on different platforms. On Windows you are supposed to use _strdup instead. Therefore we have a small wrapper called `oscap_strdup`. However we are not using that wrapper ocnsistently and in many cases we still use strdup directly. This causes a lot of issues with @jan-cerny 's work on the Windows port.

I will not be fixing strdup usage in probes in this PR. That will have to be done in a different PR.