### PR TITLE
Use oscap_strdup everywhere.

### DIFF
--- a/src/CPE/cpename.c
+++ b/src/CPE/cpename.c
@@ -214,7 +214,7 @@ bool cpe_set_field(struct cpe_name * cpe, int idx, const char *newval)
 	if (newval && strcmp(newval, "") == 0)
 		newval = NULL;
 	if (newval != NULL)
-		*fieldptr = strdup(newval);
+		*fieldptr = oscap_strdup(newval);
 	else
 		*fieldptr = NULL;
 
@@ -241,7 +241,7 @@ struct cpe_name *cpe_name_new(const char *cpestr)
 
 	if (cpestr) {
 		if (format == CPE_FORMAT_URI) {
-			char *data_ = strdup(cpestr + 5);	// without 'cpe:/'
+			char *data_ = oscap_strdup(cpestr + 5);	// without 'cpe:/'
 			char **fields_ = oscap_split(data_, ":");
 			for (i = 0; fields_[i]; ++i)
 			{
@@ -286,7 +286,7 @@ struct cpe_name *cpe_name_new(const char *cpestr)
 			free(fields_);
 		}
 		else if (format == CPE_FORMAT_STRING) {
-			char *data_ = strdup(cpestr + 8);	// without 'cpe:2.3:'
+			char *data_ = oscap_strdup(cpestr + 8);	// without 'cpe:2.3:'
 			char **fields_ = oscap_split(data_, ":");
 			for (i = 0; fields_[i] && i < CPE_TOTAL_FIELDNUM; ++i)
 			{

--- a/src/OVAL/adt/oval_string_map.c
+++ b/src/OVAL/adt/oval_string_map.c
@@ -207,7 +207,7 @@ void oval_string_map_put(struct oval_string_map *map, const char *key, void *val
 	assume_d(map != NULL, /* void */);
 	assume_d(key != NULL, /* void */);
 
-	if (rbt_str_add((rbt_t *)map, key_copy = strdup(key), val) != 0) {
+	if (rbt_str_add((rbt_t *)map, key_copy = oscap_strdup(key), val) != 0) {
 		dD("rbt_str_add: non-zero return code");
                 free(key_copy);
         }
@@ -215,12 +215,12 @@ void oval_string_map_put(struct oval_string_map *map, const char *key, void *val
 
 void oval_string_map_put_string(struct oval_string_map *map, const char *key, const char *val)
 {
-	char *str = strdup(val), *key_copy;
+	char *str = oscap_strdup(val), *key_copy;
 
 	assume_d(map != NULL, /* void */);
 	assume_d(key != NULL, /* void */);
 
-	if (rbt_str_add((rbt_t *)map, key_copy = strdup(key), str) == 0)
+	if (rbt_str_add((rbt_t *)map, key_copy = oscap_strdup(key), str) == 0)
 		return;
 	else {
 		free(str);

--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -149,7 +149,7 @@ struct oval_definition_model* oval_agent_get_definition_model(oval_agent_session
 void oval_agent_set_product_name(oval_agent_session_t *ag_sess, char * product_name)
 {
 	struct oval_generator *generator;
-	ag_sess->product_name = strdup(product_name);
+	ag_sess->product_name = oscap_strdup(product_name);
 
 	generator = oval_syschar_model_get_generator(ag_sess->sys_models[0]);
 	oval_generator_set_product_name(generator, product_name);

--- a/src/OVAL/oval_defModel.c
+++ b/src/OVAL/oval_defModel.c
@@ -78,7 +78,7 @@ struct oval_definition_model *oval_definition_model_new()
 	newmodel->test_map = oval_string_map_new();
 	newmodel->variable_map = oval_string_map_new();
 	newmodel->bound_variable_models = NULL;
-        newmodel->schema = strdup(OVAL_DEF_SCHEMA_LOCATION);
+	newmodel->schema = oscap_strdup(OVAL_DEF_SCHEMA_LOCATION);
 	newmodel->vardef_map = NULL;
 
 	return newmodel;

--- a/src/OVAL/oval_definition.c
+++ b/src/OVAL/oval_definition.c
@@ -207,7 +207,7 @@ struct oval_definition *oval_definition_clone
 		}
 		oval_string_iterator_free(notes);
 
-		new_definition->anyxml = strdup(old_definition->anyxml);
+		new_definition->anyxml = oscap_strdup(old_definition->anyxml);
 
 		oval_definition_set_criteria(new_definition, oval_criteria_node_clone(new_model, old_definition->criteria));
 	}

--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -152,7 +152,7 @@ static int oval_pdtbl_add(oval_pdtbl_t *tbl, oval_subtype_t type, int sd, const 
 	pd = oscap_talloc(oval_pd_t);
 	pd->subtype = type;
 	pd->sd      = sd;
-	pd->uri     = strdup(uri);
+	pd->uri = oscap_strdup(uri);
 
 	tbl->memb = realloc(tbl->memb, sizeof(oval_pd_t *) * (++tbl->count));
 

--- a/src/OVAL/oval_state.c
+++ b/src/OVAL/oval_state.c
@@ -154,7 +154,7 @@ struct oval_state *oval_state_new(struct oval_definition_model *model, const cha
 	state->operator = OVAL_OPERATOR_UNKNOWN;
 	state->subtype = OVAL_SUBTYPE_UNKNOWN;
 	state->comment = NULL;
-	state->id = strdup(id);
+	state->id = oscap_strdup(id);
 	state->notes = oval_collection_new();
 	state->contents = oval_collection_new();
 	state->model = model;
@@ -219,7 +219,7 @@ void oval_state_set_subtype(struct oval_state *state, oval_subtype_t subtype)
 void oval_state_add_note(struct oval_state *state, char *notes)
 {
 	__attribute__nonnull__(state);
-	oval_collection_add(state->notes, (void *)strdup(notes));
+	oval_collection_add(state->notes, (void *)oscap_strdup(notes));
 }
 
 void oval_state_set_comment(struct oval_state *state, char *comm)
@@ -227,7 +227,7 @@ void oval_state_set_comment(struct oval_state *state, char *comm)
 	__attribute__nonnull__(state);
 	if (state->comment != NULL)
 		free(state->comment);
-	state->comment = comm == NULL ? NULL : strdup(comm);
+	state->comment = comm == NULL ? NULL : oscap_strdup(comm);
 }
 
 void oval_state_set_deprecated(struct oval_state *state, bool deprecated)

--- a/src/OVAL/probes/SEAP/seap-message.c
+++ b/src/OVAL/probes/SEAP/seap-message.c
@@ -55,7 +55,7 @@ SEAP_msg_t *SEAP_msg_clone (SEAP_msg_t *msg)
         new->attrs = sm_alloc (sizeof (SEAP_attr_t) * new->attrs_cnt);
 
         for (i = 0; i < new->attrs_cnt; ++i) {
-                new->attrs[i].name  = strdup (msg->attrs[i].name);
+                new->attrs[i].name = oscap_strdup(msg->attrs[i].name);
                 new->attrs[i].value = SEXP_ref (msg->attrs[i].value);
         }
 
@@ -122,7 +122,7 @@ int SEAP_msgattr_set (SEAP_msg_t *msg, const char *attr, SEXP_t *value)
                 SEXP_VALIDATE(value);
 #endif
         msg->attrs = sm_realloc (msg->attrs, sizeof (SEAP_attr_t) * (++msg->attrs_cnt));
-        msg->attrs[msg->attrs_cnt - 1].name  = strdup (attr);
+        msg->attrs[msg->attrs_cnt - 1].name = oscap_strdup(attr);
         msg->attrs[msg->attrs_cnt - 1].value = (value != NULL ? SEXP_ref (value) : NULL);
 
         return (0);

--- a/src/OVAL/probes/SEAP/sexp-manip.c
+++ b/src/OVAL/probes/SEAP/sexp-manip.c
@@ -1922,7 +1922,7 @@ int SEXP_datatype_set (SEXP_t *s_exp, const char *name)
         t = SEXP_datatype_get (&g_datatypes, name);
 
         if (t == NULL) {
-                char *k = strdup(name);
+                char *k = oscap_strdup(name);
 
                 t = SEXP_datatype_add (&g_datatypes, k, NULL, NULL);
 
@@ -1951,7 +1951,7 @@ int SEXP_datatype_set_nth (SEXP_t *list, uint32_t n, const char *name)
         t = SEXP_datatype_get (&g_datatypes, name);
 
         if (t == NULL) {
-                char *k = strdup(name);
+                char *k = oscap_strdup(name);
 
                 t = SEXP_datatype_add (&g_datatypes, k, NULL, NULL);
 

--- a/src/OVAL/probes/SEAP/sexp-parser.c
+++ b/src/OVAL/probes/SEAP/sexp-parser.c
@@ -1870,7 +1870,7 @@ found:
 
                 if (dsc->s_exp->s_type == NULL) {
                         if (name == name_static)
-                                name = strdup(name);
+                                name = oscap_strdup(name);
 
                         dsc->s_exp->s_type = SEXP_datatype_add (&g_datatypes, name, NULL, NULL);
 
@@ -1911,7 +1911,7 @@ __PARSE_RT SEXP_parse_kl_datatype (__PARSE_PT(dsc))
 
         if (dsc->s_exp->s_type == NULL) {
                 if (name == name_static)
-                        name = strdup(name);
+                        name = oscap_strdup(name);
 
                 dsc->s_exp->s_type = SEXP_datatype_add (&g_datatypes, name, NULL, NULL);
 

--- a/src/OVAL/probes/findfile.c
+++ b/src/OVAL/probes/findfile.c
@@ -351,7 +351,7 @@ static int rglob(const char *pattern, rglob_t * result)
 		return 1;
 
 	/* get no regexp portion from pattern to path */
-	tmp_ptr = tmp = strdup(pattern);
+	tmp_ptr = tmp = oscap_strdup(pattern);
 	if (tmp[0] == '^')
 		tmp++;
 
@@ -402,7 +402,7 @@ static void find_paths_recursion(const char *path, regex_t * re, rglob_t * resul
 		return;
 
 	if (regexec(re, path, 0, NULL, 0) == 0) {	/* catch? */
-		result->pathv[result->pathc] = strdup(path);
+		result->pathv[result->pathc] = oscap_strdup(path);
 		result->pathc++;
 		if (result->pathc == result->offs) {
 			result->offs = result->offs * 2;	/* magic constant */

--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -64,6 +64,7 @@
 #endif
 
 #include "fsdev.h"
+#include "util.h"
 
 /**
  * Compare two dev_t variables.
@@ -373,7 +374,7 @@ fsdev_t *fsdev_strinit(const char *fs_names)
 	size_t fs_cnt;
 	int state, e;
 
-	pstr = strdup(fs_names);
+	pstr = oscap_strdup(fs_names);
 	state = 0;
 	fs_arr = NULL;
 	fs_cnt = 0;

--- a/src/OVAL/probes/independent/ldap57.c
+++ b/src/OVAL/probes/independent/ldap57.c
@@ -161,9 +161,9 @@ int probe_main(probe_ctx *ctx, void *mutex)
         attrs[0] = "objectClass";
 
         if (xattribute == NULL)
-                attrs[1] = strdup("1.1"); /* no attibutes */
+                attrs[1] = oscap_strdup("1.1"); /* no attibutes */
         else if (a_pattern_match)
-                attrs[1] = strdup("*");   /* collect all, we'll filter them afterwards */
+                attrs[1] = oscap_strdup("*");   /* collect all, we'll filter them afterwards */
         else
                 attrs[1] = xattribute;     /* no pattern match, use the string directly */
 

--- a/src/OVAL/probes/independent/sql.c
+++ b/src/OVAL/probes/independent/sql.c
@@ -176,7 +176,7 @@ static void dbURIInfo_clear(dbURIInfo_t *ui)
 static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 {
 	char *tmp, *tok, *copy;
-	char *conn_copy = strdup(conn);
+	char *conn_copy = oscap_strdup(conn);
 	copy = conn_copy;
 	if (copy == NULL)
 		return (-1);
@@ -189,7 +189,7 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 			tok += strlen(rest);			\
 			skipspace(tok);				\
 			if (*(tok) != '=') goto __fail;		\
-			else (dst) = strdup((tok) + 1);		\
+			else (dst) = oscap_strdup((tok) + 1);		\
 		}						\
 		else dE("Unrecognized token: '%s'", (tok)-1);		\
 	while(0)
@@ -200,13 +200,13 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 			tok += 1+strlen(rest1);				\
 			skipspace(tok);					\
 			if (*(tok) != '=') goto __fail;			\
-			else (dst1) = strdup((tok) + 1);		\
+			else (dst1) = oscap_strdup((tok) + 1);		\
 		}							\
 		else if (strncasecmp((rest2), (tok)+1, strlen(rest2)) == 0) {	\
 			tok += 1+strlen(rest2);				\
 			skipspace(tok);					\
 			if (*(tok) != '=') goto __fail;			\
-			else (dst2) = strdup((tok) + 1);		\
+			else (dst2) = oscap_strdup((tok) + 1);		\
 		}							\
 		else dE("Unrecognized token: '%s'", (tok));		\
 		while(0)

--- a/src/OVAL/probes/independent/sql57.c
+++ b/src/OVAL/probes/independent/sql57.c
@@ -176,7 +176,7 @@ static void dbURIInfo_clear(dbURIInfo_t *ui)
 static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 {
 	char *tmp, *tok, *copy;
-	char *conn_copy = strdup(conn);
+	char *conn_copy = oscap_strdup(conn);
 	copy = conn_copy;
 	if (copy == NULL)
 		return (-1);
@@ -189,7 +189,7 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 			tok += strlen(rest);			\
 			skipspace(tok);				\
 			if (*(tok) != '=') goto __fail;		\
-			else (dst) = strdup((tok) + 1);		\
+			else (dst) = oscap_strdup((tok) + 1);		\
 		}						\
 		else dE("Unrecognized token: '%s'", (tok)-1);		\
 	while(0)
@@ -200,13 +200,13 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 			tok += 1+strlen(rest1);				\
 			skipspace(tok);					\
 			if (*(tok) != '=') goto __fail;			\
-			else (dst1) = strdup((tok) + 1);		\
+			else (dst1) = oscap_strdup((tok) + 1);		\
 		}							\
 		else if (strncasecmp((rest2), (tok)+1, strlen(rest2)) == 0) {	\
 			tok += 1+strlen(rest2);				\
 			skipspace(tok);					\
 			if (*(tok) != '=') goto __fail;			\
-			else (dst2) = strdup((tok) + 1);		\
+			else (dst2) = oscap_strdup((tok) + 1);		\
 		}							\
 		else dE("Unrecognized token: '%s'", (tok));		\
 		while(0)

--- a/src/OVAL/probes/independent/system_info.c
+++ b/src/OVAL/probes/independent/system_info.c
@@ -387,7 +387,7 @@ static char * _offline_chroot_get_menuentry(int entry_num)
 		goto fail2;
 
 	grubcfg[ovec[1]] = '\0';
-	ret = strdup(grubcfg + ovec[0]);
+	ret = oscap_strdup(grubcfg + ovec[0]);
 fail2:
 	fclose(fp);
 fail:
@@ -484,7 +484,7 @@ static char * _offline_chroot_get_os_name(void)
 	if (rc > 0) {
 		saved_entry[ovec[1]] = '\0';
 		ptr = saved_entry + ovec[0];
-		ret = strdup(ptr);
+		ret = oscap_strdup(ptr);
 		pcre_free(re);
 		goto finish;
 	}
@@ -511,7 +511,7 @@ static char * _offline_chroot_get_hname(void)
 		goto finish;
 
 	hname[strcspn(hname, "\n")] = '\0';
-	ret = strdup(hname);
+	ret = oscap_strdup(hname);
 
 finish:
 	fclose(fp);
@@ -541,10 +541,10 @@ int probe_main(probe_ctx *ctx, void *arg)
 
 	if (offline_mode == PROBE_OFFLINE_NONE) {
 		if (uname(&sname) == 0) {
-			os_name = strdup(sname.sysname);
+			os_name = oscap_strdup(sname.sysname);
 			os_version = sname.version;
-			architecture = strdup(sname.machine);
-			hname = strdup(sname.nodename);
+			architecture = oscap_strdup(sname.machine);
+			hname = oscap_strdup(sname.nodename);
 		}
 	} else if (offline_mode == PROBE_OFFLINE_CHROOT) {
 		os_name = _offline_chroot_get_os_name();
@@ -555,17 +555,17 @@ int probe_main(probe_ctx *ctx, void *arg)
 
 	/* All four elements are required */
 	if (!os_name)
-		os_name = strdup(unknown);
+		os_name = oscap_strdup(unknown);
 
 	// os_version kept static as it shared memory with os_name if os_name exists
 	if (!os_version)
 		os_version = unknown;
 
 	if (!architecture)
-		architecture = strdup(unknown);
+		architecture = oscap_strdup(unknown);
 
 	if (!hname)
-		hname = strdup(unknown);
+		hname = oscap_strdup(unknown);
 
 	if (__sysinfo_saneval(os_name) < 1 ||
 		__sysinfo_saneval(os_version) < 1 ||

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -109,10 +109,10 @@ static OVAL_FTSENT *OVAL_FTSENT_new(OVAL_FTS *ofts, FTSENT *fts_ent)
 		ofts_ent->path[ofts_ent->path_len] = '\0';
 
 		ofts_ent->file_len = fts_ent->fts_namelen;
-		ofts_ent->file = strdup(fts_ent->fts_name);
+		ofts_ent->file = oscap_strdup(fts_ent->fts_name);
 	} else {
 		ofts_ent->path_len = fts_ent->fts_pathlen;
-		ofts_ent->path = strdup(fts_ent->fts_path);
+		ofts_ent->path = oscap_strdup(fts_ent->fts_path);
 
 		ofts_ent->file_len = -1;
 		ofts_ent->file = NULL;
@@ -366,7 +366,7 @@ static char *extract_fixed_path_prefix(char *path)
 		}
 	}
 
-	return strdup("/");
+	return oscap_strdup("/");
 }
 
 static int badpartial_check_slash(const char *pattern)
@@ -527,7 +527,7 @@ static int process_pattern_match(const char *path, pcre **regex_out)
 		   "All paths with the 'pattern match' operation must begin "
 		   "with a caret.", path);
 	} else {
-		pattern = strdup(path);
+		pattern = oscap_strdup(path);
 	}
 
 	regex = pcre_compile(pattern, 0, &errptr, &errofs, NULL);
@@ -801,14 +801,14 @@ OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t
 	*/
 
 	if (path_op == OVAL_OPERATION_EQUALS) {
-		paths[0] = strdup(cstr_path);
+		paths[0] = oscap_strdup(cstr_path);
 	} else if (path_op == OVAL_OPERATION_PATTERN_MATCH) {
 		if (process_pattern_match(cstr_path, &regex) != 0)
 			return NULL;
 		paths[0] = extract_fixed_path_prefix(cstr_path);
 		dI("Extracted fixed path: '%s'.", paths[0]);
 	} else {
-		paths[0] = strdup("/");
+		paths[0] = oscap_strdup("/");
 	}
 
 	/* Fail if the provided path doensn't actually exist. Symlinks
@@ -1169,7 +1169,7 @@ static FTSENT *oval_fts_read_recurse_path(OVAL_FTS *ofts)
 	case OVAL_RECURSE_DIRECTION_UP:
 		if (ofts->ofts_recurse_path_pthcpy == NULL) {
 			ofts->ofts_recurse_path_pthcpy = \
-			ofts->ofts_recurse_path_curpth = strdup(ofts->ofts_match_path_fts_ent->fts_path);
+			ofts->ofts_recurse_path_curpth = oscap_strdup(ofts->ofts_match_path_fts_ent->fts_path);
 			ofts->ofts_recurse_path_curdepth = 0;
 		}
 

--- a/src/OVAL/probes/probe/main.c
+++ b/src/OVAL/probes/probe/main.c
@@ -109,7 +109,7 @@ static int probe_opthandler_varref(int option, int op, va_list args)
 
 	OSCAP_GSYM(no_varref_ents) = realloc(OSCAP_GSYM(no_varref_ents),
 						   sizeof (char *) * ++OSCAP_GSYM(no_varref_ents_cnt));
-	OSCAP_GSYM(no_varref_ents)[OSCAP_GSYM(no_varref_ents_cnt) - 1] = strdup(o_name);
+	OSCAP_GSYM(no_varref_ents)[OSCAP_GSYM(no_varref_ents_cnt) - 1] = oscap_strdup(o_name);
 
 	qsort(OSCAP_GSYM(no_varref_ents), OSCAP_GSYM(no_varref_ents_cnt),
               sizeof (char *), (int(*)(const void *, const void *))&probe_optecmp);

--- a/src/OVAL/probes/unix/linux/iflisteners.c
+++ b/src/OVAL/probes/unix/linux/iflisteners.c
@@ -285,7 +285,7 @@ static int collect_process_info(llist *l)
 				continue;
 			node.pid = pid;
 			node.uid = euid;
-			node.cmd = strdup(cmd);
+			node.cmd = oscap_strdup(cmd);
 			node.inode = inode;
 			// We make one entry for each socket inode
 			list_append(l, &node);

--- a/src/OVAL/probes/unix/linux/inetlisteningservers.c
+++ b/src/OVAL/probes/unix/linux/inetlisteningservers.c
@@ -286,7 +286,7 @@ static int collect_process_info(llist *l)
 				continue;
 			node.pid = pid;
 			node.uid = euid;
-			node.cmd = strdup(cmd);
+			node.cmd = oscap_strdup(cmd);
 			node.inode = inode;
 			// We make one entry for each socket inode
 			list_append(l, &node);

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -158,7 +158,7 @@ static void pkgh2rep (Header h, struct rpminfo_rep *r)
 		}
 	}
 
-        r->signature_keyid = strdup(sid != NULL ? sid : "0");
+        r->signature_keyid = oscap_strdup(sid != NULL ? sid : "0");
         free (str);
 }
 

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -188,7 +188,7 @@ static int rpmverify_collect(probe_ctx *ctx,
 			((res.fflags & RPMFILE_GHOST)  && (flags & RPMVERIFY_SKIP_GHOST)))
 		      continue;
 
-		    res.file   = strdup(rpmfiFN(fi));
+		    res.file = oscap_strdup(rpmfiFN(fi));
 
 		    filepath_sexp = SEXP_string_newf("%s", res.file);
 		    if (probe_entobj_cmp(filepath_ent, filepath_sexp) != OVAL_RESULT_TRUE) {

--- a/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
+++ b/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
@@ -61,12 +61,12 @@ static void split_level(const char *level, char **sensitivity, char **category) 
 
 	level_split = strchr(level, ':');
 	if (level_split == NULL) {
-		*sensitivity = strdup(level);
+		*sensitivity = oscap_strdup(level);
 		*category = NULL;
 	}
 	else {
 		*sensitivity = strndup(level, level_split - level);
-		*category = strdup(level_split + 1);
+		*category = oscap_strdup(level_split + 1);
 	}
 }
 
@@ -96,7 +96,7 @@ static void split_range(const char *range, char **l_s, char **l_c, char **h_s, c
 		free(level);
 
 		/* high level */
-		level = strdup(range_split + 1);
+		level = oscap_strdup(range_split + 1);
 		split_level(level, h_s, h_c);
 		free(level);
 	}

--- a/src/OVAL/probes/unix/process58.c
+++ b/src/OVAL/probes/unix/process58.c
@@ -256,7 +256,7 @@ static char *get_selinux_label(int pid) {
 			freecon(pid_context);
 			return NULL;
 		}
-		selinux_label = strdup(context_type_get(context));
+		selinux_label = oscap_strdup(context_type_get(context));
 		context_free(context);
 		freecon(pid_context);
 		return selinux_label;
@@ -304,7 +304,7 @@ static char **get_posix_capability(int pid, int max_cap_id) {
 #if LIBCAP_VERSION == 2
 			cap_name = cap_to_name(cap_value);
 #else
-			cap_name = strdup(_cap_names[cap_value]);
+			cap_name = oscap_strdup(_cap_names[cap_value]);
 #endif
 			if (cap_name != NULL) {
 				char *cap_name_p = cap_name;
@@ -316,7 +316,7 @@ static char **get_posix_capability(int pid, int max_cap_id) {
 				cap_id = oscap_string_to_enum(CapabilityType, cap_name);
 				if (cap_id > -1 && cap_id <= max_cap_id) {
 					ret = realloc(ret, (ret_index + 1) * sizeof(char *));
-					ret[ret_index] = strdup(cap_name);
+					ret[ret_index] = oscap_strdup(cap_name);
 					ret_index++;
 				}
 				cap_free(cap_name);

--- a/src/OVAL/probes/unix/runlevel.c
+++ b/src/OVAL/probes/unix/runlevel.c
@@ -213,8 +213,8 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 				rep_lst = rep_lst->next;
 			}
 
-			rep_lst->service_name = strdup(service_name);
-			rep_lst->runlevel = strdup(runlevel);
+			rep_lst->service_name = oscap_strdup(service_name);
+			rep_lst->runlevel = oscap_strdup(runlevel);
 			rep_lst->start = start;
 			rep_lst->kill = kill;
 			rep_lst->next = NULL;

--- a/src/OVAL/probes/unix/sysctl.c
+++ b/src/OVAL/probes/unix/sysctl.c
@@ -129,7 +129,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 			continue;
 		}
 
-                mib    = strdup(mibpath + strlen(PROC_SYS_DIR) + 1);
+                mib = oscap_strdup(mibpath + strlen(PROC_SYS_DIR) + 1);
                 miblen = strlen(mib);
 
                 while (miblen > 0) {

--- a/src/OVAL/probes/unix/xinetd.c
+++ b/src/OVAL/probes/unix/xinetd.c
@@ -544,7 +544,7 @@ static xiconf_file_t *xiconf_read(const char *path, int flags)
 	}
 
 	/* now initialize item that do need extra memory to be allocated */
-	file->cpath = strdup(path);
+	file->cpath = oscap_strdup(path);
 
 	return (file);
 }
@@ -887,7 +887,7 @@ int xiconf_parse_section(xiconf_t *xiconf, xiconf_file_t *xifile, int type, char
 	 * blank lines or a right brace which signals and of the section.
 	 */
 	snew = xiconf_service_new();
-	snew->name = strdup(name);
+	snew->name = oscap_strdup(name);
 
 	for (;;) {
 		/*
@@ -923,7 +923,7 @@ int xiconf_parse_section(xiconf_t *xiconf, xiconf_file_t *xifile, int type, char
 		 * now there should be a attribute name, comment
 		 * or the end-of-line.
 		 */
-		key = strdup(buffer + bufidx);
+		key = oscap_strdup(buffer + bufidx);
 		if (key == NULL)
 			exit(ENOMEM);
 
@@ -1073,11 +1073,11 @@ finish_section:
 			if (scur->socket_type != NULL) {
 				// dgram => udp
 				if (strcmp(scur->socket_type, "dgram") == 0) {
-					scur->protocol = strdup("udp");
+					scur->protocol = oscap_strdup("udp");
 				}
 				// stream => tcp
 				else if (strcmp(scur->socket_type, "stream") == 0) {
-					scur->protocol = strdup("tcp");
+					scur->protocol = oscap_strdup("tcp");
 				}
 			}
 			// If we still don't know the protocol, then get the default from /etc/services
@@ -1085,7 +1085,7 @@ finish_section:
 				struct servent *service = getservbyname(scur->name, NULL);
 				dI("protocol is empty, trying to guess from /etc/services for %s", scur->name);
 				if (service != NULL) {
-					scur->protocol = strdup(service->s_proto);
+					scur->protocol = oscap_strdup(service->s_proto);
 					dI("service %s has default protocol=%s", scur->name, scur->protocol);
 				}
 				endservent();
@@ -1140,7 +1140,7 @@ finish_section:
 			st->srv = malloc (sizeof (xiconf_service_t *));
 			st->srv[0] = scur;
 
-			if (rbt_str_add (xiconf->ttree, strdup(st_key), st) != 0) {
+			if (rbt_str_add (xiconf->ttree, oscap_strdup(st_key), st) != 0) {
 				dE("Can't add strans record (k=%s) into the strans tree (%p)",
 				   st_key, xiconf->ttree);
 				return (-1);
@@ -1304,7 +1304,7 @@ int op_assign_str(void *var, char *val)
 	while(isspace(*val)) ++val;
 
 	if (*val != '\0') {
-		*((char **)(var)) = strdup(val);
+		*((char **)(var)) = oscap_strdup(val);
 		return (0);
 	} else
 		return (-1);
@@ -1351,7 +1351,7 @@ int op_assign_strl(void *var, char *val)
 		}
 		dI("Adding new member to string array: %s", tok);
 		string_array = realloc(string_array, sizeof(char *) * (++string_array_size + 1));
-		string_array[string_array_size-1] = strdup(tok);
+		string_array[string_array_size-1] = oscap_strdup(tok);
 		string_array[string_array_size] = NULL;
 	}
 	*aptr = string_array;
@@ -1382,7 +1382,7 @@ int op_insert_strl(void *var, char *val)
 		}
 		dI("Adding new member to string array: %s", tok);
 		string_array = realloc(string_array, sizeof(char *) * (++string_array_size + 1));
-		string_array[string_array_size-1] = strdup(tok);
+		string_array[string_array_size-1] = oscap_strdup(tok);
 		string_array[string_array_size] = NULL;
 	}
 	*aptr = string_array;
@@ -1485,7 +1485,7 @@ int op_assign_disabled(void *var, char *val)
 
 		if (srv == NULL) {
 			srv = xiconf_service_new();
-			srv->id = strdup (tok);
+			srv->id = oscap_strdup(tok);
 			srv->def_disabled = 1;
 
 			dI("new: def_disabled: = 1: %s", srv->id);
@@ -1526,7 +1526,7 @@ int op_assign_enabled(void *var, char *val)
 
 		if (srv == NULL) {
 			srv = xiconf_service_new();
-			srv->id = strdup (tok);
+			srv->id = oscap_strdup(tok);
 			srv->def_enabled = 1;
 
 			dI("new: def_enabled: = 1: %s", srv->id);

--- a/src/OVAL/results/oval_cmp_ip_address.c
+++ b/src/OVAL/results/oval_cmp_ip_address.c
@@ -199,7 +199,7 @@ static inline int ipv4addr_parse(const char *oval_ipv4_string, uint32_t *netmask
 	char *s, *pfx;
 	int result = -1;
 
-	s = strdup(oval_ipv4_string);
+	s = oscap_strdup(oval_ipv4_string);
 	pfx = strchr(s, '/');
 	if (pfx) {
 		int cnt;
@@ -235,7 +235,7 @@ static inline int ipv6addr_parse(const char *oval_ipv6_string, uint32_t *len_out
 	char *s, *pfx;
 	int result = -1;
 
-	s = strdup(oval_ipv6_string);
+	s = oscap_strdup(oval_ipv6_string);
 	pfx = strchr(s, '/');
 	if (pfx) {
 		*pfx++ = '\0';

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -96,7 +96,7 @@ void sce_check_result_free(struct sce_check_result* v)
 void sce_check_result_set_href(struct sce_check_result* v, const char* href)
 {
 	free(v->href);
-	v->href = strdup(href);
+	v->href = oscap_strdup(href);
 }
 
 const char* sce_check_result_get_href(struct sce_check_result* v)
@@ -107,7 +107,7 @@ const char* sce_check_result_get_href(struct sce_check_result* v)
 void sce_check_result_set_basename(struct sce_check_result* v, const char* base_name)
 {
 	free(v->basename);
-	v->basename = strdup(base_name);
+	v->basename = oscap_strdup(base_name);
 }
 
 const char* sce_check_result_get_basename(struct sce_check_result* v)
@@ -118,7 +118,7 @@ const char* sce_check_result_get_basename(struct sce_check_result* v)
 void sce_check_result_set_stdout(struct sce_check_result* v, const char* _stdout)
 {
 	free(v->std_out);
-	v->std_out = strdup(_stdout);
+	v->std_out = oscap_strdup(_stdout);
 }
 
 const char* sce_check_result_get_stdout(struct sce_check_result* v)
@@ -129,7 +129,7 @@ const char* sce_check_result_get_stdout(struct sce_check_result* v)
 void sce_check_result_set_stderr(struct sce_check_result* v, const char* _stderr)
 {
 	free(v->std_err);
-	v->std_err = strdup(_stderr);
+	v->std_err = oscap_strdup(_stderr);
 }
 
 const char* sce_check_result_get_stderr(struct sce_check_result* v)
@@ -290,7 +290,7 @@ void sce_parameters_set_xccdf_directory(struct sce_parameters* v, const char* va
 	if (v->xccdf_directory)
 		free(v->xccdf_directory);
 
-	v->xccdf_directory = value == NULL ? NULL : strdup(value);
+	v->xccdf_directory = value == NULL ? NULL : oscap_strdup(value);
 }
 
 const char* sce_parameters_get_xccdf_directory(struct sce_parameters* v)

--- a/src/XCCDF/elements.c
+++ b/src/XCCDF/elements.c
@@ -401,7 +401,7 @@ char *xccdf_attribute_copy(xmlTextReaderPtr reader, xccdf_attribute_t attr)
 {
 	const char *ret = xccdf_attribute_get(reader, attr);
 	if (ret)
-		return strdup(ret);
+		return oscap_strdup(ret);
 	return NULL;
 }
 

--- a/src/XCCDF/rule.c
+++ b/src/XCCDF/rule.c
@@ -334,7 +334,7 @@ struct xccdf_item *xccdf_rule_parse(xmlTextReaderPtr reader, struct xccdf_item *
 				if (tag == NULL)
 					break;
 				struct xccdf_profile_note *note = xccdf_profile_note_new();
-				note->reftag = strdup(tag);
+				note->reftag = oscap_strdup(tag);
 				note->text = oscap_text_new_parse(XCCDF_TEXT_PROFNOTE, reader);
 				oscap_list_add(rule->sub.rule.profile_notes, note);
 				break;
@@ -453,8 +453,8 @@ struct xccdf_ident *xccdf_ident_new(void)
 struct xccdf_ident *xccdf_ident_new_fill(const char *id, const char *sys)
 {
 	struct xccdf_ident *ident = xccdf_ident_new();
-	ident->id = strdup(id);
-	ident->system = strdup(sys);
+	ident->id = oscap_strdup(id);
+	ident->system = oscap_strdup(sys);
 	return ident;
 }
 
@@ -608,7 +608,7 @@ struct xccdf_check *xccdf_check_parse(xmlTextReaderPtr reader)
 					break;
 				struct xccdf_check_content_ref *ref = xccdf_check_content_ref_new();
 				ref->name = xccdf_attribute_copy(reader, XCCDFA_NAME);
-				ref->href = strdup(href);
+				ref->href = oscap_strdup(href);
 				oscap_list_add(check->content_refs, ref);
 				break;
 			}
@@ -622,9 +622,9 @@ struct xccdf_check *xccdf_check_parse(xmlTextReaderPtr reader)
 				if (name == NULL) // @import-name is a required attribute
 					break;
 				struct xccdf_check_import *imp = xccdf_check_import_new();
-				imp->name = strdup(name);
+				imp->name = oscap_strdup(name);
 				if (xpath) // @import-xpath is just optional
-					imp->xpath = strdup(xpath);
+					imp->xpath = oscap_strdup(xpath);
 				imp->content = oscap_element_string_copy(reader);
 				oscap_list_add(check->imports, imp);
 				break;
@@ -634,7 +634,7 @@ struct xccdf_check *xccdf_check_parse(xmlTextReaderPtr reader)
 				if (name == NULL)
 					break;
 				struct xccdf_check_export *exp = xccdf_check_export_new();
-				exp->name = strdup(name);
+				exp->name = oscap_strdup(name);
 				exp->value = xccdf_attribute_copy(reader, XCCDFA_VALUE_ID);
 				oscap_list_add(check->exports, exp);
 				break;

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -860,7 +860,7 @@ void xccdf_session_set_custom_oval_files(struct xccdf_session *session, char **o
 
 	for (int i = 0; oval_filenames[i];) {
 		resources[i] = malloc(sizeof(struct oval_content_resource));
-		resources[i]->href = strdup(basename(oval_filenames[i]));
+		resources[i]->href = oscap_strdup(basename(oval_filenames[i]));
 		resources[i]->source = oscap_source_new_from_file(oval_filenames[i]);
 		resources[i]->source_owned = true;
 		i++;
@@ -884,7 +884,7 @@ static int _xccdf_session_get_oval_from_model(struct xccdf_session *session)
 
 	_oval_content_resources_free(session->oval.resources);
 
-	xccdf_path_cpy = strdup(oscap_source_readable_origin(session->xccdf.source));
+	xccdf_path_cpy = oscap_strdup(oscap_source_readable_origin(session->xccdf.source));
 	dir_path = dirname(xccdf_path_cpy);
 
 	resources = malloc(sizeof(struct oval_content_resource *));
@@ -921,7 +921,7 @@ static int _xccdf_session_get_oval_from_model(struct xccdf_session *session)
 
 		if (source != NULL || stat(tmp_path, &sb) == 0) {
 			resources[idx] = malloc(sizeof(struct oval_content_resource));
-			resources[idx]->href = strdup(oscap_file_entry_get_file(file_entry));
+			resources[idx]->href = oscap_strdup(oscap_file_entry_get_file(file_entry));
 			if (source == NULL) {
 				source = oscap_source_new_from_file(tmp_path);
 				resources[idx]->source_owned = true;
@@ -950,7 +950,7 @@ static int _xccdf_session_get_oval_from_model(struct xccdf_session *session)
 						session->oval.progress(false, "ok\n");
 
 						resources[idx] = malloc(sizeof(struct oval_content_resource));
-						resources[idx]->href = strdup(printable_path);
+						resources[idx]->href = oscap_strdup(printable_path);
 						resources[idx]->source = oscap_source_new_take_memory(data, data_size, printable_path);
 						resources[idx]->source_owned = true;
 						idx++;

--- a/src/XCCDF_POLICY/xccdf_policy_substitute.c
+++ b/src/XCCDF_POLICY/xccdf_policy_substitute.c
@@ -84,7 +84,7 @@ static int _xccdf_text_substitution_cb(xmlNode **node, void *user_data)
 				// during Document Generation or Assessment, process the <xccdf:sub>
 				// element as if @use was set to "value".
 				free(sub_use);
-				sub_use = strdup((data->processing_type & _TAILORING_TYPE) ? "title" : "value");
+				sub_use = oscap_strdup((data->processing_type & _TAILORING_TYPE) ? "title" : "value");
 			}
 
 			if (oscap_streq(sub_use, "title")) {

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -94,7 +94,7 @@ static char * get_program_name()
                 return NULL;
         if(path_size == sizeof(path) - 1)
                 path[path_size] = '\0';
-        return strdup(path);
+        return oscap_strdup(path);
 }
 
 int setenv(const char *name, const char *value, int overwrite)

--- a/src/common/list.c
+++ b/src/common/list.c
@@ -352,7 +352,7 @@ struct oscap_string_iterator *oscap_stringlist_get_strings(const struct oscap_st
 
 bool oscap_stringlist_add_string(struct oscap_stringlist* list, const char *str)
 {
-	return oscap_list_add((struct oscap_list *) list, strdup(str));
+	return oscap_list_add((struct oscap_list *) list, oscap_strdup(str));
 }
 
 struct oscap_stringlist * oscap_stringlist_new(void)
@@ -467,7 +467,7 @@ bool oscap_htable_add(struct oscap_htable * htable, const char *key, void *item)
 	unsigned int hashcode = oscap_htable_hash(key, htable->hsize);
 	struct oscap_htable_item *newhtitem;
 	newhtitem = malloc(sizeof(struct oscap_htable_item));
-	newhtitem->key = strdup(key);
+	newhtitem->key = oscap_strdup(key);
 	newhtitem->value = item;
 	newhtitem->next = htable->table[hashcode];
 	htable->table[hashcode] = newhtitem;

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -53,7 +53,7 @@
 char *
 oscap_acquire_temp_dir()
 {
-	char *temp_dir = strdup(TEMP_DIR_TEMPLATE);
+	char *temp_dir = oscap_strdup(TEMP_DIR_TEMPLATE);
 	if (mkdtemp(temp_dir) == NULL) {
 		free(temp_dir);
 		oscap_seterr(OSCAP_EFAMILY_GLIBC, "Could not create temp directory " TEMP_DIR_TEMPLATE ". %s", strerror(errno));
@@ -144,7 +144,7 @@ oscap_acquire_url_to_filename(const char *url)
 		oscap_seterr(OSCAP_EFAMILY_NET, "Failed to escape the given url %s", url);
 		return NULL;
 	}
-	filename = strdup(curl_filename);
+	filename = oscap_strdup(curl_filename);
 	curl_free(curl_filename);
 	curl_easy_cleanup(curl);
 	curl_global_cleanup();
@@ -216,11 +216,11 @@ char *oscap_acquire_guess_realpath(const char *filepath)
 
 	char *rpath = realpath(filepath, resolved_name);
 	if (rpath != NULL)
-		rpath = strdup(rpath);
+		rpath = oscap_strdup(rpath);
 	else {
 		// file does not exists, let's try to guess realpath
 		// this is not 100% correct, but it is good enough
-		char *copy = strdup(filepath);
+		char *copy = oscap_strdup(filepath);
 		if (copy == NULL) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Cannot guess realpath for %s, directory: cannot allocate memory!", filepath);
 			return NULL;

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -229,3 +229,15 @@ char *oscap_expand_ipv6(const char *input)
 
 	return ret;
 }
+
+char *oscap_strdup(const char *str)
+{
+	if (str == NULL)
+		return NULL;
+
+#ifdef _MSC_VER
+	return _strdup(str);
+#else
+	return strdup(str);
+#endif
+}

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -312,20 +312,15 @@ struct oscap_string_map {
 	const char *string; /* string representation of the value */
 };
 
+OSCAP_HIDDEN_END;
+
 /**
  * Use strdup on string, if string is NULL, return NULL
  * @param str String we want to duplicate
  */
-static inline char *oscap_strdup(const char *str) {
-	if (str == NULL)
-		return NULL;
+char *oscap_strdup(const char *str);
 
-#ifdef _MSC_VER
-	return _strdup(str);
-#else
-	return strdup(str);
-#endif
-}
+OSCAP_HIDDEN_START;
 
 /// Just like strcmp except it's NULL-safe. Use the standard strcmp directly if possible.
 static inline int oscap_strcmp(const char *s1, const char *s2) {

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -360,10 +360,10 @@ const char *oscap_source_get_schema_version(struct oscap_source *source)
 		}
 		switch (oscap_source_get_scap_type(source)) {
 			case OSCAP_DOCUMENT_SDS:
-				source->origin.version = strdup("1.2");
+				source->origin.version = oscap_strdup("1.2");
 				break;
 			case OSCAP_DOCUMENT_ARF:
-				source->origin.version = strdup("1.1");
+				source->origin.version = oscap_strdup("1.1");
 				break;
 			case OSCAP_DOCUMENT_OVAL_DEFINITIONS:
 			case OSCAP_DOCUMENT_OVAL_VARIABLES:
@@ -384,13 +384,13 @@ const char *oscap_source_get_schema_version(struct oscap_source *source)
 				source->origin.version = cpe_lang_model_detect_version_priv(reader);
 				break;
 			case OSCAP_DOCUMENT_CVE_FEED:
-				source->origin.version = strdup("2.0");
+				source->origin.version = oscap_strdup("2.0");
 				break;
 			case OSCAP_DOCUMENT_CVRF_FEED:
-				source->origin.version = strdup("1.1");
+				source->origin.version = oscap_strdup("1.1");
 				break;
 			case OSCAP_DOCUMENT_SCE_RESULT:
-				source->origin.version = strdup("1.0");
+				source->origin.version = oscap_strdup("1.0");
 				break;
 			default:
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not determine origin.version for document %s: Unknown type: %s",

--- a/src/source/xslt.c
+++ b/src/source/xslt.c
@@ -118,7 +118,7 @@ static xmlDoc *apply_xslt_path_internal(struct oscap_source *source, const char 
 	/* is it an absolute path? */
 	char *xsltpath;
 	if (strstr(xsltfile, "/") == xsltfile) {
-		xsltpath = strdup(xsltfile);
+		xsltpath = oscap_strdup(xsltfile);
 		if (access(xsltpath, R_OK)) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "XSLT file '%s' not found when trying to transform '%s'",
 				xsltfile, oscap_source_readable_origin(source));

--- a/tests/probes/xinetd/test_probe_xinetd.c
+++ b/tests/probes/xinetd/test_probe_xinetd.c
@@ -18,7 +18,7 @@ static char *string_array_cstr(char **string_array)
 			bufpos += snprintf(buf + bufpos, sizeof(buf) - bufpos - 1, "%s ", string_array[string_array_pos]);
 		}
 	}
-	return strdup(buf);
+	return oscap_strdup(buf);
 }
 
 int main (int argc, char *argv[])

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -41,6 +41,7 @@
 
 #include "oscap-tool.h"
 #include <oscap_debug.h>
+#include "util.h"
 
 #define DS_SUBMODULES_NUM 8 /* See actual DS_SUBMODULES array
 				initialization below. */
@@ -354,11 +355,11 @@ int app_ds_sds_compose(const struct oscap_action *action) {
 	else
 		snprintf(target_abs_path, PATH_MAX, "%s/%s", previous_cwd, action->ds_action->target);
 
-	char* temp_cwd = strdup(action->ds_action->file);
+	char* temp_cwd = oscap_strdup(action->ds_action->file);
 	chdir(dirname(temp_cwd));
 	free(temp_cwd);
 
-	char* source_xccdf = strdup(action->ds_action->file);
+	char* source_xccdf = oscap_strdup(action->ds_action->file);
 	ds_sds_compose_from_xccdf(basename(source_xccdf), target_abs_path);
 	free(source_xccdf);
 

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -36,6 +36,7 @@
 #include <limits.h>
 #include <cvss_score.h>
 #include <oscap_debug.h>
+#include "util.h"
 
 #ifndef PATH_MAX
 # define PATH_MAX 1024
@@ -281,12 +282,12 @@ static void getopt_parse_env(struct oscap_module *module, int *argc, char ***arg
 	/* parse the args supplied from the env var */
 	eargv = NULL;
 	eargc = 0;
-	opts = strdup(opts);
+	opts = oscap_strdup(opts);
 	opt = strtok_r(opts, delim, &state);
 	while (opt != NULL) {
 		eargc++;
 		eargv = realloc(eargv, eargc * sizeof(char *));
-		eargv[eargc - 1] = strdup(opt);
+		eargv[eargc - 1] = oscap_strdup(opt);
 		opt = strtok_r(NULL, delim, &state);
 	}
 


### PR DESCRIPTION
MSVC deprecates `strdup()` and recommends `_strdup()` instead.
To handle this situation we already have `oscap_strdup()`. However we didn't use `oscap_strdup()` everywhere, but there were still some occurrences of `strdup()`. This pull request replace remaining occurrences of `strdup()` to `oscap_strdup()`.

We will need to use `oscap_strdup()` also in probes, but if it remains hidden and static inline, it will not be visible symbol in libopenscap.so and probes will not be able to find it. That would cause many linker errors when building probes. I have seen them.

For more details please see the respective commit messages.