### PR TITLE
 Introduce oscap_basename

### DIFF
--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -228,8 +228,9 @@ static int ds_sds_register_sce(struct ds_sds_session *session, xmlNodePtr compon
 {
 	// the cast is safe to do because we are using the GNU basename, it doesn't
 	// modify the string
-	const char* file_basename = basename((char*)relative_filepath);
+	char *file_basename = oscap_basename((char*)relative_filepath);
 	char *sce_filename = oscap_sprintf("%s/%s/%s",ds_sds_session_get_target_dir(session), target_filename_dirname, file_basename);
+	free(file_basename);
 	const int ret = ds_sds_dump_component_sce(component_inner_root->children, component_id, sce_filename);
 	free(sce_filename);
 	return ret;

--- a/src/OVAL/oval_session.c
+++ b/src/OVAL/oval_session.c
@@ -318,7 +318,9 @@ static int oval_session_setup_agent(struct oval_session *session)
 	if (session->sess)
 		oval_agent_destroy_session(session->sess);
 
-	session->sess = oval_agent_new_session(session->def_model, basename(path_clone));
+	char *base_name = oscap_basename(path_clone);
+	session->sess = oval_agent_new_session(session->def_model, base_name);
+	free(base_name);
 	if (session->sess == NULL) {
 		oscap_seterr(OSCAP_EFAMILY_OVAL, "Failed to create a new agent session.");
 		free(path_clone);

--- a/src/OVAL/probes/probe/main.c
+++ b/src/OVAL/probes/probe/main.c
@@ -216,7 +216,7 @@ int main(int argc, char *argv[])
 
 	probe.flags = 0;
 	probe.pid   = getpid();
-	probe.name  = basename(argv[0]);
+	probe.name = oscap_basename(argv[0]);
         probe.probe_exitcode = 0;
 
 	/*
@@ -365,6 +365,6 @@ int main(int argc, char *argv[])
 
 	SEAP_CTX_free(probe.SEAP_ctx);
         free(probe.option);
-
+	free(probe.name);
 	return (probe.probe_exitcode);
 }

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -616,7 +616,9 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 			{
 				struct sce_check_result* check_result = sce_check_result_new();
 				sce_check_result_set_href(check_result, tmp_href);
-				sce_check_result_set_basename(check_result, basename(tmp_href));
+				char *base_name = oscap_basename(tmp_href);
+				sce_check_result_set_basename(check_result, base_name);
+				free(base_name);
 				sce_check_result_set_stdout(check_result, stdout_buffer);
 				sce_check_result_set_stderr(check_result, stderr_buffer);
 				sce_check_result_set_exit_code(check_result, WEXITSTATUS(wstatus));

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -860,7 +860,7 @@ void xccdf_session_set_custom_oval_files(struct xccdf_session *session, char **o
 
 	for (int i = 0; oval_filenames[i];) {
 		resources[i] = malloc(sizeof(struct oval_content_resource));
-		resources[i]->href = strdup(basename(oval_filenames[i]));
+		resources[i]->href = oscap_basename(oval_filenames[i]);
 		resources[i]->source = oscap_source_new_from_file(oval_filenames[i]);
 		resources[i]->source_owned = true;
 		i++;

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -233,7 +233,9 @@ char *oscap_acquire_guess_realpath(const char *filepath)
 			free(copy);
 			return NULL;
 		}
-		rpath = oscap_sprintf("%s/%s", real_dir, basename((char *)filepath));
+		char *base_name = oscap_basename((char *)filepath);
+		rpath = oscap_sprintf("%s/%s", real_dir, base_name);
+		free(base_name);
 		free(copy);
 	}
 	return rpath;

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -35,6 +35,10 @@
 #include "_error.h"
 #include "oscap.h"
 
+#ifdef _WIN32
+#include <stdlib.h>
+#endif
+
 
 int oscap_string_to_enum(const struct oscap_string_map *map, const char *str)
 {
@@ -236,5 +240,22 @@ char *oscap_realpath(const char *path, char *resolved_path)
 	return _fullpath(resolved_path, path, MAX_PATH);
 #else
 	return realpath(path, resolved_path);
+#endif
+}
+
+char *oscap_basename(char *path)
+{
+#ifdef _WIN32
+	char fname[_MAX_FNAME];
+	char ext[_MAX_EXT];
+	_splitpath_s(path_buffer, NULL, 0, NULL, 0, fname, _MAX_FNAME, ext, _MAX_EXT);
+	size_t base_len = strlen(fname) + strlen(ext) + 1;
+	char *base = malloc(base_len);
+	strncpy(base, fname, base_len);
+	strncat(base, ext, base_len - strlen(base) - 1);
+	return base;
+#else
+	char *base = basename(path);
+	return oscap_strdup(base);
 #endif
 }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -436,4 +436,11 @@ char **oscap_split(char *str, const char *delim);
  */
 char *oscap_realpath(const char *path, char *resolved_path);
 
+/**
+ * Return filename component of a path
+ * @param path path
+ * @return filename component of path
+ */
+char *oscap_basename(char *path);
+
 #endif				/* OSCAP_UTIL_H_ */

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -41,6 +41,7 @@
 
 #include "oscap-tool.h"
 #include <oscap_debug.h>
+#include "util.h"
 
 #define DS_SUBMODULES_NUM 8 /* See actual DS_SUBMODULES array
 				initialization below. */
@@ -359,7 +360,9 @@ int app_ds_sds_compose(const struct oscap_action *action) {
 	free(temp_cwd);
 
 	char* source_xccdf = strdup(action->ds_action->file);
-	ds_sds_compose_from_xccdf(basename(source_xccdf), target_abs_path);
+	char *base_name = oscap_basename(source_xccdf);
+	ds_sds_compose_from_xccdf(base_name, target_abs_path);
+	free(base_name);
 	free(source_xccdf);
 
 	chdir(previous_cwd);


### PR DESCRIPTION
We use `basename()` on a few places across our codebase. However on Visual Studio there is no such function. Most similar functions are `_splitpath()` or `_splitpath_s()` that can break pathname into components. To avoid many `#ifdef` section introduce `oscap_basename()`.

Then it replaces all occurences of `basename()` by `oscap_basename()`.
