### PR TITLE
Introduce oscap_realpath to improve code portability

### DIFF
--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -219,7 +219,7 @@ int load_zones_path_list()
 				    name);
 				continue;
 			}
-			if (realpath(rpath, temp->zpath) != NULL)
+			if (oscap_realpath(rpath, temp->zpath) != NULL)
 				avl_add(&avl_tree_list, temp);
 		}
 	}

--- a/src/OVAL/probes/unix/symlink.c
+++ b/src/OVAL/probes/unix/symlink.c
@@ -85,7 +85,7 @@ static int collect_symlink(SEXP_t *ent, probe_ctx *ctx)
 		return 0;
 	}
 
-	linkname = realpath(pathname, resolved_name);
+	linkname = oscap_realpath(pathname, resolved_name);
 	if (linkname == NULL) {
 		if (errno == ENOENT) {
 			msg = probe_msg_creatf(OVAL_MESSAGE_LEVEL_ERROR,

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -214,7 +214,7 @@ char *oscap_acquire_guess_realpath(const char *filepath)
 {
 	char resolved_name[PATH_MAX];
 
-	char *rpath = realpath(filepath, resolved_name);
+	char *rpath = oscap_realpath(filepath, resolved_name);
 	if (rpath != NULL)
 		rpath = strdup(rpath);
 	else {
@@ -227,7 +227,7 @@ char *oscap_acquire_guess_realpath(const char *filepath)
 		}
 
 		char *dir_name = dirname(copy);
-		char *real_dir = realpath(dir_name, resolved_name);
+		char *real_dir = oscap_realpath(dir_name, resolved_name);
 		if (real_dir == NULL) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Cannot guess realpath for %s, directory: %s does not exists!", filepath, dir_name);
 			free(copy);

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -229,3 +229,12 @@ char *oscap_expand_ipv6(const char *input)
 
 	return ret;
 }
+
+char *oscap_realpath(const char *path, char *resolved_path)
+{
+#ifdef _WIN32
+	return _fullpath(resolved_path, path, MAX_PATH);
+#else
+	return realpath(path, resolved_path);
+#endif
+}

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -428,4 +428,12 @@ const char *oscap_enum_to_string(const struct oscap_string_map *map, int val);
  */
 char **oscap_split(char *str, const char *delim);
 
+/**
+ * Return the canonicalized absolute pathname.
+ * @param path path
+ * @param resolved_path pointer to a buffer
+ * @return resolved_path or NULL in case of error
+ */
+char *oscap_realpath(const char *path, char *resolved_path);
+
 #endif				/* OSCAP_UTIL_H_ */

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -55,6 +55,7 @@
 #include "oscap.h"
 #include "oscap_source.h"
 #include <oscap_debug.h>
+#include "util.h"
 
 #ifndef O_NOFOLLOW
 #define O_NOFOLLOW 0
@@ -1151,7 +1152,7 @@ bool getopt_xccdf(int argc, char **argv, struct oscap_action *action)
 		case XCCDF_OPT_OVAL_TEMPLATE:	action->oval_template = optarg; break;
 		/* we use realpath to get an absolute path to given XSLT to prevent openscap from looking
 		   into /usr/share/openscap/xsl instead of CWD */
-		case XCCDF_OPT_STYLESHEET_FILE: realpath(optarg, custom_stylesheet_path); action->stylesheet = custom_stylesheet_path; break;
+		case XCCDF_OPT_STYLESHEET_FILE: oscap_realpath(optarg, custom_stylesheet_path); action->stylesheet = custom_stylesheet_path; break;
 		case XCCDF_OPT_TAILORING_FILE:	action->tailoring_file = optarg; break;
 		case XCCDF_OPT_TAILORING_ID:	action->tailoring_id = optarg; break;
 		case XCCDF_OPT_CPE:			action->cpe = optarg; break;


### PR DESCRIPTION
Windows doesn't know `realpath()`. Instead they have a similar function `_fullpath()`. This patch introduces a wrapper function `oscap_realpath()` that wraps either `realpath()` or `_fullpath()` depending on the platform. The PR also replaces every `realpath()` by `oscap_realpath()`.