### PR TITLE
Remove variable length arrays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 configure_file("config.h.in" "config.h")
 add_definitions(-DHAVE_CONFIG_H)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -std=c99 -W -Wall -Wnonnull -Wshadow -Wformat -Wundef -Wno-unused-parameter -Wmissing-prototypes -Wno-unknown-pragmas -D_GNU_SOURCE -D_POSIX_C_SOURCE=200112L")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -std=c99 -W -Wall -Wvla -Wnonnull -Wshadow -Wformat -Wundef -Wno-unused-parameter -Wmissing-prototypes -Wno-unknown-pragmas -D_GNU_SOURCE -D_POSIX_C_SOURCE=200112L")
 if(${CMAKE_SYSTEM_NAME} EQUAL "Solaris")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__EXTENSIONS__")
 endif()

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1559,7 +1559,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_END(oval_argu_t *
 			while (oval_value_iterator_has_more(values)) {
 				char *key = oval_value_get_text(oval_value_iterator_next(values));
 				int len_key = strlen(key);
-				size_t concat_len = len_suffix + len_key + 1;
+				const size_t concat_len = len_suffix + len_key + 1;
 				char *concat = malloc(concat_len);
 				if ((len_suffix > len_key) || strncmp(suffix, key + len_key - len_suffix, len_suffix)) {
 					snprintf(concat, concat_len, "%s%s", key, suffix);

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1521,7 +1521,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_BEGIN(oval_argu_t
 			    (struct oval_value_iterator *)oval_collection_iterator(subcoll);
 			while (oval_value_iterator_has_more(values)) {
 				char *key = oval_value_get_text(oval_value_iterator_next(values));
-				size_t concat_len = len_prefix + strlen(key) + 1;
+				const size_t concat_len = len_prefix + strlen(key) + 1;
 				char *concat = malloc(concat_len);
 				if (strncmp(prefix, key, len_prefix)) {
 					snprintf(concat, concat_len, "%s%s", prefix, key);

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1599,7 +1599,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_CONCAT(oval_argu_
 	}
 	bool not_finished = (len_subcomps > 0) && _HAS_VALUES(flag);
 	if (not_finished) {
-		struct oval_value_iterator *values[len_subcomps];
+		struct oval_value_iterator **values = malloc(len_subcomps * sizeof(struct oval_value_iterator *));
 		/* bool has_some[len_subcomps]; <-- unused variable */
 		not_finished = false;
 		char *texts[len_subcomps];
@@ -1660,6 +1660,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_CONCAT(oval_argu_
 							   (oscap_destruct_func) oval_value_free);
 			}
 		}
+		free(values);
 	}
 	free(component_colls);
 	oval_component_iterator_free(subcomps);

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1602,7 +1602,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_CONCAT(oval_argu_
 		struct oval_value_iterator **values = malloc(len_subcomps * sizeof(struct oval_value_iterator *));
 		/* bool has_some[len_subcomps]; <-- unused variable */
 		not_finished = false;
-		char *texts[len_subcomps];
+		char **texts = malloc(len_subcomps * sizeof(char *));
 		int counts[len_subcomps];
 		int catnum = 1;
 		for (idx0 = 0; idx0 < len_subcomps; idx0++) {
@@ -1660,6 +1660,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_CONCAT(oval_argu_
 							   (oscap_destruct_func) oval_value_free);
 			}
 		}
+		free(texts);
 		free(values);
 	}
 	free(component_colls);

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -2142,7 +2142,8 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_ESCAPE_REGEX(oval
 			struct oval_value *value = oval_value_iterator_next(values);
 			char *text = oval_value_get_text(value);
 			int len = strlen(text);
-			char string[2 * len + 1], *insert = string;
+			char *string = malloc(2 * len + 1);
+			char *insert = string;
 			while (*text) {
 				if (_isEscape(*text))
 					*insert++ = '\\';
@@ -2150,6 +2151,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_ESCAPE_REGEX(oval
 			}
 			*insert = '\0';
 			value = oval_value_new(OVAL_DATATYPE_STRING, string);
+			free(string);
 			oval_collection_add(value_collection, value);
 		}
 		oval_value_iterator_free(values);

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1680,7 +1680,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_COUNT(oval_argu_t
 	oval_syschar_collection_flag_t flag = SYSCHAR_FLAG_UNKNOWN;
 	struct oval_component_iterator *subcomps = oval_component_get_function_components(component);
 	int len_subcomps = oval_component_iterator_remaining(subcomps);
-	struct oval_collection *component_colls[len_subcomps];
+	struct oval_collection **component_colls = malloc(len_subcomps * sizeof(struct oval_collection *));
 	for (idx0 = 0; oval_component_iterator_has_more(subcomps); idx0++) {
 		struct oval_collection *subcoll = oval_collection_new();
 		struct oval_component *subcomp = oval_component_iterator_next(subcomps);
@@ -1711,6 +1711,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_COUNT(oval_argu_t
 	for (idx0 = 0; idx0 < len_subcomps; ++idx0)
 	  oval_collection_free_items(component_colls[idx0], (oscap_destruct_func) oval_value_free);
 
+	free(component_colls);
 	return flag;
 }
 

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1589,7 +1589,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_CONCAT(oval_argu_
 	oval_syschar_collection_flag_t flag = SYSCHAR_FLAG_UNKNOWN;
 	struct oval_component_iterator *subcomps = oval_component_get_function_components(component);
 	int len_subcomps = oval_component_iterator_remaining(subcomps);
-	struct oval_collection *component_colls[len_subcomps];
+	struct oval_collection **component_colls = malloc(len_subcomps * sizeof(struct oval_collection *));
 	for (idx0 = 0; oval_component_iterator_has_more(subcomps); idx0++) {
 		struct oval_collection *subcoll = oval_collection_new();
 		struct oval_component *subcomp = oval_component_iterator_next(subcomps);
@@ -1661,6 +1661,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_CONCAT(oval_argu_
 			}
 		}
 	}
+	free(component_colls);
 	oval_component_iterator_free(subcomps);
 	return flag;
 }

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1559,13 +1559,15 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_END(oval_argu_t *
 			while (oval_value_iterator_has_more(values)) {
 				char *key = oval_value_get_text(oval_value_iterator_next(values));
 				int len_key = strlen(key);
-				char concat[len_suffix + len_key + 1];
+				size_t concat_len = len_suffix + len_key + 1;
+				char *concat = malloc(concat_len);
 				if ((len_suffix > len_key) || strncmp(suffix, key + len_key - len_suffix, len_suffix)) {
-					snprintf(concat, sizeof(concat), "%s%s", key, suffix);
+					snprintf(concat, concat_len, "%s%s", key, suffix);
 				} else {
-					snprintf(concat, sizeof(concat), "%s", key);
+					snprintf(concat, concat_len, "%s", key);
 				}
 				struct oval_value *concat_value = oval_value_new(OVAL_DATATYPE_STRING, concat);
+				free(concat);
 				oval_collection_add(value_collection, concat_value);
 			}
 			oval_value_iterator_free(values);

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1628,12 +1628,13 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_CONCAT(oval_argu_
 			for (idx0 = 0; idx0 < len_subcomps; idx0++)
 				if (texts[idx0])
 					len_cat += strlen(texts[idx0]);
-			char concat[len_cat];
+			char *concat = malloc(len_cat);
 			*concat = '\0';
 			for (idx0 = 0; idx0 < len_subcomps; idx0++)
 				if (texts[idx0])
 					strcat(concat, texts[idx0]);
 			struct oval_value *value = oval_value_new(OVAL_DATATYPE_STRING, concat);
+			free(concat);
 			oval_collection_add(value_collection, value);
 			bool rotate = true;
 			if (passnum < catnum) {

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1723,7 +1723,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_UNIQUE(oval_argu_
 	oval_syschar_collection_flag_t flag = SYSCHAR_FLAG_UNKNOWN;
 	struct oval_component_iterator *subcomps = oval_component_get_function_components(component);
 	int len_subcomps = oval_component_iterator_remaining(subcomps);
-	struct oval_collection *component_colls[len_subcomps];
+	struct oval_collection **component_colls = malloc(len_subcomps * sizeof(struct oval_collection *));
 
 	for (idx0 = 0; oval_component_iterator_has_more(subcomps); idx0++) {
 		struct oval_collection *subcoll = oval_collection_new();
@@ -1762,6 +1762,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_UNIQUE(oval_argu_
 	for (idx0 = 0; idx0 < len_subcomps; ++idx0)
 	  oval_collection_free_items(component_colls[idx0], (oscap_destruct_func) oval_value_free);
 
+	free(component_colls);
 	return flag;
 }
 

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1784,7 +1784,8 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_SPLIT(oval_argu_t
 		while (oval_value_iterator_has_more(values)) {
 			char *text = oval_value_get_text(oval_value_iterator_next(values));
 			if (len_delim) {
-				char split[strlen(text) + 2], *split0 = split;
+				char *split = malloc(strlen(text) + 2);
+				char *split0 = split;
 				*split0 = '\0';
 				strcat(split0, text);
 				split0[strlen(text) + 1] = '\0';	/*last two characters are EOS */
@@ -1797,6 +1798,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_SPLIT(oval_argu_t
 				}
 				value = oval_value_new(OVAL_DATATYPE_STRING, split0);
 				oval_collection_add(value_collection, value);
+				free(split);
 			} else {	/*Empty delimiter, Split at every character */
 				char split[] = { '\0', '\0' };
 				int idx;

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1521,13 +1521,15 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_BEGIN(oval_argu_t
 			    (struct oval_value_iterator *)oval_collection_iterator(subcoll);
 			while (oval_value_iterator_has_more(values)) {
 				char *key = oval_value_get_text(oval_value_iterator_next(values));
-				char concat[len_prefix + strlen(key) + 1];
+				size_t concat_len = len_prefix + strlen(key) + 1;
+				char *concat = malloc(concat_len);
 				if (strncmp(prefix, key, len_prefix)) {
-					snprintf(concat, sizeof(concat), "%s%s", prefix, key);
+					snprintf(concat, concat_len, "%s%s", prefix, key);
 				} else {
-					snprintf(concat, sizeof(concat), "%s", key);
+					snprintf(concat, concat_len, "%s", key);
 				}
 				struct oval_value *concat_value = oval_value_new(OVAL_DATATYPE_STRING, concat);
+				free(concat);
 				oval_collection_add(value_collection, concat_value);
 			}
 			oval_value_iterator_free(values);

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1841,12 +1841,13 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_SUBSTRING(oval_ar
 			txtlen = strlen(text);
 			sublen = (len < 0 || (size_t) len > txtlen) ? txtlen : (size_t) len;
 			if ((size_t) beg < txtlen) {
-				char substr[sublen + 1];
+				char *substr = malloc(sublen + 1);
 
 				strncpy(substr, text + beg, sublen);
 				substr[sublen] = '\0';
 
 				value = oval_value_new(OVAL_DATATYPE_STRING, substr);
+				free(substr);
 				oval_collection_add(value_collection, value);
 			} else {
 				flag = SYSCHAR_FLAG_ERROR;

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1603,7 +1603,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_CONCAT(oval_argu_
 		/* bool has_some[len_subcomps]; <-- unused variable */
 		not_finished = false;
 		char **texts = malloc(len_subcomps * sizeof(char *));
-		int counts[len_subcomps];
+		int *counts = malloc(len_subcomps * sizeof(int));
 		int catnum = 1;
 		for (idx0 = 0; idx0 < len_subcomps; idx0++) {
 			struct oval_value_iterator *comp_values =
@@ -1660,6 +1660,7 @@ static oval_syschar_collection_flag_t _oval_component_evaluate_CONCAT(oval_argu_
 							   (oscap_destruct_func) oval_value_free);
 			}
 		}
+		free(counts);
 		free(texts);
 		free(values);
 	}

--- a/src/OVAL/oval_enumerations.c
+++ b/src/OVAL/oval_enumerations.c
@@ -420,9 +420,11 @@ xmlNs *oval_family_to_namespace(oval_family_t family, const char *schema_ns, xml
 		return NULL;
 	}
 	/* We need to allocate memory also for '#' and '\0'. */
-	char family_uri[strlen(schema_ns) + 1 + strlen(family_text) + 1];
+	char *family_uri = malloc(strlen(schema_ns) + 1 + strlen(family_text) + 1);
 	sprintf(family_uri,"%s#%s", schema_ns, family_text);
-	return xmlSearchNsByHref(doc, parent, BAD_CAST family_uri);
+	xmlNs *ns = xmlSearchNsByHref(doc, parent, BAD_CAST family_uri);
+	free(family_uri);
+	return ns;
 }
 
 static const struct oscap_string_map OVAL_SUBTYPE_AIX_MAP[] = {

--- a/src/OVAL/oval_object.c
+++ b/src/OVAL/oval_object.c
@@ -401,7 +401,7 @@ xmlNode *oval_object_to_dom(struct oval_object *object, xmlDoc * doc, xmlNode * 
 
 	/* get object name */
 	const char *subtype_text = oval_subtype_get_text(subtype);
-	char object_name[strlen(subtype_text) + 8];
+	char *object_name = malloc(strlen(subtype_text) + 8);
 	sprintf(object_name, "%s_object", subtype_text);
 
 	oval_family_t family = oval_object_get_family(object);
@@ -409,6 +409,7 @@ xmlNode *oval_object_to_dom(struct oval_object *object, xmlDoc * doc, xmlNode * 
 	/* search namespace & create child */
 	xmlNs *ns_family = oval_family_to_namespace(family, (const char *) OVAL_DEFINITIONS_NAMESPACE, doc, parent);
 	object_node = xmlNewTextChild(parent, ns_family, BAD_CAST object_name, NULL);
+	free(object_name);
 
 	char *id = oval_object_get_id(object);
 	xmlNewProp(object_node, BAD_CAST "id", BAD_CAST id);

--- a/src/OVAL/oval_schema_version.c
+++ b/src/OVAL/oval_schema_version.c
@@ -62,9 +62,8 @@ oval_schema_version_t oval_schema_version_from_cstr(const char *ver_str)
 		dE("Regular expression compilation failed with %s", pattern);
 		return version;
 	}
-	const int ovector_size = OVECTOR_LEN;
 	int ovector[OVECTOR_LEN];
-	int rc = pcre_exec(re, NULL, ver_str, strlen(ver_str), 0, 0, ovector, ovector_size);
+	int rc = pcre_exec(re, NULL, ver_str, strlen(ver_str), 0, 0, ovector, OVECTOR_LEN);
 	pcre_free(re);
 	if (rc < 0) {
 		dE("Regular expression %s did not match string %s", pattern, ver_str);

--- a/src/OVAL/oval_schema_version.c
+++ b/src/OVAL/oval_schema_version.c
@@ -34,6 +34,8 @@
 
 #include <pcre.h>
 
+#define OVECTOR_LEN 30 // must be a multiple of 30
+
 static int _parse_int(const char *substring, size_t substring_length)
 {
 	/* Pay attention that substring_length != strlen(substring) */
@@ -60,8 +62,8 @@ oval_schema_version_t oval_schema_version_from_cstr(const char *ver_str)
 		dE("Regular expression compilation failed with %s", pattern);
 		return version;
 	}
-	const int ovector_size = 30; // must be a multiple of 30
-	int ovector[ovector_size];
+	const int ovector_size = OVECTOR_LEN;
+	int ovector[OVECTOR_LEN];
 	int rc = pcre_exec(re, NULL, ver_str, strlen(ver_str), 0, 0, ovector, ovector_size);
 	pcre_free(re);
 	if (rc < 0) {

--- a/src/OVAL/oval_schema_version.c
+++ b/src/OVAL/oval_schema_version.c
@@ -37,10 +37,12 @@
 static int _parse_int(const char *substring, size_t substring_length)
 {
 	/* Pay attention that substring_length != strlen(substring) */
-	char buffer[substring_length + 1]; // +1 for a zero byte
+	char *buffer = malloc(substring_length + 1); // +1 for a zero byte
 	strncpy(buffer, substring, substring_length);
 	buffer[substring_length] = '\0';
-	return atoi(buffer);
+	int i = atoi(buffer);
+	free(buffer);
+	return i;
 }
 
 oval_schema_version_t oval_schema_version_from_cstr(const char *ver_str)

--- a/src/OVAL/oval_state.c
+++ b/src/OVAL/oval_state.c
@@ -335,7 +335,7 @@ xmlNode *oval_state_to_dom(struct oval_state *state, xmlDoc * doc, xmlNode * par
 	/* get state name */
 	oval_subtype_t subtype = oval_state_get_subtype(state);
 	const char *subtype_text = oval_subtype_get_text(subtype);
-	char state_name[strlen(subtype_text) + 7];
+	char *state_name = malloc(strlen(subtype_text) + 7);
 	sprintf(state_name, "%s_state", subtype_text);
 
 	oval_family_t family = oval_state_get_family(state);
@@ -343,6 +343,7 @@ xmlNode *oval_state_to_dom(struct oval_state *state, xmlDoc * doc, xmlNode * par
 	/* search namespace & create child */ 
 	xmlNs *ns_family = oval_family_to_namespace(family, (const char *) OVAL_DEFINITIONS_NAMESPACE, doc, parent);
 	xmlNode *state_node = xmlNewTextChild(parent, ns_family, BAD_CAST state_name, NULL);
+	free(state_name);
 
 	char *id = oval_state_get_id(state);
 	xmlNewProp(state_node, BAD_CAST "id", BAD_CAST id);

--- a/src/OVAL/oval_sysItem.c
+++ b/src/OVAL/oval_sysItem.c
@@ -257,7 +257,7 @@ void oval_sysitem_to_dom(struct oval_sysitem *sysitem, xmlDoc * doc, xmlNode * p
 		if (subtype) {
 			/* get item subtype */
 			const char *subtype_text = oval_subtype_get_text(subtype);
-			char tagname[strlen(subtype_text) + 6];
+			char *tagname = malloc(strlen(subtype_text) + 6);
 			sprintf(tagname, "%s_item", subtype_text);
 
 			oval_family_t family = oval_subtype_get_family(subtype);
@@ -265,6 +265,7 @@ void oval_sysitem_to_dom(struct oval_sysitem *sysitem, xmlDoc * doc, xmlNode * p
 			/* search namespace & create child */
 			xmlNs *ns_family = oval_family_to_namespace(family, (const char *) OVAL_SYSCHAR_NAMESPACE, doc, parent);
 			xmlNode *tag_sysitem = xmlNewTextChild(parent, ns_family, BAD_CAST tagname, NULL);
+			free(tagname);
 
 			/* attributes */
 			xmlNewProp(tag_sysitem, BAD_CAST "id", BAD_CAST oval_sysitem_get_id(sysitem));

--- a/src/OVAL/oval_test.c
+++ b/src/OVAL/oval_test.c
@@ -452,7 +452,7 @@ xmlNode *oval_test_to_dom(struct oval_test *test, xmlDoc * doc, xmlNode * parent
 
 	/* get test name */
 	const char *subtype_text = oval_subtype_get_text(subtype);
-	char test_name[strlen(subtype_text) + 6];
+	char *test_name = malloc(strlen(subtype_text) + 6);
 	sprintf(test_name, "%s_test", subtype_text);
 
 	oval_family_t family = oval_test_get_family(test);
@@ -460,6 +460,7 @@ xmlNode *oval_test_to_dom(struct oval_test *test, xmlDoc * doc, xmlNode * parent
 	/* search namespace & create child */
 	xmlNs *ns_family = oval_family_to_namespace(family, (const char *) OVAL_DEFINITIONS_NAMESPACE, doc, parent);
 	test_node = xmlNewTextChild(parent, ns_family, BAD_CAST test_name, NULL);
+	free(test_name);
 
 	char *id = oval_test_get_id(test);
 	xmlNewProp(test_node, BAD_CAST "id", BAD_CAST id);

--- a/src/OVAL/probes/crapi/digest.c
+++ b/src/OVAL/probes/crapi/digest.c
@@ -68,7 +68,7 @@ int crapi_mdigest_fd (int fd, int num, ... /* crapi_alg_t alg, void *dst, size_t
 {
         register int i;
         va_list ap;
-        struct digest_ctbl_t ctbl[num];
+        struct digest_ctbl_t *ctbl = malloc(num * sizeof(struct digest_ctbl_t));
 
         crapi_alg_t alg;
         void       *dst;
@@ -176,12 +176,13 @@ int crapi_mdigest_fd (int fd, int num, ... /* crapi_alg_t alg, void *dst, size_t
 			continue;
                 ctbl[i].fini (ctbl[i].ctx);
 	}
-
+        free(ctbl);
         return (0);
 fail:
         for (i = 0; i < num; ++i)
                 if (ctbl[i].ctx != NULL)
                         ctbl[i].free (ctbl[i].ctx);
 
+        free(ctbl);
         return (-1);
 }

--- a/src/OVAL/probes/unix/process58.c
+++ b/src/OVAL/probes/unix/process58.c
@@ -105,6 +105,8 @@ extern char const *_cap_names[];
 #include <ctype.h>
 #include "common/oscap_buffer.h"
 
+#define CHUNK_SIZE 1024
+
 /* Convenience structure for the results being reported */
 struct result_info {
         const char *command_line;
@@ -387,10 +389,9 @@ static inline bool get_process_cmdline(const char* filepath, struct oscap_buffer
 
 
 	for(;;) {
-		static const int chunk_size = 1024;
-		char chunk[chunk_size];
+		char chunk[CHUNK_SIZE];
 		// Read data, store to buffer
-		ssize_t read_size = read(fd, chunk, chunk_size );
+		ssize_t read_size = read(fd, chunk, CHUNK_SIZE);
 		if (read_size < 0) {
 			close(fd);
 			return false;
@@ -398,7 +399,7 @@ static inline bool get_process_cmdline(const char* filepath, struct oscap_buffer
 		oscap_buffer_append_binary_data(buffer, chunk, read_size);
 
 		// If reach end of file, then end the loop
-		if (chunk_size != read_size) {
+		if (CHUNK_SIZE != read_size) {
 			break;
 		}
 	}

--- a/src/XCCDF/result.c
+++ b/src/XCCDF/result.c
@@ -51,13 +51,14 @@
 #include "common/debug_priv.h"
 #include "source/oscap_source_priv.h"
 
+#define XCCDF_NUMERIC_SIZE 32
+
 // References containing STIG Rule IDs can be found by their href attribute, it must match the following url
 static const char *DISA_STIG_VIEWER_HREF = "http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx";
 
 // constants
 static const xccdf_numeric XCCDF_SCORE_MAX_DAFAULT = 100.0f;
 static const char *XCCDF_INSTANCE_DEFAULT_CONTEXT = "undefined";
-const size_t XCCDF_NUMERIC_SIZE = 32;
 const char *XCCDF_NUMERIC_FORMAT = "%f";
 
 // prototypes

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1569,12 +1569,14 @@ int xccdf_session_export_oval(struct xccdf_session *session)
 			j = 0;
 			varmod_itr = oval_definition_model_get_variable_models(defmod);
 			while (oval_variable_model_iterator_has_more(varmod_itr)) {
-				char fname[strlen(sname) + 32];
+				size_t fname_len = strlen(sname) + 32;
+				char *fname = malloc(fname_len);
 				struct oval_variable_model *varmod;
 
 				varmod = oval_variable_model_iterator_next(varmod_itr);
-				snprintf(fname, sizeof(fname), "%s-%d.variables-%d.xml", sname, i, j++);
+				snprintf(fname, fname_len, "%s-%d.variables-%d.xml", sname, i, j++);
 				oval_variable_model_export(varmod, fname);
+				free(fname);
 			}
 			if (escaped_url != NULL)
 				free(escaped_url);

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1569,7 +1569,7 @@ int xccdf_session_export_oval(struct xccdf_session *session)
 			j = 0;
 			varmod_itr = oval_definition_model_get_variable_models(defmod);
 			while (oval_variable_model_iterator_has_more(varmod_itr)) {
-				size_t fname_len = strlen(sname) + 32;
+				const size_t fname_len = strlen(sname) + 32;
 				char *fname = malloc(fname_len);
 				struct oval_variable_model *varmod;
 

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1245,7 +1245,7 @@ static int _app_xslt(struct oscap_source *infile, const char *xsltfile, const ch
 
 	/* add params oscap-version & pwd */
 	const char *stdparams[] = { "oscap-version", oscap_get_version(), "pwd", pwd, NULL };
-	size_t par_cnt = _paramlist_size(params) + _paramlist_size(stdparams) + 1;
+	const size_t par_cnt = _paramlist_size(params) + _paramlist_size(stdparams) + 1;
 	const char **par = malloc(par_cnt * sizeof(const char *));
 	size_t s = _paramlist_cpy(par, params);
 	s += _paramlist_cpy(par + s, stdparams);

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1245,11 +1245,14 @@ static int _app_xslt(struct oscap_source *infile, const char *xsltfile, const ch
 
 	/* add params oscap-version & pwd */
 	const char *stdparams[] = { "oscap-version", oscap_get_version(), "pwd", pwd, NULL };
-	const char *par[_paramlist_size(params) + _paramlist_size(stdparams) + 1];
+	size_t par_cnt = _paramlist_size(params) + _paramlist_size(stdparams) + 1;
+	const char **par = malloc(par_cnt * sizeof(const char *));
 	size_t s = _paramlist_cpy(par, params);
 	s += _paramlist_cpy(par + s, stdparams);
 
-	return oscap_source_apply_xslt_path(infile, xsltfile, outfile, par, oscap_path_to_xslt()) == -1;
+	int ret = oscap_source_apply_xslt_path(infile, xsltfile, outfile, par, oscap_path_to_xslt());
+	free(par);
+	return ret == -1;
 }
 
 static inline int _xccdf_gen_report(struct oscap_source *infile, const char *id, const char *outfile, const char *show, const char* sce_template, const char* profile)

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -2030,7 +2030,7 @@ struct xccdf_result * xccdf_policy_evaluate(struct xccdf_policy * policy)
 		// previous behaviour for backwards compatibility
 		rid_prefix = "OSCAP-Test-";
 	}
-	size_t rid_len = strlen(rid_prefix) + strlen(id) + 1; // + 1 for terminating '\0'
+	const size_t rid_len = strlen(rid_prefix) + strlen(id) + 1; // + 1 for terminating '\0'
 	char *rid = malloc(rid_len);
 	snprintf(rid, rid_len, "%s%s", rid_prefix, id);
 	xccdf_result_set_id(result, rid);

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -2017,26 +2017,24 @@ struct xccdf_result * xccdf_policy_evaluate(struct xccdf_policy * policy)
     const struct xccdf_version_info* version_info = xccdf_benchmark_get_schema_version(benchmark);
     doc_version = xccdf_version_info_get_version(version_info);
 
+	const char *rid_prefix;
 #ifdef __USE_GNU
-    if (strverscmp("1.2", doc_version) >= 0)
+	if (strverscmp("1.2", doc_version) >= 0)
 #else
-    if (strcmp("1.2", doc_version) >= 0)
+	if (strcmp("1.2", doc_version) >= 0)
 #endif
-    {
-        // we have to enforce a certain type of ids for XCCDF 1.2+
-
-        char rid[32+strlen(id)];
-        sprintf(rid, "xccdf_org.open-scap_testresult_%s", id);
-        xccdf_result_set_id(result, rid);
-    }
-    else {
-
-    	// previous behaviour for backwards compatibility
-
-        char rid[11+strlen(id)];
-        sprintf(rid, "OSCAP-Test-%s", id);
-        xccdf_result_set_id(result, rid);
-    }
+	{
+		// we have to enforce a certain type of ids for XCCDF 1.2+
+		rid_prefix = "xccdf_org.open-scap_testresult_";
+	} else {
+		// previous behaviour for backwards compatibility
+		rid_prefix = "OSCAP-Test-";
+	}
+	size_t rid_len = strlen(rid_prefix) + strlen(id) + 1; // + 1 for terminating '\0'
+	char *rid = malloc(rid_len);
+	snprintf(rid, rid_len, "%s%s", rid_prefix, id);
+	xccdf_result_set_id(result, rid);
+	free(rid);
 
     free(id);
 

--- a/src/source/xslt.c
+++ b/src/source/xslt.c
@@ -156,8 +156,7 @@ static xmlDoc *apply_xslt_path_internal(struct oscap_source *source, const char 
 		}
 	}
 
-	char **args = malloc(sizeof(char *) * (argc + 1));
-	memset(args, 0, sizeof(char *) * (argc + 1));
+	char **args = calloc(argc + 1, sizeof(char *));
 
 	for (size_t i = 0; i < argc; i += 2) {
 		args[i] = (char*) params[i];

--- a/src/source/xslt.c
+++ b/src/source/xslt.c
@@ -107,9 +107,6 @@ static xmlDoc *apply_xslt_path_internal(struct oscap_source *source, const char 
 	size_t argc = 0;
 	while(params[argc]) argc += 2;
 
-	char *args[argc+1];
-	memset(args, 0, sizeof(char*) * (argc + 1));
-
 	// Should we change all XCCDF namespaces (versioned) to one?
 	// This is a workaround needed to make XSLTs work with multiple versions.
 	// (currently 1.1 and 1.2)
@@ -159,6 +156,9 @@ static xmlDoc *apply_xslt_path_internal(struct oscap_source *source, const char 
 		}
 	}
 
+	char **args = malloc(sizeof(char *) * (argc + 1));
+	memset(args, 0, sizeof(char *) * (argc + 1));
+
 	for (size_t i = 0; i < argc; i += 2) {
 		args[i] = (char*) params[i];
 		if (params[i+1]) args[i+1] = oscap_sprintf("'%s'", params[i+1]);
@@ -168,6 +168,7 @@ static xmlDoc *apply_xslt_path_internal(struct oscap_source *source, const char 
 	for (size_t i = 0; args[i]; i += 2) {
 		free(args[i+1]);
 	}
+	free(args);
 	if (transformed == NULL) {
 		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not apply XSLT %s to XML file: %s", xsltpath,
 			oscap_source_readable_origin(source));

--- a/tests/API/XCCDF/unittests/test_oscap_common.c
+++ b/tests/API/XCCDF/unittests/test_oscap_common.c
@@ -26,6 +26,8 @@
 #include "common/util.h"
 #include "../../../assume.h"
 
+#define SEEN_LEN 9
+
 static bool _simple_string_filter(void *first, void *second)
 {
 	return !oscap_strcmp((char *)first, (char *)second);
@@ -201,8 +203,8 @@ static void _test_hit_single_item1(void)
 
 static void _test_hit_multiple_items1(void)
 {
-	static const int n = 9;
-	bool seen[n];
+	static const int n = SEEN_LEN;
+	bool seen[SEEN_LEN];
 	struct oscap_htable *h = oscap_htable_new1(_htable_cmp, 1);
 	for (int i = 0; i < n; i++) {
 		char key[10];

--- a/tests/API/XCCDF/unittests/test_oscap_common.c
+++ b/tests/API/XCCDF/unittests/test_oscap_common.c
@@ -135,10 +135,9 @@ static void _test_hit_single_item(void)
 
 static void _test_hit_multiple_items(void)
 {
-	static const int n = SEEN_LEN;
 	bool seen[SEEN_LEN];
 	struct oscap_htable *h = oscap_htable_new();
-	for (int i = 0; i < n; i++) {
+	for (int i = 0; i < SEEN_LEN; i++) {
 		char key[10];
 		snprintf(key, 10, "%d", i);
 		assume(oscap_htable_add(h, key, NULL));
@@ -155,9 +154,9 @@ static void _test_hit_multiple_items(void)
 		seen[key[0] - '0'] = true;
 		i++;
 	}
-	assume(i == n);
+	assume(i == SEEN_LEN);
 	oscap_htable_iterator_free(hit);
-	for (i = 0; i < n; i++) {
+	for (i = 0; i < SEEN_LEN; i++) {
 		assume(seen[i]);
 	}
 	oscap_htable_free0(h);
@@ -203,10 +202,9 @@ static void _test_hit_single_item1(void)
 
 static void _test_hit_multiple_items1(void)
 {
-	static const int n = SEEN_LEN;
 	bool seen[SEEN_LEN];
 	struct oscap_htable *h = oscap_htable_new1(_htable_cmp, 1);
-	for (int i = 0; i < n; i++) {
+	for (int i = 0; i < SEEN_LEN; i++) {
 		char key[10];
 		snprintf(key, 10, "%d", i);
 		assume(oscap_htable_add(h, key, NULL));
@@ -223,9 +221,9 @@ static void _test_hit_multiple_items1(void)
 		seen[key[0] - '0'] = true;
 		i++;
 	}
-	assume(i == n);
+	assume(i == SEEN_LEN);
 	oscap_htable_iterator_free(hit);
-	for (i = 0; i < n; i++) {
+	for (i = 0; i < SEEN_LEN; i++) {
 		assume(seen[i]);
 	}
 	oscap_htable_free0(h);

--- a/tests/API/XCCDF/unittests/test_oscap_common.c
+++ b/tests/API/XCCDF/unittests/test_oscap_common.c
@@ -135,8 +135,8 @@ static void _test_hit_single_item(void)
 
 static void _test_hit_multiple_items(void)
 {
-	static const int n = 9;
-	bool seen[n];
+	static const int n = SEEN_LEN;
+	bool seen[SEEN_LEN];
 	struct oscap_htable *h = oscap_htable_new();
 	for (int i = 0; i < n; i++) {
 		char key[10];

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -87,15 +87,18 @@ int app_xslt(const char *infile, const char *xsltfile, const char *outfile, cons
 
 	/* add params oscap-version & pwd */
 	const char *stdparams[] = { "oscap-version", oscap_get_version(), "pwd", pwd, NULL };
-	const char *par[paramlist_size(params) + paramlist_size(stdparams) + 1];
+	size_t par_size = paramlist_size(params) + paramlist_size(stdparams) + 1;
+	const char **par = malloc(par_size * sizeof(const char *));
 	size_t s  = paramlist_cpy(par    , params);
         paramlist_cpy(par + s, stdparams);
 
 	if (oscap_apply_xslt(infile, xsltfile, outfile, par)==-1) {
 		fprintf(stderr, "%s: %s\n", OSCAP_ERR_MSG, oscap_err_desc());
+		free(par);
 		return OSCAP_ERROR;
 	}
 
+	free(par);
 	return OSCAP_OK;
 }
 

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -87,7 +87,7 @@ int app_xslt(const char *infile, const char *xsltfile, const char *outfile, cons
 
 	/* add params oscap-version & pwd */
 	const char *stdparams[] = { "oscap-version", oscap_get_version(), "pwd", pwd, NULL };
-	size_t par_size = paramlist_size(params) + paramlist_size(stdparams) + 1;
+	const size_t par_size = paramlist_size(params) + paramlist_size(stdparams) + 1;
 	const char **par = malloc(par_size * sizeof(const char *));
 	size_t s  = paramlist_cpy(par    , params);
         paramlist_cpy(par + s, stdparams);


### PR DESCRIPTION
Variable length arrays are unfortunately unsupported by Microsoft Visual Studio. 

This PR removes variable length arrays from the whole codebase.

I also add a warning for GCC which will prevent future contributors to contribute code
with variable length arrays.