### PR TITLE
Add OSCAP_API macro

### DIFF
--- a/src/CCE/public/cce.h
+++ b/src/CCE/public/cce.h
@@ -30,6 +30,7 @@
 
 #include <stdbool.h>
 #include "oscap.h"
+#include "oscap_export.h"
 
 #ifndef _CCE_H
 #define _CCE_H
@@ -64,56 +65,56 @@ struct cce_reference;
  * Get an iterator to the contents of the CCE.
  * @memberof cce
  */
-struct cce_entry_iterator *cce_get_entries(const struct cce *cce);
+OSCAP_API struct cce_entry_iterator *cce_get_entries(const struct cce *cce);
 
 /**
  * Get an CCE entry by ID.
  * @memberof cce
  * @retval NULL if given entry does not exist
  */
-struct cce_entry *cce_get_entry(const struct cce *cce, const char *id);
+OSCAP_API struct cce_entry *cce_get_entry(const struct cce *cce, const char *id);
 
 /**
  * Get CCE entry ID.
  * @memberof cce_entry
  */
-const char *cce_entry_get_id(const struct cce_entry *cce);
+OSCAP_API const char *cce_entry_get_id(const struct cce_entry *cce);
 
 /**
  * Get CCE entry desription.
  * @memberof cce_entry
  */
-const char *cce_entry_get_description(const struct cce_entry *cce);
+OSCAP_API const char *cce_entry_get_description(const struct cce_entry *cce);
 
 /**
  * Get an iterator to CCE entry's parameters.
  * @memberof cce_entry
  */
-struct oscap_string_iterator *cce_entry_get_params(const struct cce_entry *cce);
+OSCAP_API struct oscap_string_iterator *cce_entry_get_params(const struct cce_entry *cce);
 
 /**
  * Get an iterator to CCE entry's technical mechanisms.
  * @memberof cce_entry
  */
-struct oscap_string_iterator *cce_entry_get_tech_mechs(const struct cce_entry *cce);
+OSCAP_API struct oscap_string_iterator *cce_entry_get_tech_mechs(const struct cce_entry *cce);
 
 /**
  * Get an iterator to CCE entry's references.
  * @memberof cce_entry
  */
-struct cce_reference_iterator *cce_entry_get_references(const struct cce_entry *cce);
+OSCAP_API struct cce_reference_iterator *cce_entry_get_references(const struct cce_entry *cce);
 
 /**
  * Get source of CCE reference.
  * @memberof cce_reference
  */
-const char *cce_reference_get_source(const struct cce_reference *ref);
+OSCAP_API const char *cce_reference_get_source(const struct cce_reference *ref);
 
 /**
  * Get contents of CCE reference.
  * @memberof cce_reference
  */
-const char *cce_reference_get_value(const struct cce_reference *ref);
+OSCAP_API const char *cce_reference_get_value(const struct cce_reference *ref);
 
 /************************************************************/
 /** @} End of Getters group */
@@ -131,13 +132,13 @@ const char *cce_reference_get_value(const struct cce_reference *ref);
  */
 struct cce_reference_iterator;
 /// @memberof cce_reference_iterator
-struct cce_reference *cce_reference_iterator_next(struct cce_reference_iterator *it);
+OSCAP_API struct cce_reference *cce_reference_iterator_next(struct cce_reference_iterator *it);
 /// @memberof cce_reference_iterator
-bool cce_reference_iterator_has_more(struct cce_reference_iterator *it);
+OSCAP_API bool cce_reference_iterator_has_more(struct cce_reference_iterator *it);
 /// @memberof cce_reference_iterator
-void cce_reference_iterator_free(struct cce_reference_iterator *it);
+OSCAP_API void cce_reference_iterator_free(struct cce_reference_iterator *it);
 /// @memberof cce_reference_iterator
-void cce_reference_iterator_reset(struct cce_reference_iterator *it);
+OSCAP_API void cce_reference_iterator_reset(struct cce_reference_iterator *it);
 
 /**
  * @struct cce_entry_iterator
@@ -146,13 +147,13 @@ void cce_reference_iterator_reset(struct cce_reference_iterator *it);
  */
 struct cce_entry_iterator;
 /// @memberof cce_entry_iterator
-struct cce_entry *cce_entry_iterator_next(struct cce_entry_iterator *it);
+OSCAP_API struct cce_entry *cce_entry_iterator_next(struct cce_entry_iterator *it);
 /// @memberof cce_entry_iterator
-bool cce_entry_iterator_has_more(struct cce_entry_iterator *it);
+OSCAP_API bool cce_entry_iterator_has_more(struct cce_entry_iterator *it);
 /// @memberof cce_entry_iterator
-void cce_entry_iterator_free(struct cce_entry_iterator *it);
+OSCAP_API void cce_entry_iterator_free(struct cce_entry_iterator *it);
 /// @memberof cce_entry_iterator
-void cce_entry_iterator_reset(struct cce_entry_iterator *it);
+OSCAP_API void cce_entry_iterator_reset(struct cce_entry_iterator *it);
 
 /************************************************************/
 /** @} End of Iterators group */
@@ -163,7 +164,7 @@ void cce_entry_iterator_reset(struct cce_entry_iterator *it);
  * @param fname XML file name to porcess
  * @retval NULL on failure
  */
-struct cce *cce_new(const char *fname);
+OSCAP_API struct cce *cce_new(const char *fname);
 
 /**
  * CCE structure destructor.
@@ -171,7 +172,7 @@ struct cce *cce_new(const char *fname);
  * @memberof cce
  * @param cce pointer to target structure
  */
-void cce_free(struct cce *cce);
+OSCAP_API void cce_free(struct cce *cce);
 
 /************************************************************/
 /**
@@ -185,14 +186,14 @@ void cce_free(struct cce *cce);
  * @param filename file to be validated
  * @return result of validation (true / false)
  */
-bool cce_validate(const char *filename);
+OSCAP_API bool cce_validate(const char *filename);
 
 /**
  * Get supported version of CCE XML
  * @return version of XML file format
  * @memberof cce
  */
-const char * cce_supported(void);
+OSCAP_API const char * cce_supported(void);
 
 /************************************************************/
 /** @} End of Evaluators group */

--- a/src/CPE/public/cpe_dict.h
+++ b/src/CPE/public/cpe_dict.h
@@ -41,6 +41,7 @@
 #include "cpe_name.h"
 #include "oscap_text.h"
 #include "oscap_source.h"
+#include "oscap_export.h"
 
 /**
  * @struct cpe_dict_model
@@ -122,67 +123,67 @@ struct cpe_language;
  * @memberof cpe_item_metadata
  * @param item metadata of CPE item
  */
-const char *cpe_item_metadata_get_modification_date(const struct cpe_item_metadata *item);
+OSCAP_API const char *cpe_item_metadata_get_modification_date(const struct cpe_item_metadata *item);
 
 /** cpe_item_metadata function to get status
  * @memberof cpe_item_metadata
  * @param item metadata of CPE item
  */
-const char *cpe_item_metadata_get_status(const struct cpe_item_metadata *item);
+OSCAP_API const char *cpe_item_metadata_get_status(const struct cpe_item_metadata *item);
 
 /** cpe_item_metadata function to get nvd ID
  * @memberof cpe_item_metadata
  * @param item metadata of CPE item
  */
-const char *cpe_item_metadata_get_nvd_id(const struct cpe_item_metadata *item);
+OSCAP_API const char *cpe_item_metadata_get_nvd_id(const struct cpe_item_metadata *item);
 
 /** cpe_item_metadata function to get NVD ID of deprecated item
  * @memberof cpe_item_metadata
  * @param item metadata of CPE item
  */
-const char *cpe_item_metadata_get_deprecated_by_nvd_id(const struct cpe_item_metadata *item);
+OSCAP_API const char *cpe_item_metadata_get_deprecated_by_nvd_id(const struct cpe_item_metadata *item);
 
 /** cpe_check functions to get system
  * @memberof cpe_check
  * @param item CPE check item
  */
-const char *cpe_check_get_system(const struct cpe_check *item);
+OSCAP_API const char *cpe_check_get_system(const struct cpe_check *item);
 
 /** cpe_check functions to get href
  * @memberof cpe_check
  * @param item CPE check item
  */
-const char *cpe_check_get_href(const struct cpe_check *item);
+OSCAP_API const char *cpe_check_get_href(const struct cpe_check *item);
 
 /** cpe_check functions to get identifier
  * @memberof cpe_check
  * @param item CPE check item
  */
-const char *cpe_check_get_identifier(const struct cpe_check *item);
+OSCAP_API const char *cpe_check_get_identifier(const struct cpe_check *item);
 
 /** cpe_reference functions to get href of reference
  * @memberof cpe_reference
  * @param item CPE reference item
  */
-const char *cpe_reference_get_href(const struct cpe_reference *item);
+OSCAP_API const char *cpe_reference_get_href(const struct cpe_reference *item);
 
 /** cpe_reference functions to get content of reference
  * @memberof cpe_reference
  * @param item CPE reference item
  */
-const char *cpe_reference_get_content(const struct cpe_reference *item);
+OSCAP_API const char *cpe_reference_get_content(const struct cpe_reference *item);
 
 /** cpe_item functions to get variable member name
  * @memberof cpe_item
  * @param item CPE item
  */
-struct cpe_name *cpe_item_get_name(const struct cpe_item *item);
+OSCAP_API struct cpe_name *cpe_item_get_name(const struct cpe_item *item);
 
 /** cpe_item functions to get variable member deprecated_by
  * @memberof cpe_item
  * @param item CPE item
  */
-struct cpe_name *cpe_item_get_deprecated_by(const struct cpe_item *item);
+OSCAP_API struct cpe_name *cpe_item_get_deprecated_by(const struct cpe_item *item);
 
 /** cpe_item functions to get variable member deprecated_by
  * @memberof cpe_item
@@ -191,37 +192,37 @@ struct cpe_name *cpe_item_get_deprecated_by(const struct cpe_item *item);
  * @deprecated This function has been deprecated by @ref cpe_item_get_deprecated_by.
  * This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(struct cpe_name *cpe_item_get_deprecated(const struct cpe_item *item));
+OSCAP_API OSCAP_DEPRECATED(struct cpe_name *cpe_item_get_deprecated(const struct cpe_item *item));
 
 /** cpe_item functions to get variable member date
  * @memberof cpe_item
  * @param item CPE item
  */
-const char *cpe_item_get_deprecation_date(const struct cpe_item *item);
+OSCAP_API const char *cpe_item_get_deprecation_date(const struct cpe_item *item);
 
 /** cpe_item functions to get metadata of cpe_item
  * @memberof cpe_item
  * @param item CPE item
  */
-struct cpe_item_metadata *cpe_item_get_metadata(const struct cpe_item *item);
+OSCAP_API struct cpe_item_metadata *cpe_item_get_metadata(const struct cpe_item *item);
 
 /** cpe_item functions to get CPE references
  * @memberof cpe_item
  * @param item CPE item
  */
-struct cpe_reference_iterator *cpe_item_get_references(const struct cpe_item *item);
+OSCAP_API struct cpe_reference_iterator *cpe_item_get_references(const struct cpe_item *item);
 
 /** cpe_item functions to get CPE checks
  * @memberof cpe_item
  * @param item CPE item
  */
-struct cpe_check_iterator *cpe_item_get_checks(const struct cpe_item *item);
+OSCAP_API struct cpe_check_iterator *cpe_item_get_checks(const struct cpe_item *item);
 
 /** cpe_item functions to get CPE titles
  * @memberof cpe_item
  * @param item CPE item
  */
-struct oscap_text_iterator *cpe_item_get_titles(const struct cpe_item *item);
+OSCAP_API struct oscap_text_iterator *cpe_item_get_titles(const struct cpe_item *item);
 
 /** cpe_item functions to get CPE notes
  * @memberof cpe_item
@@ -229,31 +230,31 @@ struct oscap_text_iterator *cpe_item_get_titles(const struct cpe_item *item);
  * @deprecated This function has been deprecated and it may be dropped from later
  * versions of the library. (Please see upstream ticket #339 for further details).
  */
-OSCAP_DEPRECATED(struct oscap_text_iterator *cpe_item_get_notes(const struct cpe_item *item));
+OSCAP_API OSCAP_DEPRECATED(struct oscap_text_iterator *cpe_item_get_notes(const struct cpe_item *item));
 
 /** cpe_generator functions to get product name
  * @memberof cpe_generator
  * @param item document generator
  */
-const char *cpe_generator_get_product_name(const struct cpe_generator *item);
+OSCAP_API const char *cpe_generator_get_product_name(const struct cpe_generator *item);
 
 /** cpe_generator functions to get product version
  * @memberof cpe_generator
  * @param item document generator
  */
-const char *cpe_generator_get_product_version(const struct cpe_generator *item);
+OSCAP_API const char *cpe_generator_get_product_version(const struct cpe_generator *item);
 
 /** cpe_generator functions to get document schema version
  * @memberof cpe_generator
  * @param item document generator
  */
-const char *cpe_generator_get_schema_version(const struct cpe_generator *item);
+OSCAP_API const char *cpe_generator_get_schema_version(const struct cpe_generator *item);
 
 /** cpe_generator functions to get timestamp from generator
  * @memberof cpe_generator
  * @param item document generator
  */
-const char *cpe_generator_get_timestamp(const struct cpe_generator *item);
+OSCAP_API const char *cpe_generator_get_timestamp(const struct cpe_generator *item);
 
 /** cpe_dict_model functions to get the base version from CPE dictionary model
  *
@@ -266,167 +267,167 @@ const char *cpe_generator_get_timestamp(const struct cpe_generator *item);
  * @memberof cpe_dict_model
  * @param item dictionary model
  */
-int cpe_dict_model_get_base_version(const struct cpe_dict_model *item);
+OSCAP_API int cpe_dict_model_get_base_version(const struct cpe_dict_model *item);
 
 /** cpe_dict_model functions to get the base version from CPE dictionary model
  * @memberof cpe_dict_model
  * @param item dictionary model
  */
-bool cpe_dict_model_set_base_version(struct cpe_dict_model *item, int base_version);
+OSCAP_API bool cpe_dict_model_set_base_version(struct cpe_dict_model *item, int base_version);
 
 /** cpe_dict_model functions to get generator from CPE dictionary model
  * @memberof cpe_dict_model
  * @memberof cpe_generator
  * @param item dictionary model
  */
-struct cpe_generator *cpe_dict_model_get_generator(const struct cpe_dict_model *item);
+OSCAP_API struct cpe_generator *cpe_dict_model_get_generator(const struct cpe_dict_model *item);
 
 /** cpe_dict_model functions to get CPE items
  * @memberof cpe_dict_model
  * @param item dictionary model
  */
-struct cpe_item_iterator *cpe_dict_model_get_items(const struct cpe_dict_model *item);
+OSCAP_API struct cpe_item_iterator *cpe_dict_model_get_items(const struct cpe_dict_model *item);
 
 /** cpe_dict_model functions to get vendors
  * @memberof cpe_dict_model
  * @param item dictionary model
  */
-struct cpe_vendor_iterator *cpe_dict_model_get_vendors(const struct cpe_dict_model *item);
+OSCAP_API struct cpe_vendor_iterator *cpe_dict_model_get_vendors(const struct cpe_dict_model *item);
 
 /** cpe_vendor functions to get vendor value
  * @memberof cpe_vendor
  * @param item cpe_vendor
  */
-const char *cpe_vendor_get_value(const struct cpe_vendor *item);
+OSCAP_API const char *cpe_vendor_get_value(const struct cpe_vendor *item);
 
 /** cpe_vendor functions to get vendor titles
  * @memberof cpe_vendor
  * @param item cpe_vendor
  */
-struct oscap_text_iterator *cpe_vendor_get_titles(const struct cpe_vendor *item);
+OSCAP_API struct oscap_text_iterator *cpe_vendor_get_titles(const struct cpe_vendor *item);
 
 /** cpe_vendor functions to get vendor products
  * @memberof cpe_vendor
  * @param item cpe_vendor
  */
-struct cpe_product_iterator *cpe_vendor_get_products(const struct cpe_vendor *item);
+OSCAP_API struct cpe_product_iterator *cpe_vendor_get_products(const struct cpe_vendor *item);
 
 /** cpe_product functions to get product value
  * @memberof cpe_product
  * @param item cpe_product
  */
-const char *cpe_product_get_value(const struct cpe_product *item);
+OSCAP_API const char *cpe_product_get_value(const struct cpe_product *item);
 
 /** cpe_product functions to get product part
  * @memberof cpe_product
  * @param item cpe_product
  */
-cpe_part_t cpe_product_get_part(const struct cpe_product *item);
+OSCAP_API cpe_part_t cpe_product_get_part(const struct cpe_product *item);
 
 /** cpe_product functions to get versions of product
  * @memberof cpe_product
  * @memberof cpe_version
  * @param item cpe_product
  */
-struct cpe_version_iterator *cpe_product_get_versions(const struct cpe_product *item);
+OSCAP_API struct cpe_version_iterator *cpe_product_get_versions(const struct cpe_product *item);
 
 /** cpe_version functions to get vupdates of versions
  * @memberof cpe_version
  * @param item cpe_version
  */
-const char *cpe_version_get_value(const struct cpe_version *item);
+OSCAP_API const char *cpe_version_get_value(const struct cpe_version *item);
 
 /** cpe_version functions to get value of version
  * @memberof cpe_version
  * @memberof cpe_update
  * @param item cpe_version
  */
-struct cpe_update_iterator *cpe_version_get_updates(const struct cpe_version *item);
+OSCAP_API struct cpe_update_iterator *cpe_version_get_updates(const struct cpe_version *item);
 
 /** cpe_update functions to get updates of version
  * @memberof cpe_update
  * @param item
  */
-const char *cpe_update_get_value(const struct cpe_update *item);
+OSCAP_API const char *cpe_update_get_value(const struct cpe_update *item);
 
 /** cpe_update functions to get editions of update
  * @memberof cpe_update
  * @memberof cpe_edition
  * @param item cpe_update of product element
  */
-struct cpe_edition_iterator *cpe_update_get_editions(const struct cpe_update *item);
+OSCAP_API struct cpe_edition_iterator *cpe_update_get_editions(const struct cpe_update *item);
 
 /** cpe_edition functions to get value of edition
  * @memberof cpe_edition
  * @param item cpe_edition of update
  */
-const char *cpe_edition_get_value(const struct cpe_edition *item);
+OSCAP_API const char *cpe_edition_get_value(const struct cpe_edition *item);
 
 /** cpe_edition functions to get languages of edition
  * @memberof cpe_edition
  * @memberof cpe_language
  * @param item cpe_edition of update
  */
-struct cpe_language_iterator *cpe_edition_get_languages(const struct cpe_edition *item);
+OSCAP_API struct cpe_language_iterator *cpe_edition_get_languages(const struct cpe_edition *item);
 
 /** cpe_language functions to get value of language
  * @memberof cpe_language
  * @param item language
  */
-const char *cpe_language_get_value(const struct cpe_language *item);
+OSCAP_API const char *cpe_language_get_value(const struct cpe_language *item);
 
 /************************************************************/
 /** @} End of Getters group */
 
 /// @memberof cpe_check
-void cpe_check_free(struct cpe_check *check);
+OSCAP_API void cpe_check_free(struct cpe_check *check);
 /// @memberof cpe_reference
-void cpe_reference_free(struct cpe_reference *ref);
+OSCAP_API void cpe_reference_free(struct cpe_reference *ref);
 /// @memberof cpe_vendor
-void cpe_vendor_free(struct cpe_vendor *vendor);
+OSCAP_API void cpe_vendor_free(struct cpe_vendor *vendor);
 /// @memberof cpe_product
-void cpe_product_free(struct cpe_product *product);
+OSCAP_API void cpe_product_free(struct cpe_product *product);
 /// @memberof cpe_version
-void cpe_version_free(struct cpe_version *version);
+OSCAP_API void cpe_version_free(struct cpe_version *version);
 /// @memberof cpe_update
-void cpe_update_free(struct cpe_update *update);
+OSCAP_API void cpe_update_free(struct cpe_update *update);
 /// @memberof cpe_edition
-void cpe_edition_free(struct cpe_edition *edition);
+OSCAP_API void cpe_edition_free(struct cpe_edition *edition);
 /// @memberof cpe_language
-void cpe_language_free(struct cpe_language *language);
+OSCAP_API void cpe_language_free(struct cpe_language *language);
 /// @memberof cpe_itemmetadata
-void cpe_itemmetadata_free(struct cpe_item_metadata *meta);
+OSCAP_API void cpe_itemmetadata_free(struct cpe_item_metadata *meta);
 /// @memberof cpe_dict_model
-void cpe_dict_model_free(struct cpe_dict_model *dict);
+OSCAP_API void cpe_dict_model_free(struct cpe_dict_model *dict);
 /// @memberof cpe_generator
-void cpe_generator_free(struct cpe_generator *generator);
+OSCAP_API void cpe_generator_free(struct cpe_generator *generator);
 /// @memberof cpe_item
-void cpe_item_free(struct cpe_item *item);
+OSCAP_API void cpe_item_free(struct cpe_item *item);
 
 /// @memberof cpe_dict_model
-struct cpe_dict_model *cpe_dict_model_new(void);
+OSCAP_API struct cpe_dict_model *cpe_dict_model_new(void);
 /// @memberof cpe_generator
-struct cpe_generator *cpe_generator_new(void);
+OSCAP_API struct cpe_generator *cpe_generator_new(void);
 /// @memberof cpe_check
-struct cpe_check *cpe_check_new(void);
+OSCAP_API struct cpe_check *cpe_check_new(void);
 /// @memberof cpe_reference
-struct cpe_reference *cpe_reference_new(void);
+OSCAP_API struct cpe_reference *cpe_reference_new(void);
 /// @memberof cpe_item
-struct cpe_item *cpe_item_new(void);
+OSCAP_API struct cpe_item *cpe_item_new(void);
 /// @memberof cpe_vendor
-struct cpe_vendor *cpe_vendor_new(void);
+OSCAP_API struct cpe_vendor *cpe_vendor_new(void);
 /// @memberof cpe_product
-struct cpe_product *cpe_product_new(void);
+OSCAP_API struct cpe_product *cpe_product_new(void);
 /// @memberof cpe_version
-struct cpe_version *cpe_version_new(void);
+OSCAP_API struct cpe_version *cpe_version_new(void);
 /// @memberof cpe_update
-struct cpe_update *cpe_update_new(void);
+OSCAP_API struct cpe_update *cpe_update_new(void);
 /// @memberof cpe_edition
-struct cpe_edition *cpe_edition_new(void);
+OSCAP_API struct cpe_edition *cpe_edition_new(void);
 /// @memberof cpe_language
-struct cpe_language *cpe_language_new(void);
+OSCAP_API struct cpe_language *cpe_language_new(void);
 /// @memberof cpe_item_metadata
-struct cpe_item_metadata *cpe_item_metadata_new(void);
+OSCAP_API struct cpe_item_metadata *cpe_item_metadata_new(void);
 
 /************************************************************/
 /**
@@ -437,119 +438,119 @@ struct cpe_item_metadata *cpe_item_metadata_new(void);
  */
 
 /// @memberof cpe_item
-bool cpe_item_set_name(struct cpe_item *item, const struct cpe_name *new_name);
+OSCAP_API bool cpe_item_set_name(struct cpe_item *item, const struct cpe_name *new_name);
 
 /// @memberof cpe_item
-bool cpe_item_set_deprecated_by(struct cpe_item *item, const struct cpe_name *new_deprecated_by);
+OSCAP_API bool cpe_item_set_deprecated_by(struct cpe_item *item, const struct cpe_name *new_deprecated_by);
 
 /// @memberof cpe_item
-bool cpe_item_set_deprecation_date(struct cpe_item *item, const char *new_deprecation_date);
+OSCAP_API bool cpe_item_set_deprecation_date(struct cpe_item *item, const char *new_deprecation_date);
 
 /// @memberof cpe_item_metadata
 bool cpe_item_metadata_set_modification_date(struct cpe_item_metadata *item_metadata,
 					     const char *new_modification_date);
 
 /// @memberof cpe_item_metadata
-bool cpe_item_metadata_set_status(struct cpe_item_metadata *item_metadata, const char *new_status);
+OSCAP_API bool cpe_item_metadata_set_status(struct cpe_item_metadata *item_metadata, const char *new_status);
 
 /// @memberof cpe_item_metadata
-bool cpe_item_metadata_set_nvd_id(struct cpe_item_metadata *item_metadata, const char *new_nvd_id);
+OSCAP_API bool cpe_item_metadata_set_nvd_id(struct cpe_item_metadata *item_metadata, const char *new_nvd_id);
 
 /// @memberof cpe_item_metadata
 bool cpe_item_metadata_set_deprecated_by_nvd_id(struct cpe_item_metadata *item_metadata,
 						const char *new_deprecated_by_nvd_id);
 
 /// @memberof cpe_check
-bool cpe_check_set_system(struct cpe_check *check, const char *new_system);
+OSCAP_API bool cpe_check_set_system(struct cpe_check *check, const char *new_system);
 
 /// @memberof cpe_check
-bool cpe_check_set_href(struct cpe_check *check, const char *new_href);
+OSCAP_API bool cpe_check_set_href(struct cpe_check *check, const char *new_href);
 
 /// @memberof cpe_check
-bool cpe_check_set_identifier(struct cpe_check *check, const char *new_identifier);
+OSCAP_API bool cpe_check_set_identifier(struct cpe_check *check, const char *new_identifier);
 
 /// @memberof cpe_reference
-bool cpe_reference_set_href(struct cpe_reference *reference, const char *new_href);
+OSCAP_API bool cpe_reference_set_href(struct cpe_reference *reference, const char *new_href);
 
 /// @memberof cpe_reference
-bool cpe_reference_set_content(struct cpe_reference *reference, const char *new_content);
+OSCAP_API bool cpe_reference_set_content(struct cpe_reference *reference, const char *new_content);
 
 /// @memberof cpe_generator
-bool cpe_generator_set_product_name(struct cpe_generator *generator, const char *new_product_name);
+OSCAP_API bool cpe_generator_set_product_name(struct cpe_generator *generator, const char *new_product_name);
 
 /// @memberof cpe_generator
-bool cpe_generator_set_product_version(struct cpe_generator *generator, const char *new_product_version);
+OSCAP_API bool cpe_generator_set_product_version(struct cpe_generator *generator, const char *new_product_version);
 
 /// @memberof cpe_generator
-bool cpe_generator_set_schema_version(struct cpe_generator *generator, const char *new_schema_version);
+OSCAP_API bool cpe_generator_set_schema_version(struct cpe_generator *generator, const char *new_schema_version);
 
 /// @memberof cpe_generator
-bool cpe_generator_set_timestamp(struct cpe_generator *generator, const char *new_timestamp);
+OSCAP_API bool cpe_generator_set_timestamp(struct cpe_generator *generator, const char *new_timestamp);
 
 /// @memberof cpe_vendor
-bool cpe_vendor_set_value(struct cpe_vendor *vendor, const char *new_value);
+OSCAP_API bool cpe_vendor_set_value(struct cpe_vendor *vendor, const char *new_value);
 
 /// @memberof cpe_product
-bool cpe_product_set_value(struct cpe_product *product, const char *new_value);
+OSCAP_API bool cpe_product_set_value(struct cpe_product *product, const char *new_value);
 
 /// @memberof cpe_product
-bool cpe_product_set_part(struct cpe_product *product, cpe_part_t new_part);
+OSCAP_API bool cpe_product_set_part(struct cpe_product *product, cpe_part_t new_part);
 
 /// @memberof cpe_version
-bool cpe_version_set_value(struct cpe_version *version, const char *new_value);
+OSCAP_API bool cpe_version_set_value(struct cpe_version *version, const char *new_value);
 
 /// @memberof cpe_update
-bool cpe_update_set_value(struct cpe_update *update, const char *new_value);
+OSCAP_API bool cpe_update_set_value(struct cpe_update *update, const char *new_value);
 
 /// @memberof cpe_edition
-bool cpe_edition_set_value(struct cpe_edition *edition, const char *new_value);
+OSCAP_API bool cpe_edition_set_value(struct cpe_edition *edition, const char *new_value);
 
 /// @memberof cpe_language
-bool cpe_language_set_value(struct cpe_language *language, const char *new_value);
+OSCAP_API bool cpe_language_set_value(struct cpe_language *language, const char *new_value);
 
 /*
  * Add functions
  */
 
 /// @memberof cpe_item
-bool cpe_item_add_reference(struct cpe_item *item, struct cpe_reference *new_reference);
+OSCAP_API bool cpe_item_add_reference(struct cpe_item *item, struct cpe_reference *new_reference);
 
 /// @memberof cpe_item
-bool cpe_item_add_check(struct cpe_item *item, struct cpe_check *new_check);
+OSCAP_API bool cpe_item_add_check(struct cpe_item *item, struct cpe_check *new_check);
 
 /// @memberof cpe_item
-bool cpe_item_add_title(struct cpe_item *item, struct oscap_text *new_title);
+OSCAP_API bool cpe_item_add_title(struct cpe_item *item, struct oscap_text *new_title);
 
 /**
  * @memberof cpe_item
  * @deprecated This function has been deprecated and it may be dropped from later
  * versions of the library. (Please see upstream ticket #339 for further details).
  */
-OSCAP_DEPRECATED(bool cpe_item_add_note(struct cpe_item *item, struct oscap_text *new_title));
+OSCAP_API OSCAP_DEPRECATED(bool cpe_item_add_note(struct cpe_item *item, struct oscap_text *new_title));
 
 /// @memberof cpe_dict_model
-bool cpe_dict_model_add_item(struct cpe_dict_model *dict, struct cpe_item *new_item);
+OSCAP_API bool cpe_dict_model_add_item(struct cpe_dict_model *dict, struct cpe_item *new_item);
 
 /// @memberof cpe_dict_model
-bool cpe_dict_model_add_vendor(struct cpe_dict_model *dict, struct cpe_vendor *new_vendor);
+OSCAP_API bool cpe_dict_model_add_vendor(struct cpe_dict_model *dict, struct cpe_vendor *new_vendor);
 
 /// @memberof cpe_vendor
-bool cpe_vendor_add_title(struct cpe_vendor *vendor, struct oscap_text *new_title);
+OSCAP_API bool cpe_vendor_add_title(struct cpe_vendor *vendor, struct oscap_text *new_title);
 
 /// @memberof cpe_vendor
-bool cpe_vendor_add_product(struct cpe_vendor *vendor, struct cpe_product *new_product);
+OSCAP_API bool cpe_vendor_add_product(struct cpe_vendor *vendor, struct cpe_product *new_product);
 
 /// @memberof cpe_product
-bool cpe_product_add_version(struct cpe_product *product, struct cpe_version *new_version);
+OSCAP_API bool cpe_product_add_version(struct cpe_product *product, struct cpe_version *new_version);
 
 /// @memberof cpe_version
-bool cpe_version_add_update(struct cpe_version *version, struct cpe_update *new_update);
+OSCAP_API bool cpe_version_add_update(struct cpe_version *version, struct cpe_update *new_update);
 
 /// @memberof cpe_update
-bool cpe_update_add_edition(struct cpe_update *update, struct cpe_edition *new_edition);
+OSCAP_API bool cpe_update_add_edition(struct cpe_update *update, struct cpe_edition *new_edition);
 
 /// @memberof cpe_edition
-bool cpe_edition_add_language(struct cpe_edition *edition, struct cpe_language *new_language);
+OSCAP_API bool cpe_edition_add_language(struct cpe_edition *edition, struct cpe_language *new_language);
 
 
 /************************************************************/
@@ -573,26 +574,26 @@ struct cpe_item_iterator;
  * @see oscap_iterator
  * @memberof cpe_item_iterator
  */
-struct cpe_item *cpe_item_iterator_next(struct cpe_item_iterator *it);
+OSCAP_API struct cpe_item *cpe_item_iterator_next(struct cpe_item_iterator *it);
 
 /**
  * Iterator over CPE dictionary items.
  * @see oscap_iterator
  * @memberof cpe_item_iterator
  */
-bool cpe_item_iterator_has_more(struct cpe_item_iterator *it);
+OSCAP_API bool cpe_item_iterator_has_more(struct cpe_item_iterator *it);
 
 /**
  * Iterator over CPE dictionary items.
  * @see oscap_iterator
  * @memberof cpe_item_iterator
  */
-void cpe_item_iterator_free(struct cpe_item_iterator *it);
+OSCAP_API void cpe_item_iterator_free(struct cpe_item_iterator *it);
 
 /// @memberof cpe_item
-void cpe_item_iterator_remove(struct cpe_item_iterator *it);
+OSCAP_API void cpe_item_iterator_remove(struct cpe_item_iterator *it);
 /// @memberof cpe_item_iterator
-void cpe_item_iterator_reset(struct cpe_item_iterator *it);
+OSCAP_API void cpe_item_iterator_reset(struct cpe_item_iterator *it);
 
 /**
  * @struct cpe_reference_iterator
@@ -606,26 +607,26 @@ struct cpe_reference_iterator;
  * @see oscap_iterator
  * @memberof cpe_reference_iterator
  */
-struct cpe_reference *cpe_reference_iterator_next(struct cpe_reference_iterator *it);
+OSCAP_API struct cpe_reference *cpe_reference_iterator_next(struct cpe_reference_iterator *it);
 
 /**
  * Iterator over CPE item reference items.
  * @see oscap_iterator
  * @memberof cpe_reference_iterator
  */
-bool cpe_reference_iterator_has_more(struct cpe_reference_iterator *it);
+OSCAP_API bool cpe_reference_iterator_has_more(struct cpe_reference_iterator *it);
 
 /**
  * Iterator over CPE item reference items.
  * @see oscap_iterator
  * @memberof cpe_reference_iterator
  */
-void cpe_reference_iterator_free(struct cpe_reference_iterator *it);
+OSCAP_API void cpe_reference_iterator_free(struct cpe_reference_iterator *it);
 
 /// @memberof cpe_reference_iterator
-void cpe_reference_iterator_remove(struct cpe_reference_iterator *it);
+OSCAP_API void cpe_reference_iterator_remove(struct cpe_reference_iterator *it);
 /// @memberof cpe_reference_iterator
-void cpe_reference_iterator_reset(struct cpe_reference_iterator *it);
+OSCAP_API void cpe_reference_iterator_reset(struct cpe_reference_iterator *it);
 
 /**
  * @struct cpe_check_iterator
@@ -639,26 +640,26 @@ struct cpe_check_iterator;
  * @see oscap_iterator
  * @memberof cpe_check_iterator
  */
-struct cpe_check *cpe_check_iterator_next(struct cpe_check_iterator *it);
+OSCAP_API struct cpe_check *cpe_check_iterator_next(struct cpe_check_iterator *it);
 
 /**
  * Iterator over CPE item check items.
  * @see oscap_iterator
  * @memberof cpe_check_iterator
  */
-bool cpe_check_iterator_has_more(struct cpe_check_iterator *it);
+OSCAP_API bool cpe_check_iterator_has_more(struct cpe_check_iterator *it);
 
 /**
  * Iterator over CPE item check items.
  * @see oscap_iterator
  * @memberof cpe_check_iterator
  */
-void cpe_check_iterator_free(struct cpe_check_iterator *it);
+OSCAP_API void cpe_check_iterator_free(struct cpe_check_iterator *it);
 
 /// @memberof cpe_check_iterator
-void cpe_check_iterator_remove(struct cpe_check_iterator *it);
+OSCAP_API void cpe_check_iterator_remove(struct cpe_check_iterator *it);
 /// @memberof cpe_check_iterator
-void cpe_check_iterator_reset(struct cpe_check_iterator *it);
+OSCAP_API void cpe_check_iterator_reset(struct cpe_check_iterator *it);
 
 /**
  * @struct cpe_vendor_iterator
@@ -672,26 +673,26 @@ struct cpe_vendor_iterator;
  * @see oscap_iterator
  * @memberof cpe_vendor_iterator
  */
-struct cpe_vendor *cpe_vendor_iterator_next(struct cpe_vendor_iterator *it);
+OSCAP_API struct cpe_vendor *cpe_vendor_iterator_next(struct cpe_vendor_iterator *it);
 
 /**
  * Iterator over CPE vendor items.
  * @see oscap_iterator
  * @memberof cpe_vendor_iterator
  */
-bool cpe_vendor_iterator_has_more(struct cpe_vendor_iterator *it);
+OSCAP_API bool cpe_vendor_iterator_has_more(struct cpe_vendor_iterator *it);
 
 /**
  * Iterator over CPE vendor items.
  * @see oscap_iterator
  * @memberof cpe_vendor_iterator
  */
-void cpe_vendor_iterator_free(struct cpe_vendor_iterator *it);
+OSCAP_API void cpe_vendor_iterator_free(struct cpe_vendor_iterator *it);
 
 /// @memberof cpe_vendor_iterator
-void cpe_vendor_iterator_remove(struct cpe_vendor_iterator *it);
+OSCAP_API void cpe_vendor_iterator_remove(struct cpe_vendor_iterator *it);
 /// @memberof cpe_vendor_iterator
-void cpe_vendor_iterator_reset(struct cpe_vendor_iterator *it);
+OSCAP_API void cpe_vendor_iterator_reset(struct cpe_vendor_iterator *it);
 
 /**
  * @struct cpe_product_iterator
@@ -705,26 +706,26 @@ struct cpe_product_iterator;
  * @see oscap_iterator
  * @memberof cpe_product_iterator
  */
-struct cpe_product *cpe_product_iterator_next(struct cpe_product_iterator *it);
+OSCAP_API struct cpe_product *cpe_product_iterator_next(struct cpe_product_iterator *it);
 
 /**
  * Iterator over CPE product items.
  * @see oscap_iterator
  * @memberof cpe_product_iterator
  */
-bool cpe_product_iterator_has_more(struct cpe_product_iterator *it);
+OSCAP_API bool cpe_product_iterator_has_more(struct cpe_product_iterator *it);
 
 /**
  * Iterator over CPE product items.
  * @see oscap_iterator
  * @memberof cpe_product_iterator
  */
-void cpe_product_iterator_free(struct cpe_product_iterator *it);
+OSCAP_API void cpe_product_iterator_free(struct cpe_product_iterator *it);
 
 /// @memberof cpe_product_iterator
-void cpe_product_iterator_remove(struct cpe_product_iterator *it);
+OSCAP_API void cpe_product_iterator_remove(struct cpe_product_iterator *it);
 /// @memberof cpe_product_iterator
-void cpe_product_iterator_reset(struct cpe_product_iterator *it);
+OSCAP_API void cpe_product_iterator_reset(struct cpe_product_iterator *it);
 
 /**
  * @struct cpe_version_iterator
@@ -738,26 +739,26 @@ struct cpe_version_iterator;
  * @see oscap_iterator
  * @memberof cpe_version_iterator
  */
-struct cpe_version *cpe_version_iterator_next(struct cpe_version_iterator *it);
+OSCAP_API struct cpe_version *cpe_version_iterator_next(struct cpe_version_iterator *it);
 
 /**
  * Iterator over CPE version items.
  * @see oscap_iterator
  * @memberof cpe_version_iterator
  */
-bool cpe_version_iterator_has_more(struct cpe_version_iterator *it);
+OSCAP_API bool cpe_version_iterator_has_more(struct cpe_version_iterator *it);
 
 /**
  * Iterator over CPE version items.
  * @see oscap_iterator
  * @memberof cpe_version_iterator
  */
-void cpe_version_iterator_free(struct cpe_version_iterator *it);
+OSCAP_API void cpe_version_iterator_free(struct cpe_version_iterator *it);
 
 /// @memberof cpe_version_iterator
-void cpe_version_iterator_remove(struct cpe_version_iterator *it);
+OSCAP_API void cpe_version_iterator_remove(struct cpe_version_iterator *it);
 /// @memberof cpe_version_iterator
-void cpe_version_iterator_reset(struct cpe_version_iterator *it);
+OSCAP_API void cpe_version_iterator_reset(struct cpe_version_iterator *it);
 
 /**
  * @struct cpe_update_iterator
@@ -771,26 +772,26 @@ struct cpe_update_iterator;
  * @see oscap_iterator
  * @memberof cpe_update_iterator
  */
-struct cpe_update *cpe_update_iterator_next(struct cpe_update_iterator *it);
+OSCAP_API struct cpe_update *cpe_update_iterator_next(struct cpe_update_iterator *it);
 
 /**
  * Iterator over CPE update items.
  * @see oscap_iterator
  * @memberof cpe_update_iterator
  */
-bool cpe_update_iterator_has_more(struct cpe_update_iterator *it);
+OSCAP_API bool cpe_update_iterator_has_more(struct cpe_update_iterator *it);
 
 /**
  * Iterator over CPE update items.
  * @see oscap_iterator
  * @memberof cpe_update_iterator
  */
-void cpe_update_iterator_free(struct cpe_update_iterator *it);
+OSCAP_API void cpe_update_iterator_free(struct cpe_update_iterator *it);
 
 /// @memberof cpe_update_iterator
-void cpe_update_iterator_remove(struct cpe_update_iterator *it);
+OSCAP_API void cpe_update_iterator_remove(struct cpe_update_iterator *it);
 /// @memberof cpe_update_iterator
-void cpe_update_iterator_reset(struct cpe_update_iterator *it);
+OSCAP_API void cpe_update_iterator_reset(struct cpe_update_iterator *it);
 
 /**
  * @struct cpe_edition_iterator
@@ -804,26 +805,26 @@ struct cpe_edition_iterator;
  * @see oscap_iterator
  * @memberof cpe_edition_iterator
  */
-struct cpe_edition *cpe_edition_iterator_next(struct cpe_edition_iterator *it);
+OSCAP_API struct cpe_edition *cpe_edition_iterator_next(struct cpe_edition_iterator *it);
 
 /**
  * Iterator over CPE edition items.
  * @see oscap_iterator
  * @memberof cpe_edition_iterator
  */
-bool cpe_edition_iterator_has_more(struct cpe_edition_iterator *it);
+OSCAP_API bool cpe_edition_iterator_has_more(struct cpe_edition_iterator *it);
 
 /**
  * Iterator over CPE edition items.
  * @see oscap_iterator
  * @memberof cpe_edition_iterator
  */
-void cpe_edition_iterator_free(struct cpe_edition_iterator *it);
+OSCAP_API void cpe_edition_iterator_free(struct cpe_edition_iterator *it);
 
 /// @memberof cpe_edition_iterator
-void cpe_edition_iterator_remove(struct cpe_edition_iterator *it);
+OSCAP_API void cpe_edition_iterator_remove(struct cpe_edition_iterator *it);
 /// @memberof cpe_edition_iterator
-void cpe_edition_iterator_reset(struct cpe_edition_iterator *it);
+OSCAP_API void cpe_edition_iterator_reset(struct cpe_edition_iterator *it);
 
 /**
  * @struct cpe_language_iterator
@@ -837,26 +838,26 @@ struct cpe_language_iterator;
  * @see oscap_iterator
  * @memberof cpe_language_iterator
  */
-struct cpe_language *cpe_language_iterator_next(struct cpe_language_iterator *it);
+OSCAP_API struct cpe_language *cpe_language_iterator_next(struct cpe_language_iterator *it);
 
 /**
  * Iterator over CPE language items.
  * @see oscap_iterator
  * @memberof cpe_language_iterator
  */
-bool cpe_language_iterator_has_more(struct cpe_language_iterator *it);
+OSCAP_API bool cpe_language_iterator_has_more(struct cpe_language_iterator *it);
 
 /**
  * Iterator over CPE language items.
  * @see oscap_iterator
  * @memberof cpe_language_iterator
  */
-void cpe_language_iterator_free(struct cpe_language_iterator *it);
+OSCAP_API void cpe_language_iterator_free(struct cpe_language_iterator *it);
 
 /// @memberof cpe_language_iterator
-void cpe_language_iterator_remove(struct cpe_language_iterator *it);
+OSCAP_API void cpe_language_iterator_remove(struct cpe_language_iterator *it);
 /// @memberof cpe_language_iterator
-void cpe_language_iterator_reset(struct cpe_language_iterator *it);
+OSCAP_API void cpe_language_iterator_reset(struct cpe_language_iterator *it);
 
 /************************************************************/
 /** @} End of Iterators group */
@@ -872,7 +873,7 @@ void cpe_language_iterator_reset(struct cpe_language_iterator *it);
  * @return version of XML file format
  * @memberof cpe_dict_model
  */
-const char * cpe_dict_model_supported(void);
+OSCAP_API const char * cpe_dict_model_supported(void);
 
 /**
  * Detects which version the given CPE file is
@@ -881,7 +882,7 @@ const char * cpe_dict_model_supported(void);
  * @deprecated This function has been deprecated by @ref oscap_source_get_schema_version.
  * This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(char *cpe_dict_detect_version(const char* file));
+OSCAP_API OSCAP_DEPRECATED(char *cpe_dict_detect_version(const char* file));
 
 /** 
  * Verify wether given CPE is known according to specified dictionary
@@ -891,7 +892,7 @@ OSCAP_DEPRECATED(char *cpe_dict_detect_version(const char* file));
  * @param dict used CPE dictionary
  * @return true if dictionary contains given CPE
  */
-bool cpe_name_match_dict(struct cpe_name *cpe, struct cpe_dict_model *dict);
+OSCAP_API bool cpe_name_match_dict(struct cpe_name *cpe, struct cpe_dict_model *dict);
 
 /** 
  * Verify if CPE given by string is known according to specified dictionary
@@ -901,7 +902,7 @@ bool cpe_name_match_dict(struct cpe_name *cpe, struct cpe_dict_model *dict);
  * @param dict used CPE dictionary
  * @return true if dictionary contains given CPE
  */
-bool cpe_name_match_dict_str(const char *cpe, struct cpe_dict_model *dict);
+OSCAP_API bool cpe_name_match_dict_str(const char *cpe, struct cpe_dict_model *dict);
 
 /**
  * Verify whether given CPE is applicable to current platform by evaluating checks associated with it
@@ -912,10 +913,10 @@ bool cpe_name_match_dict_str(const char *cpe, struct cpe_dict_model *dict);
  * @param dict used CPE dictionary
  * @return true if dictionary contains given CPE and the CPE is applicable
  */
-bool cpe_name_applicable_dict(struct cpe_name *cpe, struct cpe_dict_model *dict, cpe_check_fn cb, void* usr);
+OSCAP_API bool cpe_name_applicable_dict(struct cpe_name *cpe, struct cpe_dict_model *dict, cpe_check_fn cb, void* usr);
 
 /// @memberof cpe_item
-bool cpe_item_is_applicable(struct cpe_item* item, cpe_check_fn cb, void* usr);
+OSCAP_API bool cpe_item_is_applicable(struct cpe_item* item, cpe_check_fn cb, void* usr);
 
 /************************************************************/
 /** @} End of Evaluators group */
@@ -925,7 +926,7 @@ bool cpe_item_is_applicable(struct cpe_item* item, cpe_check_fn cb, void* usr);
  * @param dict CPE Dict model
  * @memberof cpe_dict_model
  */
-void cpe_dict_model_export(const struct cpe_dict_model *dict, const char *file);
+OSCAP_API void cpe_dict_model_export(const struct cpe_dict_model *dict, const char *file);
 
 /** 
  * Load new CPE dictionary from file
@@ -936,7 +937,7 @@ void cpe_dict_model_export(const struct cpe_dict_model *dict, const char *file);
  * @deprecated This function has been deprecated by @ref cpe_dict_model_import_source.
  * This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(struct cpe_dict_model *cpe_dict_model_import(const char *file));
+OSCAP_API OSCAP_DEPRECATED(struct cpe_dict_model *cpe_dict_model_import(const char *file));
 
 /**
  * Load new CPE dictionary from an oscap_source
@@ -944,7 +945,7 @@ OSCAP_DEPRECATED(struct cpe_dict_model *cpe_dict_model_import(const char *file))
  * @param source The oscap_source to parse content from
  * @returns new dictionary or NULL
  */
-struct cpe_dict_model *cpe_dict_model_import_source(struct oscap_source *source);
+OSCAP_API struct cpe_dict_model *cpe_dict_model_import_source(struct oscap_source *source);
 
 
 /**
@@ -952,7 +953,7 @@ struct cpe_dict_model *cpe_dict_model_import_source(struct oscap_source *source)
  * @note This is intended for internal use only!
  * @see cpe_dict_model_get_origin_file
  */
-bool cpe_dict_model_set_origin_file(struct cpe_dict_model* dict, const char* origin_file);
+OSCAP_API bool cpe_dict_model_set_origin_file(struct cpe_dict_model* dict, const char* origin_file);
 
 /**
  * Gets the file the CPE dict model was loaded from
@@ -961,7 +962,7 @@ bool cpe_dict_model_set_origin_file(struct cpe_dict_model* dict, const char* ori
  * testing. We can't do applicability here in the CPE module because that
  * would create awful interdependencies.
  */
-const char* cpe_dict_model_get_origin_file(const struct cpe_dict_model* dict);
+OSCAP_API const char* cpe_dict_model_get_origin_file(const struct cpe_dict_model* dict);
 
 /** @} */
 

--- a/src/CPE/public/cpe_lang.h
+++ b/src/CPE/public/cpe_lang.h
@@ -42,6 +42,7 @@
 #include "oscap.h"
 #include "oscap_text.h"
 #include "oscap_source.h"
+#include "oscap_export.h"
 
 /**
  * CPE language operators
@@ -93,11 +94,11 @@ struct cpe_testexpr;
 struct cpe_platform_iterator;
 
 /// @memberof cpe_platform_iterator
-struct cpe_platform *cpe_platform_iterator_next(struct cpe_platform_iterator *it);
+OSCAP_API struct cpe_platform *cpe_platform_iterator_next(struct cpe_platform_iterator *it);
 /// @memberof cpe_platform_iterator
-bool cpe_platform_iterator_has_more(struct cpe_platform_iterator *it);
+OSCAP_API bool cpe_platform_iterator_has_more(struct cpe_platform_iterator *it);
 /// @memberof cpe_platform_iterator
-void cpe_platform_iterator_free(struct cpe_platform_iterator *it);
+OSCAP_API void cpe_platform_iterator_free(struct cpe_platform_iterator *it);
 
 /**
  * @struct cpe_testexpr_iterator
@@ -106,11 +107,11 @@ void cpe_platform_iterator_free(struct cpe_platform_iterator *it);
  */
 struct cpe_testexpr_iterator;
 /// @memberof cpe_testexpr_iterator
-struct cpe_testexpr *cpe_testexpr_iterator_next(struct cpe_testexpr_iterator *it);
+OSCAP_API struct cpe_testexpr *cpe_testexpr_iterator_next(struct cpe_testexpr_iterator *it);
 /// @memberof cpe_testexpr_iterator
-bool cpe_testexpr_iterator_has_more(struct cpe_testexpr_iterator *it);
+OSCAP_API bool cpe_testexpr_iterator_has_more(struct cpe_testexpr_iterator *it);
 /// @memberof cpe_testexpr_iterator
-void cpe_testexpr_iterator_free(struct cpe_testexpr_iterator *it);
+OSCAP_API void cpe_testexpr_iterator_free(struct cpe_testexpr_iterator *it);
 
 /************************************************************/
 /** @} End of Iterators group */
@@ -127,61 +128,61 @@ void cpe_testexpr_iterator_free(struct cpe_testexpr_iterator *it);
  * cpe_testexpr functions to get variable members
  * @memberof cpe_testexpr
  */
-cpe_lang_oper_t cpe_testexpr_get_oper(const struct cpe_testexpr *item);
+OSCAP_API cpe_lang_oper_t cpe_testexpr_get_oper(const struct cpe_testexpr *item);
 
 /**
  * Get CPE expression subexpression.
  * Not valid for CPE_LANG_OPER_MATCH operation.
  * @memberof cpe_testexpr
  */
-struct cpe_testexpr_iterator *cpe_testexpr_get_meta_expr(const struct cpe_testexpr *item);
+OSCAP_API struct cpe_testexpr_iterator *cpe_testexpr_get_meta_expr(const struct cpe_testexpr *item);
 
 /**
  * Get CPE name to match against.
  * Only valid for CPE_LANG_OPER_MATCH.
  * @memberof cpe_testexpr
  */
-const struct cpe_name *cpe_testexpr_get_meta_cpe(const struct cpe_testexpr *item);
+OSCAP_API const struct cpe_name *cpe_testexpr_get_meta_cpe(const struct cpe_testexpr *item);
 
 /**
  * Get check system to evaluate
  * Only valid for CPE_LANG_OPER_CHECK.
  * @memberof cpe_testexpr
  */
-const char* cpe_testexpr_get_meta_check_system(const struct cpe_testexpr *item);
+OSCAP_API const char* cpe_testexpr_get_meta_check_system(const struct cpe_testexpr *item);
 
 /**
  * Get check href to evaluate
  * Only valid for CPE_LANG_OPER_CHECK.
  * @memberof cpe_testexpr
  */
-const char* cpe_testexpr_get_meta_check_href(const struct cpe_testexpr *item);
+OSCAP_API const char* cpe_testexpr_get_meta_check_href(const struct cpe_testexpr *item);
 
 /**
  * Get check idref to evaluate
  * Only valid for CPE_LANG_OPER_CHECK.
  * @memberof cpe_testexpr
  */
-const char* cpe_testexpr_get_meta_check_id(const struct cpe_testexpr *item);
+OSCAP_API const char* cpe_testexpr_get_meta_check_id(const struct cpe_testexpr *item);
 
 /**
  * Function to get next expr from array
  * @param expr CPE Test expression structure
  * @memberof cpe_testexpr
  */
-const struct cpe_testexpr *cpe_testexpr_get_next(const struct cpe_testexpr *expr);
+OSCAP_API const struct cpe_testexpr *cpe_testexpr_get_next(const struct cpe_testexpr *expr);
 
 /**
  * cpe_lang_model function to get CPE platforms
  * @memberof cpe_lang_model
  */
-struct cpe_platform_iterator *cpe_lang_model_get_platforms(const struct cpe_lang_model *item);
+OSCAP_API struct cpe_platform_iterator *cpe_lang_model_get_platforms(const struct cpe_lang_model *item);
 
 /**
  * cpe_lang_model function to get CPE platforms
  * @memberof cpe_lang_model
  */
-struct cpe_platform *cpe_lang_model_get_item(const struct cpe_lang_model *item, const char *key);
+OSCAP_API struct cpe_platform *cpe_lang_model_get_item(const struct cpe_lang_model *item, const char *key);
 
 /**
  * Verify whether given CPE platform idref is applicable by evaluating test expression associated with it
@@ -191,28 +192,28 @@ struct cpe_platform *cpe_lang_model_get_item(const struct cpe_lang_model *item, 
  * @param lang_model used CPE language model
  * @return true if lang model contains given platform and the platform is applicable
  */
-bool cpe_platform_applicable_lang_model(const char* platform, struct cpe_lang_model *lang_model, cpe_check_fn check_cb, cpe_dict_fn dict_cb, void* usr);
+OSCAP_API bool cpe_platform_applicable_lang_model(const char* platform, struct cpe_lang_model *lang_model, cpe_check_fn check_cb, cpe_dict_fn dict_cb, void* usr);
 
 /**
  * cpe_platform functions to get id
  * @memberof cpe_platform
  */
-const char *cpe_platform_get_id(const struct cpe_platform *item);
+OSCAP_API const char *cpe_platform_get_id(const struct cpe_platform *item);
 /**
  * cpe_platform functions to get remark
  * @memberof cpe_platform
  */
-const char *cpe_platform_get_remark(const struct cpe_platform *item);
+OSCAP_API const char *cpe_platform_get_remark(const struct cpe_platform *item);
 /**
  * cpe_platform functions to get titles
  * @memberof cpe_platform
  */
-struct oscap_text_iterator *cpe_platform_get_titles(const struct cpe_platform *item);
+OSCAP_API struct oscap_text_iterator *cpe_platform_get_titles(const struct cpe_platform *item);
 /**
  * cpe_platform functions to get test expression
  * @memberof cpe_platform
  */
-const struct cpe_testexpr *cpe_platform_get_expr(const struct cpe_platform *item);
+OSCAP_API const struct cpe_testexpr *cpe_platform_get_expr(const struct cpe_platform *item);
 
 /************************************************************/
 /** @} End of Getters group */
@@ -229,12 +230,12 @@ const struct cpe_testexpr *cpe_platform_get_expr(const struct cpe_platform *item
  * Add platform to CPE lang model
  * @memberof cpe_lang_model
  */
-bool cpe_lang_model_add_platform(struct cpe_lang_model *lang, struct cpe_platform *platform);
+OSCAP_API bool cpe_lang_model_add_platform(struct cpe_lang_model *lang, struct cpe_platform *platform);
 /**
  * Add title to platform
  * @memberof cpe_platform
  */
-bool cpe_platform_add_title(struct cpe_platform *platform, struct oscap_text *title);
+OSCAP_API bool cpe_platform_add_title(struct cpe_platform *platform, struct oscap_text *title);
 
 /**
  * Add XML namespace to CPE lang model
@@ -248,32 +249,32 @@ bool cpe_platform_add_title(struct cpe_platform *platform, struct oscap_text *ti
  * Expression has to be of type CPE_LANG_OPER_AND or CPE_LANG_OPER_OR, possibly with negation.
  * @memberof cpe_testexpr
  */
-bool cpe_testexpr_add_subexpression(struct cpe_testexpr *expr, struct cpe_testexpr *sub);
+OSCAP_API bool cpe_testexpr_add_subexpression(struct cpe_testexpr *expr, struct cpe_testexpr *sub);
 
 /**
  * Set ID of CPE platform
  * @memberof cpe_platform
  */
-bool cpe_platform_set_id(struct cpe_platform *platform, const char *new_id);
+OSCAP_API bool cpe_platform_set_id(struct cpe_platform *platform, const char *new_id);
 /**
  * Set remark of CPE platform
  * @memberof cpe_platform
  */
-bool cpe_platform_set_remark(struct cpe_platform *platform, const char *new_remark);
+OSCAP_API bool cpe_platform_set_remark(struct cpe_platform *platform, const char *new_remark);
 /**
  * Set evaluation expression for this CPE platform.
  *
  * Expression has to be a logical-test (i.e. its operation shall be AND or OR, possibly with negation)
  * @memberof cpe_platform
  */
-bool cpe_platform_set_expr(struct cpe_platform *platform, struct cpe_testexpr *expr);
+OSCAP_API bool cpe_platform_set_expr(struct cpe_platform *platform, struct cpe_testexpr *expr);
 /**
  * Set CPE operation.
  *
  * Any subexpressions and CPE names associated with this expression will be removed.
  * @memberof cpe_testexpr
  */
-bool cpe_testexpr_set_oper(struct cpe_testexpr *expr, cpe_lang_oper_t oper);
+OSCAP_API bool cpe_testexpr_set_oper(struct cpe_testexpr *expr, cpe_lang_oper_t oper);
 
 /**
  * Set CPE name.
@@ -282,64 +283,64 @@ bool cpe_testexpr_set_oper(struct cpe_testexpr *expr, cpe_lang_oper_t oper);
  * this function has no effect and returns false.
  * @memberof cpe_testexpr
  */
-bool cpe_testexpr_set_name(struct cpe_testexpr *expr, struct cpe_name *name);
+OSCAP_API bool cpe_testexpr_set_name(struct cpe_testexpr *expr, struct cpe_name *name);
 
 /************************************************************/
 /** @} End of Setters group */
 
 /// @memberof cpe_platform_iterator
-void cpe_platform_iterator_remove(struct cpe_platform_iterator *it, struct cpe_lang_model *parent);
+OSCAP_API void cpe_platform_iterator_remove(struct cpe_platform_iterator *it, struct cpe_lang_model *parent);
 /// @memberof cpe_testexpr_iterator
-void cpe_platform_iterator_reset(struct cpe_platform_iterator *it);
+OSCAP_API void cpe_platform_iterator_reset(struct cpe_platform_iterator *it);
 
 /**
  * Constructor of CPE Language model
  * @memberof cpe_lang_model
  */
-struct cpe_lang_model *cpe_lang_model_new(void);
+OSCAP_API struct cpe_lang_model *cpe_lang_model_new(void);
 
 /**
  * Constructor of CPE test expression
  * @memberof cpe_testexpr
  */
-struct cpe_testexpr *cpe_testexpr_new(void);
+OSCAP_API struct cpe_testexpr *cpe_testexpr_new(void);
 
 /**
  * Constructor of CPE Platform
  * @memberof cpe_platform
  */
-struct cpe_platform *cpe_platform_new(void);
+OSCAP_API struct cpe_platform *cpe_platform_new(void);
 
 /**
  * Clone CPE test expression
  * @param old_expr CPE test expression
  * @memberof cpe_testexpr
  */
-struct cpe_testexpr * cpe_testexpr_clone(struct cpe_testexpr * old_expr);
+OSCAP_API struct cpe_testexpr * cpe_testexpr_clone(struct cpe_testexpr * old_expr);
 
 /**
  * Free function of CPE test expression
  * @memberof cpe_testexpr
  */
-void cpe_testexpr_free(struct cpe_testexpr *expr);
+OSCAP_API void cpe_testexpr_free(struct cpe_testexpr *expr);
 
 /**
  * Reset function of CPE test expression
  * @memberof cpe_testexpr
  */
-void cpe_testexpr_iterator_reset(struct cpe_testexpr_iterator *it);
+OSCAP_API void cpe_testexpr_iterator_reset(struct cpe_testexpr_iterator *it);
 
 /**
  * Free function of CPE test expression
  * @memberof cpe_lang_model
  */
-void cpe_lang_model_free(struct cpe_lang_model *platformspec);
+OSCAP_API void cpe_lang_model_free(struct cpe_lang_model *platformspec);
 
 /**
  * Free function of CPE Platform
  * @memberof cpe_platform
  */
-void cpe_platform_free(struct cpe_platform *platform);
+OSCAP_API void cpe_platform_free(struct cpe_platform *platform);
 
 /************************************************************/
 /**
@@ -352,7 +353,7 @@ void cpe_platform_free(struct cpe_platform *platform);
  * @return version of XML file format
  * @memberof cpe_lang_model
  */
-const char * cpe_lang_model_supported(void);
+OSCAP_API const char * cpe_lang_model_supported(void);
 
 /**
  * Detect version of given CPE language XML
@@ -360,7 +361,7 @@ const char * cpe_lang_model_supported(void);
  * @deprecated This function has been deprecated by @ref oscap_source_get_schema_version.
  * This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(char * cpe_lang_model_detect_version(const char* file));
+OSCAP_API OSCAP_DEPRECATED(char * cpe_lang_model_detect_version(const char* file));
 
 /**
  * Function to match cpe in platform
@@ -369,7 +370,7 @@ OSCAP_DEPRECATED(char * cpe_lang_model_detect_version(const char* file));
  * @param platform CPE platform
  * @memberof cpe_platform
  */
-bool cpe_platform_match_cpe(struct cpe_name **cpe, size_t n, const struct cpe_platform *platform);
+OSCAP_API bool cpe_platform_match_cpe(struct cpe_name **cpe, size_t n, const struct cpe_platform *platform);
 
 /************************************************************/
 /** @} End of Evaluators group */
@@ -380,20 +381,20 @@ bool cpe_platform_match_cpe(struct cpe_name **cpe, size_t n, const struct cpe_pl
  * @deprecated This function has been deprecated by @ref cpe_lang_model_import_source
  * This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(struct cpe_lang_model *cpe_lang_model_import(const char *file));
+OSCAP_API OSCAP_DEPRECATED(struct cpe_lang_model *cpe_lang_model_import(const char *file));
 
 /**
  * Load CPE language model from an oscap_source.
  * @memberof cpe_lang_model
  */
-struct cpe_lang_model *cpe_lang_model_import_source(struct oscap_source *source);
+OSCAP_API struct cpe_lang_model *cpe_lang_model_import_source(struct oscap_source *source);
 
 /**
  * Sets the origin file hint
  * @note This is intended for internal use only!
  * @see cpe_lang_model_get_origin_file
  */
-bool cpe_lang_model_set_origin_file(struct cpe_lang_model* lang_model, const char* origin_file);
+OSCAP_API bool cpe_lang_model_set_origin_file(struct cpe_lang_model* lang_model, const char* origin_file);
 
 /**
  * Gets the file the CPE dict model was loaded from
@@ -402,7 +403,7 @@ bool cpe_lang_model_set_origin_file(struct cpe_lang_model* lang_model, const cha
  * testing. We can't do applicability here in the CPE module because that
  * would create awful interdependencies.
  */
-const char* cpe_lang_model_get_origin_file(const struct cpe_lang_model* lang_model);
+OSCAP_API const char* cpe_lang_model_get_origin_file(const struct cpe_lang_model* lang_model);
 
 /**
  * Write the lang_model to a file.
@@ -410,7 +411,7 @@ const char* cpe_lang_model_get_origin_file(const struct cpe_lang_model* lang_mod
  * @param spec CPE lang model
  * @param file filename
  */
-void cpe_lang_model_export(const struct cpe_lang_model *spec, const char *file);
+OSCAP_API void cpe_lang_model_export(const struct cpe_lang_model *spec, const char *file);
 
 /**@}*/
 

--- a/src/CPE/public/cpe_name.h
+++ b/src/CPE/public/cpe_name.h
@@ -40,6 +40,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "oscap_export.h"
 
 /// enumeration of possible CPE parts
 typedef enum {
@@ -73,21 +74,21 @@ struct cpe_name;
  * @return new structure holding parsed data
  * @retval NULL on failure
  */
-struct cpe_name *cpe_name_new(const char *cpe);
+OSCAP_API struct cpe_name *cpe_name_new(const char *cpe);
 
 /**
  * Clone CPE Name
  * @param old_name CPE name
  * @memberof cpe_name
  */
-struct cpe_name * cpe_name_clone(struct cpe_name * old_name);
+OSCAP_API struct cpe_name * cpe_name_clone(struct cpe_name * old_name);
 
 /**
  * Destructor. Frees any used resources and safely destroys @a cpe.
  * @memberof cpe_name
  * @param cpe CPE to be deleted
  */
-void cpe_name_free(struct cpe_name *cpe);
+OSCAP_API void cpe_name_free(struct cpe_name *cpe);
 
 /************************************************************/
 /**
@@ -101,73 +102,73 @@ void cpe_name_free(struct cpe_name *cpe);
  * Get how the CPE name was loaded and how it should be saved
  * @memberof cpe_name
  */
-cpe_format_t cpe_name_get_format(const struct cpe_name *cpe);
+OSCAP_API cpe_format_t cpe_name_get_format(const struct cpe_name *cpe);
 
 /**
  * Get CPE name part type field.
  * @memberof cpe_name
  */
-cpe_part_t cpe_name_get_part(const struct cpe_name *cpe);
+OSCAP_API cpe_part_t cpe_name_get_part(const struct cpe_name *cpe);
 
 /**
  * Get CPE name vendor field.
  * @memberof cpe_name
  */
-const char *cpe_name_get_vendor(const struct cpe_name *cpe);
+OSCAP_API const char *cpe_name_get_vendor(const struct cpe_name *cpe);
 
 /**
  * Get CPE name product field.
  * @memberof cpe_name
  */
-const char *cpe_name_get_product(const struct cpe_name *cpe);
+OSCAP_API const char *cpe_name_get_product(const struct cpe_name *cpe);
 
 /**
  * Get CPE name version field.
  * @memberof cpe_name
  */
-const char *cpe_name_get_version(const struct cpe_name *cpe);
+OSCAP_API const char *cpe_name_get_version(const struct cpe_name *cpe);
 
 /**
  * Get CPE name update field.
  * @memberof cpe_name
  */
-const char *cpe_name_get_update(const struct cpe_name *cpe);
+OSCAP_API const char *cpe_name_get_update(const struct cpe_name *cpe);
 
 /**
  * Get CPE name edition field.
  * @memberof cpe_name
  */
-const char *cpe_name_get_edition(const struct cpe_name *cpe);
+OSCAP_API const char *cpe_name_get_edition(const struct cpe_name *cpe);
 
 /**
  * Get CPE name language field.
  * @memberof cpe_name
  */
-const char *cpe_name_get_language(const struct cpe_name *cpe);
+OSCAP_API const char *cpe_name_get_language(const struct cpe_name *cpe);
 
 /**
  * Get CPE name sw_edition field.
  * @memberof cpe_name
  */
-const char *cpe_name_get_sw_edition(const struct cpe_name *cpe);
+OSCAP_API const char *cpe_name_get_sw_edition(const struct cpe_name *cpe);
 
 /**
  * Get CPE name target_sw field.
  * @memberof cpe_name
  */
-const char *cpe_name_get_target_sw(const struct cpe_name *cpe);
+OSCAP_API const char *cpe_name_get_target_sw(const struct cpe_name *cpe);
 
 /**
  * Get CPE name target_hw field.
  * @memberof cpe_name
  */
-const char *cpe_name_get_target_hw(const struct cpe_name *cpe);
+OSCAP_API const char *cpe_name_get_target_hw(const struct cpe_name *cpe);
 
 /**
  * Get CPE name other field.
  * @memberof cpe_name
  */
-const char *cpe_name_get_other(const struct cpe_name *cpe);
+OSCAP_API const char *cpe_name_get_other(const struct cpe_name *cpe);
 
 /**
  * Return CPE URI as a new string in specified format.
@@ -178,7 +179,7 @@ const char *cpe_name_get_other(const struct cpe_name *cpe);
  * @return CPE URI as string
  * @retval NULL on failure
  */
-char *cpe_name_get_as_format(const struct cpe_name *cpe, cpe_format_t format);
+OSCAP_API char *cpe_name_get_as_format(const struct cpe_name *cpe, cpe_format_t format);
 
 /**
  * Return CPE URI as a new string in the format in which it was loaded.
@@ -188,7 +189,7 @@ char *cpe_name_get_as_format(const struct cpe_name *cpe, cpe_format_t format);
  * @return CPE URI as string
  * @retval NULL on failure
  */
-char *cpe_name_get_as_str(const struct cpe_name *cpe);
+OSCAP_API char *cpe_name_get_as_str(const struct cpe_name *cpe);
 
 /************************************************************/
 /** @} End of Getters group */
@@ -205,73 +206,73 @@ char *cpe_name_get_as_str(const struct cpe_name *cpe);
  * Set how the CPE name was loaded and how it should be saved
  * @memberof cpe_name
  */
-bool cpe_name_set_format(struct cpe_name *cpe, cpe_format_t newval);
+OSCAP_API bool cpe_name_set_format(struct cpe_name *cpe, cpe_format_t newval);
 
 /**
  * Set CPE name part type field.
  * @memberof cpe_name
  */
-bool cpe_name_set_part(struct cpe_name *cpe, cpe_part_t newval);
+OSCAP_API bool cpe_name_set_part(struct cpe_name *cpe, cpe_part_t newval);
 
 /**
  * Set CPE name vendor field.
  * @memberof cpe_name
  */
-bool cpe_name_set_vendor(struct cpe_name *cpe, const char *newval);
+OSCAP_API bool cpe_name_set_vendor(struct cpe_name *cpe, const char *newval);
 
 /**
  * Set CPE name product field.
  * @memberof cpe_name
  */
-bool cpe_name_set_product(struct cpe_name *cpe, const char *newval);
+OSCAP_API bool cpe_name_set_product(struct cpe_name *cpe, const char *newval);
 
 /**
  * Set CPE name version field.
  * @memberof cpe_name
  */
-bool cpe_name_set_version(struct cpe_name *cpe, const char *newval);
+OSCAP_API bool cpe_name_set_version(struct cpe_name *cpe, const char *newval);
 
 /**
  * Set CPE name update field.
  * @memberof cpe_name
  */
-bool cpe_name_set_update(struct cpe_name *cpe, const char *newval);
+OSCAP_API bool cpe_name_set_update(struct cpe_name *cpe, const char *newval);
 
 /**
  * Set CPE name edition field.
  * @memberof cpe_name
  */
-bool cpe_name_set_edition(struct cpe_name *cpe, const char *newval);
+OSCAP_API bool cpe_name_set_edition(struct cpe_name *cpe, const char *newval);
 
 /**
  * Set CPE name language field.
  * @memberof cpe_name
  */
-bool cpe_name_set_language(struct cpe_name *cpe, const char *newval);
+OSCAP_API bool cpe_name_set_language(struct cpe_name *cpe, const char *newval);
 
 /**
  * Set CPE name sw_edition field.
  * @memberof cpe_name
  */
-bool cpe_name_set_sw_edition(struct cpe_name *cpe, const char *newval);
+OSCAP_API bool cpe_name_set_sw_edition(struct cpe_name *cpe, const char *newval);
 
 /**
  * Set CPE name target_sw field.
  * @memberof cpe_name
  */
-bool cpe_name_set_target_sw(struct cpe_name *cpe, const char *newval);
+OSCAP_API bool cpe_name_set_target_sw(struct cpe_name *cpe, const char *newval);
 
 /**
  * Set CPE name target_hw field.
  * @memberof cpe_name
  */
-bool cpe_name_set_target_hw(struct cpe_name *cpe, const char *newval);
+OSCAP_API bool cpe_name_set_target_hw(struct cpe_name *cpe, const char *newval);
 
 /**
  * Set CPE name other field.
  * @memberof cpe_name
  */
-bool cpe_name_set_other(struct cpe_name *cpe, const char *newval);
+OSCAP_API bool cpe_name_set_other(struct cpe_name *cpe, const char *newval);
 
 /************************************************************/
 /** @} End of Setters group */
@@ -287,7 +288,7 @@ bool cpe_name_set_other(struct cpe_name *cpe, const char *newval);
  * according to CPE specification v 2.1.
  * @memberof cpe_name
  */
-bool cpe_name_match_one(const struct cpe_name *cpe, const struct cpe_name *against);
+OSCAP_API bool cpe_name_match_one(const struct cpe_name *cpe, const struct cpe_name *against);
 
 /**
  * Check if CPE @a name matches any CPE in @a namelist.
@@ -297,7 +298,7 @@ bool cpe_name_match_one(const struct cpe_name *cpe, const struct cpe_name *again
  * @param namelist list of names to search in
  * @return true if @a name was found within @a namelist
  */
-bool cpe_name_match_cpes(const struct cpe_name *name, size_t n, struct cpe_name **namelist);
+OSCAP_API bool cpe_name_match_cpes(const struct cpe_name *name, size_t n, struct cpe_name **namelist);
 
 /**
  * Write CPE URI @a cpe to file a descriptor @a f
@@ -307,21 +308,21 @@ bool cpe_name_match_cpes(const struct cpe_name *name, size_t n, struct cpe_name 
  * @return number of written characters
  * @retval <0 on failure
  */
-int cpe_name_write(const struct cpe_name *cpe, FILE * f);
+OSCAP_API int cpe_name_write(const struct cpe_name *cpe, FILE * f);
 
 /**
  * Looks at given string and returns format it is in
  *
  * CPE_FORMAT_UNKNOWN is used in case of errors
  */
-cpe_format_t cpe_name_get_format_of_str(const char *str);
+OSCAP_API cpe_format_t cpe_name_get_format_of_str(const char *str);
 
 /**
  * Checks whether @a str is valid CPE string (in any supported format).
  * @memberof cpe_name
  * @param str string to be validated
  */
-bool cpe_name_check(const char *str);
+OSCAP_API bool cpe_name_check(const char *str);
 
 /**
  * Match CPE URI @a candidate against list of @a n CPE URIs given by @a targets.
@@ -333,14 +334,14 @@ bool cpe_name_check(const char *str);
  * @retval -1 on mismatch
  * @retval -2 invalid CPE URI was given as parameter
  */
-int cpe_name_match_strs(const char *candidate, size_t n, char **targets);
+OSCAP_API int cpe_name_match_strs(const char *candidate, size_t n, char **targets);
 
 /**
  * Get supported version of CPE uri XML
  * @return version of XML file format
  * @memberof cpe_name
  */
-const char * cpe_name_supported(void);
+OSCAP_API const char * cpe_name_supported(void);
 
 /************************************************************/
 /** @} End of Evaluators group */
@@ -359,7 +360,7 @@ const char * cpe_name_supported(void);
  *
  * returns true = applicable, false = not applicable
  */
-typedef bool *(*cpe_check_fn) (const char*, const char*, const char*, void*);
+OSCAP_API typedef bool *(*cpe_check_fn) (const char*, const char*, const char*, void*);
 
 /**
  * Shared callback definition used to match CPE names to perform applicability tests
@@ -368,6 +369,6 @@ typedef bool *(*cpe_check_fn) (const char*, const char*, const char*, void*);
  * second argument = arbitrary pointer / user data
  * returns true = matched to existing applicable name, false = not matched/not applicable
  */
-typedef bool *(*cpe_dict_fn) (const struct cpe_name*, void*);
+OSCAP_API typedef bool *(*cpe_dict_fn) (const struct cpe_name*, void*);
 
 #endif				/* _CPEURI_H_ */

--- a/src/CVE/public/cve_nvd.h
+++ b/src/CVE/public/cve_nvd.h
@@ -38,6 +38,7 @@
 #include <time.h>
 #include "oscap.h"
 #include "cpe_name.h"
+#include "oscap_export.h"
 
 /** 
  * @struct cve_model
@@ -91,134 +92,134 @@ struct cvss_impact;
  * @param cve_model CVE model
  * @memberof cve_entry
  */
-struct cve_entry_iterator *cve_model_get_entries(const struct cve_model *cve_model);
+OSCAP_API struct cve_entry_iterator *cve_model_get_entries(const struct cve_model *cve_model);
 
 /**
  * Get CVE entry ID
  * @param item CVE entry
  * @memberof cve_entry
  */
-const char *cve_entry_get_id(const struct cve_entry *item);
+OSCAP_API const char *cve_entry_get_id(const struct cve_entry *item);
 
 /**
  * Get CVE entry CWE
  * @param item CVE entry
  * @memberof cve_entry
  */
-const char *cve_entry_get_cwe(const struct cve_entry *item);
+OSCAP_API const char *cve_entry_get_cwe(const struct cve_entry *item);
 
 /**
  * Get CVE entry summary
  * @param item CVE entry
  * @memberof cve_entry
  */
-struct cve_summary_iterator *cve_entry_get_summaries(const struct cve_entry *item);
+OSCAP_API struct cve_summary_iterator *cve_entry_get_summaries(const struct cve_entry *item);
 
 /**
  * Get an iterator to CVE entry's references
  * @param item CVE entry
  * @memberof cve_entry
  */
-struct cve_reference_iterator *cve_entry_get_references(const struct cve_entry *item);
+OSCAP_API struct cve_reference_iterator *cve_entry_get_references(const struct cve_entry *item);
 
 /**
  * Get CVE reference values
  * @param ref CVE reference
  * @memberof cve_reference
  */
-const char *cve_reference_get_value(const struct cve_reference *ref);
+OSCAP_API const char *cve_reference_get_value(const struct cve_reference *ref);
 
 /**
  * Get CVE reference href
  * @param ref CVE reference
  * @memberof cve_reference
  */
-const char *cve_reference_get_href(const struct cve_reference *ref);
+OSCAP_API const char *cve_reference_get_href(const struct cve_reference *ref);
 
 /**
  * Get CVE reference type
  * @param ref CVE reference
  * @memberof cve_reference
  */
-const char *cve_reference_get_type(const struct cve_reference *ref);
+OSCAP_API const char *cve_reference_get_type(const struct cve_reference *ref);
 
 /**
  * Get CVE reference source
  * @param ref CVE reference
  * @memberof cve_reference
  */
-const char *cve_reference_get_source(const struct cve_reference *ref);
+OSCAP_API const char *cve_reference_get_source(const struct cve_reference *ref);
 /// @memberof cve_reference
-const char *cve_reference_get_lang(const struct cve_reference *ref);
+OSCAP_API const char *cve_reference_get_lang(const struct cve_reference *ref);
 
 /**
  * Get value from CVE summary
  * @param summary CVE summary
  * @memberof cve_summary
  */
-const char *cve_summary_get_summary(const struct cve_summary *summary);
+OSCAP_API const char *cve_summary_get_summary(const struct cve_summary *summary);
 /**
  * Get CVE product value
  * @param prodct CVE product
  * @memberof cve_
  */
-const char *cve_product_get_value(const struct cve_product *product);
+OSCAP_API const char *cve_product_get_value(const struct cve_product *product);
 /**
  * Get CVE entry value
  * @param entry CVE entry
  * @memberof cve_entry
  */
-const char *cwe_entry_get_value(const struct cwe_entry *entry);
+OSCAP_API const char *cwe_entry_get_value(const struct cwe_entry *entry);
 /**
  * Get CVE configuration id
  * @param conf CVE vulnerable configuration
  * @memberof cve_configuration
  */
-const char *cve_configuration_get_id(const struct cve_configuration *conf);
+OSCAP_API const char *cve_configuration_get_id(const struct cve_configuration *conf);
 /**
  * Get CVE entry published date
  * @param entry CVE entry
  * @memberof cve_entry
  */
-const char *cve_entry_get_published(const struct cve_entry *entry);
+OSCAP_API const char *cve_entry_get_published(const struct cve_entry *entry);
 /**
  * Get CVE entry modified
  * @param entry CVE entry
  * @memberof cve_entry
  */
-const char *cve_entry_get_modified(const struct cve_entry *entry);
+OSCAP_API const char *cve_entry_get_modified(const struct cve_entry *entry);
 /**
  * Get CVE entry protection
  * @param entry CVE entry
  * @memberof cve_entry
  */
-const char *cve_entry_get_sec_protection(const struct cve_entry *entry);
+OSCAP_API const char *cve_entry_get_sec_protection(const struct cve_entry *entry);
 
 /**
  * Get CVE entry products
  * @param entry CVE entry
  * @memberof cve_entry
  */
-struct cve_product_iterator *cve_entry_get_products(const struct cve_entry *entry);
+OSCAP_API struct cve_product_iterator *cve_entry_get_products(const struct cve_entry *entry);
 /**
  * Get CVE .
  * @param entry CVE entry
  * @memberof cve_entry
  */
-struct cve_configuration_iterator *cve_entry_get_configurations(const struct cve_entry *entry);
+OSCAP_API struct cve_configuration_iterator *cve_entry_get_configurations(const struct cve_entry *entry);
 /**
  * Get CVE configuration test expression.
  * @param conf CVE configuration
  * @memberof cve_configuration
  */
-const struct cpe_testexpr *cve_configuration_get_expr(const struct cve_configuration *conf);
+OSCAP_API const struct cpe_testexpr *cve_configuration_get_expr(const struct cve_configuration *conf);
 
 /**
  * Get CVSS structure from CVE.
  * @param item CVE entry
  * @memberof cve_entry
  */
-const struct cvss_impact *cve_entry_get_cvss(const struct cve_entry *item);
+OSCAP_API const struct cvss_impact *cve_entry_get_cvss(const struct cve_entry *item);
 
 /************************************************************/
 /** @} End of Getters group */
@@ -238,19 +239,19 @@ const struct cvss_impact *cve_entry_get_cvss(const struct cve_entry *item);
  * @memberof cve_model
  * @return true if added, false otherwise
  */
-bool cve_model_add_entry(struct cve_model *model, struct cve_entry *new_entry);
+OSCAP_API bool cve_model_add_entry(struct cve_model *model, struct cve_entry *new_entry);
 
 /// @memberof cve_entry
-bool cve_entry_add_product(struct cve_entry *entry, struct cve_product *new_product);
+OSCAP_API bool cve_entry_add_product(struct cve_entry *entry, struct cve_product *new_product);
 
 /// @memberof cve_entry
-bool cve_entry_add_reference(struct cve_entry *entry, struct cve_reference *new_reference);
+OSCAP_API bool cve_entry_add_reference(struct cve_entry *entry, struct cve_reference *new_reference);
 
 /// @memberof cve_entry
-bool cve_entry_add_summary(struct cve_entry *entry, struct cve_summary *new_summary);
+OSCAP_API bool cve_entry_add_summary(struct cve_entry *entry, struct cve_summary *new_summary);
 
 /// @memberof cve_entry
-bool cve_entry_add_configuration(struct cve_entry *entry, struct cve_configuration *new_configuration);
+OSCAP_API bool cve_entry_add_configuration(struct cve_entry *entry, struct cve_configuration *new_configuration);
 
 /**
  * Set id of CVE entry
@@ -259,7 +260,7 @@ bool cve_entry_add_configuration(struct cve_entry *entry, struct cve_configurati
  * @memberof cve_entry
  * return true if set, false otherwise
  */
-bool cve_entry_set_id(struct cve_entry *entry, const char *new_id);
+OSCAP_API bool cve_entry_set_id(struct cve_entry *entry, const char *new_id);
 /**
  * Set publish date of CVE entry
  * @param entry CVE entry
@@ -267,7 +268,7 @@ bool cve_entry_set_id(struct cve_entry *entry, const char *new_id);
  * @memberof cve_entry
  * return true if set, false otherwise
  */
-bool cve_entry_set_published(struct cve_entry *entry, const char *new_published);
+OSCAP_API bool cve_entry_set_published(struct cve_entry *entry, const char *new_published);
 /**
  * Set modified date of CVE entry
  * @param entry CVE entry
@@ -275,7 +276,7 @@ bool cve_entry_set_published(struct cve_entry *entry, const char *new_published)
  * @memberof cve_entry
  * return true if set, false otherwise
  */
-bool cve_entry_set_modified(struct cve_entry *entry, const char *new_modified);
+OSCAP_API bool cve_entry_set_modified(struct cve_entry *entry, const char *new_modified);
 /**
  * Set protection of CVE entry
  * @param entry CVE entry
@@ -283,7 +284,7 @@ bool cve_entry_set_modified(struct cve_entry *entry, const char *new_modified);
  * @memberof cve_entry
  * return true if set, false otherwise
  */
-bool cve_entry_set_sec_protection(struct cve_entry *entry, const char *new_protection);
+OSCAP_API bool cve_entry_set_sec_protection(struct cve_entry *entry, const char *new_protection);
 /**
  * Set cwe of CVE entry
  * @param entry CVE entry
@@ -291,7 +292,7 @@ bool cve_entry_set_sec_protection(struct cve_entry *entry, const char *new_prote
  * @memberof cve_entry
  * return true if set, false otherwise
  */
-bool cve_entry_set_cwe(struct cve_entry *entry, const char *cwe);
+OSCAP_API bool cve_entry_set_cwe(struct cve_entry *entry, const char *cwe);
 /**
  * Set value of CVE entry
  * @param entry CVE entry
@@ -299,7 +300,7 @@ bool cve_entry_set_cwe(struct cve_entry *entry, const char *cwe);
  * @memberof cve_entry
  * return true if set, false otherwise
  */
-bool cwe_entry_set_value(struct cwe_entry *entry, const char *new_value);
+OSCAP_API bool cwe_entry_set_value(struct cwe_entry *entry, const char *new_value);
 
 /**
  * Set value of CVE reference
@@ -308,7 +309,7 @@ bool cwe_entry_set_value(struct cwe_entry *entry, const char *new_value);
  * @memberof cve_reference
  * return true if set, false otherwise
  */
-bool cve_reference_set_value(struct cve_reference *reference, const char *new_value);
+OSCAP_API bool cve_reference_set_value(struct cve_reference *reference, const char *new_value);
 /**
  * Set href of CVE reference
  * @param reference CVE reference
@@ -316,7 +317,7 @@ bool cve_reference_set_value(struct cve_reference *reference, const char *new_va
  * @memberof cve_reference href
  * return true if set, false otherwise
  */
-bool cve_reference_set_href(struct cve_reference *reference, const char *new_href);
+OSCAP_API bool cve_reference_set_href(struct cve_reference *reference, const char *new_href);
 /**
  * Set type of CVE reference
  * @param reference CVE reference
@@ -324,7 +325,7 @@ bool cve_reference_set_href(struct cve_reference *reference, const char *new_hre
  * @memberof cve_reference type
  * return true if set, false otherwise
  */
-bool cve_reference_set_type(struct cve_reference *reference, const char *new_type);
+OSCAP_API bool cve_reference_set_type(struct cve_reference *reference, const char *new_type);
 /**
  * Set source of CVE reference
  * @param reference CVE reference
@@ -332,10 +333,10 @@ bool cve_reference_set_type(struct cve_reference *reference, const char *new_typ
  * @memberof cve_reference
  * return true if set, false otherwise
  */
-bool cve_reference_set_source(struct cve_reference *reference, const char *new_source);
+OSCAP_API bool cve_reference_set_source(struct cve_reference *reference, const char *new_source);
 
 /// @memberof cve_reference
-bool cve_reference_set_lang(struct cve_reference *reference, const char *new_lang);
+OSCAP_API bool cve_reference_set_lang(struct cve_reference *reference, const char *new_lang);
 
 /**
  * Set id of CVE configuration
@@ -344,7 +345,7 @@ bool cve_reference_set_lang(struct cve_reference *reference, const char *new_lan
  * @memberof cve_configuration
  * @return true if set, false otherwise
  */
-bool cve_configuration_set_id(struct cve_configuration *conf, const char *new_id);
+OSCAP_API bool cve_configuration_set_id(struct cve_configuration *conf, const char *new_id);
 /**
  * Set value of CVE product
  * @param product CVE product
@@ -352,7 +353,7 @@ bool cve_configuration_set_id(struct cve_configuration *conf, const char *new_id
  * @memberof cve_product
  * @return true if set, false otherwise
  */
-bool cve_product_set_value(struct cve_product *product, const char *new_value);
+OSCAP_API bool cve_product_set_value(struct cve_product *product, const char *new_value);
 /**
  * Set summary of CVE summary
  * @param summary CVE summary
@@ -360,7 +361,7 @@ bool cve_product_set_value(struct cve_product *product, const char *new_value);
  * @memberof cve_summary
  * @return true if set, false otherwise
  */
-bool cve_summary_set_summary(struct cve_summary *summary, const char *new_summary);
+OSCAP_API bool cve_summary_set_summary(struct cve_summary *summary, const char *new_summary);
 
 /************************************************************/
 /** @} End of Setters group */
@@ -381,15 +382,15 @@ struct cve_entry_iterator;
 /** 
  * @memberof cve_entry_iterator 
  */
-struct cve_entry *cve_entry_iterator_next(struct cve_entry_iterator *it);
+OSCAP_API struct cve_entry *cve_entry_iterator_next(struct cve_entry_iterator *it);
 /** 
  * @memberof cve_entry_iterator 
  */
-bool cve_entry_iterator_has_more(struct cve_entry_iterator *it);
+OSCAP_API bool cve_entry_iterator_has_more(struct cve_entry_iterator *it);
 /** 
  * @memberof cve_entry_iterator 
  */
-void cve_entry_iterator_free(struct cve_entry_iterator *it);
+OSCAP_API void cve_entry_iterator_free(struct cve_entry_iterator *it);
 
 /** @struct cve_summary_iterator
  * Iterator over CVE summaries.
@@ -400,15 +401,15 @@ struct cve_summary_iterator;
 /** 
  * @memberof cve_summary_iterator
  */
-struct cve_summary *cve_summary_iterator_next(struct cve_summary_iterator *it);
+OSCAP_API struct cve_summary *cve_summary_iterator_next(struct cve_summary_iterator *it);
 /** 
  * @memberof cve_summary_iterator
  */
-bool cve_summary_iterator_has_more(struct cve_summary_iterator *it);
+OSCAP_API bool cve_summary_iterator_has_more(struct cve_summary_iterator *it);
 /**
  * @memberof cve_summary_iterator 
  */
-void cve_summary_iterator_free(struct cve_summary_iterator *it);
+OSCAP_API void cve_summary_iterator_free(struct cve_summary_iterator *it);
 
 /** @struct cve_product_iterator
  * Iterator over CVE products.
@@ -419,15 +420,15 @@ struct cve_product_iterator;
 /** 
  * @memberof cve_product_iterator 
  */
-struct cve_product *cve_product_iterator_next(struct cve_product_iterator *it);
+OSCAP_API struct cve_product *cve_product_iterator_next(struct cve_product_iterator *it);
 /** 
  * @memberof cve_product_iterator 
  */
-bool cve_product_iterator_has_more(struct cve_product_iterator *it);
+OSCAP_API bool cve_product_iterator_has_more(struct cve_product_iterator *it);
 /** 
  * @memberof cve_product_iterator 
  */
-void cve_product_iterator_free(struct cve_product_iterator *it);
+OSCAP_API void cve_product_iterator_free(struct cve_product_iterator *it);
 
 /** @struct cve_configuration_iterator
  * Iterator over CVE vulnerable configurations.
@@ -438,15 +439,15 @@ struct cve_configuration_iterator;
 /** 
  * @memberof cve_configuration_iterator 
  */
-struct cve_configuration *cve_configuration_iterator_next(struct cve_configuration_iterator *it);
+OSCAP_API struct cve_configuration *cve_configuration_iterator_next(struct cve_configuration_iterator *it);
 /** 
  * @memberof cve_configuration_iterator 
  */
-bool cve_configuration_iterator_has_more(struct cve_configuration_iterator *it);
+OSCAP_API bool cve_configuration_iterator_has_more(struct cve_configuration_iterator *it);
 /** 
  * @memberof cve_configuration_iterator
  */
-void cve_configuration_iterator_free(struct cve_configuration_iterator *it);
+OSCAP_API void cve_configuration_iterator_free(struct cve_configuration_iterator *it);
 
 /** @struct cve_reference_iterator
  * Iterator over CVE references.
@@ -457,15 +458,15 @@ struct cve_reference_iterator;
 /**
  * @memberof cve_reference_iterator
  */
-struct cve_reference *cve_reference_iterator_next(struct cve_reference_iterator *it);
+OSCAP_API struct cve_reference *cve_reference_iterator_next(struct cve_reference_iterator *it);
 /**
  * @memberof cve_reference_iterator
  */
-bool cve_reference_iterator_has_more(struct cve_reference_iterator *it);
+OSCAP_API bool cve_reference_iterator_has_more(struct cve_reference_iterator *it);
 /**
  * @memberof cve_reference_iterator
  */
-void cve_reference_iterator_free(struct cve_reference_iterator *it);
+OSCAP_API void cve_reference_iterator_free(struct cve_reference_iterator *it);
 
 
 /************************************************************/
@@ -482,7 +483,7 @@ void cve_reference_iterator_free(struct cve_reference_iterator *it);
  * @return version of XML file format
  * @memberof cve_model
  */
-const char * cve_model_supported(void);
+OSCAP_API const char * cve_model_supported(void);
 
 /************************************************************/
 /** @} End of Evaluators group */
@@ -492,168 +493,168 @@ const char * cve_model_supported(void);
  * @memberof cve_entry
  * @return New CVE entry
  */
-struct cve_entry *cve_entry_new(void);
+OSCAP_API struct cve_entry *cve_entry_new(void);
 /**
  * New CVE vulnerability configuration
  * @memberof cve_configuration
  * @return New CVE vulnerability configuration
  */
-struct cve_configuration *cve_configuration_new(void);
+OSCAP_API struct cve_configuration *cve_configuration_new(void);
 /**
  * New CWE entry
  * @memberof cwe_entry
  * @return New CWE entry
  */
-struct cwe_entry *cwe_entry_new(void);
+OSCAP_API struct cwe_entry *cwe_entry_new(void);
 /**
  * New CVE product
  * @memberof cve_product
  * @return New CVE product
  */
-struct cve_product *cve_product_new(void);
+OSCAP_API struct cve_product *cve_product_new(void);
 /**
  * New CVE summary
  * @memberof cve_summary
  * @return New CVE summary
  */
-struct cve_summary *cve_summary_new(void);
+OSCAP_API struct cve_summary *cve_summary_new(void);
 /**
  * New CVE reference
  * @memberof cve_reference
  * @return New CVE reference
  */
-struct cve_reference *cve_reference_new(void);
+OSCAP_API struct cve_reference *cve_reference_new(void);
 /**
  * New CVE model
  * @memberof cve_model
  * @return New CVE model
  */
-struct cve_model *cve_model_new(void);
+OSCAP_API struct cve_model *cve_model_new(void);
 
 /**
  * Clone CVE entry
  * @param old_entry CVE entry
  * @memberof cve_entry
  */
-struct cve_entry * cve_entry_clone(struct cve_entry * old_entry);
+OSCAP_API struct cve_entry * cve_entry_clone(struct cve_entry * old_entry);
 
 /**
  * Clone CVE configuration
  * @param old_conf CVE configuration
  * @memberof cve_configuration
  */
-struct cve_configuration * cve_configuration_clone(struct cve_configuration * old_conf);
+OSCAP_API struct cve_configuration * cve_configuration_clone(struct cve_configuration * old_conf);
 
 /**
  * Clone CWE entry
  * @param old_entry CWE entry
  * @memberof cwe_entry
  */
-struct cwe_entry * cwe_entry_clone(struct cwe_entry * old_entry);
+OSCAP_API struct cwe_entry * cwe_entry_clone(struct cwe_entry * old_entry);
 
 /**
  * Clone CVE product
  * @param old_product CVE product
  * @memberof cve_product
  */
-struct cve_product * cve_product_clone(struct cve_product * old_product);
+OSCAP_API struct cve_product * cve_product_clone(struct cve_product * old_product);
 
 /**
  * Clone CVE summary
  * @param old_sum CVE summary
  * @memberof cve_summary
  */
-struct cve_summary * cve_summary_clone(struct cve_summary * old_sum);
+OSCAP_API struct cve_summary * cve_summary_clone(struct cve_summary * old_sum);
 
 /**
  * Clone CVE reference
  * @param old_ref CVE reference
  * @memberof cve_reference
  */
-struct cve_reference * cve_reference_clone(struct cve_reference * old_ref);
+OSCAP_API struct cve_reference * cve_reference_clone(struct cve_reference * old_ref);
 
 /**
  * Clone CVE model
  * @param old_model CVE model
  * @memberof cve_model
  */
-struct cve_model * cve_model_clone(struct cve_model * old_model);
+OSCAP_API struct cve_model * cve_model_clone(struct cve_model * old_model);
 
 /**
  * Free CVE model
  * @param cve_model CVE model
  * @memberof cve_model
  */
-void cve_model_free(struct cve_model *cve_model);
+OSCAP_API void cve_model_free(struct cve_model *cve_model);
 
 /**
  * Free CVE entry
  * @param entry CVE entry
  * @memberof cve_entry
  */
-void cve_entry_free(struct cve_entry *entry);
+OSCAP_API void cve_entry_free(struct cve_entry *entry);
 
 /**
  * Free CVE summary
  * @param summary CVE summary
  * @memberof cve_summary
  */
-void cve_summary_free(struct cve_summary *summary);
+OSCAP_API void cve_summary_free(struct cve_summary *summary);
 
 /**
  * Free CVE product
  * @param product CVE product
  * @memberof cve_product
  */
-void cve_product_free(struct cve_product *product);
+OSCAP_API void cve_product_free(struct cve_product *product);
 
 /**
  * Free CVE reference
  * @param ref CVE reference
  * @memberof cve_reference
  */
-void cve_reference_free(struct cve_reference *ref);
+OSCAP_API void cve_reference_free(struct cve_reference *ref);
 
 /**
  * Free CVE entry
  * @param entry CVE entry
  * @memberof cve_entry
  */
-void cwe_entry_free(struct cwe_entry *entry);
+OSCAP_API void cwe_entry_free(struct cwe_entry *entry);
 
 /**
  * Free CVE configuration
  * @param conf CVE vulnerability configuration
  * @memberof cve_configuration
  */
-void cve_configuration_free(struct cve_configuration *conf);
+OSCAP_API void cve_configuration_free(struct cve_configuration *conf);
 
 /**@}*/
 
 /// @memberof cve_entry_iterator
-void cve_entry_iterator_remove(struct cve_entry_iterator *it);
+OSCAP_API void cve_entry_iterator_remove(struct cve_entry_iterator *it);
 /// @memberof cve_entry_iterator
-void cve_entry_iterator_reset(struct cve_entry_iterator *it);
+OSCAP_API void cve_entry_iterator_reset(struct cve_entry_iterator *it);
 
 /// @memberof cve_product_iterator
-void cve_product_iterator_remove(struct cve_product_iterator *it);
+OSCAP_API void cve_product_iterator_remove(struct cve_product_iterator *it);
 /// @memberof cve_product_iterator
-void cve_product_iterator_reset(struct cve_product_iterator *it);
+OSCAP_API void cve_product_iterator_reset(struct cve_product_iterator *it);
 
 /// @memberof cve_reference_iterator
-void cve_reference_iterator_remove(struct cve_reference_iterator *it);
+OSCAP_API void cve_reference_iterator_remove(struct cve_reference_iterator *it);
 /// @memberof cve_reference_iterator
-void cve_reference_iterator_reset(struct cve_reference_iterator *it);
+OSCAP_API void cve_reference_iterator_reset(struct cve_reference_iterator *it);
 
 /// @memberof cve_summary_iterator
-void cve_summary_iterator_remove(struct cve_summary_iterator *it);
+OSCAP_API void cve_summary_iterator_remove(struct cve_summary_iterator *it);
 /// @memberof cve_summary_iterator
-void cve_summary_iterator_reset(struct cve_summary_iterator *it);
+OSCAP_API void cve_summary_iterator_reset(struct cve_summary_iterator *it);
 
 /// @memberof cve_configuration_iterator
-void cve_configuration_iterator_remove(struct cve_configuration_iterator *it);
+OSCAP_API void cve_configuration_iterator_remove(struct cve_configuration_iterator *it);
 /// @memberof cve_configuration_iterator
-void cve_configuration_iterator_reset(struct cve_configuration_iterator *it);
+OSCAP_API void cve_configuration_iterator_reset(struct cve_configuration_iterator *it);
 
 /**
  * Export CVE model to XML file
@@ -661,7 +662,7 @@ void cve_configuration_iterator_reset(struct cve_configuration_iterator *it);
  * @param cve CVE model
  * @param file OSCAP export target
  */
-void cve_model_export(struct cve_model *cve, const char *file);
+OSCAP_API void cve_model_export(struct cve_model *cve, const char *file);
 
 /**
  * Parses the specified XML file and creates a list of CVE data structures.
@@ -670,16 +671,16 @@ void cve_model_export(struct cve_model *cve, const char *file);
  * @param file filename
  * @return non-negative value indicates the number of CVEs in the list, negative value indicates an error
  */
-struct cve_model *cve_model_import(const char *file);
+OSCAP_API struct cve_model *cve_model_import(const char *file);
 
 /// @memberof cve_model
-const char *cve_model_get_nvd_xml_version(const struct cve_model *item);
+OSCAP_API const char *cve_model_get_nvd_xml_version(const struct cve_model *item);
 /// @memberof cve_model
-bool cve_model_set_nvd_xml_version(struct cve_model *obj, const char *newval);
+OSCAP_API bool cve_model_set_nvd_xml_version(struct cve_model *obj, const char *newval);
 /// @memberof cve_model
-const char *cve_model_get_pub_date(const struct cve_model *item);
+OSCAP_API const char *cve_model_get_pub_date(const struct cve_model *item);
 /// @memberof cve_model
-bool cve_model_set_pub_date(struct cve_model *obj, const char *newval);
+OSCAP_API bool cve_model_set_pub_date(struct cve_model *obj, const char *newval);
 
 /**@}*/
 

--- a/src/CVRF/public/cvrf.h
+++ b/src/CVRF/public/cvrf.h
@@ -33,6 +33,7 @@
 #include "oscap.h"
 #include "oscap_source.h"
 #include "cvss_score.h"
+#include "oscap_export.h"
 
 
 /************************************************************************************************
@@ -50,28 +51,28 @@ struct cvrf_product_status;
  * @memberof cvrf_product_status
  * @return New CVRF ProductStatus
  */
-struct cvrf_product_status *cvrf_product_status_new(void);
+OSCAP_API struct cvrf_product_status *cvrf_product_status_new(void);
 
 /**
  * Deallocates memory for a Status element of the ProductStatuses container
  * @memberof cvrf_product_status
  * @param status The CVRF Status element to be freed
  */
-void cvrf_product_status_free(struct cvrf_product_status *status);
+OSCAP_API void cvrf_product_status_free(struct cvrf_product_status *status);
 
 /**
  * @memberof cvrf_product_status
  * @param stat Original Status structure to be cloned
  * @return New cloned Status structure with same data as the original
  */
-struct cvrf_product_status *cvrf_product_status_clone(const struct cvrf_product_status *stat);
+OSCAP_API struct cvrf_product_status *cvrf_product_status_clone(const struct cvrf_product_status *stat);
 
 /**
  * @memberof cvrf_product_status
  * @param stat Status structure with stringlist of ProductIDs
  * @return Iterator for the stringlist of ProductIDs
  */
-struct oscap_string_iterator *cvrf_product_status_get_ids(struct cvrf_product_status *stat);
+OSCAP_API struct oscap_string_iterator *cvrf_product_status_get_ids(struct cvrf_product_status *stat);
 
 
 /************************************************************************************************
@@ -90,21 +91,21 @@ struct cvrf_threat;
  * @memberof cvrf_threat
  * @return New CVRF Threat structure
  */
-struct cvrf_threat *cvrf_threat_new(void);
+OSCAP_API struct cvrf_threat *cvrf_threat_new(void);
 
 /**
  * Deallocates memory for a Threat element of the Threats container
  * @memberof cvrf_threat
  * @param threat The CVRF Threat structure to be freed
  */
-void cvrf_threat_free(struct cvrf_threat *threat);
+OSCAP_API void cvrf_threat_free(struct cvrf_threat *threat);
 
 /**
  * @memberof cvrf_threat
  * @param threat Original Threat structure to be cloned
  * @return New cloned Threat structure with same data as the original
  */
-struct cvrf_threat *cvrf_threat_clone(const struct cvrf_threat *threat);
+OSCAP_API struct cvrf_threat *cvrf_threat_clone(const struct cvrf_threat *threat);
 
 /**
  * @memberof cvrf_threat
@@ -112,7 +113,7 @@ struct cvrf_threat *cvrf_threat_clone(const struct cvrf_threat *threat);
  * Datetime that the Threat was identified and documented
  * @return contents of Date attribute within a Threat element
  */
-const char *cvrf_threat_get_date(const struct cvrf_threat *threat);
+OSCAP_API const char *cvrf_threat_get_date(const struct cvrf_threat *threat);
 
 /**
  * @memberof cvrf_threat
@@ -120,7 +121,7 @@ const char *cvrf_threat_get_date(const struct cvrf_threat *threat);
  * Description contains a human-readable explanation of the threat
  * @return contents of Description element within a Threat element
  */
-const char *cvrf_threat_get_description(const struct cvrf_threat *threat);
+OSCAP_API const char *cvrf_threat_get_description(const struct cvrf_threat *threat);
 
 /**
  * @memberof cvrf_threat
@@ -129,7 +130,7 @@ const char *cvrf_threat_get_description(const struct cvrf_threat *threat);
  * ProductIDs reference the ProductID of a FullProductName element in the document
  * @return Iterator for the stringlist of ProductIDs
  */
-struct oscap_string_iterator *cvrf_threat_get_product_ids(struct cvrf_threat *threat);
+OSCAP_API struct oscap_string_iterator *cvrf_threat_get_product_ids(struct cvrf_threat *threat);
 
 /**
  * @memberof cvrf_threat
@@ -138,7 +139,7 @@ struct oscap_string_iterator *cvrf_threat_get_product_ids(struct cvrf_threat *th
  * GroupIDs reference the GroupID of a Group element in the document
  * @return Iterator for the stringlist of GroupIDs
  */
-struct oscap_string_iterator *cvrf_threat_get_group_ids(struct cvrf_threat *threat);
+OSCAP_API struct oscap_string_iterator *cvrf_threat_get_group_ids(struct cvrf_threat *threat);
 
 /**
  * @memberof cvrf_threat
@@ -146,7 +147,7 @@ struct oscap_string_iterator *cvrf_threat_get_group_ids(struct cvrf_threat *thre
  * @param date Datetime that the Threat was identified and documented
  * @return true on success
  */
-bool cvrf_threat_set_date(struct cvrf_threat *threat, const char *date);
+OSCAP_API bool cvrf_threat_set_date(struct cvrf_threat *threat, const char *date);
 
 /**
  * @memberof cvrf_threat
@@ -154,7 +155,7 @@ bool cvrf_threat_set_date(struct cvrf_threat *threat, const char *date);
  * @param description A human-readable explanation of the threat
  * @return true on success
  */
-bool cvrf_threat_set_description(struct cvrf_threat *threat, const char *description);
+OSCAP_API bool cvrf_threat_set_description(struct cvrf_threat *threat, const char *description);
 
 
 /************************************************************************************************
@@ -173,21 +174,21 @@ struct cvrf_remediation;
  * @memberof cvrf_remediation
  * @return New CVRF Remediation
  */
-struct cvrf_remediation *cvrf_remediation_new(void);
+OSCAP_API struct cvrf_remediation *cvrf_remediation_new(void);
 
 /**
  * Deallocates memory for a Remediation element of the Remediations container
  * @memberof cvrf_remediation
  * @param remed The CVRF Remediation structure to be freed
  */
-void cvrf_remediation_free(struct cvrf_remediation *remed);
+OSCAP_API void cvrf_remediation_free(struct cvrf_remediation *remed);
 
 /**
  * @memberof cvrf_remediation
  * @param remed Original Remediation structure to be cloned
  * @return New cloned Remediation structure with same data as the original
  */
-struct cvrf_remediation *cvrf_remediation_clone(const struct cvrf_remediation *remed);
+OSCAP_API struct cvrf_remediation *cvrf_remediation_clone(const struct cvrf_remediation *remed);
 
 /**
  * @memberof cvrf_remediation
@@ -195,7 +196,7 @@ struct cvrf_remediation *cvrf_remediation_clone(const struct cvrf_remediation *r
  * Date that the Remediation was created
  * @return contents of Date attribute of the Remediation attribute
  */
-const char *cvrf_remediation_get_date(const struct cvrf_remediation *remed);
+OSCAP_API const char *cvrf_remediation_get_date(const struct cvrf_remediation *remed);
 
 /**
  * @memberof cvrf_remediation
@@ -203,7 +204,7 @@ const char *cvrf_remediation_get_date(const struct cvrf_remediation *remed);
  * Description contains a human-readable explanation of Remediation process
  * @return contents of Description element within a Remediation element
  */
-const char *cvrf_remediation_get_description(const struct cvrf_remediation *remed);
+OSCAP_API const char *cvrf_remediation_get_description(const struct cvrf_remediation *remed);
 
 /**
  * @memberof cvrf_remediation
@@ -211,7 +212,7 @@ const char *cvrf_remediation_get_description(const struct cvrf_remediation *reme
  * Optional URL link to a Remediation for a particular Vulnerability
  * @return contents of URL element within a Remediation element
  */
-const char *cvrf_remediation_get_url(const struct cvrf_remediation *remed);
+OSCAP_API const char *cvrf_remediation_get_url(const struct cvrf_remediation *remed);
 
 /**
  * @memberof cvrf_remediation
@@ -219,7 +220,7 @@ const char *cvrf_remediation_get_url(const struct cvrf_remediation *remed);
  * Contains vendor-defined constraints for products used to resolve the Vulnerability
  * @return contents of Entitlement element within a Remediation element
  */
-const char *cvrf_remediation_get_entitlement(const struct cvrf_remediation *remed);
+OSCAP_API const char *cvrf_remediation_get_entitlement(const struct cvrf_remediation *remed);
 
 /**
  * @memberof cvrf_remediation
@@ -228,7 +229,7 @@ const char *cvrf_remediation_get_entitlement(const struct cvrf_remediation *reme
  * ProductIDs reference the ProductID of a FullProductName element in the document
  * @return Iterator for the stringlist of ProductIDs
  */
-struct oscap_string_iterator *cvrf_remediation_get_product_ids(struct cvrf_remediation *remed);
+OSCAP_API struct oscap_string_iterator *cvrf_remediation_get_product_ids(struct cvrf_remediation *remed);
 
 /**
  * @memberof cvrf_remediation
@@ -237,7 +238,7 @@ struct oscap_string_iterator *cvrf_remediation_get_product_ids(struct cvrf_remed
  * GroupIDs reference the GroupID of a Group element in the document
  * @return Iterator for the stringlist of GroupIDs
  */
-struct oscap_string_iterator *cvrf_remediation_get_group_ids(struct cvrf_remediation *remed);
+OSCAP_API struct oscap_string_iterator *cvrf_remediation_get_group_ids(struct cvrf_remediation *remed);
 
 /**
  * @memberof cvrf_remediation
@@ -245,7 +246,7 @@ struct oscap_string_iterator *cvrf_remediation_get_group_ids(struct cvrf_remedia
  * @param date Date that the Remediation was created
  * @return true on success
  */
-bool cvrf_remediation_set_date(struct cvrf_remediation *remed, const char *date);
+OSCAP_API bool cvrf_remediation_set_date(struct cvrf_remediation *remed, const char *date);
 
 /**
  * @memberof cvrf_remediation
@@ -253,7 +254,7 @@ bool cvrf_remediation_set_date(struct cvrf_remediation *remed, const char *date)
  * @param description a human-readable explanation of Remediation process
  * @return true on success
  */
-bool cvrf_remediation_set_description(struct cvrf_remediation *remed, const char *description);
+OSCAP_API bool cvrf_remediation_set_description(struct cvrf_remediation *remed, const char *description);
 
 /**
  * @memberof cvrf_remediation
@@ -261,7 +262,7 @@ bool cvrf_remediation_set_description(struct cvrf_remediation *remed, const char
  * @param url Optional URL link to a Remediation for a particular Vulnerability
  * @return true on success
  */
-bool cvrf_remediation_set_url(struct cvrf_remediation *remed, const char *url);
+OSCAP_API bool cvrf_remediation_set_url(struct cvrf_remediation *remed, const char *url);
 
 /**
  * @memberof cvrf_remediation
@@ -269,7 +270,7 @@ bool cvrf_remediation_set_url(struct cvrf_remediation *remed, const char *url);
  * @param entitlement vendor-defined constraints for products used to resolve the Vulnerability
  * @return true on success
  */
-bool cvrf_remediation_set_entitlement(struct cvrf_remediation *remed, const char *entitlement);
+OSCAP_API bool cvrf_remediation_set_entitlement(struct cvrf_remediation *remed, const char *entitlement);
 
 
 /************************************************************************************************
@@ -289,21 +290,21 @@ struct cvrf_score_set;
  * @memberof cvrf_score_set
  * @return New CVRF ScoreSet structure
  */
-struct cvrf_score_set *cvrf_score_set_new(void);
+OSCAP_API struct cvrf_score_set *cvrf_score_set_new(void);
 
 /**
  * Deallocates memory for a ScoreSet element of the CVSSScoreSets container
  * @memberof cvrf_score_set
  * @param score_set The CVRF ScoreSet structure to be freed
  */
-void cvrf_score_set_free(struct cvrf_score_set *score_set);
+OSCAP_API void cvrf_score_set_free(struct cvrf_score_set *score_set);
 
 /**
  * @memberof cvrf_score_set
  * @param score_set Original ScoreSet structure to be cloned
  * @return New cloned ScoreSet structure with same data as the original
  */
-struct cvrf_score_set *cvrf_score_set_clone(const struct cvrf_score_set *score_set);
+OSCAP_API struct cvrf_score_set *cvrf_score_set_clone(const struct cvrf_score_set *score_set);
 
 /**
  * @memberof cvrf_score_set
@@ -311,7 +312,7 @@ struct cvrf_score_set *cvrf_score_set_clone(const struct cvrf_score_set *score_s
  * Contains official CVSS notation of values used to compute all the scores
  * @return contents of Vector element within a ScoreSet element
  */
-const char *cvrf_score_set_get_vector(const struct cvrf_score_set *score_set);
+OSCAP_API const char *cvrf_score_set_get_vector(const struct cvrf_score_set *score_set);
 
 /**
  * @memberof cvrf_score_set
@@ -320,14 +321,14 @@ const char *cvrf_score_set_get_vector(const struct cvrf_score_set *score_set);
  * ProductIDs reference the ProductID of a FullProductName element in the document
  * @return Iterator for the stringlist of ProductIDs
  */
-struct oscap_string_iterator *cvrf_score_set_get_product_ids(struct cvrf_score_set *score_set);
+OSCAP_API struct oscap_string_iterator *cvrf_score_set_get_product_ids(struct cvrf_score_set *score_set);
 
 /**
  * @memberof cvrf_score_set
  * @param score_set ScoreSet structure
  * @return CVSS impact structure generated by parsing XML ScoreSet element in CVRF document
  */
-struct cvss_impact *cvrf_score_set_get_impact(const struct cvrf_score_set *score_set);
+OSCAP_API struct cvss_impact *cvrf_score_set_get_impact(const struct cvrf_score_set *score_set);
 
 /**
  * @memberof cvrf_score_set
@@ -335,7 +336,7 @@ struct cvss_impact *cvrf_score_set_get_impact(const struct cvrf_score_set *score
  * Range: 0.0 - 10.0
  * @return string representation of BaseScore element within a ScoreSet element
  */
-char *cvrf_score_set_get_base_score(const struct cvrf_score_set *score_set);
+OSCAP_API char *cvrf_score_set_get_base_score(const struct cvrf_score_set *score_set);
 
 /**
  * @memberof cvrf_score_set
@@ -343,7 +344,7 @@ char *cvrf_score_set_get_base_score(const struct cvrf_score_set *score_set);
  * Range: 0.0 - 10.0
  * @return string representation of EnvironmentalScore element within a ScoreSet element
  */
-char *cvrf_score_set_get_environmental_score(const struct cvrf_score_set *score_set);
+OSCAP_API char *cvrf_score_set_get_environmental_score(const struct cvrf_score_set *score_set);
 
 /**
  * @memberof cvrf_score_set
@@ -351,7 +352,7 @@ char *cvrf_score_set_get_environmental_score(const struct cvrf_score_set *score_
  * Range: 0.0 - 10.0
  * @return string representation of TemporalScore element within a ScoreSet element
  */
-char *cvrf_score_set_get_temporal_score(const struct cvrf_score_set *score_set);
+OSCAP_API char *cvrf_score_set_get_temporal_score(const struct cvrf_score_set *score_set);
 
 /**
  * @memberof cvrf_score_set
@@ -359,7 +360,7 @@ char *cvrf_score_set_get_temporal_score(const struct cvrf_score_set *score_set);
  * @param vector Official CVSS notation of values used to compute all the scores
  * @return true on success
  */
-bool cvrf_score_set_set_vector(struct cvrf_score_set *score_set, const char *vector);
+OSCAP_API bool cvrf_score_set_set_vector(struct cvrf_score_set *score_set, const char *vector);
 
 /**
  * @memberof cvrf_score_set
@@ -367,7 +368,7 @@ bool cvrf_score_set_set_vector(struct cvrf_score_set *score_set, const char *vec
  * @param impact CVSS impact structure with scores for parent Vulnerability
  * @return true on success
  */
-bool cvrf_score_set_set_impact(struct cvrf_score_set *score_set, struct cvss_impact *impact);
+OSCAP_API bool cvrf_score_set_set_impact(struct cvrf_score_set *score_set, struct cvss_impact *impact);
 
 /**
  * @memberof cvrf_score_set
@@ -376,7 +377,7 @@ bool cvrf_score_set_set_impact(struct cvrf_score_set *score_set, struct cvss_imp
  * @param score String representation of the CVSS score
  * @return true on success
  */
-bool cvrf_score_set_add_metric(struct cvrf_score_set *score_set, enum cvss_category category, const char *score);
+OSCAP_API bool cvrf_score_set_add_metric(struct cvrf_score_set *score_set, enum cvss_category category, const char *score);
 
 
 /************************************************************************************************
@@ -395,21 +396,21 @@ struct cvrf_involvement;
  * @memberof cvrf_involvement
  * @return New CVRF Involvement
  */
-struct cvrf_involvement *cvrf_involvement_new(void);
+OSCAP_API struct cvrf_involvement *cvrf_involvement_new(void);
 
 /**
  * Deallocates memory for an Involvement element
  * @memberof cvrf_involvement
  * @param involve The CVRF Involvement structure to be freed
  */
-void cvrf_involvement_free(struct cvrf_involvement *involve);
+OSCAP_API void cvrf_involvement_free(struct cvrf_involvement *involve);
 
 /**
  * @memberof cvrf_involvement
  * @param involve Original Involvement structure to be cloned
  * @return New cloned Involvement structure with same data as the original
  */
-struct cvrf_involvement *cvrf_involvement_clone(const struct cvrf_involvement *involve);
+OSCAP_API struct cvrf_involvement *cvrf_involvement_clone(const struct cvrf_involvement *involve);
 
 /**
  * @memberof cvrf_involvement
@@ -417,7 +418,7 @@ struct cvrf_involvement *cvrf_involvement_clone(const struct cvrf_involvement *i
  * Gives context about the involvement or about the Party's contribution
  * @return contents of Description element within Involvement element
  */
-const char *cvrf_involvement_get_description(const struct cvrf_involvement *involve);
+OSCAP_API const char *cvrf_involvement_get_description(const struct cvrf_involvement *involve);
 
 /**
  * @memberof cvrf_involvement
@@ -425,7 +426,7 @@ const char *cvrf_involvement_get_description(const struct cvrf_involvement *invo
  * @param description Gives context about the involvement or about the Party's contribution
  * @return true on success
  */
-bool cvrf_involvement_set_description(struct cvrf_involvement *involve, const char *description);
+OSCAP_API bool cvrf_involvement_set_description(struct cvrf_involvement *involve, const char *description);
 
 /************************************************************************************************
  * @struct cvrf_vulnerability_cwe
@@ -440,21 +441,21 @@ struct cvrf_vulnerability_cwe;
  * @memberof cvrf_vulnerability_cwe
  * @return New CWE structure
  */
-struct cvrf_vulnerability_cwe *cvrf_vulnerability_cwe_new(void);
+OSCAP_API struct cvrf_vulnerability_cwe *cvrf_vulnerability_cwe_new(void);
 
 /**
  * Deallocates memory for a CWE element
  * @memberof cvrf_vulnerability_cwe
  * @param cwe The CWE structure to be freed
  */
-void cvrf_vulnerability_cwe_free(struct cvrf_vulnerability_cwe *cwe);
+OSCAP_API void cvrf_vulnerability_cwe_free(struct cvrf_vulnerability_cwe *cwe);
 
 /**
  * @memberof cvrf_vulnerability_cwe
  * @param cwe Original CWE structure to be cloned
  * @return New cloned CWE structure with same data as the original
  */
-struct cvrf_vulnerability_cwe *cvrf_vulnerability_cwe_clone(const struct cvrf_vulnerability_cwe *cwe);
+OSCAP_API struct cvrf_vulnerability_cwe *cvrf_vulnerability_cwe_clone(const struct cvrf_vulnerability_cwe *cwe);
 
 /**
  * @memberof cvrf_vulnerability_cwe
@@ -462,7 +463,7 @@ struct cvrf_vulnerability_cwe *cvrf_vulnerability_cwe_clone(const struct cvrf_vu
  *
  * @return contents of a the CWE element
  */
-const char *cvrf_vulnerability_cwe_get_cwe(const struct cvrf_vulnerability_cwe *vuln_cwe);
+OSCAP_API const char *cvrf_vulnerability_cwe_get_cwe(const struct cvrf_vulnerability_cwe *vuln_cwe);
 
 /**
  * @memberof cvrf_vulnerability_cwe
@@ -470,7 +471,7 @@ const char *cvrf_vulnerability_cwe_get_cwe(const struct cvrf_vulnerability_cwe *
  *
  * @return ID attribute of a CWE element
  */
-const char *cvrf_vulnerability_cwe_get_id(const struct cvrf_vulnerability_cwe *vuln_cwe);
+OSCAP_API const char *cvrf_vulnerability_cwe_get_id(const struct cvrf_vulnerability_cwe *vuln_cwe);
 
 
 /**
@@ -479,7 +480,7 @@ const char *cvrf_vulnerability_cwe_get_id(const struct cvrf_vulnerability_cwe *v
  * @param cwe CWE name and content of the CWE element
  * @return true on success
  */
-bool cvrf_vulnerability_cwe_set_cwe(struct cvrf_vulnerability_cwe *vuln_cwe, const char *cwe);
+OSCAP_API bool cvrf_vulnerability_cwe_set_cwe(struct cvrf_vulnerability_cwe *vuln_cwe, const char *cwe);
 
 /**
  * @memberof cvrf_vulnerability_cwe
@@ -487,7 +488,7 @@ bool cvrf_vulnerability_cwe_set_cwe(struct cvrf_vulnerability_cwe *vuln_cwe, con
  * @param id Unique identifier for a CWE
  * @return true on success
  */
-bool cvrf_vulnerability_cwe_set_id(struct cvrf_vulnerability_cwe *vuln_cwe, const char *id);
+OSCAP_API bool cvrf_vulnerability_cwe_set_id(struct cvrf_vulnerability_cwe *vuln_cwe, const char *id);
 
 /************************************************************************************************
  * @struct cvrf_vulnerability
@@ -510,21 +511,21 @@ struct cvrf_vulnerability;
  * @memberof cvrf_vulnerability
  * @return New CVRF Vulnerability
  */
-struct cvrf_vulnerability *cvrf_vulnerability_new(void);
+OSCAP_API struct cvrf_vulnerability *cvrf_vulnerability_new(void);
 
 /**
  * Deallocates memory for a Vulnerability element
  * @memberof cvrf_vulnerability
  * @param vulnerability The CVRF Vulnerability structure to be freed
  */
-void cvrf_vulnerability_free(struct cvrf_vulnerability *vulnerability);
+OSCAP_API void cvrf_vulnerability_free(struct cvrf_vulnerability *vulnerability);
 
 /**
  * @memberof cvrf_vulnerability
  * @param vuln Original Vulnerability structure to be cloned
  * @return New cloned Vulnerability structure with same data as the original
  */
-struct cvrf_vulnerability *cvrf_vulnerability_clone(const struct cvrf_vulnerability *vuln);
+OSCAP_API struct cvrf_vulnerability *cvrf_vulnerability_clone(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability
@@ -532,7 +533,7 @@ struct cvrf_vulnerability *cvrf_vulnerability_clone(const struct cvrf_vulnerabil
  * @param prod ProductID of the CPE; this is the prefix of package ProductIDs in Statuses
  * @return 0 on success, -1 on failure
  */
-int cvrf_vulnerability_filter_by_product(struct cvrf_vulnerability *vuln, const char *prod);
+OSCAP_API int cvrf_vulnerability_filter_by_product(struct cvrf_vulnerability *vuln, const char *prod);
 
 /**
  * @memberof cvrf_vulnerability
@@ -540,7 +541,7 @@ int cvrf_vulnerability_filter_by_product(struct cvrf_vulnerability *vuln, const 
  * Index and ordering of a Vulnerability element within a document
  * @return Ordinal attribute of a Vulnerability element
  */
-int cvrf_vulnerability_get_ordinal(const struct cvrf_vulnerability *vuln);
+OSCAP_API int cvrf_vulnerability_get_ordinal(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability
@@ -548,7 +549,7 @@ int cvrf_vulnerability_get_ordinal(const struct cvrf_vulnerability *vuln);
  * Canonical name of Vulnerability; should match nomenclature of references elsewhere
  * @return contents of a Title element within a Vulnerability element
  */
-const char *cvrf_vulnerability_get_title(const struct cvrf_vulnerability *vuln);
+OSCAP_API const char *cvrf_vulnerability_get_title(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability
@@ -556,7 +557,7 @@ const char *cvrf_vulnerability_get_title(const struct cvrf_vulnerability *vuln);
  * Unique ID of the Vulnerability given by the document producer
  * @return contents of an ID element within a Vulnerability element
  */
-const char *cvrf_vulnerability_get_system_id(const struct cvrf_vulnerability *vuln);
+OSCAP_API const char *cvrf_vulnerability_get_system_id(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability
@@ -564,7 +565,7 @@ const char *cvrf_vulnerability_get_system_id(const struct cvrf_vulnerability *vu
  * Gives name or numbering system of the Vulnerability ID
  * @return contents of SystemName attribute within an ID element
  */
-const char *cvrf_vulnerability_get_system_name(const struct cvrf_vulnerability *vuln);
+OSCAP_API const char *cvrf_vulnerability_get_system_name(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability
@@ -572,7 +573,7 @@ const char *cvrf_vulnerability_get_system_name(const struct cvrf_vulnerability *
  * DateTime value of the original discovery time for this Vulnerability
  * @return contents of DiscoveryDate element within a Vulnerability element
  */
-const char *cvrf_vulnerability_get_discovery_date(const struct cvrf_vulnerability *vuln);
+OSCAP_API const char *cvrf_vulnerability_get_discovery_date(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability
@@ -580,7 +581,7 @@ const char *cvrf_vulnerability_get_discovery_date(const struct cvrf_vulnerabilit
  * DateTime value of the original public release time for this Vulnerability
  * @return contents of ReleaseDate element within a Vulnerability element
  */
-const char *cvrf_vulnerability_get_release_date(const struct cvrf_vulnerability *vuln);
+OSCAP_API const char *cvrf_vulnerability_get_release_date(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability
@@ -588,7 +589,7 @@ const char *cvrf_vulnerability_get_release_date(const struct cvrf_vulnerability 
  * MITRE standard CVE ID used to track Vulnerabilities
  * @return contents of CVE element within a Vulnerability element
  */
-const char *cvrf_vulnerability_get_cve_id(const struct cvrf_vulnerability *vuln);
+OSCAP_API const char *cvrf_vulnerability_get_cve_id(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability
@@ -596,7 +597,7 @@ const char *cvrf_vulnerability_get_cve_id(const struct cvrf_vulnerability *vuln)
  * @param ordinal Index of a Vulnerability element within a document
  * @return true on success
  */
-bool cvrf_vulnerability_set_ordinal(struct cvrf_vulnerability *vuln, int ordinal);
+OSCAP_API bool cvrf_vulnerability_set_ordinal(struct cvrf_vulnerability *vuln, int ordinal);
 
 /**
  * @memberof cvrf_vulnerability
@@ -604,7 +605,7 @@ bool cvrf_vulnerability_set_ordinal(struct cvrf_vulnerability *vuln, int ordinal
  * @param vulnerability_title Canonical name of Vulnerability
  * @return true on success
  */
-bool cvrf_vulnerability_set_title(struct cvrf_vulnerability *vuln, const char *vulnerability_title);
+OSCAP_API bool cvrf_vulnerability_set_title(struct cvrf_vulnerability *vuln, const char *vulnerability_title);
 
 /**
  * @memberof cvrf_vulnerability
@@ -612,7 +613,7 @@ bool cvrf_vulnerability_set_title(struct cvrf_vulnerability *vuln, const char *v
  * @param id Unique ID of the Vulnerability given by the document producer
  * @return true on success
  */
-bool cvrf_vulnerability_set_system_id(struct cvrf_vulnerability *vuln, const char *id);
+OSCAP_API bool cvrf_vulnerability_set_system_id(struct cvrf_vulnerability *vuln, const char *id);
 
 /**
  * @memberof cvrf_vulnerability
@@ -620,7 +621,7 @@ bool cvrf_vulnerability_set_system_id(struct cvrf_vulnerability *vuln, const cha
  * @param sys_name Name or numbering system of the Vulnerability ID
  * @return true on success
  */
-bool cvrf_vulnerability_set_system_name(struct cvrf_vulnerability *vuln, const char *sys_name);
+OSCAP_API bool cvrf_vulnerability_set_system_name(struct cvrf_vulnerability *vuln, const char *sys_name);
 
 /**
  * @memberof cvrf_vulnerability
@@ -628,7 +629,7 @@ bool cvrf_vulnerability_set_system_name(struct cvrf_vulnerability *vuln, const c
  * @param Original discovery time for this Vulnerability
  * @return true on success
  */
-bool cvrf_vulnerability_set_discovery_date(struct cvrf_vulnerability *vuln, const char *discovery_date);
+OSCAP_API bool cvrf_vulnerability_set_discovery_date(struct cvrf_vulnerability *vuln, const char *discovery_date);
 
 /**
  * @memberof cvrf_vulnerability
@@ -636,7 +637,7 @@ bool cvrf_vulnerability_set_discovery_date(struct cvrf_vulnerability *vuln, cons
  * @param release_date Original public release time for this Vulnerability
  * @return true on success
  */
-bool cvrf_vulnerability_set_release_date(struct cvrf_vulnerability *vuln, const char *release_date);
+OSCAP_API bool cvrf_vulnerability_set_release_date(struct cvrf_vulnerability *vuln, const char *release_date);
 
 /**
  * @memberof cvrf_vulnerability
@@ -644,7 +645,7 @@ bool cvrf_vulnerability_set_release_date(struct cvrf_vulnerability *vuln, const 
  * @param cve_id MITRE standard CVE ID used to track Vulnerabilities
  * @return true on success
  */
-bool cvrf_vulnerability_set_cve_id(struct cvrf_vulnerability *vuln, const char *cve_id);
+OSCAP_API bool cvrf_vulnerability_set_cve_id(struct cvrf_vulnerability *vuln, const char *cve_id);
 
 
 /*-------------------------------------------------------------------------*\
@@ -656,21 +657,21 @@ bool cvrf_vulnerability_set_cve_id(struct cvrf_vulnerability *vuln, const char *
  * @param vuln CVRF Vulnerability structure
  * @return Iterator for the list of Reference elements in the References container
  */
-struct oscap_iterator *cvrf_vulnerability_get_references(struct cvrf_vulnerability *vuln);
+OSCAP_API struct oscap_iterator *cvrf_vulnerability_get_references(struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability
  * @param vuln CVRF Vulnerability structure
  * @return Iterator for the list of Acknowledgment elements in the Acknowledgments container
  */
-struct oscap_iterator *cvrf_vulnerability_get_acknowledgments(struct cvrf_vulnerability *vuln);
+OSCAP_API struct oscap_iterator *cvrf_vulnerability_get_acknowledgments(struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability
  * @param vuln CVRF Vulnerability structure
  * @return Iterator for the list of Note elements in the Notes container
  */
-struct oscap_iterator *cvrf_vulnerability_get_notes(struct cvrf_vulnerability *vuln);
+OSCAP_API struct oscap_iterator *cvrf_vulnerability_get_notes(struct cvrf_vulnerability *vuln);
 
 /*******************************************
  * @struct cvrf_vulnerability_cwe_iterator
@@ -685,49 +686,49 @@ struct cvrf_vulnerability_cwe_iterator;
  * @param vulnerability_cwe CWE structure to be added to the Vulnerability
  * @return true on success
  */
-bool cvrf_vulnerability_add_vulnerability_cwe(struct cvrf_vulnerability *vuln, struct cvrf_vulnerability_cwe *vulnerability_cwe);
+OSCAP_API bool cvrf_vulnerability_add_vulnerability_cwe(struct cvrf_vulnerability *vuln, struct cvrf_vulnerability_cwe *vulnerability_cwe);
 
 /**
  * @memberof cvrf_vulnerability
  * @param vuln CVRF Vulnerability structure
  * @return Iterator representing list of all CWEs in the Vulnerability
  */
-struct cvrf_vulnerability_cwe_iterator *cvrf_vulnerability_get_vulnerability_cwes(const struct cvrf_vulnerability *vuln);
+OSCAP_API struct cvrf_vulnerability_cwe_iterator *cvrf_vulnerability_get_vulnerability_cwes(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability_cwe_iterator
  * @param it CWE iterator structure
  * @return Next CWE in list of all CWEs in the Vulnerability
  */
-struct cvrf_vulnerability_cwe *cvrf_vulnerability_cwe_iterator_next(struct cvrf_vulnerability_cwe_iterator *it);
+OSCAP_API struct cvrf_vulnerability_cwe *cvrf_vulnerability_cwe_iterator_next(struct cvrf_vulnerability_cwe_iterator *it);
 
 /**
  * @memberof cvrf_vulnerability_cwe_iterator
  * @param it CWE iterator structure
  * @return true if the iterator has another CWE element left
  */
-bool cvrf_vulnerability_cwe_iterator_has_more(struct cvrf_vulnerability_cwe_iterator *it);
+OSCAP_API bool cvrf_vulnerability_cwe_iterator_has_more(struct cvrf_vulnerability_cwe_iterator *it);
 
 /**
  * Deallocate memory for the CWE Iterator structure
  * @memberof cvrf_vulnerability_cwe_iterator
  * @param it CWE iterator structure
  */
-void cvrf_vulnerability_cwe_iterator_free(struct cvrf_vulnerability_cwe_iterator *it);
+OSCAP_API void cvrf_vulnerability_cwe_iterator_free(struct cvrf_vulnerability_cwe_iterator *it);
 
 /**
  * Restart iterator at the first CWE in the Vulnerability
  * @memberof cvrf_vulnerability_cwe_iterator
  * @param it CWE iterator structure
  */
-void cvrf_vulnerability_cwe_iterator_reset(struct cvrf_vulnerability_cwe_iterator *it);
+OSCAP_API void cvrf_vulnerability_cwe_iterator_reset(struct cvrf_vulnerability_cwe_iterator *it);
 
 /**
  * Detaches and frees the CWE iterator structure
  * @memberof cvrf_vulnerability_cwe_iterator
  * @param it CWE iterator structure
  */
-void cvrf_vulnerability_cwe_iterator_remove(struct cvrf_vulnerability_cwe_iterator *it);
+OSCAP_API void cvrf_vulnerability_cwe_iterator_remove(struct cvrf_vulnerability_cwe_iterator *it);
 
 /*******************************************
  * @struct cvrf_involvement_iterator
@@ -742,49 +743,49 @@ struct cvrf_involvement_iterator;
  * @param involvement CVRF Involvement structure to be added to the Vulnerability
  * @return true on success
  */
-bool cvrf_vulnerability_add_involvement(struct cvrf_vulnerability *vuln, struct cvrf_involvement *involvement);
+OSCAP_API bool cvrf_vulnerability_add_involvement(struct cvrf_vulnerability *vuln, struct cvrf_involvement *involvement);
 
 /**
  * @memberof cvrf_vulnerability
  * @param vuln CVRF Vulnerability structure
  * @return Iterator representing list of all Involvements in the Vulnerability
  */
-struct cvrf_involvement_iterator *cvrf_vulnerability_get_involvements(const struct cvrf_vulnerability *vuln);
+OSCAP_API struct cvrf_involvement_iterator *cvrf_vulnerability_get_involvements(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_involvement_iterator
  * @param it CVRF Involvement iterator structure
  * @return Next CVRF Involvement in list of all Involvements in the Vulnerability
  */
-struct cvrf_involvement *cvrf_involvement_iterator_next(struct cvrf_involvement_iterator *it);
+OSCAP_API struct cvrf_involvement *cvrf_involvement_iterator_next(struct cvrf_involvement_iterator *it);
 
 /**
  * @memberof cvrf_involvement_iterator
  * @param it CVRF Involvement iterator structure
  * @return true if the iterator has another Involvement element left
  */
-bool cvrf_involvement_iterator_has_more(struct cvrf_involvement_iterator *it);
+OSCAP_API bool cvrf_involvement_iterator_has_more(struct cvrf_involvement_iterator *it);
 
 /**
  * Deallocate memory for the CVRF Involvement Iterator structure
  * @memberof cvrf_involvement_iterator
  * @param it CVRF Involvement iterator structure
  */
-void cvrf_involvement_iterator_free(struct cvrf_involvement_iterator *it);
+OSCAP_API void cvrf_involvement_iterator_free(struct cvrf_involvement_iterator *it);
 
 /**
  * Restart iterator at the first Involvement in the Vulnerability
  * @memberof cvrf_involvement_iterator
  * @param it CVRF Involvement iterator structure
  */
-void cvrf_involvement_iterator_reset(struct cvrf_involvement_iterator *it);
+OSCAP_API void cvrf_involvement_iterator_reset(struct cvrf_involvement_iterator *it);
 
 /**
  * Detaches and frees the Involvement iterator structure
  * @memberof cvrf_involvement_iterator
  * @param it CVRF Involvement iterator structure
  */
-void cvrf_involvement_iterator_remove(struct cvrf_involvement_iterator *it);
+OSCAP_API void cvrf_involvement_iterator_remove(struct cvrf_involvement_iterator *it);
 
 /*******************************************
  * @struct cvrf_score_set_iterator
@@ -799,49 +800,49 @@ struct cvrf_score_set_iterator;
  * @param vuln CVRF ScoreSet structure to be added to the Vulnerability
  * @return true on success
  */
-bool cvrf_vulnerability_add_score_set(struct cvrf_vulnerability *vuln, struct cvrf_score_set *score_set);
+OSCAP_API bool cvrf_vulnerability_add_score_set(struct cvrf_vulnerability *vuln, struct cvrf_score_set *score_set);
 
 /**
  * @memberof cvrf_vulnerability
  * @param vuln CVRF Vulnerability structure
  * @return Iterator representing list of all ScoreSets in the Vulnerability
  */
-struct cvrf_score_set_iterator *cvrf_vulnerability_get_score_sets(const struct cvrf_vulnerability *vuln);
+OSCAP_API struct cvrf_score_set_iterator *cvrf_vulnerability_get_score_sets(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_score_set_iterator
  * @param it CVRF ScoreSet iterator structure
  * @return Next CVRF ScoreSet in list of all CVSSScoreSets in the Vulnerability
  */
-struct cvrf_score_set *cvrf_score_set_iterator_next(struct cvrf_score_set_iterator *it);
+OSCAP_API struct cvrf_score_set *cvrf_score_set_iterator_next(struct cvrf_score_set_iterator *it);
 
 /**
  * @memberof cvrf_score_set_iterator
  * @param it CVRF ScoreSet iterator structure
  * @return true if the iterator has another ScoreSet element left
  */
-bool cvrf_score_set_iterator_has_more(struct cvrf_score_set_iterator *it);
+OSCAP_API bool cvrf_score_set_iterator_has_more(struct cvrf_score_set_iterator *it);
 
 /**
  * Deallocate memory for the CVRF ScoreSet Iterator structure
  * @memberof cvrf_score_set_iterator
  * @param it CVRF ScoreSet iterator structure
  */
-void cvrf_score_set_iterator_free(struct cvrf_score_set_iterator *it);
+OSCAP_API void cvrf_score_set_iterator_free(struct cvrf_score_set_iterator *it);
 
 /**
  * Restart iterator at the first ScoreSet in the Vulnerability
  * @memberof cvrf_score_set_iterator
  * @param it CVRF ScoreSet iterator structure
  */
-void cvrf_score_set_iterator_reset(struct cvrf_score_set_iterator *it);
+OSCAP_API void cvrf_score_set_iterator_reset(struct cvrf_score_set_iterator *it);
 
 /**
  * Detaches and frees the ScoreSet iterator structure
  * @memberof cvrf_score_set_iterator
  * @param it CVRF ScoreSet iterator structure
  */
-void cvrf_score_set_iterator_remove(struct cvrf_score_set_iterator *it);
+OSCAP_API void cvrf_score_set_iterator_remove(struct cvrf_score_set_iterator *it);
 
 /*******************************************
  * @struct cvrf_product_status_iterator
@@ -856,49 +857,49 @@ struct cvrf_product_status_iterator;
  * @param vuln CVRF Status structure to be added to the Vulnerability
  * @return true on success
  */
-bool cvrf_vulnerability_add_cvrf_product_status(struct cvrf_vulnerability *vuln, struct cvrf_product_status *stat);
+OSCAP_API bool cvrf_vulnerability_add_cvrf_product_status(struct cvrf_vulnerability *vuln, struct cvrf_product_status *stat);
 
 /**
  * @memberof cvrf_vulnerability
  * @param vuln CVRF Vulnerability structure
  * @return Iterator representing list of all Statuses in the Vulnerability
  */
-struct cvrf_product_status_iterator *cvrf_vulnerability_get_product_statuses(const struct cvrf_vulnerability *vuln);
+OSCAP_API struct cvrf_product_status_iterator *cvrf_vulnerability_get_product_statuses(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_product_status_iterator
  * @param it CVRF ProductStatus iterator structure
  * @return Next CVRF Status in list of all ProductStatuses in the Vulnerability
  */
-struct cvrf_product_status *cvrf_product_status_iterator_next(struct cvrf_product_status_iterator *it);
+OSCAP_API struct cvrf_product_status *cvrf_product_status_iterator_next(struct cvrf_product_status_iterator *it);
 
 /**
  * @memberof cvrf_product_status_iterator
  * @param it CVRF Status iterator structure
  * @return true if the iterator has another Status element left
  */
-bool cvrf_product_status_iterator_has_more(struct cvrf_product_status_iterator *it);
+OSCAP_API bool cvrf_product_status_iterator_has_more(struct cvrf_product_status_iterator *it);
 
 /**
  * Deallocate memory for the CVRF Status Iterator structure
  * @memberof cvrf_product_status_iterator
  * @param it CVRF Status iterator structure
  */
-void cvrf_product_status_iterator_free(struct cvrf_product_status_iterator *it);
+OSCAP_API void cvrf_product_status_iterator_free(struct cvrf_product_status_iterator *it);
 
 /**
  * Restart iterator at the first Status in the Vulnerability
  * @memberof cvrf_product_status_iterator
  * @param it CVRF Status iterator structure
  */
-void cvrf_product_status_iterator_reset(struct cvrf_product_status_iterator *it);
+OSCAP_API void cvrf_product_status_iterator_reset(struct cvrf_product_status_iterator *it);
 
 /**
  * Detaches and frees the Status iterator structure
  * @memberof cvrf_product_status_iterator
  * @param it CVRF Status iterator structure
  */
-void cvrf_product_status_iterator_remove(struct cvrf_product_status_iterator *it);
+OSCAP_API void cvrf_product_status_iterator_remove(struct cvrf_product_status_iterator *it);
 
 /*******************************************
  * @struct cvrf_remediation_iterator
@@ -913,49 +914,49 @@ struct cvrf_remediation_iterator;
  * @param vuln CVRF Remediation structure to be added to the Vulnerability
  * @return true on success
  */
-bool cvrf_vulnerability_add_remediation(struct cvrf_vulnerability *vuln, struct cvrf_remediation *remed);
+OSCAP_API bool cvrf_vulnerability_add_remediation(struct cvrf_vulnerability *vuln, struct cvrf_remediation *remed);
 
 /**
  * @memberof cvrf_vulnerability
  * @param vuln CVRF Vulnerability structure
  * @return Iterator representing list of all Remediations in the Vulnerability
  */
-struct cvrf_remediation_iterator *cvrf_vulnerability_get_remediations(const struct cvrf_vulnerability *vuln);
+OSCAP_API struct cvrf_remediation_iterator *cvrf_vulnerability_get_remediations(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_remediation_iterator
  * @param it CVRF Remediation iterator structure
  * @return Next CVRF Remediation in list of all Remediations in the Vulnerability
  */
-struct cvrf_remediation *cvrf_remediation_iterator_next(struct cvrf_remediation_iterator *it);
+OSCAP_API struct cvrf_remediation *cvrf_remediation_iterator_next(struct cvrf_remediation_iterator *it);
 
 /**
  * @memberof cvrf_remediation_iterator
  * @param it CVRF Remediation iterator structure
  * @return true if the iterator has another Remediation element left
  */
-bool cvrf_remediation_iterator_has_more(struct cvrf_remediation_iterator *it);
+OSCAP_API bool cvrf_remediation_iterator_has_more(struct cvrf_remediation_iterator *it);
 
 /**
  * Deallocate memory for the CVRF Remediation Iterator structure
  * @memberof cvrf_remediation_iterator
  * @param it CVRF Remediation iterator structure
  */
-void cvrf_remediation_iterator_free(struct cvrf_remediation_iterator *it);
+OSCAP_API void cvrf_remediation_iterator_free(struct cvrf_remediation_iterator *it);
 
 /**
  * Restart iterator at the first Remediation in the Vulnerability
  * @memberof cvrf_remediation_iterator
  * @param it CVRF Remediation iterator structure
  */
-void cvrf_remediation_iterator_reset(struct cvrf_remediation_iterator *it);
+OSCAP_API void cvrf_remediation_iterator_reset(struct cvrf_remediation_iterator *it);
 
 /**
  * Detaches and frees the Remediation iterator structure
  * @memberof cvrf_remediation_iterator
  * @param it CVRF Remediation iterator structure
  */
-void cvrf_remediation_iterator_remove(struct cvrf_remediation_iterator *it);
+OSCAP_API void cvrf_remediation_iterator_remove(struct cvrf_remediation_iterator *it);
 
 /*******************************************
  * @struct cvrf_threat_iterator
@@ -970,49 +971,49 @@ struct cvrf_threat_iterator;
  * @param vuln CVRF Threat structure to be added to the Vulnerability
  * @return true on success
  */
-bool cvrf_vulnerability_add_threat(struct cvrf_vulnerability *vuln, struct cvrf_threat *threat);
+OSCAP_API bool cvrf_vulnerability_add_threat(struct cvrf_vulnerability *vuln, struct cvrf_threat *threat);
 
 /**
  * @memberof cvrf_vulnerability
  * @param vuln CVRF Vulnerability structure
  * @return Iterator representing list of all Threats in the Vulnerability
  */
-struct cvrf_threat_iterator *cvrf_vulnerability_get_threats(const struct cvrf_vulnerability *vuln);
+OSCAP_API struct cvrf_threat_iterator *cvrf_vulnerability_get_threats(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_threat_iterator
  * @param it CVRF Threat iterator structure
  * @return Next CVRF Threat in list of all Threats in the Vulnerability
  */
-struct cvrf_threat *cvrf_threat_iterator_next(struct cvrf_threat_iterator *it);
+OSCAP_API struct cvrf_threat *cvrf_threat_iterator_next(struct cvrf_threat_iterator *it);
 
 /**
  * @memberof cvrf_threat_iterator
  * @param it CVRF Threat iterator structure
  * @return true if the iterator has another Threat element left
  */
-bool cvrf_threat_iterator_has_more(struct cvrf_threat_iterator *it);
+OSCAP_API bool cvrf_threat_iterator_has_more(struct cvrf_threat_iterator *it);
 
 /**
  * Deallocate memory for the CVRF Threat Iterator structure
  * @memberof cvrf_threat_iterator
  * @param it CVRF Threat iterator structure
  */
-void cvrf_threat_iterator_free(struct cvrf_threat_iterator *it);
+OSCAP_API void cvrf_threat_iterator_free(struct cvrf_threat_iterator *it);
 
 /**
  * Restart iterator at the first Threat in the Vulnerability
  * @memberof cvrf_threat_iterator
  * @param it CVRF Threat iterator structure
  */
-void cvrf_threat_iterator_reset(struct cvrf_threat_iterator *it);
+OSCAP_API void cvrf_threat_iterator_reset(struct cvrf_threat_iterator *it);
 
 /**
  * Detaches and frees the Threat iterator structure
  * @memberof cvrf_threat_iterator
  * @param it CVRF Threat iterator structure
  */
-void cvrf_threat_iterator_remove(struct cvrf_threat_iterator *it);
+OSCAP_API void cvrf_threat_iterator_remove(struct cvrf_threat_iterator *it);
 
 /************************************************************************************************
  * @struct cvrf_product_name
@@ -1030,21 +1031,21 @@ struct cvrf_product_name;
  * @memberof cvrf_product_name
  * @return New FullProductName
  */
-struct cvrf_product_name *cvrf_product_name_new(void);
+OSCAP_API struct cvrf_product_name *cvrf_product_name_new(void);
 
 /**
  * Deallocates memory for a FullProductName element
  * @memberof cvrf_product_name
  * @param full_name The CVRF FullProductName structure to be freed
  */
-void cvrf_product_name_free(struct cvrf_product_name *full_name);
+OSCAP_API void cvrf_product_name_free(struct cvrf_product_name *full_name);
 
 /**
  * @memberof cvrf_product_name
  * @param full_name Original FullProductName structure to be cloned
  * @return New cloned FullProductName structure with same data as the original
  */
-struct cvrf_product_name *cvrf_product_name_clone(const struct cvrf_product_name *full_name);
+OSCAP_API struct cvrf_product_name *cvrf_product_name_clone(const struct cvrf_product_name *full_name);
 
 /**
  * @memberof cvrf_product_name
@@ -1052,7 +1053,7 @@ struct cvrf_product_name *cvrf_product_name_clone(const struct cvrf_product_name
  *
  * @return ProductID attribute within the FullProductName element
  */
-const char *cvrf_product_name_get_product_id(const struct cvrf_product_name *full_name);
+OSCAP_API const char *cvrf_product_name_get_product_id(const struct cvrf_product_name *full_name);
 
 /**
  * @memberof cvrf_product_name
@@ -1060,7 +1061,7 @@ const char *cvrf_product_name_get_product_id(const struct cvrf_product_name *ful
  *
  * @return CPE information contained in the FullProductName element
  */
-const char *cvrf_product_name_get_cpe(const struct cvrf_product_name *full_name);
+OSCAP_API const char *cvrf_product_name_get_cpe(const struct cvrf_product_name *full_name);
 
 /**
  * @memberof cvrf_product_name
@@ -1068,7 +1069,7 @@ const char *cvrf_product_name_get_cpe(const struct cvrf_product_name *full_name)
  *
  * @return true on success
  */
-bool cvrf_product_name_set_product_id(struct cvrf_product_name *full_name, const char *product_id);
+OSCAP_API bool cvrf_product_name_set_product_id(struct cvrf_product_name *full_name, const char *product_id);
 
 /**
  * @memberof cvrf_product_name
@@ -1076,7 +1077,7 @@ bool cvrf_product_name_set_product_id(struct cvrf_product_name *full_name, const
  *
  * @return true on success
  */
-bool cvrf_product_name_set_cpe(struct cvrf_product_name *full_name, const char *cpe);
+OSCAP_API bool cvrf_product_name_set_cpe(struct cvrf_product_name *full_name, const char *cpe);
 
 /************************************************************************************************
  * @struct cvrf_group
@@ -1095,21 +1096,21 @@ struct cvrf_group;
  * @memberof cvrf_group
  * @return New CVRF Group structure
  */
-struct cvrf_group *cvrf_group_new(void);
+OSCAP_API struct cvrf_group *cvrf_group_new(void);
 
 /**
  * Deallocates memory for a Group element
  * @memberof cvrf_group
  * @param group The CVRF Group structure to be freed
  */
-void cvrf_group_free(struct cvrf_group *group);
+OSCAP_API void cvrf_group_free(struct cvrf_group *group);
 
 /**
  * @memberof cvrf_group
  * @param group Original Group structure to be cloned
  * @return New cloned Group structure with same data as the original
  */
-struct cvrf_group *cvrf_group_clone(const struct cvrf_group *group);
+OSCAP_API struct cvrf_group *cvrf_group_clone(const struct cvrf_group *group);
 
 /**
  * @memberof cvrf_group
@@ -1117,7 +1118,7 @@ struct cvrf_group *cvrf_group_clone(const struct cvrf_group *group);
  * Unique identifier for a Group; used for referencing the Group elsewhere in the document
  * @return contents of GroupID attribute of a Group element
  */
-const char *cvrf_group_get_group_id(const struct cvrf_group *group);
+OSCAP_API const char *cvrf_group_get_group_id(const struct cvrf_group *group);
 
 /**
  * @memberof cvrf_group
@@ -1125,7 +1126,7 @@ const char *cvrf_group_get_group_id(const struct cvrf_group *group);
  * Short and human-readable description about the Group
  * @return contents of Description element of a Group element
  */
-const char *cvrf_group_get_description(const struct cvrf_group *group);
+OSCAP_API const char *cvrf_group_get_description(const struct cvrf_group *group);
 
 /**
  * @memberof cvrf_group
@@ -1133,7 +1134,7 @@ const char *cvrf_group_get_description(const struct cvrf_group *group);
  * @param group_id Unique identifier for a Group for referencing elsewhere in the document
  * @return true on success
  */
-bool cvrf_group_set_group_id(struct cvrf_group *group, const char *group_id);
+OSCAP_API bool cvrf_group_set_group_id(struct cvrf_group *group, const char *group_id);
 
 /**
  * @memberof cvrf_group
@@ -1141,7 +1142,7 @@ bool cvrf_group_set_group_id(struct cvrf_group *group, const char *group_id);
  * @param description Short and human-readable description about the Group
  * @return true on success
  */
-bool cvrf_group_set_description(struct cvrf_group *group, const char *description);
+OSCAP_API bool cvrf_group_set_description(struct cvrf_group *group, const char *description);
 
 /**
  * @memberof cvrf_group
@@ -1149,7 +1150,7 @@ bool cvrf_group_set_description(struct cvrf_group *group, const char *descriptio
  * List of all ProductIDs representing the products that belong to this Group
  * @return Iterator for the stringlist of ProductIDs
  */
-struct oscap_string_iterator *cvrf_group_get_product_ids(struct cvrf_group *group);
+OSCAP_API struct oscap_string_iterator *cvrf_group_get_product_ids(struct cvrf_group *group);
 
 
 /************************************************************************************************
@@ -1168,21 +1169,21 @@ struct cvrf_relationship;
  * @memberof cvrf_relationship
  * @return New CVRF Relationship structure
  */
-struct cvrf_relationship *cvrf_relationship_new(void);
+OSCAP_API struct cvrf_relationship *cvrf_relationship_new(void);
 
 /**
  * Deallocates memory for a Relationship element
  * @memberof cvrf_relationship
  * @param relationship The CVRF Relationship structure to be freed
  */
-void cvrf_relationship_free(struct cvrf_relationship *relationship);
+OSCAP_API void cvrf_relationship_free(struct cvrf_relationship *relationship);
 
 /**
  * @memberof cvrf_relationship
  * @param relation Original Relationship structure to be cloned
  * @return New cloned Relationship structure with same data as the original
  */
-struct cvrf_relationship *cvrf_relationship_clone(const struct cvrf_relationship *relation);
+OSCAP_API struct cvrf_relationship *cvrf_relationship_clone(const struct cvrf_relationship *relation);
 
 /**
  * @memberof cvrf_relationship
@@ -1190,7 +1191,7 @@ struct cvrf_relationship *cvrf_relationship_clone(const struct cvrf_relationship
  * Reference to a package ProductID that is a component of the CPE in RelatesToProductReference
  * @return contents of ProductReference attribute of a Relationship element
  */
-const char *cvrf_relationship_get_product_reference(const struct cvrf_relationship *relation);
+OSCAP_API const char *cvrf_relationship_get_product_reference(const struct cvrf_relationship *relation);
 
 /**
  * @memberof cvrf_relationship
@@ -1198,7 +1199,7 @@ const char *cvrf_relationship_get_product_reference(const struct cvrf_relationsh
  * ProductID for a CPE referenced in preceding Branches in the ProductTree
  * @return contents of RelatesToProductReference attribute of a Relationship element
  */
-const char *cvrf_relationship_get_relates_to_ref(const struct cvrf_relationship *relation);
+OSCAP_API const char *cvrf_relationship_get_relates_to_ref(const struct cvrf_relationship *relation);
 
 /**
  * @memberof cvrf_relationship
@@ -1206,7 +1207,7 @@ const char *cvrf_relationship_get_relates_to_ref(const struct cvrf_relationship 
  * Typically combines references to the CPE and package ProductID named in Relationship attributes
  * @return FullProductName child element of a Relationship element
  */
-struct cvrf_product_name *cvrf_relationship_get_product_name(const struct cvrf_relationship *relation);
+OSCAP_API struct cvrf_product_name *cvrf_relationship_get_product_name(const struct cvrf_relationship *relation);
 
 /**
  * @memberof cvrf_relationship
@@ -1214,7 +1215,7 @@ struct cvrf_product_name *cvrf_relationship_get_product_name(const struct cvrf_r
  * @param product_reference Combined reference to the CPE and package ProductID
  * @return true on success
  */
-bool cvrf_relationship_set_product_reference(struct cvrf_relationship *relation, const char *product_reference);
+OSCAP_API bool cvrf_relationship_set_product_reference(struct cvrf_relationship *relation, const char *product_reference);
 
 /**
  * @memberof cvrf_relationship
@@ -1222,7 +1223,7 @@ bool cvrf_relationship_set_product_reference(struct cvrf_relationship *relation,
  * @param relates_to_ref ProductID for a CPE referenced in preceding Branches in the ProductTree
  * @return true on success
  */
-bool cvrf_relationship_set_relates_to_ref(struct cvrf_relationship *relation, const char *relates_to_ref);
+OSCAP_API bool cvrf_relationship_set_relates_to_ref(struct cvrf_relationship *relation, const char *relates_to_ref);
 
 /**
  * @memberof cvrf_relationship
@@ -1230,7 +1231,7 @@ bool cvrf_relationship_set_relates_to_ref(struct cvrf_relationship *relation, co
  * @param name References to the CPE and package ProductID named in Relationship attributes
  * @return true on success
  */
-bool cvrf_relationship_set_product_name(struct cvrf_relationship *relation, struct cvrf_product_name *name);
+OSCAP_API bool cvrf_relationship_set_product_name(struct cvrf_relationship *relation, struct cvrf_product_name *name);
 
 /************************************************************************************************
  * @struct cvrf_branch
@@ -1248,21 +1249,21 @@ struct cvrf_branch;
  * @memberof cvrf_branch
  * @return New CVRF branch
  */
-struct cvrf_branch *cvrf_branch_new(void);
+OSCAP_API struct cvrf_branch *cvrf_branch_new(void);
 
 /**
  * Deallocates memory for a Branch element
  * @memberof cvrf_branch
  * @param branch The CVRF Branch structure to be freed
  */
-void cvrf_branch_free(struct cvrf_branch *branch);
+OSCAP_API void cvrf_branch_free(struct cvrf_branch *branch);
 
 /**
  * @memberof cvrf_branch
  * @param branch Original Branch structure to be cloned
  * @return New cloned Branch structure with same data as the original
  */
-struct cvrf_branch *cvrf_branch_clone(const struct cvrf_branch *branch);
+OSCAP_API struct cvrf_branch *cvrf_branch_clone(const struct cvrf_branch *branch);
 
 /**
  * @memberof cvrf_branch
@@ -1270,7 +1271,7 @@ struct cvrf_branch *cvrf_branch_clone(const struct cvrf_branch *branch);
  * Canonical description of the Branch; paired with Branch Type
  * @return contents of Name attribute within a Branch element
  */
-const char *cvrf_branch_get_branch_name(const struct cvrf_branch *branch);
+OSCAP_API const char *cvrf_branch_get_branch_name(const struct cvrf_branch *branch);
 
 /**
  * @memberof cvrf_branch
@@ -1278,7 +1279,7 @@ const char *cvrf_branch_get_branch_name(const struct cvrf_branch *branch);
  * Child element and endpoint of tree for branches not of the type 'Product Family'
  * @return FullProductName child element of a Branch element
  */
-struct cvrf_product_name *cvrf_branch_get_product_name(const struct cvrf_branch *branch);
+OSCAP_API struct cvrf_product_name *cvrf_branch_get_product_name(const struct cvrf_branch *branch);
 
 /**
  * @memberof cvrf_branch
@@ -1286,7 +1287,7 @@ struct cvrf_product_name *cvrf_branch_get_product_name(const struct cvrf_branch 
  * Sub-branch children of 'Product Family'-type Branches
  * @return Iterator for sub-branch structures for this Branch element
  */
-struct oscap_iterator *cvrf_branch_get_subbranches(struct cvrf_branch *branch);
+OSCAP_API struct oscap_iterator *cvrf_branch_get_subbranches(struct cvrf_branch *branch);
 
 /**
  * @memberof cvrf_branch
@@ -1294,7 +1295,7 @@ struct oscap_iterator *cvrf_branch_get_subbranches(struct cvrf_branch *branch);
  * @param branch_name Canonical description of the Branch; paired with Branch Type
  * @return true on success
  */
-bool cvrf_branch_set_branch_name(struct cvrf_branch *branch, const char *branch_name);
+OSCAP_API bool cvrf_branch_set_branch_name(struct cvrf_branch *branch, const char *branch_name);
 
 /**
  * @memberof cvrf_branch
@@ -1302,7 +1303,7 @@ bool cvrf_branch_set_branch_name(struct cvrf_branch *branch, const char *branch_
  * @param name Child element and endpoint of tree for branches not of the type 'Product Family'
  * @return true on success
  */
-bool cvrf_branch_set_product_name(struct cvrf_branch *branch, struct cvrf_product_name *name);
+OSCAP_API bool cvrf_branch_set_product_name(struct cvrf_branch *branch, struct cvrf_product_name *name);
 
 /************************************************************************************************
  *@struct cvrf_product_tree
@@ -1320,7 +1321,7 @@ struct cvrf_product_tree;
  * @memberof cvrf_product_tree
  * @return New CVRF ProductTree
  */
-struct cvrf_product_tree *cvrf_product_tree_new(void);
+OSCAP_API struct cvrf_product_tree *cvrf_product_tree_new(void);
 
 /**
  * Deallocates memory for a ProductTree element and all its child Branches, Relationships,
@@ -1328,14 +1329,14 @@ struct cvrf_product_tree *cvrf_product_tree_new(void);
  * @memberof cvrf_product_tree
  * @param tree The CVRF ProductTree structure to be freed
  */
-void cvrf_product_tree_free(struct cvrf_product_tree *tree);
+OSCAP_API void cvrf_product_tree_free(struct cvrf_product_tree *tree);
 
 /**
  * @memberof cvrf_product_tree
  * @param tree Original ProductTree structure to be cloned
  * @return New cloned ProductTree structure with same data as the original
  */
-struct cvrf_product_tree *cvrf_product_tree_clone(const struct cvrf_product_tree *tree);
+OSCAP_API struct cvrf_product_tree *cvrf_product_tree_clone(const struct cvrf_product_tree *tree);
 
 /**
  * Find the unique ProductID for the given CPE by searching the branches of the
@@ -1346,7 +1347,7 @@ struct cvrf_product_tree *cvrf_product_tree_clone(const struct cvrf_product_tree
  * @param cpe CPE string in the FullProductName element used to get the ProductID
  * @return ProductID for the given CPE
  */
-const char *get_cvrf_product_id_from_cpe(struct cvrf_product_tree *tree, const char *cpe);
+OSCAP_API const char *get_cvrf_product_id_from_cpe(struct cvrf_product_tree *tree, const char *cpe);
 
 /**
  * Use the CPE name to find the matching ProductID, then filter the tree by removing
@@ -1356,13 +1357,13 @@ const char *get_cvrf_product_id_from_cpe(struct cvrf_product_tree *tree, const c
  * @param cpe CPE name used to filter all unrelated elements
  * @return 0 on success, -1 on failure
  */
-int cvrf_product_tree_filter_by_cpe(struct cvrf_product_tree *tree, const char *cpe);
+OSCAP_API int cvrf_product_tree_filter_by_cpe(struct cvrf_product_tree *tree, const char *cpe);
 
 /*---------------------------------------------------------------------*\
 |				Iterators of child elements of ProductTree				|
 \*---------------------------------------------------------------------*/
 
-struct oscap_iterator *cvrf_product_tree_get_branches(struct cvrf_product_tree *tree);
+OSCAP_API struct oscap_iterator *cvrf_product_tree_get_branches(struct cvrf_product_tree *tree);
 
 /*******************************************
  * @struct cvrf_product_name_iterator
@@ -1377,49 +1378,49 @@ struct cvrf_product_name_iterator;
  * @param full_name CVRF FullProductName structure to be added to the ProductTree
  * @return true on success
  */
-bool cvrf_product_tree_add_product_name(struct cvrf_product_tree *tree, struct cvrf_product_name *full_name);
+OSCAP_API bool cvrf_product_tree_add_product_name(struct cvrf_product_tree *tree, struct cvrf_product_name *full_name);
 
 /**
  * @memberof cvrf_product_tree
  * @param tree CVRF ProductTree structure
  * @return Iterator representing list of all FullProductNames in the ProductTree
  */
-struct cvrf_product_name_iterator *cvrf_product_tree_get_product_names(const struct cvrf_product_tree *tree);
+OSCAP_API struct cvrf_product_name_iterator *cvrf_product_tree_get_product_names(const struct cvrf_product_tree *tree);
 
 /**
  * @memberof cvrf_product_name_iterator
  * @param it CVRF FullProductName iterator structure
  * @return Next CVRF FullProductName in list of all FullProductNames in the ProductTree
  */
-struct cvrf_product_name *cvrf_product_name_iterator_next(struct cvrf_product_name_iterator *it);
+OSCAP_API struct cvrf_product_name *cvrf_product_name_iterator_next(struct cvrf_product_name_iterator *it);
 
 /**
  * @memberof cvrf_product_name_iterator
  * @param it CVRF FullProductName iterator structure
  * @return true if the Iterator has another FullProductName element left
  */
-bool cvrf_product_name_iterator_has_more(struct cvrf_product_name_iterator *it);
+OSCAP_API bool cvrf_product_name_iterator_has_more(struct cvrf_product_name_iterator *it);
 
 /**
  * Deallocate memory for the CVRF FullProductName Iterator structure
  * @memberof cvrf_product_name_iterator
  * @param it CVRF FullProductName iterator structure
  */
-void cvrf_product_name_iterator_free(struct cvrf_product_name_iterator *it);
+OSCAP_API void cvrf_product_name_iterator_free(struct cvrf_product_name_iterator *it);
 
 /**
  * Restart iterator at the first FullProductName element in the ProductTree
  * @memberof cvrf_product_name_iterator
  * @param it CVRF FullProductName iterator structure
  */
-void cvrf_product_name_iterator_reset(struct cvrf_product_name_iterator *it);
+OSCAP_API void cvrf_product_name_iterator_reset(struct cvrf_product_name_iterator *it);
 
 /**
  * Detaches and frees the FullProductName iterator structure
  * @memberof cvrf_product_name_iterator
  * @param it CVRF FullProductName iterator structure
  */
-void cvrf_product_name_iterator_remove(struct cvrf_product_name_iterator *it);
+OSCAP_API void cvrf_product_name_iterator_remove(struct cvrf_product_name_iterator *it);
 
 /*******************************************
  * @struct cvrf_relationship_iterator
@@ -1434,49 +1435,49 @@ struct cvrf_relationship_iterator;
  * @param relation CVRF Relationship structure to be added to the ProductTree
  * @return true on success
  */
-bool cvrf_product_tree_add_relationship(struct cvrf_product_tree *tree, struct cvrf_relationship *relation);
+OSCAP_API bool cvrf_product_tree_add_relationship(struct cvrf_product_tree *tree, struct cvrf_relationship *relation);
 
 /**
  * @memberof cvrf_product_tree
  * @param tree CVRF ProductTree structure
  * @return Iterator representing list of all Relationships in the ProductTree
  */
-struct cvrf_relationship_iterator *cvrf_product_tree_get_relationships(const struct cvrf_product_tree *tree);
+OSCAP_API struct cvrf_relationship_iterator *cvrf_product_tree_get_relationships(const struct cvrf_product_tree *tree);
 
 /**
  * @memberof cvrf_relationship_iterator
  * @param it CVRF Relationship iterator structure
  * @return Next CVRF Relationship in list of all Relationships in the ProductTree
  */
-struct cvrf_relationship *cvrf_relationship_iterator_next(struct cvrf_relationship_iterator *it);
+OSCAP_API struct cvrf_relationship *cvrf_relationship_iterator_next(struct cvrf_relationship_iterator *it);
 
 /**
  * @memberof cvrf_relationship_iterator
  * @param it CVRF Relationship iterator structure
  * @return true if the Iterator has another Relationship element left
  */
-bool cvrf_relationship_iterator_has_more(struct cvrf_relationship_iterator *it);
+OSCAP_API bool cvrf_relationship_iterator_has_more(struct cvrf_relationship_iterator *it);
 
 /**
  * Deallocate memory for the CVRF Relationship Iterator structure
  * @memberof cvrf_relationship_iterator
  * @param it CVRF Relationship iterator structure
  */
-void cvrf_relationship_iterator_free(struct cvrf_relationship_iterator *it);
+OSCAP_API void cvrf_relationship_iterator_free(struct cvrf_relationship_iterator *it);
 
 /**
  * Restart iterator at the first Relationship element in the ProductTree
  * @memberof cvrf_relationship_iterator
  * @param it CVRF Relationship iterator structure
  */
-void cvrf_relationship_iterator_reset(struct cvrf_relationship_iterator *it);
+OSCAP_API void cvrf_relationship_iterator_reset(struct cvrf_relationship_iterator *it);
 
 /**
  * Detaches and frees the Relationship iterator structure
  * @memberof cvrf_relationship_iterator
  * @param it CVRF Relationship iterator structure
  */
-void cvrf_relationship_iterator_remove(struct cvrf_relationship_iterator *it);
+OSCAP_API void cvrf_relationship_iterator_remove(struct cvrf_relationship_iterator *it);
 
 
 /*******************************************
@@ -1492,49 +1493,49 @@ struct cvrf_group_iterator;
  * @param group CVRF Group structure to be added to the ProductTree
  * @return true on success
  */
-bool cvrf_product_tree_add_group(struct cvrf_product_tree *tree, struct cvrf_group *group);
+OSCAP_API bool cvrf_product_tree_add_group(struct cvrf_product_tree *tree, struct cvrf_group *group);
 
 /**
  * @memberof cvrf_product_tree
  * @param tree CVRF ProductTree structure
  * @return Iterator representing list of all Groups in the ProductTree
  */
-struct cvrf_group_iterator *cvrf_product_tree_get_product_groups(const struct cvrf_product_tree *tree);
+OSCAP_API struct cvrf_group_iterator *cvrf_product_tree_get_product_groups(const struct cvrf_product_tree *tree);
 
 /**
  * @memberof cvrf_group_iterator
  * @param it CVRF Group iterator structure
  * @return Next CVRF Group in ProductGroups container in the ProductTree
  */
-struct cvrf_group *cvrf_group_iterator_next(struct cvrf_group_iterator *it);
+OSCAP_API struct cvrf_group *cvrf_group_iterator_next(struct cvrf_group_iterator *it);
 
 /**
  * @memberof cvrf_group_iterator
  * @param it CVRF Group iterator structure
  * @return true if the Iterator has another Group element left
  */
-bool cvrf_group_iterator_has_more(struct cvrf_group_iterator *it);
+OSCAP_API bool cvrf_group_iterator_has_more(struct cvrf_group_iterator *it);
 
 /**
  * Deallocate memory for the CVRF Group Iterator structure
  * @memberof cvrf_group_iterator
  * @param it CVRF Group iterator structure
  */
-void cvrf_group_iterator_free(struct cvrf_group_iterator *it);
+OSCAP_API void cvrf_group_iterator_free(struct cvrf_group_iterator *it);
 
 /**
  * Restart iterator at the first Group element in the ProductTree
  * @memberof cvrf_group_iterator
  * @param it CVRF Group iterator structure
  */
-void cvrf_group_iterator_reset(struct cvrf_group_iterator *it);
+OSCAP_API void cvrf_group_iterator_reset(struct cvrf_group_iterator *it);
 
 /**
  * Detaches and frees the Group iterator structure
  * @memberof cvrf_group_iterator
  * @param it CVRF Group iterator structure
  */
-void cvrf_group_iterator_remove(struct cvrf_group_iterator *it);
+OSCAP_API void cvrf_group_iterator_remove(struct cvrf_group_iterator *it);
 
 
 /************************************************************************************************
@@ -1553,21 +1554,21 @@ struct cvrf_acknowledgment;
  * @memberof cvrf_acknowledgment
  * @return New CVRF Acknowledgment structure
  */
-struct cvrf_acknowledgment *cvrf_acknowledgment_new(void);
+OSCAP_API struct cvrf_acknowledgment *cvrf_acknowledgment_new(void);
 
 /**
  * Deallocates memory for an Acknowledgment element of the Acknowledgments container
  * @memberof cvrf_acknowledgment
  * @param ack The CVRF Acknowledgment structure to be freed
  */
-void cvrf_acknowledgment_free(struct cvrf_acknowledgment *ack);
+OSCAP_API void cvrf_acknowledgment_free(struct cvrf_acknowledgment *ack);
 
 /**
  * @memberof cvrf_acknowledgment
  * @param ack Original Acknowledgment structure to be cloned
  * @return New cloned Acknowledgment structure with same data as the original
  */
-struct cvrf_acknowledgment *cvrf_acknowledgment_clone(const struct cvrf_acknowledgment *ack);
+OSCAP_API struct cvrf_acknowledgment *cvrf_acknowledgment_clone(const struct cvrf_acknowledgment *ack);
 
 /**
  * @memberof cvrf_acknowledgment
@@ -1575,7 +1576,7 @@ struct cvrf_acknowledgment *cvrf_acknowledgment_clone(const struct cvrf_acknowle
  * Contextual information about acknowledgers or acknowledged parties
  * @return contents of Description element within an Acknowledgment element
  */
-const char *cvrf_acknowledgment_get_description(const struct cvrf_acknowledgment *ack);
+OSCAP_API const char *cvrf_acknowledgment_get_description(const struct cvrf_acknowledgment *ack);
 
 /**
  * @memberof cvrf_acknowledgment
@@ -1583,7 +1584,7 @@ const char *cvrf_acknowledgment_get_description(const struct cvrf_acknowledgment
  * @param description Contextual information about acknowledgers or acknowledged parties
  * @return true on success
  */
-bool cvrf_acknowledgment_set_description(struct cvrf_acknowledgment *ack, const char *description);
+OSCAP_API bool cvrf_acknowledgment_set_description(struct cvrf_acknowledgment *ack, const char *description);
 
 /**
  * @memberof cvrf_acknowledgment
@@ -1591,7 +1592,7 @@ bool cvrf_acknowledgment_set_description(struct cvrf_acknowledgment *ack, const 
  * List of names of all parties who are being acknowledged
  * @return String iterator representing list of all names
  */
-struct oscap_string_iterator *cvrf_acknowledgment_get_names(const struct cvrf_acknowledgment *ack);
+OSCAP_API struct oscap_string_iterator *cvrf_acknowledgment_get_names(const struct cvrf_acknowledgment *ack);
 
 /**
  * @memberof cvrf_acknowledgment
@@ -1599,7 +1600,7 @@ struct oscap_string_iterator *cvrf_acknowledgment_get_names(const struct cvrf_ac
  * Organizations of parties and/or organization(s) itself being acknowledged
  * @return String iterator representing list of all organizations
  */
-struct oscap_string_iterator *cvrf_acknowledgment_get_organizations(const struct cvrf_acknowledgment *ack);
+OSCAP_API struct oscap_string_iterator *cvrf_acknowledgment_get_organizations(const struct cvrf_acknowledgment *ack);
 
 /**
  * @memberof cvrf_acknowledgment
@@ -1607,7 +1608,7 @@ struct oscap_string_iterator *cvrf_acknowledgment_get_organizations(const struct
  * URLs to people or parties being acknowledged
  * @return String iterator representing list of all URLs
  */
-struct oscap_string_iterator *cvrf_acknowledgment_get_urls(const struct cvrf_acknowledgment *ack);
+OSCAP_API struct oscap_string_iterator *cvrf_acknowledgment_get_urls(const struct cvrf_acknowledgment *ack);
 
 /************************************************************************************************
  * @struct cvrf_note
@@ -1623,21 +1624,21 @@ struct cvrf_note;
  * @memberof cvrf_note
  * @return New CVRF Note structure
  */
-struct cvrf_note *cvrf_note_new(void);
+OSCAP_API struct cvrf_note *cvrf_note_new(void);
 
 /**
  * Deallocates memory for a Note element of the Notes container
  * @memberof cvrf_note
  * @param note The CVRF Note structure to be freed
  */
-void cvrf_note_free(struct cvrf_note *note);
+OSCAP_API void cvrf_note_free(struct cvrf_note *note);
 
 /**
  * @memberof cvrf_note
  * @param note Original Note structure to be cloned
  * @return New cloned Note structure with same data as the original
  */
-struct cvrf_note *cvrf_note_clone(const struct cvrf_note *note);
+OSCAP_API struct cvrf_note *cvrf_note_clone(const struct cvrf_note *note);
 
 /**
  * @memberof cvrf_note
@@ -1645,7 +1646,7 @@ struct cvrf_note *cvrf_note_clone(const struct cvrf_note *note);
  * Index of a Note element within a Notes container
  * @return Ordinal attribute of the Note element
  */
-int cvrf_note_get_ordinal(const struct cvrf_note *note);
+OSCAP_API int cvrf_note_get_ordinal(const struct cvrf_note *note);
 
 /**
  * @memberof cvrf_note
@@ -1653,7 +1654,7 @@ int cvrf_note_get_ordinal(const struct cvrf_note *note);
  * Party to whom the information in this note is directed
  * @return Contents of Audience attribute of the Note element
  */
-const char *cvrf_note_get_audience(const struct cvrf_note *note);
+OSCAP_API const char *cvrf_note_get_audience(const struct cvrf_note *note);
 
 /**
  * @memberof cvrf_note
@@ -1661,7 +1662,7 @@ const char *cvrf_note_get_audience(const struct cvrf_note *note);
  * Concise description of the contents of the Note
  * @return Contents of Title attribute of the Note element
  */
-const char *cvrf_note_get_title(const struct cvrf_note *note);
+OSCAP_API const char *cvrf_note_get_title(const struct cvrf_note *note);
 
 /**
  * @memberof cvrf_note
@@ -1669,7 +1670,7 @@ const char *cvrf_note_get_title(const struct cvrf_note *note);
  * Information relating to the document that is contained in the Note
  * @return Contents of the Note element itself
  */
-const char *cvrf_note_get_contents(const struct cvrf_note *note);
+OSCAP_API const char *cvrf_note_get_contents(const struct cvrf_note *note);
 
 /**
  * @memberof cvrf_note
@@ -1677,7 +1678,7 @@ const char *cvrf_note_get_contents(const struct cvrf_note *note);
  * @param ordinal Index of a Note element within a Notes container
  * @return true on success
  */
-bool cvrf_note_set_ordinal(struct cvrf_note *note, int ordinal);
+OSCAP_API bool cvrf_note_set_ordinal(struct cvrf_note *note, int ordinal);
 
 /**
  * @memberof cvrf_note
@@ -1685,7 +1686,7 @@ bool cvrf_note_set_ordinal(struct cvrf_note *note, int ordinal);
  * @param audience Party to whom the information in this note is directed
  * @return true on success
  */
-bool cvrf_note_set_audience(struct cvrf_note *note, const char *audience);
+OSCAP_API bool cvrf_note_set_audience(struct cvrf_note *note, const char *audience);
 
 /**
  * @memberof cvrf_note
@@ -1693,7 +1694,7 @@ bool cvrf_note_set_audience(struct cvrf_note *note, const char *audience);
  * @param title Concise description of the contents of the Note
  * @return true on success
  */
-bool cvrf_note_set_title(struct cvrf_note *note, const char *title);
+OSCAP_API bool cvrf_note_set_title(struct cvrf_note *note, const char *title);
 
 /**
  * @memberof cvrf_note
@@ -1701,7 +1702,7 @@ bool cvrf_note_set_title(struct cvrf_note *note, const char *title);
  * @param contents Information that is contained in the Note
  * @return true on success
  */
-bool cvrf_note_set_contents(struct cvrf_note *note, const char *contents);
+OSCAP_API bool cvrf_note_set_contents(struct cvrf_note *note, const char *contents);
 
 
 /************************************************************************************************
@@ -1719,21 +1720,21 @@ struct cvrf_revision;
  * @memberof cvrf_revision
  * @return New CVRF Revision
  */
-struct cvrf_revision *cvrf_revision_new(void);
+OSCAP_API struct cvrf_revision *cvrf_revision_new(void);
 
 /**
  * Deallocates memory for a Revision element of the RevisionHistory container
  * @memberof cvrf_revision
  * @param revision The CVRF Revision structure to be freed
  */
-void cvrf_revision_free(struct cvrf_revision *revision);
+OSCAP_API void cvrf_revision_free(struct cvrf_revision *revision);
 
 /**
  * @memberof cvrf_revision
  * @param revision Original Revision structure to be cloned
  * @return New cloned Revision structure with same data as the original
  */
-struct cvrf_revision *cvrf_revision_clone(const struct cvrf_revision *revision);
+OSCAP_API struct cvrf_revision *cvrf_revision_clone(const struct cvrf_revision *revision);
 
 /**
  * @memberof cvrf_revision
@@ -1741,7 +1742,7 @@ struct cvrf_revision *cvrf_revision_clone(const struct cvrf_revision *revision);
  * Numeric representation of document version in tokenized format "nn.nn.nn.nn"
  * @return contents of Number element within the Revision element
  */
-const char *cvrf_revision_get_number(const struct cvrf_revision *revision);
+OSCAP_API const char *cvrf_revision_get_number(const struct cvrf_revision *revision);
 
 /**
  * @memberof cvrf_revision
@@ -1749,7 +1750,7 @@ const char *cvrf_revision_get_number(const struct cvrf_revision *revision);
  * Datetime of when the Revision was made
  * @return contents of Date element within the Revision element
  */
-const char *cvrf_revision_get_date(const struct cvrf_revision *revision);
+OSCAP_API const char *cvrf_revision_get_date(const struct cvrf_revision *revision);
 
 /**
  * @memberof cvrf_revision
@@ -1757,7 +1758,7 @@ const char *cvrf_revision_get_date(const struct cvrf_revision *revision);
  * Short list of items changed and/or reasons for making the change
  * @return contents of Description element within the Revision element
  */
-const char *cvrf_revision_get_description(const struct cvrf_revision *revision);
+OSCAP_API const char *cvrf_revision_get_description(const struct cvrf_revision *revision);
 
 /**
  * @memberof cvrf_revision
@@ -1765,7 +1766,7 @@ const char *cvrf_revision_get_description(const struct cvrf_revision *revision);
  * @param number Numeric representation of document version in format "nn.nn.nn.nn"
  * @return true on success
  */
-bool cvrf_revision_set_number(struct cvrf_revision *revision, const char *number);
+OSCAP_API bool cvrf_revision_set_number(struct cvrf_revision *revision, const char *number);
 
 /**
  * @memberof cvrf_revision
@@ -1773,7 +1774,7 @@ bool cvrf_revision_set_number(struct cvrf_revision *revision, const char *number
  * @param date Datetime of when the Revision was made
  * @return true on success
  */
-bool cvrf_revision_set_date(struct cvrf_revision *revision, const char *date);
+OSCAP_API bool cvrf_revision_set_date(struct cvrf_revision *revision, const char *date);
 
 /**
  * @memberof cvrf_revision
@@ -1781,7 +1782,7 @@ bool cvrf_revision_set_date(struct cvrf_revision *revision, const char *date);
  * @param description Short list of items changed and/or reasons for making the change
  * @return true on success
  */
-bool cvrf_revision_set_description(struct cvrf_revision *revision, const char *description);
+OSCAP_API bool cvrf_revision_set_description(struct cvrf_revision *revision, const char *description);
 
 /************************************************************************************************
  * @struct cvrf_doc_tracking
@@ -1801,21 +1802,21 @@ struct cvrf_doc_tracking;
  * @memberof cvrf_doc_tracking
  * @return New CVRF DocumentTracking
  */
-struct cvrf_doc_tracking *cvrf_doc_tracking_new(void);
+OSCAP_API struct cvrf_doc_tracking *cvrf_doc_tracking_new(void);
 
 /**
  * Deallocates memory for a DocumentTracking element
  * @memberof cvrf_doc_tracking
  * @param tracking The CVRF DocumentTracking structure to be freed
  */
-void cvrf_doc_tracking_free(struct cvrf_doc_tracking *tracking);
+OSCAP_API void cvrf_doc_tracking_free(struct cvrf_doc_tracking *tracking);
 
 /**
  * @memberof cvrf_doc_tracking
  * @param tracking Original DocumentTracking structure to be cloned
  * @return New cloned DocumentTracking structure with same data as the original
  */
-struct cvrf_doc_tracking *cvrf_doc_tracking_clone(const struct cvrf_doc_tracking *tracking);
+OSCAP_API struct cvrf_doc_tracking *cvrf_doc_tracking_clone(const struct cvrf_doc_tracking *tracking);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1823,7 +1824,7 @@ struct cvrf_doc_tracking *cvrf_doc_tracking_clone(const struct cvrf_doc_tracking
  * Short identifier to unambiguously reference the document in any context
  * @return contents of ID element within Identification element
  */
-const char *cvrf_doc_tracking_get_tracking_id(const struct cvrf_doc_tracking *tracking);
+OSCAP_API const char *cvrf_doc_tracking_get_tracking_id(const struct cvrf_doc_tracking *tracking);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1831,7 +1832,7 @@ const char *cvrf_doc_tracking_get_tracking_id(const struct cvrf_doc_tracking *tr
  * Optional alternative ID(s) for the document
  * @return Iterator for the stringlist of Alias elements within Identification element
  */
-struct oscap_string_iterator *cvrf_doc_tracking_get_aliases(struct cvrf_doc_tracking *tracking);
+OSCAP_API struct oscap_string_iterator *cvrf_doc_tracking_get_aliases(struct cvrf_doc_tracking *tracking);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1839,7 +1840,7 @@ struct oscap_string_iterator *cvrf_doc_tracking_get_aliases(struct cvrf_doc_trac
  * Counter to track the document in tokenized format "nn" - "nn.nn.nn.nn"
  * @return contents of @return contents of Version element within DocumentTracking element
  */
-const char *cvrf_doc_tracking_get_version(const struct cvrf_doc_tracking *tracking);
+OSCAP_API const char *cvrf_doc_tracking_get_version(const struct cvrf_doc_tracking *tracking);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1847,7 +1848,7 @@ const char *cvrf_doc_tracking_get_version(const struct cvrf_doc_tracking *tracki
  * Datetime of the document's original release by the issuer
  * @return contents of InitialReleaseDate element within DocumentTracking element
  */
-const char *cvrf_doc_tracking_get_init_release_date(const struct cvrf_doc_tracking *tracking);
+OSCAP_API const char *cvrf_doc_tracking_get_init_release_date(const struct cvrf_doc_tracking *tracking);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1855,7 +1856,7 @@ const char *cvrf_doc_tracking_get_init_release_date(const struct cvrf_doc_tracki
  * Datetime of the document's current release by the issuer
  * @return contents of CurrentReleaseDate element within DocumentTracking element
  */
-const char *cvrf_doc_tracking_get_cur_release_date(const struct cvrf_doc_tracking *tracking);
+OSCAP_API const char *cvrf_doc_tracking_get_cur_release_date(const struct cvrf_doc_tracking *tracking);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1863,7 +1864,7 @@ const char *cvrf_doc_tracking_get_cur_release_date(const struct cvrf_doc_trackin
  * Name and optional version of the generator of the document
  * @return contents of Engine element within Generator element
  */
-const char *cvrf_doc_tracking_get_generator_engine(const struct cvrf_doc_tracking *tracking);
+OSCAP_API const char *cvrf_doc_tracking_get_generator_engine(const struct cvrf_doc_tracking *tracking);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1871,7 +1872,7 @@ const char *cvrf_doc_tracking_get_generator_engine(const struct cvrf_doc_trackin
  * Datetime of when the document was generated
  * @return contents of Date element within Generator element
  */
-const char *cvrf_doc_tracking_get_generator_date(const struct cvrf_doc_tracking *tracking);
+OSCAP_API const char *cvrf_doc_tracking_get_generator_date(const struct cvrf_doc_tracking *tracking);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1879,7 +1880,7 @@ const char *cvrf_doc_tracking_get_generator_date(const struct cvrf_doc_tracking 
  * @param id Short identifier to unambiguously reference the document in any context
  * @return true on success
  */
-bool cvrf_doc_tracking_set_tracking_id(struct cvrf_doc_tracking *tracking, const char *id);
+OSCAP_API bool cvrf_doc_tracking_set_tracking_id(struct cvrf_doc_tracking *tracking, const char *id);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1887,7 +1888,7 @@ bool cvrf_doc_tracking_set_tracking_id(struct cvrf_doc_tracking *tracking, const
  * @param version Counter to track the document in tokenized format "nn" - "nn.nn.nn.nn"
  * @return true on success
  */
-bool cvrf_doc_tracking_set_version(struct cvrf_doc_tracking *tracking, const char *version);
+OSCAP_API bool cvrf_doc_tracking_set_version(struct cvrf_doc_tracking *tracking, const char *version);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1895,7 +1896,7 @@ bool cvrf_doc_tracking_set_version(struct cvrf_doc_tracking *tracking, const cha
  * @param init_release_date Datetime of the document's original release by the issuer
  * @return true on success
  */
-bool cvrf_doc_tracking_set_init_release_date(struct cvrf_doc_tracking *tracking, const char *init_release_date);
+OSCAP_API bool cvrf_doc_tracking_set_init_release_date(struct cvrf_doc_tracking *tracking, const char *init_release_date);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1903,7 +1904,7 @@ bool cvrf_doc_tracking_set_init_release_date(struct cvrf_doc_tracking *tracking,
  * @param cur_release_date Datetime of the document's current release by the issuer
  * @return true on success
  */
-bool cvrf_doc_tracking_set_cur_release_date(struct cvrf_doc_tracking *tracking, const char *cur_release_date);
+OSCAP_API bool cvrf_doc_tracking_set_cur_release_date(struct cvrf_doc_tracking *tracking, const char *cur_release_date);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1911,7 +1912,7 @@ bool cvrf_doc_tracking_set_cur_release_date(struct cvrf_doc_tracking *tracking, 
  * @param generator_engine Name and optional version of the generator of the document
  * @return true on success
  */
-bool cvrf_doc_tracking_set_generator_engine(struct cvrf_doc_tracking *tracking, const char *generator_engine);
+OSCAP_API bool cvrf_doc_tracking_set_generator_engine(struct cvrf_doc_tracking *tracking, const char *generator_engine);
 
 /**
  * @memberof cvrf_doc_tracking
@@ -1919,7 +1920,7 @@ bool cvrf_doc_tracking_set_generator_engine(struct cvrf_doc_tracking *tracking, 
  * @param generator_date Datetime of when the document was generated
  * @return true on success
  */
-bool cvrf_doc_tracking_set_generator_date(struct cvrf_doc_tracking *tracking, const char *generator_date);
+OSCAP_API bool cvrf_doc_tracking_set_generator_date(struct cvrf_doc_tracking *tracking, const char *generator_date);
 
 
 /*******************************************
@@ -1935,49 +1936,49 @@ struct cvrf_revision_iterator;
  * @param revision CVRF Revision structure to be added to the DocumentTracking
  * @return true on success
  */
-bool cvrf_doc_tracking_add_revision(struct cvrf_doc_tracking *tracking, struct cvrf_revision *revision);
+OSCAP_API bool cvrf_doc_tracking_add_revision(struct cvrf_doc_tracking *tracking, struct cvrf_revision *revision);
 
 /**
  * @memberof cvrf_doc_tracking
  * @param tracking CVRF DocumentTracking structure
  * @return Iterator representing list of all Revisions in the DocumentTracking
  */
-struct cvrf_revision_iterator *cvrf_doc_tracking_get_revision_history(const struct cvrf_doc_tracking *tracking);
+OSCAP_API struct cvrf_revision_iterator *cvrf_doc_tracking_get_revision_history(const struct cvrf_doc_tracking *tracking);
 
 /**
  * @memberof cvrf_revision_iterator
  * @param it CVRF Revision iterator structure
  * @return Next CVRF Revision in list of all Revisions in the DocumentTracking
  */
-struct cvrf_revision *cvrf_revision_iterator_next(struct cvrf_revision_iterator *it);
+OSCAP_API struct cvrf_revision *cvrf_revision_iterator_next(struct cvrf_revision_iterator *it);
 
 /**
  * @memberof cvrf_revision_iterator
  * @param it CVRF Revision iterator structure
  * @return true if the iterator has another Revision element left
  */
-bool cvrf_revision_iterator_has_more(struct cvrf_revision_iterator *it);
+OSCAP_API bool cvrf_revision_iterator_has_more(struct cvrf_revision_iterator *it);
 
 /**
  * Deallocate memory for the CVRF Revision Iterator structure
  * @memberof cvrf_revision_iterator
  * @param it CVRF Revision iterator structure
  */
-void cvrf_revision_iterator_free(struct cvrf_revision_iterator *it);
+OSCAP_API void cvrf_revision_iterator_free(struct cvrf_revision_iterator *it);
 
 /**
  * Restart iterator at the first Revision in the DocumentTracking
  * @memberof cvrf_revision_iterator
  * @param it CVRF Revision iterator structure
  */
-void cvrf_revision_iterator_reset(struct cvrf_revision_iterator *it);
+OSCAP_API void cvrf_revision_iterator_reset(struct cvrf_revision_iterator *it);
 
 /**
  * Detaches and frees the Revision iterator structure
  * @memberof cvrf_revision_iterator
  * @param it CVRF Revision iterator structure
  */
-void cvrf_revision_iterator_remove(struct cvrf_revision_iterator *it);
+OSCAP_API void cvrf_revision_iterator_remove(struct cvrf_revision_iterator *it);
 
 
 /************************************************************************************************
@@ -1996,21 +1997,21 @@ struct cvrf_doc_publisher;
  * @memberof cvrf_doc_publisher
  * @return New CVRF DocumentPublisher structure
  */
-struct cvrf_doc_publisher *cvrf_doc_publisher_new(void);
+OSCAP_API struct cvrf_doc_publisher *cvrf_doc_publisher_new(void);
 
 /**
  * Deallocates memory for a DocumentPublisher element
  * @memberof cvrf_doc_publisher
  * @param publisher The CVRF DocumentPublisher structure to be freed
  */
-void cvrf_doc_publisher_free(struct cvrf_doc_publisher *publisher);
+OSCAP_API void cvrf_doc_publisher_free(struct cvrf_doc_publisher *publisher);
 
 /**
  * @memberof cvrf_doc_publisher
  * @param revision Original DocumentPublisher structure to be cloned
  * @return New cloned DocumentPublisher structure with same data as the original
  */
-struct cvrf_doc_publisher *cvrf_doc_publisher_clone(const struct cvrf_doc_publisher *publisher);
+OSCAP_API struct cvrf_doc_publisher *cvrf_doc_publisher_clone(const struct cvrf_doc_publisher *publisher);
 
 /**
  * @memberof cvrf_doc_publisher
@@ -2018,7 +2019,7 @@ struct cvrf_doc_publisher *cvrf_doc_publisher_clone(const struct cvrf_doc_publis
  * Unique ID of the Vendor, if any, who published the document
  * @return Content of the VendorID attribute of the DocumentPublisher element
  */
-const char *cvrf_doc_publisher_get_vendor_id(const struct cvrf_doc_publisher *publisher);
+OSCAP_API const char *cvrf_doc_publisher_get_vendor_id(const struct cvrf_doc_publisher *publisher);
 
 /**
  * @memberof cvrf_doc_publisher
@@ -2026,7 +2027,7 @@ const char *cvrf_doc_publisher_get_vendor_id(const struct cvrf_doc_publisher *pu
  * Contains information needed to get contact with the document publisher
  * @return Content of the ContactDetails element of the DocumentPublisher element
  */
-const char *cvrf_doc_publisher_get_contact_details(const struct cvrf_doc_publisher *publisher);
+OSCAP_API const char *cvrf_doc_publisher_get_contact_details(const struct cvrf_doc_publisher *publisher);
 
 /**
  * @memberof cvrf_doc_publisher
@@ -2034,7 +2035,7 @@ const char *cvrf_doc_publisher_get_contact_details(const struct cvrf_doc_publish
  * Contains name of the issuer and their level of authority over the document's release
  * @return Content of the IssuingAuthority element of the DocumentPublisher element
  */
-const char *cvrf_doc_publisher_get_issuing_authority(const struct cvrf_doc_publisher *publisher);
+OSCAP_API const char *cvrf_doc_publisher_get_issuing_authority(const struct cvrf_doc_publisher *publisher);
 
 /**
  * @memberof cvrf_doc_publisher
@@ -2042,7 +2043,7 @@ const char *cvrf_doc_publisher_get_issuing_authority(const struct cvrf_doc_publi
  * @param vendor_id Unique ID of the Vendor, if any, who published the document
  * @return true on success
  */
-bool cvrf_doc_publisher_set_vendor_id(struct cvrf_doc_publisher *publisher, const char *vendor_id);
+OSCAP_API bool cvrf_doc_publisher_set_vendor_id(struct cvrf_doc_publisher *publisher, const char *vendor_id);
 
 /**
  * @memberof cvrf_doc_publisher
@@ -2050,7 +2051,7 @@ bool cvrf_doc_publisher_set_vendor_id(struct cvrf_doc_publisher *publisher, cons
  * @param contact_details Information needed to get contact with the document publisher
  * @return true on success
  */
-bool cvrf_doc_publisher_set_contact_details(struct cvrf_doc_publisher *publisher, const char *contact_details);
+OSCAP_API bool cvrf_doc_publisher_set_contact_details(struct cvrf_doc_publisher *publisher, const char *contact_details);
 
 /**
  * @memberof cvrf_doc_publisher
@@ -2058,7 +2059,7 @@ bool cvrf_doc_publisher_set_contact_details(struct cvrf_doc_publisher *publisher
  * @param issuing_authority Name of the issuer and their level of authority over the document's release
  * @return true on success
  */
-bool cvrf_doc_publisher_set_issuing_authority(struct cvrf_doc_publisher *publisher, const char *issuing_authority);
+OSCAP_API bool cvrf_doc_publisher_set_issuing_authority(struct cvrf_doc_publisher *publisher, const char *issuing_authority);
 
 /************************************************************************************************
  * @struct cvrf_reference
@@ -2074,21 +2075,21 @@ struct cvrf_reference;
  * @memberof cvrf_reference
  * @return New CVRF Reference
  */
-struct cvrf_reference *cvrf_reference_new(void);
+OSCAP_API struct cvrf_reference *cvrf_reference_new(void);
 
 /**
  * Deallocates memory for a Reference element of the References container
  * @memberof cvrf_reference
  * @param reference The CVRF Reference structure to be freed
  */
-void cvrf_reference_free(struct cvrf_reference *reference);
+OSCAP_API void cvrf_reference_free(struct cvrf_reference *reference);
 
 /**
  * @memberof cvrf_reference
  * @param revision Original Reference structure to be cloned
  * @return New cloned Reference structure with same data as the original
  */
-struct cvrf_reference *cvrf_reference_clone(const struct cvrf_reference *ref);
+OSCAP_API struct cvrf_reference *cvrf_reference_clone(const struct cvrf_reference *ref);
 
 /**
  * @memberof cvrf_reference
@@ -2096,7 +2097,7 @@ struct cvrf_reference *cvrf_reference_clone(const struct cvrf_reference *ref);
  * Contains fixed URL link to the advisory or other reference
  * @return Contents of URL element within the Reference element
  */
-const char *cvrf_reference_get_url(const struct cvrf_reference *reference);
+OSCAP_API const char *cvrf_reference_get_url(const struct cvrf_reference *reference);
 
 /**
  * @memberof cvrf_reference
@@ -2104,7 +2105,7 @@ const char *cvrf_reference_get_url(const struct cvrf_reference *reference);
  * Title or name of the Reference element
  * @return Contents of Description element within the Reference element
  */
-const char *cvrf_reference_get_description(const struct cvrf_reference *reference);
+OSCAP_API const char *cvrf_reference_get_description(const struct cvrf_reference *reference);
 
 /**
  * @memberof cvrf_reference
@@ -2112,7 +2113,7 @@ const char *cvrf_reference_get_description(const struct cvrf_reference *referenc
  * @param url Contains fixed URL link to the advisory or other reference
  * @return true on success
  */
-bool cvrf_reference_set_url(struct cvrf_reference *reference, const char *url);
+OSCAP_API bool cvrf_reference_set_url(struct cvrf_reference *reference, const char *url);
 
 /**
  * @memberof cvrf_reference
@@ -2120,7 +2121,7 @@ bool cvrf_reference_set_url(struct cvrf_reference *reference, const char *url);
  * @param description Title or name of the Reference element
  * @return true on success
  */
-bool cvrf_reference_set_description(struct cvrf_reference *reference, const char *description);
+OSCAP_API bool cvrf_reference_set_description(struct cvrf_reference *reference, const char *description);
 
 /************************************************************************************************
  * @struct cvrf_document
@@ -2133,7 +2134,7 @@ struct cvrf_document;
  * @memberof cvrf_document
  * @return New CVRF Document structure
  */
-struct cvrf_document *cvrf_document_new(void);
+OSCAP_API struct cvrf_document *cvrf_document_new(void);
 
 /**
  * Deallocates memory for the CVRF Document structure and all its child DocumentTracking,
@@ -2141,14 +2142,14 @@ struct cvrf_document *cvrf_document_new(void);
  * @memberof cvrf_document
  * @param doc The CVRF Document structure to be freed
  */
-void cvrf_document_free(struct cvrf_document *doc);
+OSCAP_API void cvrf_document_free(struct cvrf_document *doc);
 
 /**
  * @memberof cvrf_document
  * @param revision Original Document structure to be cloned
  * @return New cloned Document structure with same data as the original
  */
-struct cvrf_document *cvrf_document_clone(const struct cvrf_document *doc);
+OSCAP_API struct cvrf_document *cvrf_document_clone(const struct cvrf_document *doc);
 
 /**
  * @memberof cvrf_document
@@ -2156,7 +2157,7 @@ struct cvrf_document *cvrf_document_clone(const struct cvrf_document *doc);
  * Contains legal restrains about reproducing and using the document
  * @return contents of the DocumentDistribution element within the root cvrfdoc element
  */
-const char *cvrf_document_get_doc_distribution(const struct cvrf_document *doc);
+OSCAP_API const char *cvrf_document_get_doc_distribution(const struct cvrf_document *doc);
 
 /**
  * @memberof cvrf_document
@@ -2164,7 +2165,7 @@ const char *cvrf_document_get_doc_distribution(const struct cvrf_document *doc);
  * Conveys information about the severity of Vulnerabilities in the document
  * @return contents of the AggregateSeverity element within the root cvrfdoc element
  */
-const char *cvrf_document_get_aggregate_severity(const struct cvrf_document *doc);
+OSCAP_API const char *cvrf_document_get_aggregate_severity(const struct cvrf_document *doc);
 
 /**
  * @memberof cvrf_document
@@ -2172,7 +2173,7 @@ const char *cvrf_document_get_aggregate_severity(const struct cvrf_document *doc
  * Contains URL with link to Namespace of the AggregateSeverity element
  * @return contents of the Namespace attribute of the AggregateSeverity element
  */
-const char *cvrf_document_get_namespace(const struct cvrf_document *doc);
+OSCAP_API const char *cvrf_document_get_namespace(const struct cvrf_document *doc);
 
 /**
  * @memberof cvrf_document
@@ -2180,7 +2181,7 @@ const char *cvrf_document_get_namespace(const struct cvrf_document *doc);
  * Structure with all elements for tracking and referencing the document itself
  * @return DocumentTracking structure of the cvrfdoc root element
  */
-struct cvrf_doc_tracking *cvrf_document_get_tracking(const struct cvrf_document *doc);
+OSCAP_API struct cvrf_doc_tracking *cvrf_document_get_tracking(const struct cvrf_document *doc);
 
 /**
  * @memberof cvrf_document
@@ -2188,7 +2189,7 @@ struct cvrf_doc_tracking *cvrf_document_get_tracking(const struct cvrf_document 
  * Structure with all elements that give information about the publisher
  * @return DocumentPublisher structure of the cvrfdoc root element
  */
-struct cvrf_doc_publisher *cvrf_document_get_publisher(const struct cvrf_document *doc);
+OSCAP_API struct cvrf_doc_publisher *cvrf_document_get_publisher(const struct cvrf_document *doc);
 
 /**
  * @memberof cvrf_document
@@ -2196,7 +2197,7 @@ struct cvrf_doc_publisher *cvrf_document_get_publisher(const struct cvrf_documen
  * Represents the DocumentNotes container that holds all Note elements
  * @return Iterator for the list of Notes within the DocumentNotes container
  */
-struct oscap_iterator *cvrf_document_get_notes(struct cvrf_document *doc);
+OSCAP_API struct oscap_iterator *cvrf_document_get_notes(struct cvrf_document *doc);
 
 /**
  * @memberof cvrf_document
@@ -2204,7 +2205,7 @@ struct oscap_iterator *cvrf_document_get_notes(struct cvrf_document *doc);
  * Represents the DocumentReferences container that holds all Reference elements
  * @return Iterator for the list of References within the DocumentReferences container
  */
-struct oscap_iterator *cvrf_document_get_references(struct cvrf_document *doc);
+OSCAP_API struct oscap_iterator *cvrf_document_get_references(struct cvrf_document *doc);
 
 /**
  * @memberof cvrf_document
@@ -2212,7 +2213,7 @@ struct oscap_iterator *cvrf_document_get_references(struct cvrf_document *doc);
  * Represents the Acknowledgments container that holds all Acknowledgment elements
  * @return Iterator for the Acknowledgment list within the Acknowledgments container
  */
-struct oscap_iterator *cvrf_document_get_acknowledgments(struct cvrf_document *doc);
+OSCAP_API struct oscap_iterator *cvrf_document_get_acknowledgments(struct cvrf_document *doc);
 
 /**
  * @memberof cvrf_document
@@ -2220,7 +2221,7 @@ struct oscap_iterator *cvrf_document_get_acknowledgments(struct cvrf_document *d
  * @param distribution Legal restrains about reproducing and using the document
  * @return true on success
  */
-bool cvrf_document_set_doc_distribution(struct cvrf_document *doc, const char *distribution);
+OSCAP_API bool cvrf_document_set_doc_distribution(struct cvrf_document *doc, const char *distribution);
 
 /**
  * @memberof cvrf_document
@@ -2228,7 +2229,7 @@ bool cvrf_document_set_doc_distribution(struct cvrf_document *doc, const char *d
  * @param severity Information about the severity of Vulnerabilities in the document
  * @return true on success
  */
-bool cvrf_document_set_aggregate_severity(struct cvrf_document *doc, const char *severity);
+OSCAP_API bool cvrf_document_set_aggregate_severity(struct cvrf_document *doc, const char *severity);
 
 /**
  * @memberof cvrf_document
@@ -2236,7 +2237,7 @@ bool cvrf_document_set_aggregate_severity(struct cvrf_document *doc, const char 
  * @param ns URL with link to Namespace of the AggregateSeverity element
  * @return true on success
  */
-bool cvrf_document_set_namespace(struct cvrf_document *doc, const char *ns);
+OSCAP_API bool cvrf_document_set_namespace(struct cvrf_document *doc, const char *ns);
 
 /**
  * @memberof cvrf_document
@@ -2244,7 +2245,7 @@ bool cvrf_document_set_namespace(struct cvrf_document *doc, const char *ns);
  * @param publisher Structure with all elements that give information about the publisher
  * @return true on success
  */
-bool cvrf_document_set_publisher(struct cvrf_document *doc, struct cvrf_doc_publisher *publisher);
+OSCAP_API bool cvrf_document_set_publisher(struct cvrf_document *doc, struct cvrf_doc_publisher *publisher);
 
 /**
  * @memberof cvrf_document
@@ -2252,7 +2253,7 @@ bool cvrf_document_set_publisher(struct cvrf_document *doc, struct cvrf_doc_publ
  * @param track Structure with all elements for tracking and referencing the document itself
  * @return true on success
  */
-bool cvrf_document_set_tracking(struct cvrf_document *doc, struct cvrf_doc_tracking *track);
+OSCAP_API bool cvrf_document_set_tracking(struct cvrf_document *doc, struct cvrf_doc_tracking *track);
 
 /************************************************************************************************
  * @struct cvrf_model
@@ -2269,21 +2270,21 @@ struct cvrf_model;
  * @memberof cvrf_model
  * @return New CVRF model
  */
-struct cvrf_model *cvrf_model_new(void);
+OSCAP_API struct cvrf_model *cvrf_model_new(void);
 
 /**
  * Deallocates memory for the CVRF Model structure and all its child elements
  * @memberof cvrf_model
  * @param cvrf The CVRF Model structure to be freed
  */
-void cvrf_model_free(struct cvrf_model *cvrf);
+OSCAP_API void cvrf_model_free(struct cvrf_model *cvrf);
 
 /**
  * @memberof cvrf_model
  * @param model Original CVRF Model structure to be cloned
  * @return New cloned CVRF Model structure with same data as the original
  */
-struct cvrf_model *cvrf_model_clone(const struct cvrf_model *model);
+OSCAP_API struct cvrf_model *cvrf_model_clone(const struct cvrf_model *model);
 
 /**
  * Removes all Branches, Relationships, and ProductIDs within Vulnerabilities that
@@ -2293,7 +2294,7 @@ struct cvrf_model *cvrf_model_clone(const struct cvrf_model *model);
  * @param cpe CPE name by which to filter the Model
  * @return 0 on success, -1 on failure
  */
-int cvrf_model_filter_by_cpe(struct cvrf_model *model, const char *cpe);
+OSCAP_API int cvrf_model_filter_by_cpe(struct cvrf_model *model, const char *cpe);
 
 /**
  * @memberof cvrf_model
@@ -2301,7 +2302,7 @@ int cvrf_model_filter_by_cpe(struct cvrf_model *model, const char *cpe);
  * Definitive canonical name for the document
  * @return Contents of DocumentTitle element within the root cvrfdoc element
  */
-const char *cvrf_model_get_doc_title(const struct cvrf_model *model);
+OSCAP_API const char *cvrf_model_get_doc_title(const struct cvrf_model *model);
 
 /**
  * @memberof cvrf_model
@@ -2309,7 +2310,7 @@ const char *cvrf_model_get_doc_title(const struct cvrf_model *model);
  * Short canonical name of the document's type
  * @return Contents of DocumentType element within the root cvrfdoc element
  */
-const char *cvrf_model_get_doc_type(const struct cvrf_model *model);
+OSCAP_API const char *cvrf_model_get_doc_type(const struct cvrf_model *model);
 
 /**
  * @memberof cvrf_model
@@ -2317,7 +2318,7 @@ const char *cvrf_model_get_doc_type(const struct cvrf_model *model);
  * @param doc_title Definitive canonical name for the document
  * @return true on success
  */
-bool cvrf_model_set_doc_title(struct cvrf_model *model, const char *doc_title);
+OSCAP_API bool cvrf_model_set_doc_title(struct cvrf_model *model, const char *doc_title);
 
 /**
  * @memberof cvrf_model
@@ -2325,7 +2326,7 @@ bool cvrf_model_set_doc_title(struct cvrf_model *model, const char *doc_title);
  * @param doc_type Short canonical name of the document's type
  * @return true on success
  */
-bool cvrf_model_set_doc_type(struct cvrf_model *model, const char *doc_type);
+OSCAP_API bool cvrf_model_set_doc_type(struct cvrf_model *model, const char *doc_type);
 
 /**
  * @memberof cvrf_model
@@ -2333,7 +2334,7 @@ bool cvrf_model_set_doc_type(struct cvrf_model *model, const char *doc_type);
  * Contains all Product names needed for referencing elsewhere in the document
  * @return ProductTree structure within the root cvrfdoc element
  */
-struct cvrf_product_tree *cvrf_model_get_product_tree(struct cvrf_model *model);
+OSCAP_API struct cvrf_product_tree *cvrf_model_get_product_tree(struct cvrf_model *model);
 
 /**
  * @memberof cvrf_model
@@ -2342,14 +2343,14 @@ struct cvrf_product_tree *cvrf_model_get_product_tree(struct cvrf_model *model);
  * DocumentTracking, DocumentPublisher, and Notes
  * @return Document structures within the root cvrfdoc element
  */
-struct cvrf_document *cvrf_model_get_document(const struct cvrf_model *model);
+OSCAP_API struct cvrf_document *cvrf_model_get_document(const struct cvrf_model *model);
 
 /**
  * @memberof cvrf_model
  * @param model CVRF Model structure
  * @return Unique ID used to track this document
  */
-const char *cvrf_model_get_identification(struct cvrf_model *model);
+OSCAP_API const char *cvrf_model_get_identification(struct cvrf_model *model);
 
 /**
  * @memberof cvrf_model
@@ -2357,7 +2358,7 @@ const char *cvrf_model_get_identification(struct cvrf_model *model);
  * @param doc Structure that holds all document-related metadata
  * @return true on success
  */
-bool cvrf_model_set_document(struct cvrf_model *model, struct cvrf_document *doc);
+OSCAP_API bool cvrf_model_set_document(struct cvrf_model *model, struct cvrf_document *doc);
 
 /*******************************************
  * @struct cvrf_vulnerability_iterator
@@ -2371,7 +2372,7 @@ struct cvrf_vulnerability_iterator;
  * @param model CVRF Model structure
  * @return Iterator representing list of all Vulnerabilities in the model
  */
-struct cvrf_vulnerability_iterator *cvrf_model_get_vulnerabilities(const struct cvrf_model *model);
+OSCAP_API struct cvrf_vulnerability_iterator *cvrf_model_get_vulnerabilities(const struct cvrf_model *model);
 
 /**
  * @memberof cvrf_model
@@ -2379,42 +2380,42 @@ struct cvrf_vulnerability_iterator *cvrf_model_get_vulnerabilities(const struct 
  * @param vuln CVRF Vulnerability structure to be added to the model
  * @return true on success
  */
-bool cvrf_model_add_vulnerability(struct cvrf_model *model, struct cvrf_vulnerability *vuln);
+OSCAP_API bool cvrf_model_add_vulnerability(struct cvrf_model *model, struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability_iterator
  * @param it CVRF Vulnerability iterator structure
  * @return Next CVRF Vulnerability in list of all Vulnerabilities in the document
  */
-struct cvrf_vulnerability *cvrf_vulnerability_iterator_next(struct cvrf_vulnerability_iterator *it);
+OSCAP_API struct cvrf_vulnerability *cvrf_vulnerability_iterator_next(struct cvrf_vulnerability_iterator *it);
 
 /**
  * @memberof cvrf_vulnerability_iterator
  * @param it CVRF Vulnerability iterator structure
  * @return true if the iterator has another Vulnerability element left
  */
-bool cvrf_vulnerability_iterator_has_more(struct cvrf_vulnerability_iterator *it);
+OSCAP_API bool cvrf_vulnerability_iterator_has_more(struct cvrf_vulnerability_iterator *it);
 
 /**
  * Deallocate memory for the CVRF Vulnerability Iterator structure
  * @memberof cvrf_vulnerability_iterator
  * @param it CVRF Vulnerability iterator structure
  */
-void cvrf_vulnerability_iterator_free(struct cvrf_vulnerability_iterator *it);
+OSCAP_API void cvrf_vulnerability_iterator_free(struct cvrf_vulnerability_iterator *it);
 
 /**
  * Restart iterator at the first Vulnerability in the document
  * @memberof cvrf_vulnerability_iterator
  * @param it CVRF Vulnerability iterator structure
  */
-void cvrf_vulnerability_iterator_reset(struct cvrf_vulnerability_iterator *it);
+OSCAP_API void cvrf_vulnerability_iterator_reset(struct cvrf_vulnerability_iterator *it);
 
 /**
  * Detaches and frees the Vulnerability iterator structure
  * @memberof cvrf_vulnerability_iterator
  * @param it CVRF Vulnerability iterator structure
  */
-void cvrf_vulnerability_iterator_remove(struct cvrf_vulnerability_iterator *it);
+OSCAP_API void cvrf_vulnerability_iterator_remove(struct cvrf_vulnerability_iterator *it);
 
 
 /************************************************************************************************
@@ -2429,21 +2430,21 @@ struct cvrf_index;
  * @memberof cvrf_index
  * @return New CVRF index structure
  */
-struct cvrf_index *cvrf_index_new(void);
+OSCAP_API struct cvrf_index *cvrf_index_new(void);
 
 /**
  * Deallocates memory for the CVRF Index structure and all the Models it contains
  * @memberof cvrf_index
  * @param index The CVRF Index structure to be freed
  */
-void cvrf_index_free(struct cvrf_index *index);
+OSCAP_API void cvrf_index_free(struct cvrf_index *index);
 
 /**
  * @memberof cvrf_index
  * @param index Original CVRF Index structure to be cloned
  * @return New cloned CVRF Index structure with same data as the original
  */
-struct cvrf_index *cvrf_index_clone(const struct cvrf_index *index);
+OSCAP_API struct cvrf_index *cvrf_index_clone(const struct cvrf_index *index);
 
 /**
  * @memberof cvrf_index
@@ -2451,7 +2452,7 @@ struct cvrf_index *cvrf_index_clone(const struct cvrf_index *index);
  * Reference to source URL used to find all CVRF files contained in the index
  * @return String representation of source URL, if one was used
  */
-const char *cvrf_index_get_source_url(const struct cvrf_index *index);
+OSCAP_API const char *cvrf_index_get_source_url(const struct cvrf_index *index);
 
 /**
  * @memberof cvrf_index
@@ -2459,7 +2460,7 @@ const char *cvrf_index_get_source_url(const struct cvrf_index *index);
  * Reference to path to local index file with list of all CVRF files contained in the index
  * @return String representation of source filepath
  */
-const char *cvrf_index_get_index_file(const struct cvrf_index *index);
+OSCAP_API const char *cvrf_index_get_index_file(const struct cvrf_index *index);
 
 /**
  * @memberof cvrf_index
@@ -2467,7 +2468,7 @@ const char *cvrf_index_get_index_file(const struct cvrf_index *index);
  * @param url Source URL used to find all CVRF files contained in the index
  * @return true on success
  */
-bool cvrf_index_set_source_url(struct cvrf_index *index, const char *url);
+OSCAP_API bool cvrf_index_set_source_url(struct cvrf_index *index, const char *url);
 
 /**
  * @memberof cvrf_index
@@ -2475,7 +2476,7 @@ bool cvrf_index_set_source_url(struct cvrf_index *index, const char *url);
  * @param index_file Filepath with list of all CVRF files contained in the index
  * @return true on success
  */
-bool cvrf_index_set_index_file(struct cvrf_index *index, const char *index_file);
+OSCAP_API bool cvrf_index_set_index_file(struct cvrf_index *index, const char *index_file);
 
 /*******************************************
  * @struct cvrf_model_iterator
@@ -2490,49 +2491,49 @@ struct cvrf_model_iterator;
  * @param model CVRF Model structure to be added to the Index structure
  * @return true on success
  */
-bool cvrf_index_add_model(struct cvrf_index *index, struct cvrf_model *model);
+OSCAP_API bool cvrf_index_add_model(struct cvrf_index *index, struct cvrf_model *model);
 
 /**
  * @memberof cvrf_index
  * @param index CVRF Index structure
  * @return Iterator representing list of all Models in the Index
  */
-struct cvrf_model_iterator *cvrf_index_get_models(const struct cvrf_index *index);
+OSCAP_API struct cvrf_model_iterator *cvrf_index_get_models(const struct cvrf_index *index);
 
 /**
  * @memberof cvrf_model_iterator
  * @param it CVRF Model iterator structure
  * @return Next CVRF Model in list of all Models in the Index
  */
-struct cvrf_model *cvrf_model_iterator_next(struct cvrf_model_iterator *it);
+OSCAP_API struct cvrf_model *cvrf_model_iterator_next(struct cvrf_model_iterator *it);
 
 /**
  * @memberof cvrf_model_iterator
  * @param it CVRF Model iterator structure
  * @return true if the iterator has another Model element left
  */
-bool cvrf_model_iterator_has_more(struct cvrf_model_iterator *it);
+OSCAP_API bool cvrf_model_iterator_has_more(struct cvrf_model_iterator *it);
 
 /**
  * Deallocate memory for the CVRF Model Iterator structure
  * @memberof cvrf_model_iterator
  * @param it CVRF Model iterator structure
  */
-void cvrf_model_iterator_free(struct cvrf_model_iterator *it);
+OSCAP_API void cvrf_model_iterator_free(struct cvrf_model_iterator *it);
 
 /**
  * Restart iterator at the first Model contained in the Index
  * @memberof cvrf_model_iterator
  * @param it CVRF Model iterator structure
  */
-void cvrf_model_iterator_reset(struct cvrf_model_iterator *it);
+OSCAP_API void cvrf_model_iterator_reset(struct cvrf_model_iterator *it);
 
 /**
  * Detaches and frees the Model iterator structure
  * @memberof cvrf_model_iterator
  * @param it CVRF Model iterator structure
  */
-void cvrf_model_iterator_remove(struct cvrf_model_iterator *it);
+OSCAP_API void cvrf_model_iterator_remove(struct cvrf_model_iterator *it);
 
 
 /************************************************************************************************
@@ -2548,35 +2549,35 @@ struct cvrf_session;
  * @param source OSCAP import source for a CVRF document
  * @return CVRF session structure generated from this import source
  */
-struct cvrf_session *cvrf_session_new_from_source_model(struct oscap_source *source);
+OSCAP_API struct cvrf_session *cvrf_session_new_from_source_model(struct oscap_source *source);
 
 /**
  * @memberof cvrf_session
  * @param source OSCAP import source for an index of CVRF files
  * @return CVRF session structure generated from this import source
  */
-struct cvrf_session *cvrf_session_new_from_source_index(struct oscap_source *source);
+OSCAP_API struct cvrf_session *cvrf_session_new_from_source_index(struct oscap_source *source);
 
 /**
  * Deallocates memory for a CVRF Session structure
  * @memberof cvrf_session
  * @param session CVRF session structure to be freed
  */
-void cvrf_session_free(struct cvrf_session *session);
+OSCAP_API void cvrf_session_free(struct cvrf_session *session);
 
 /**
  * @memberof cvrf_session
  * @param session CVRF session structure
  * @return CVRF model structure imported into the session, if any
  */
-struct cvrf_model *cvrf_session_get_model(struct cvrf_session *session);
+OSCAP_API struct cvrf_model *cvrf_session_get_model(struct cvrf_session *session);
 
 /**
  * @memberof cvrf_session
  * @param session CVRF session structure
  * @return CVRF index structure imported into the session, if any
  */
-struct cvrf_index *cvrf_session_get_index(const struct cvrf_session *session);
+OSCAP_API struct cvrf_index *cvrf_session_get_index(const struct cvrf_session *session);
 
 /**
  * After filtering the CVRF model structure by the CPE, all the ProductIDs related
@@ -2585,14 +2586,14 @@ struct cvrf_index *cvrf_session_get_index(const struct cvrf_session *session);
  * @param session CVRF session structure
  * @return Iterator for the list of ProductIDs maintained by the session structure
  */
-struct oscap_string_iterator *cvrf_session_get_product_ids(struct cvrf_session *session);
+OSCAP_API struct oscap_string_iterator *cvrf_session_get_product_ids(struct cvrf_session *session);
 
 /**
  * @memberof cvrf_session
  * @param session CVRF session structure
  * @return CPE used to evaluate the CVRF model(s)
  */
-const char *cvrf_session_get_os_name(const struct cvrf_session *session);
+OSCAP_API const char *cvrf_session_get_os_name(const struct cvrf_session *session);
 
 /**
  * Add the CVRF model to be evaluated to the Session structure
@@ -2600,7 +2601,7 @@ const char *cvrf_session_get_os_name(const struct cvrf_session *session);
  * @param session CVRF session structure
  * @param model CVRF model to be added to the CVRF session structure
  */
-void cvrf_session_set_model(struct cvrf_session *session, struct cvrf_model *model);
+OSCAP_API void cvrf_session_set_model(struct cvrf_session *session, struct cvrf_model *model);
 
 /**
  * Add the CVRF index to be evaluated to the Session structure
@@ -2609,7 +2610,7 @@ void cvrf_session_set_model(struct cvrf_session *session, struct cvrf_model *mod
  * @param index CVRF index to be added to the CVRF session structure
  * @return true on success
  */
-bool cvrf_session_set_index(struct cvrf_session *session, struct cvrf_index *index);
+OSCAP_API bool cvrf_session_set_index(struct cvrf_session *session, struct cvrf_index *index);
 
 /**
  * Add the CPE name for filtering of relevant ProductIDs and CVRF elements
@@ -2618,7 +2619,7 @@ bool cvrf_session_set_index(struct cvrf_session *session, struct cvrf_index *ind
  * @param os_name CPE name to be added to the Session structure
  * @return true on success
  */
-bool cvrf_session_set_os_name(struct cvrf_session *session, const char *os_name);
+OSCAP_API bool cvrf_session_set_os_name(struct cvrf_session *session, const char *os_name);
 
 /************************************************************************************************
  * @struct cvrf_rpm_attributes
@@ -2633,21 +2634,21 @@ struct cvrf_rpm_attributes;
  * @memberof cvrf_rpm_attributes
  * @return New CVRF RPM attributes structure
  */
-struct cvrf_rpm_attributes *cvrf_rpm_attributes_new(void);
+OSCAP_API struct cvrf_rpm_attributes *cvrf_rpm_attributes_new(void);
 
 /**
  * Deallocate memory for the CVRF RPM attributes structure
  * @memberof cvrf_rpm_attributes
  * @param attributes CVRF RPM attributes structure to be freed
  */
-void cvrf_rpm_attributes_free(struct cvrf_rpm_attributes *attributes);
+OSCAP_API void cvrf_rpm_attributes_free(struct cvrf_rpm_attributes *attributes);
 
 /**
  * @memberof cvrf_rpm_attributes
  * @param attributes CVRF RPM Attributes structure
  * @return Entire RPM package name
  */
-const char *cvrf_rpm_attributes_get_full_package_name(const struct cvrf_rpm_attributes *attributes);
+OSCAP_API const char *cvrf_rpm_attributes_get_full_package_name(const struct cvrf_rpm_attributes *attributes);
 
 /**
  * Used to check if the RPM file exists on the system during evaluation
@@ -2655,7 +2656,7 @@ const char *cvrf_rpm_attributes_get_full_package_name(const struct cvrf_rpm_attr
  * @param attributes CVRF RPM Attributes structure
  * @return RPM package name (without release or version)
  */
-const char *cvrf_rpm_attributes_get_rpm_name(const struct cvrf_rpm_attributes *attributes);
+OSCAP_API const char *cvrf_rpm_attributes_get_rpm_name(const struct cvrf_rpm_attributes *attributes);
 
 /**
  * Used to check if the system is vulnerable by comparing EVR from the system to EVR in the
@@ -2664,7 +2665,7 @@ const char *cvrf_rpm_attributes_get_rpm_name(const struct cvrf_rpm_attributes *a
  * @param attributes CVRF RPM Attributes structure
  * @return EVR format of the RPM package
  */
-const char *cvrf_rpm_attributes_get_evr_format(const struct cvrf_rpm_attributes *attributes);
+OSCAP_API const char *cvrf_rpm_attributes_get_evr_format(const struct cvrf_rpm_attributes *attributes);
 
 /**
  * @memberof cvrf_rpm_attributes
@@ -2672,7 +2673,7 @@ const char *cvrf_rpm_attributes_get_evr_format(const struct cvrf_rpm_attributes 
  * @param full_package Full length RPM package name
  * @return true on success
  */
-bool cvrf_rpm_attributes_set_full_package_name(struct cvrf_rpm_attributes *attributes, const char *full_package);
+OSCAP_API bool cvrf_rpm_attributes_set_full_package_name(struct cvrf_rpm_attributes *attributes, const char *full_package);
 
 /**
  * @memberof cvrf_rpm_attributes
@@ -2680,7 +2681,7 @@ bool cvrf_rpm_attributes_set_full_package_name(struct cvrf_rpm_attributes *attri
  * @param rpm_name Package name (without version or release) of an RPM package
  * @return true on success
  */
-bool cvrf_rpm_attributes_set_rpm_name(struct cvrf_rpm_attributes *attributes, const char *rpm_name);
+OSCAP_API bool cvrf_rpm_attributes_set_rpm_name(struct cvrf_rpm_attributes *attributes, const char *rpm_name);
 
 /**
  * @memberof cvrf_rpm_attributes
@@ -2688,7 +2689,7 @@ bool cvrf_rpm_attributes_set_rpm_name(struct cvrf_rpm_attributes *attributes, co
  * @param evr_format String representation of the EVR of an RPM package
  * @return true on success
  */
-bool cvrf_rpm_attributes_set_evr_format(struct cvrf_rpm_attributes *attributes, const char *evr_format);
+OSCAP_API bool cvrf_rpm_attributes_set_evr_format(struct cvrf_rpm_attributes *attributes, const char *evr_format);
 
 
 /************************************************************************************************/
@@ -2700,7 +2701,7 @@ bool cvrf_rpm_attributes_set_evr_format(struct cvrf_rpm_attributes *attributes, 
  * @return version of XML file format
  * @memberof cvrf_model
  */
-const char * cvrf_model_supported(void);
+OSCAP_API const char * cvrf_model_supported(void);
 
 /**
  * Parses specified text index file and parses each filename in the list
@@ -2709,7 +2710,7 @@ const char * cvrf_model_supported(void);
  * @param index_source OSCAP source with path to CVRF file
  * @return New CVRF index containing all CVRF models
  */
-struct cvrf_index *cvrf_index_import(struct oscap_source *index_source);
+OSCAP_API struct cvrf_index *cvrf_index_import(struct oscap_source *index_source);
 
 /**
  * Parses the specified XML file and creates a list of CVRF data structures.
@@ -2717,7 +2718,7 @@ struct cvrf_index *cvrf_index_import(struct oscap_source *index_source);
  * @param source OSCAP source with path to CVRF file
  * @return New CVRF model structure
  */
-struct cvrf_model *cvrf_model_import(struct oscap_source *source);
+OSCAP_API struct cvrf_model *cvrf_model_import(struct oscap_source *source);
 
 /**
  * Export CVRF Index to the export source as an XML doc
@@ -2725,7 +2726,7 @@ struct cvrf_model *cvrf_model_import(struct oscap_source *source);
  * @param index CVRF index structure
  * @return Export target source for the Index, NULL on failure
  */
-struct oscap_source *cvrf_index_get_export_source(struct cvrf_index *index);
+OSCAP_API struct oscap_source *cvrf_index_get_export_source(struct cvrf_index *index);
 
 /**
  * Export CVRF Model to the export source as an XML doc
@@ -2733,7 +2734,7 @@ struct oscap_source *cvrf_index_get_export_source(struct cvrf_index *index);
  * @param model CVRF Model structure
  * @return Export target source for the Model, NULL on failure
  */
-struct oscap_source *cvrf_model_get_export_source(struct cvrf_model *model);
+OSCAP_API struct oscap_source *cvrf_model_get_export_source(struct cvrf_model *model);
 
 /**
  * Import and parse the CVRF Model from the provided source, filter it by CPE to find
@@ -2743,7 +2744,7 @@ struct oscap_source *cvrf_model_get_export_source(struct cvrf_model *model);
  * @param os_name CPE name used to find relevant RPM packages to check for vulnerabilities
  * @return OSCAP source export target for the results XML file
  */
-struct oscap_source *cvrf_model_get_results_source(struct oscap_source *import_source, const char *os_name);
+OSCAP_API struct oscap_source *cvrf_model_get_results_source(struct oscap_source *import_source, const char *os_name);
 
 /**
  * Import and parse the CVRF Index from the provided source, filter it by CPE to find
@@ -2753,7 +2754,7 @@ struct oscap_source *cvrf_model_get_results_source(struct oscap_source *import_s
  * @param os_name CPE name used to find relevant RPM packages to check for vulnerabilities
  * @return OSCAP source export target for the results XML file
  */
-struct oscap_source *cvrf_index_get_results_source(struct oscap_source *import_source, const char *os_name);
+OSCAP_API struct oscap_source *cvrf_index_get_results_source(struct oscap_source *import_source, const char *os_name);
 
 
 /**@}*/

--- a/src/CVSS/public/cvss_score.h
+++ b/src/CVSS/public/cvss_score.h
@@ -38,10 +38,11 @@
 #include <stdbool.h>
 #include <time.h>
 #include <stdio.h>
+#include "oscap_export.h"
 
 
 /// Get supported version of CVSS XML
-const char *cvss_model_supported(void);
+OSCAP_API const char *cvss_model_supported(void);
 
 /// CVSS score category
 enum cvss_category {
@@ -163,37 +164,37 @@ struct cvss_impact;
 struct cvss_metrics;
 
 /// Round @a x to one decimal place as described in CVSS standard
-float cvss_round(float x);
+OSCAP_API float cvss_round(float x);
 
 /// @memberof cvss_impact
-struct cvss_impact *cvss_impact_new(void);
+OSCAP_API struct cvss_impact *cvss_impact_new(void);
 /// @memberof cvss_impact
-struct cvss_impact *cvss_impact_new_from_vector(const char *cvss_vector);
+OSCAP_API struct cvss_impact *cvss_impact_new_from_vector(const char *cvss_vector);
 /// @memberof cvss_impact
-struct cvss_impact *cvss_impact_clone(const struct cvss_impact* impact);
+OSCAP_API struct cvss_impact *cvss_impact_clone(const struct cvss_impact* impact);
 /// @memberof cvss_impact
 //struct cvss_impact *cvss_impact_new_parse(const char *filename);
 /// @memberof cvss_impact
-void cvss_impact_free(struct cvss_impact* impact);
+OSCAP_API void cvss_impact_free(struct cvss_impact* impact);
 /**
  * Write out a human-readable textual description of CVSS impact contents.
  * @param impact Impact to describe
  * @param f file handle to write the description to
  * @memberof cvss_impact
  */
-void cvss_impact_describe(const struct cvss_impact *impact, FILE *f);
+OSCAP_API void cvss_impact_describe(const struct cvss_impact *impact, FILE *f);
 
 /// @memberof cvss_impact
-struct cvss_metrics *cvss_impact_get_base_metrics(const struct cvss_impact* impact);
+OSCAP_API struct cvss_metrics *cvss_impact_get_base_metrics(const struct cvss_impact* impact);
 /// @memberof cvss_impact
-struct cvss_metrics *cvss_impact_get_temporal_metrics(const struct cvss_impact* impact);
+OSCAP_API struct cvss_metrics *cvss_impact_get_temporal_metrics(const struct cvss_impact* impact);
 /// @memberof cvss_impact
-struct cvss_metrics *cvss_impact_get_environmental_metrics(const struct cvss_impact* impact);
+OSCAP_API struct cvss_metrics *cvss_impact_get_environmental_metrics(const struct cvss_impact* impact);
 /// Set base, temporal, or environmental metrics (type is determined from the metrics itself)
 /// @memberof cvss_impact
-bool cvss_impact_set_metrics(struct cvss_impact* impact, struct cvss_metrics *metrics);
+OSCAP_API bool cvss_impact_set_metrics(struct cvss_impact* impact, struct cvss_metrics *metrics);
 /// @memberof cvss_impact
-char *cvss_impact_to_vector(const struct cvss_impact* impact);
+OSCAP_API char *cvss_impact_to_vector(const struct cvss_impact* impact);
 
 /**
  * @name Score calculators
@@ -216,7 +217,7 @@ char *cvss_impact_to_vector(const struct cvss_impact* impact);
  * @see cvss_impact_adjusted_base_score()
  * @memberof cvss_impact
  */
-float cvss_impact_base_exploitability_subscore(const struct cvss_impact* impact);
+OSCAP_API float cvss_impact_base_exploitability_subscore(const struct cvss_impact* impact);
 
 /**
  * Calculate impact subscore of base score.
@@ -226,7 +227,7 @@ float cvss_impact_base_exploitability_subscore(const struct cvss_impact* impact)
  * @see cvss_impact_base_score()
  * @memberof cvss_impact
  */
-float cvss_impact_base_impact_subscore(const struct cvss_impact* impact);
+OSCAP_API float cvss_impact_base_impact_subscore(const struct cvss_impact* impact);
 
 /**
  * Calculate base score.
@@ -240,7 +241,7 @@ float cvss_impact_base_impact_subscore(const struct cvss_impact* impact);
  * @see cvss_impact_base_adjusted_impact_subscore()
  * @memberof cvss_impact
  */
-float cvss_impact_base_score(const struct cvss_impact* impact);
+OSCAP_API float cvss_impact_base_score(const struct cvss_impact* impact);
 
 /**
  * Calculate temporal multiplier.
@@ -255,7 +256,7 @@ float cvss_impact_base_score(const struct cvss_impact* impact);
  * @see cvss_impact_adjusted_temporal_score()
  * @memberof cvss_impact
  */
-float cvss_impact_temporal_multiplier(const struct cvss_impact* impact);
+OSCAP_API float cvss_impact_temporal_multiplier(const struct cvss_impact* impact);
 
 /**
  * Calculate temporal score.
@@ -266,7 +267,7 @@ float cvss_impact_temporal_multiplier(const struct cvss_impact* impact);
  * @see cvss_impact_adjusted_temporal_score()
  * @memberof cvss_impact
  */
-float cvss_impact_temporal_score(const struct cvss_impact* impact);
+OSCAP_API float cvss_impact_temporal_score(const struct cvss_impact* impact);
 
 /**
  * Calculate impact subscore of base score adjusted to particular environment.
@@ -276,7 +277,7 @@ float cvss_impact_temporal_score(const struct cvss_impact* impact);
  * @see cvss_impact_adjusted_base_score()
  * @memberof cvss_impact
  */
-float cvss_impact_base_adjusted_impact_subscore(const struct cvss_impact* impact);
+OSCAP_API float cvss_impact_base_adjusted_impact_subscore(const struct cvss_impact* impact);
 
 /**
  * Calculate base score adjusted to particular environment.
@@ -285,7 +286,7 @@ float cvss_impact_base_adjusted_impact_subscore(const struct cvss_impact* impact
  * @see cvss_impact_base_score()
  * @memberof cvss_impact
  */
-float cvss_impact_adjusted_base_score(const struct cvss_impact* impact);
+OSCAP_API float cvss_impact_adjusted_base_score(const struct cvss_impact* impact);
 
 /**
  * Calculate temporal score adjusted to particular environment.
@@ -294,7 +295,7 @@ float cvss_impact_adjusted_base_score(const struct cvss_impact* impact);
  * @see cvss_impact_temporal_score()
  * @memberof cvss_impact
  */
-float cvss_impact_adjusted_temporal_score(const struct cvss_impact* impact);
+OSCAP_API float cvss_impact_adjusted_temporal_score(const struct cvss_impact* impact);
 
 /**
  * Calculate environmental score.
@@ -307,39 +308,39 @@ float cvss_impact_adjusted_temporal_score(const struct cvss_impact* impact);
  * @see cvss_impact_adjusted_temporal_score()
  * @memberof cvss_impact
  */
-float cvss_impact_environmental_score(const struct cvss_impact* impact);
+OSCAP_API float cvss_impact_environmental_score(const struct cvss_impact* impact);
 
 /** @} */
 
 /// @memberof cvss_metrics
-struct cvss_metrics *cvss_metrics_new(enum cvss_category category);
+OSCAP_API struct cvss_metrics *cvss_metrics_new(enum cvss_category category);
 /// @memberof cvss_metrics
-struct cvss_metrics *cvss_metrics_clone(const struct cvss_metrics* metrics);
+OSCAP_API struct cvss_metrics *cvss_metrics_clone(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-void cvss_metrics_free(struct cvss_metrics* metrics);
+OSCAP_API void cvss_metrics_free(struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_category cvss_metrics_get_category(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_category cvss_metrics_get_category(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-const char *cvss_metrics_get_source(const struct cvss_metrics* metrics);
+OSCAP_API const char *cvss_metrics_get_source(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_source(struct cvss_metrics* metrics, const char *new_source);
+OSCAP_API bool cvss_metrics_set_source(struct cvss_metrics* metrics, const char *new_source);
 /// @memberof cvss_metrics
-const char *cvss_metrics_get_generated_on_datetime(const struct cvss_metrics* metrics);
+OSCAP_API const char *cvss_metrics_get_generated_on_datetime(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_generated_on_datetime(struct cvss_metrics* metrics, const char *new_datetime);
+OSCAP_API bool cvss_metrics_set_generated_on_datetime(struct cvss_metrics* metrics, const char *new_datetime);
 /// @memberof cvss_metrics
-const char *cvss_metrics_get_upgraded_from_version(const struct cvss_metrics* metrics);
+OSCAP_API const char *cvss_metrics_get_upgraded_from_version(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_upgraded_from_version(struct cvss_metrics* metrics, const char *new_upgraded_from_version);
+OSCAP_API bool cvss_metrics_set_upgraded_from_version(struct cvss_metrics* metrics, const char *new_upgraded_from_version);
 /// @memberof cvss_metrics
-float cvss_metrics_get_score(const struct cvss_metrics* metrics);
+OSCAP_API float cvss_metrics_get_score(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_score(struct cvss_metrics* metrics, float score);
+OSCAP_API bool cvss_metrics_set_score(struct cvss_metrics* metrics, float score);
 /**
  * Validate CVSS metrics completeness
  * @memberof cvss_metrics
  */
-bool cvss_metrics_is_valid(const struct cvss_metrics* metrics);
+OSCAP_API bool cvss_metrics_is_valid(const struct cvss_metrics* metrics);
 
 /**
  * @name Vector values
@@ -352,62 +353,62 @@ bool cvss_metrics_is_valid(const struct cvss_metrics* metrics);
  */
 
 /// @memberof cvss_metrics
-enum cvss_access_vector cvss_metrics_get_access_vector(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_access_vector cvss_metrics_get_access_vector(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_access_complexity cvss_metrics_get_access_complexity(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_access_complexity cvss_metrics_get_access_complexity(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_authentication cvss_metrics_get_authentication(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_authentication cvss_metrics_get_authentication(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_cia_impact cvss_metrics_get_confidentiality_impact(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_cia_impact cvss_metrics_get_confidentiality_impact(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_cia_impact cvss_metrics_get_integrity_impact(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_cia_impact cvss_metrics_get_integrity_impact(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_cia_impact cvss_metrics_get_availability_impact(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_cia_impact cvss_metrics_get_availability_impact(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_exploitability cvss_metrics_get_exploitability(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_exploitability cvss_metrics_get_exploitability(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_remediation_level cvss_metrics_get_remediation_level(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_remediation_level cvss_metrics_get_remediation_level(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_report_confidence cvss_metrics_get_report_confidence(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_report_confidence cvss_metrics_get_report_confidence(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_collateral_damage_potential cvss_metrics_get_collateral_damage_potential(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_collateral_damage_potential cvss_metrics_get_collateral_damage_potential(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_target_distribution cvss_metrics_get_target_distribution(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_target_distribution cvss_metrics_get_target_distribution(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_cia_requirement cvss_metrics_get_confidentiality_requirement(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_cia_requirement cvss_metrics_get_confidentiality_requirement(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_cia_requirement cvss_metrics_get_integrity_requirement(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_cia_requirement cvss_metrics_get_integrity_requirement(const struct cvss_metrics* metrics);
 /// @memberof cvss_metrics
-enum cvss_cia_requirement cvss_metrics_get_availability_requirement(const struct cvss_metrics* metrics);
+OSCAP_API enum cvss_cia_requirement cvss_metrics_get_availability_requirement(const struct cvss_metrics* metrics);
 
 /// @memberof cvss_metrics
-bool cvss_metrics_set_access_vector(struct cvss_metrics* metrics, enum cvss_access_vector);
+OSCAP_API bool cvss_metrics_set_access_vector(struct cvss_metrics* metrics, enum cvss_access_vector);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_access_complexity(struct cvss_metrics* metrics, enum cvss_access_complexity);
+OSCAP_API bool cvss_metrics_set_access_complexity(struct cvss_metrics* metrics, enum cvss_access_complexity);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_authentication(struct cvss_metrics* metrics, enum cvss_authentication);
+OSCAP_API bool cvss_metrics_set_authentication(struct cvss_metrics* metrics, enum cvss_authentication);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_confidentiality_impact(struct cvss_metrics* metrics, enum cvss_cia_impact);
+OSCAP_API bool cvss_metrics_set_confidentiality_impact(struct cvss_metrics* metrics, enum cvss_cia_impact);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_integrity_impact(struct cvss_metrics* metrics, enum cvss_cia_impact);
+OSCAP_API bool cvss_metrics_set_integrity_impact(struct cvss_metrics* metrics, enum cvss_cia_impact);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_availability_impact(struct cvss_metrics* metrics, enum cvss_cia_impact);
+OSCAP_API bool cvss_metrics_set_availability_impact(struct cvss_metrics* metrics, enum cvss_cia_impact);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_exploitability(struct cvss_metrics* metrics, enum cvss_exploitability);
+OSCAP_API bool cvss_metrics_set_exploitability(struct cvss_metrics* metrics, enum cvss_exploitability);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_remediation_level(struct cvss_metrics* metrics, enum cvss_remediation_level);
+OSCAP_API bool cvss_metrics_set_remediation_level(struct cvss_metrics* metrics, enum cvss_remediation_level);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_report_confidence(struct cvss_metrics* metrics, enum cvss_report_confidence);
+OSCAP_API bool cvss_metrics_set_report_confidence(struct cvss_metrics* metrics, enum cvss_report_confidence);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_collateral_damage_potential(struct cvss_metrics* metrics, enum cvss_collateral_damage_potential);
+OSCAP_API bool cvss_metrics_set_collateral_damage_potential(struct cvss_metrics* metrics, enum cvss_collateral_damage_potential);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_target_distribution(struct cvss_metrics* metrics, enum cvss_target_distribution);
+OSCAP_API bool cvss_metrics_set_target_distribution(struct cvss_metrics* metrics, enum cvss_target_distribution);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_confidentiality_requirement(struct cvss_metrics* metrics, enum cvss_cia_requirement);
+OSCAP_API bool cvss_metrics_set_confidentiality_requirement(struct cvss_metrics* metrics, enum cvss_cia_requirement);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_integrity_requirement(struct cvss_metrics* metrics, enum cvss_cia_requirement);
+OSCAP_API bool cvss_metrics_set_integrity_requirement(struct cvss_metrics* metrics, enum cvss_cia_requirement);
 /// @memberof cvss_metrics
-bool cvss_metrics_set_availability_requirement(struct cvss_metrics* metrics, enum cvss_cia_requirement);
+OSCAP_API bool cvss_metrics_set_availability_requirement(struct cvss_metrics* metrics, enum cvss_cia_requirement);
 
 
 /** @} */

--- a/src/DS/public/ds_rds_session.h
+++ b/src/DS/public/ds_rds_session.h
@@ -29,6 +29,7 @@
 #include "oscap.h"
 #include "oscap_source.h"
 #include "scap_ds.h"
+#include "oscap_export.h"
 
 /**
  * The ds_rds_session is structure tight closely to oscap_source.
@@ -47,14 +48,14 @@ struct ds_rds_session;
  * @param source The oscap_source representing a result datastream
  * @returns newly created ds_rds_session structure
  */
-struct ds_rds_session *ds_rds_session_new_from_source(struct oscap_source *source);
+OSCAP_API struct ds_rds_session *ds_rds_session_new_from_source(struct oscap_source *source);
 
 /**
  * Dispose ds_rds_session structure.
  * @memberof ds_rds_session
  * @param rds_session The session to dispose
  */
-void ds_rds_session_free(struct ds_rds_session *rds_session);
+OSCAP_API void ds_rds_session_free(struct ds_rds_session *rds_session);
 
 /**
  * Get Result DataStream index
@@ -62,7 +63,7 @@ void ds_rds_session_free(struct ds_rds_session *rds_session);
  * @param session Session to query RDS index from
  * @returns Result DataStream index owned by session
  */
-struct rds_index *ds_rds_session_get_rds_idx(struct ds_rds_session *session);
+OSCAP_API struct rds_index *ds_rds_session_get_rds_idx(struct ds_rds_session *session);
 
 /**
  * Set target directory for the component files
@@ -71,7 +72,7 @@ struct rds_index *ds_rds_session_get_rds_idx(struct ds_rds_session *session);
  * @param target_dir PAth to the target storage dir
  * @returns 0 on success
  */
-int ds_rds_session_set_target_dir(struct ds_rds_session *session, const char *target_dir);
+OSCAP_API int ds_rds_session_set_target_dir(struct ds_rds_session *session, const char *target_dir);
 
 /**
  * Store cached component files to the hard drive
@@ -79,7 +80,7 @@ int ds_rds_session_set_target_dir(struct ds_rds_session *session, const char *ta
  * @param session The Result DataStream session
  * @returns zero on success
  */
-int ds_rds_session_dump_component_files(struct ds_rds_session *session);
+OSCAP_API int ds_rds_session_dump_component_files(struct ds_rds_session *session);
 
 /**
  * Select arf:report from result DataStream and return it in form of oscap_source.
@@ -89,7 +90,7 @@ int ds_rds_session_dump_component_files(struct ds_rds_session *session);
  * this arguement is NULL.
  * @returns oscap_source owned by the ds_rds_session or NULL on error
  */
-struct oscap_source *ds_rds_session_select_report(struct ds_rds_session *session, const char *report_id);
+OSCAP_API struct oscap_source *ds_rds_session_select_report(struct ds_rds_session *session, const char *report_id);
 
 /**
  * Select arf:report-request from result DataStream and return it in form of oscap_source.
@@ -100,7 +101,7 @@ struct oscap_source *ds_rds_session_select_report(struct ds_rds_session *session
  * session will error out.
  * @returns oscap_source owned by the ds_rds_session or NULL on error
  */
-struct oscap_source *ds_rds_session_select_report_request(struct ds_rds_session *session, const char *report_request_id);
+OSCAP_API struct oscap_source *ds_rds_session_select_report_request(struct ds_rds_session *session, const char *report_request_id);
 
 /**
  * Replace currently selected report with the content of the source. The previously
@@ -111,7 +112,7 @@ struct oscap_source *ds_rds_session_select_report_request(struct ds_rds_session 
  * @param source The oscap_source to replase selected report with.
  * @returns 0 on success
  */
-int ds_rds_session_replace_report_with_source(struct ds_rds_session *session, struct oscap_source *source);
+OSCAP_API int ds_rds_session_replace_report_with_source(struct ds_rds_session *session, struct oscap_source *source);
 
 /**
  * Returns HTML representation of the given result datastream
@@ -119,6 +120,6 @@ int ds_rds_session_replace_report_with_source(struct ds_rds_session *session, st
  * @param rds_session The ds_rds_session to build HTML from
  * @returns a buffer of HTML content that should be freed by the caller
  */
-char *ds_rds_session_get_html_report(struct ds_rds_session *rds_session);
+OSCAP_API char *ds_rds_session_get_html_report(struct ds_rds_session *rds_session);
 
 #endif

--- a/src/DS/public/ds_sds_session.h
+++ b/src/DS/public/ds_sds_session.h
@@ -30,6 +30,7 @@
 #include "oscap_source.h"
 #include "scap_ds.h"
 #include "oscap_download_cb.h"
+#include "oscap_export.h"
 
 /**
  * The ds_sds_session is structure tight closely to oscap_source.
@@ -54,7 +55,7 @@ struct ds_sds_session;
  * @param source The oscap_source representing a source datastream
  * @returns newly created ds_sds_session structure
  */
-struct ds_sds_session *ds_sds_session_new_from_source(struct oscap_source *source);
+OSCAP_API struct ds_sds_session *ds_sds_session_new_from_source(struct oscap_source *source);
 
 /**
  * Get Source DataStream index
@@ -62,13 +63,13 @@ struct ds_sds_session *ds_sds_session_new_from_source(struct oscap_source *sourc
  * @param session Registry to query SDS index from
  * @returns source DataStream owned by session
  */
-struct ds_sds_index *ds_sds_session_get_sds_idx(struct ds_sds_session *session);
+OSCAP_API struct ds_sds_index *ds_sds_session_get_sds_idx(struct ds_sds_session *session);
 
 /**
  * Dispose ds_sds_session structure.
  * @param sds_session Registry to dispose
  */
-void ds_sds_session_free(struct ds_sds_session *sds_session);
+OSCAP_API void ds_sds_session_free(struct ds_sds_session *sds_session);
 
 /**
  * Select Checklist (XCCDF presumably) from DataStream collection. Parameters may be
@@ -80,7 +81,7 @@ void ds_sds_session_free(struct ds_sds_session *sds_session);
  * @param benchmark_id ID of Benchmark element within checklist
  * @returns XCCDF checklist in form of oscap_source
  */
-struct oscap_source *ds_sds_session_select_checklist(struct ds_sds_session *session, const char *datastream_id, const char *component_id, const char *benchmark_id);
+OSCAP_API struct oscap_source *ds_sds_session_select_checklist(struct ds_sds_session *session, const char *datastream_id, const char *component_id, const char *benchmark_id);
 
 /**
  * Select XCCDF Tailoring from DataStream collection. The ds_sds_session_select_checklist
@@ -90,7 +91,7 @@ struct oscap_source *ds_sds_session_select_checklist(struct ds_sds_session *sess
  * @param component_id ID of tailoring file within checklist container
  * @returns XCCdF tailoring in form of oscap_source
  */
-struct oscap_source *ds_sds_session_select_tailoring(struct ds_sds_session *session, const char *component_id);
+OSCAP_API struct oscap_source *ds_sds_session_select_tailoring(struct ds_sds_session *session, const char *component_id);
 
 /**
  * Set the ID of DataStream within collection to use. Note that
@@ -100,7 +101,7 @@ struct oscap_source *ds_sds_session_select_tailoring(struct ds_sds_session *sess
  * @param datastream_id DataStream ID to set
  * @returns 0 on success
  */
-int ds_sds_session_set_datastream_id(struct ds_sds_session *session, const char *datastream_id);
+OSCAP_API int ds_sds_session_set_datastream_id(struct ds_sds_session *session, const char *datastream_id);
 
 /**
  * Return ID of currently selected DataStream within the DataStream collection.
@@ -108,7 +109,7 @@ int ds_sds_session_set_datastream_id(struct ds_sds_session *session, const char 
  * @param session The Source DataStream sesssion
  * @returns ID of selected datastream or NULL
  */
-const char *ds_sds_session_get_datastream_id(const struct ds_sds_session *session);
+OSCAP_API const char *ds_sds_session_get_datastream_id(const struct ds_sds_session *session);
 
 /**
  * Return ID of currently selected component representing XCCDF within the DataStream
@@ -116,7 +117,7 @@ const char *ds_sds_session_get_datastream_id(const struct ds_sds_session *sessio
  * @param session The Source DataStream session
  * @returns ID of selected component or NULL
  */
-const char *ds_sds_session_get_checklist_id(const struct ds_sds_session *session);
+OSCAP_API const char *ds_sds_session_get_checklist_id(const struct ds_sds_session *session);
 
 /**
  * Get component from Source DataStream by its href. This assumes that the component
@@ -129,7 +130,7 @@ const char *ds_sds_session_get_checklist_id(const struct ds_sds_session *session
  * element or the target name provided previously by caller of upper mentioned functions.
  * @returns oscap_source representing the component or NULL
  */
-struct oscap_source *ds_sds_session_get_component_by_href(struct ds_sds_session *session, const char *href);
+OSCAP_API struct oscap_source *ds_sds_session_get_component_by_href(struct ds_sds_session *session, const char *href);
 
 /**
  * Check whether given component can be registered.
@@ -139,7 +140,7 @@ struct oscap_source *ds_sds_session_get_component_by_href(struct ds_sds_session 
  * @returns true if at least one matching component exists, false otherwise
  * @see ds_sds_session_register_component_with_dependencies
  */
-bool ds_sds_session_can_register_component(struct ds_sds_session *session, const char *container_name, const char *component_id);
+OSCAP_API bool ds_sds_session_can_register_component(struct ds_sds_session *session, const char *container_name, const char *component_id);
 
 /**
  * Register component and its dependencies to internal cache. This functions extracts
@@ -152,7 +153,7 @@ bool ds_sds_session_can_register_component(struct ds_sds_session *session, const
  * @param target filename or NULL
  * @returns 0 on success
  */
-int ds_sds_session_register_component_with_dependencies(struct ds_sds_session *session, const char *container_name, const char *component_id, const char *target_filename);
+OSCAP_API int ds_sds_session_register_component_with_dependencies(struct ds_sds_session *session, const char *container_name, const char *component_id, const char *target_filename);
 
 /**
  * Store cached component files to the disc.
@@ -160,7 +161,7 @@ int ds_sds_session_register_component_with_dependencies(struct ds_sds_session *s
  * @param session The Source DataStream session
  * @returns 0 on success
  */
-int ds_sds_session_dump_component_files(struct ds_sds_session *session);
+OSCAP_API int ds_sds_session_dump_component_files(struct ds_sds_session *session);
 
 /**
  * Set target directory for the component files
@@ -169,7 +170,7 @@ int ds_sds_session_dump_component_files(struct ds_sds_session *session);
  * @param target_dir Path to the target storage dir
  * @returns 0 on success
  */
-int ds_sds_session_set_target_dir(struct ds_sds_session *session, const char *target_dir);
+OSCAP_API int ds_sds_session_set_target_dir(struct ds_sds_session *session, const char *target_dir);
 
 /**
  * Reset session for further use.
@@ -181,7 +182,7 @@ int ds_sds_session_set_target_dir(struct ds_sds_session *session, const char *ta
  * @memberof ds_sds_session
  * @param session The Source DataStream session to reset
  */
-void ds_sds_session_reset(struct ds_sds_session *session);
+OSCAP_API void ds_sds_session_reset(struct ds_sds_session *session);
 
 /**
  * Set property of remote content.
@@ -191,7 +192,7 @@ void ds_sds_session_reset(struct ds_sds_session *session);
  * @param callback used to notify user about download proceeds. This might be safely set
  * to NULL -- ignoring user notification.
  */
-void ds_sds_session_set_remote_resources(struct ds_sds_session *session, bool allowed, download_progress_calllback_t callback);
+OSCAP_API void ds_sds_session_set_remote_resources(struct ds_sds_session *session, bool allowed, download_progress_calllback_t callback);
 
 /**
  * Returns HTML representation of selected checklist in form of OpenSCAP guide.
@@ -201,6 +202,6 @@ void ds_sds_session_set_remote_resources(struct ds_sds_session *session, bool al
  * generate guide for
  * @returns a buffer of HTML content that should be freed by the caller
  */
-char *ds_sds_session_get_html_guide(struct ds_sds_session *session, const char *profile_id);
+OSCAP_API char *ds_sds_session_get_html_guide(struct ds_sds_session *session, const char *profile_id);
 
 #endif

--- a/src/DS/public/scap_ds.h
+++ b/src/DS/public/scap_ds.h
@@ -33,6 +33,7 @@
 #define OPENSCAP_DS_H
 
 #include "oscap.h"
+#include "oscap_export.h"
 
 /**
  * @brief takes given source data stream and decomposes it into separate files
@@ -69,7 +70,7 @@
  * @deprecated This function has been deprecated. Make a use of ds_sds_session
  *     instread. This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(int ds_sds_decompose(const char* input_file, const char* id, const char* xccdf_id, const char* target_dir, const char* target_filename));
+OSCAP_API OSCAP_DEPRECATED(int ds_sds_decompose(const char* input_file, const char* id, const char* xccdf_id, const char* target_dir, const char* target_filename));
 
 /**
  * @brief same as ds_sds_decompose but works with other components than just XCCDFs
@@ -89,7 +90,7 @@ OSCAP_DEPRECATED(int ds_sds_decompose(const char* input_file, const char* id, co
  * @deprecated This function has been deprecated. Make a use of ds_sds_session
  *     instread. This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(int ds_sds_decompose_custom(const char* input_file, const char* id, const char* target_dir, const char* container_name, const char* component_id, const char* target_filename));
+OSCAP_API OSCAP_DEPRECATED(int ds_sds_decompose_custom(const char* input_file, const char* id, const char* target_dir, const char* container_name, const char* component_id, const char* target_filename));
 
 /**
  * @brief takes given xccdf file and constructs a source datastream
@@ -106,7 +107,7 @@ OSCAP_DEPRECATED(int ds_sds_decompose_custom(const char* input_file, const char*
  * 	    0 if no errors were encountered
  * 	   -1 in case of errors
  */
-int ds_sds_compose_from_xccdf(const char* xccdf_file, const char* target_datastream);
+OSCAP_API int ds_sds_compose_from_xccdf(const char* xccdf_file, const char* target_datastream);
 
 /**
  * @brief append a new given component to the existing source datastream
@@ -124,13 +125,13 @@ int ds_sds_compose_from_xccdf(const char* xccdf_file, const char* target_datastr
  *
  * @returns 0 in case of success
  */
-int ds_sds_compose_add_component(const char *target_datastream, const char *datastream_id, const char *new_component, bool extended);
+OSCAP_API int ds_sds_compose_add_component(const char *target_datastream, const char *datastream_id, const char *new_component, bool extended);
 
 /**
  * @deprecated This function has been deprecated. Make a use of ds_rds_session
  * instread. This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(int ds_rds_decompose(const char* input_file, const char* report_id, const char* request_id, const char* target_dir));
+OSCAP_API OSCAP_DEPRECATED(int ds_rds_decompose(const char* input_file, const char* report_id, const char* request_id, const char* target_dir));
 
 /**
  * @brief takes given source data stream and XCCDF result file and makes a result data stream
@@ -154,7 +155,7 @@ OSCAP_DEPRECATED(int ds_rds_decompose(const char* input_file, const char* report
  * 	    0 if no errors were encountered
  * 	   -1 in case of errors
  */
-int ds_rds_create(const char* sds_file, const char* xccdf_result_file,
+OSCAP_API int ds_rds_create(const char* sds_file, const char* xccdf_result_file,
         const char** oval_result_files, const char* target_file);
 
 /**
@@ -176,58 +177,58 @@ int ds_rds_create(const char* sds_file, const char* xccdf_result_file,
 struct ds_stream_index;
 
 /// @memberof ds_stream_index
-struct ds_stream_index* ds_stream_index_new(void);
+OSCAP_API struct ds_stream_index* ds_stream_index_new(void);
 /// @memberof ds_stream_index
-void ds_stream_index_free(struct ds_stream_index* s);
+OSCAP_API void ds_stream_index_free(struct ds_stream_index* s);
 
 /**
  * @brief Gets ID of the <data-stream> element the index represents.
  *
  * @memberof ds_stream_index
  */
-const char* ds_stream_index_get_id(struct ds_stream_index* s);
+OSCAP_API const char* ds_stream_index_get_id(struct ds_stream_index* s);
 
 /**
  * @brief Timestamp of creation OR modification of the <data-stream> element the index represents.
  *
  * @memberof ds_stream_index
  */
-const char* ds_stream_index_get_timestamp(struct ds_stream_index* s);
+OSCAP_API const char* ds_stream_index_get_timestamp(struct ds_stream_index* s);
 
 /**
  * @brief scap-version of the the <data-stream> element the index represents.
  *
  * @memberof ds_stream_index
  */
-const char* ds_stream_index_get_version(struct ds_stream_index* s);
+OSCAP_API const char* ds_stream_index_get_version(struct ds_stream_index* s);
 
 /**
  * @brief Retrieves iterator over all components inside the <checks> element.
  *
  * @memberof ds_stream_index
  */
-struct oscap_string_iterator* ds_stream_index_get_checks(struct ds_stream_index* s);
+OSCAP_API struct oscap_string_iterator* ds_stream_index_get_checks(struct ds_stream_index* s);
 
 /**
  * @brief Retrieves iterator over all components inside the <checklists> element.
  *
  * @memberof ds_stream_index
  */
-struct oscap_string_iterator* ds_stream_index_get_checklists(struct ds_stream_index* s);
+OSCAP_API struct oscap_string_iterator* ds_stream_index_get_checklists(struct ds_stream_index* s);
 
 /**
  * @brief Retrieves iterator over all components inside the <dictionaries> element.
  *
  * @memberof ds_stream_index
  */
-struct oscap_string_iterator* ds_stream_index_get_dictionaries(struct ds_stream_index* s);
+OSCAP_API struct oscap_string_iterator* ds_stream_index_get_dictionaries(struct ds_stream_index* s);
 
 /**
  * @brief Retrieves iterator over all components inside the <extended-components> element.
  *
  * @memberof ds_stream_index
  */
-struct oscap_string_iterator* ds_stream_index_get_extended_components(struct ds_stream_index* s);
+OSCAP_API struct oscap_string_iterator* ds_stream_index_get_extended_components(struct ds_stream_index* s);
 
 /**
  * @struct ds_sds_index
@@ -243,23 +244,23 @@ struct oscap_string_iterator* ds_stream_index_get_extended_components(struct ds_
 struct ds_sds_index;
 
 /// @memberof ds_sds_index
-struct ds_sds_index* ds_sds_index_new(void);
+OSCAP_API struct ds_sds_index* ds_sds_index_new(void);
 /// @memberof ds_sds_index
-void ds_sds_index_free(struct ds_sds_index* s);
+OSCAP_API void ds_sds_index_free(struct ds_sds_index* s);
 
 /**
  * @brief retrieves a stream index by data-stream ID
  *
  * @memberof ds_sds_index
  */
-struct ds_stream_index* ds_sds_index_get_stream(struct ds_sds_index* s, const char* stream_id);
+OSCAP_API struct ds_stream_index* ds_sds_index_get_stream(struct ds_sds_index* s, const char* stream_id);
 
 /**
  * @brief retrieves all streams indexed inside this structure
  *
  * @memberof ds_sds_index
  */
-struct ds_stream_index_iterator* ds_sds_index_get_streams(struct ds_sds_index* s);
+OSCAP_API struct ds_stream_index_iterator* ds_sds_index_get_streams(struct ds_sds_index* s);
 
 /**
  * @brief imports given source datastream and indexes it
@@ -269,7 +270,7 @@ struct ds_stream_index_iterator* ds_sds_index_get_streams(struct ds_sds_index* s
  * @deprecated This function has been deprecated. Make a use of ds_sds_session
  *     instread. This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(struct ds_sds_index *ds_sds_index_import(const char* file));
+OSCAP_API OSCAP_DEPRECATED(struct ds_sds_index *ds_sds_index_import(const char* file));
 
 /**
  * @brief chooses datastream and checklist id combination given the IDs
@@ -283,7 +284,7 @@ OSCAP_DEPRECATED(struct ds_sds_index *ds_sds_index_import(const char* file));
  * component_id is actually a component-ref ID, the reason is that we need the component-ref
  * to know which other components are in the catalog and thus needed when splitting.
  */
-int ds_sds_index_select_checklist(struct ds_sds_index* s,
+OSCAP_API int ds_sds_index_select_checklist(struct ds_sds_index* s,
 		const char** datastream_id, const char** component_id);
 
 /**
@@ -302,7 +303,7 @@ int ds_sds_index_select_checklist(struct ds_sds_index* s,
  * will be overwritten if 0 is returned. The values are never used, unlike with
  * ds_sds_index_select_checklist.
  */
-int ds_sds_index_select_checklist_by_benchmark_id(struct ds_sds_index* s,
+OSCAP_API int ds_sds_index_select_checklist_by_benchmark_id(struct ds_sds_index* s,
 		const char *benchmark_id, const char **datastream_id, const char **component_ref_id);
 
 /** 
@@ -312,20 +313,20 @@ int ds_sds_index_select_checklist_by_benchmark_id(struct ds_sds_index* s,
 struct ds_stream_index_iterator;
 
 /// @memberof ds_stream_index_iterator
-struct ds_stream_index *ds_stream_index_iterator_next(struct ds_stream_index_iterator *it);
+OSCAP_API struct ds_stream_index *ds_stream_index_iterator_next(struct ds_stream_index_iterator *it);
 /// @memberof ds_stream_index_iterator
-bool ds_stream_index_iterator_has_more(struct ds_stream_index_iterator *it);
+OSCAP_API bool ds_stream_index_iterator_has_more(struct ds_stream_index_iterator *it);
 /// @memberof ds_stream_index_iterator
-void ds_stream_index_iterator_free(struct ds_stream_index_iterator *it);
+OSCAP_API void ds_stream_index_iterator_free(struct ds_stream_index_iterator *it);
 
 /**
  * @struct rds_report_request_index
  */
 struct rds_report_request_index;
 
-struct rds_report_request_index* rds_report_request_index_new(void);
-void rds_report_request_index_free(struct rds_report_request_index* s);
-const char* rds_report_request_index_get_id(struct rds_report_request_index* s);
+OSCAP_API struct rds_report_request_index* rds_report_request_index_new(void);
+OSCAP_API void rds_report_request_index_free(struct rds_report_request_index* s);
+OSCAP_API const char* rds_report_request_index_get_id(struct rds_report_request_index* s);
 
 /**
  * @struct rds_asset_index
@@ -337,17 +338,17 @@ struct rds_asset_index;
  */
 struct rds_report_index;
 
-struct rds_asset_index* rds_asset_index_new(void);
-void rds_asset_index_free(struct rds_asset_index* s);
-const char* rds_asset_index_get_id(struct rds_asset_index* s);
-void rds_asset_index_add_report_ref(struct rds_asset_index* s, struct rds_report_index* report);
-struct rds_report_index_iterator* rds_asset_index_get_reports(struct rds_asset_index* s);
+OSCAP_API struct rds_asset_index* rds_asset_index_new(void);
+OSCAP_API void rds_asset_index_free(struct rds_asset_index* s);
+OSCAP_API const char* rds_asset_index_get_id(struct rds_asset_index* s);
+OSCAP_API void rds_asset_index_add_report_ref(struct rds_asset_index* s, struct rds_report_index* report);
+OSCAP_API struct rds_report_index_iterator* rds_asset_index_get_reports(struct rds_asset_index* s);
 
-struct rds_report_index* rds_report_index_new(void);
-void rds_report_index_free(struct rds_report_index* s);
-const char* rds_report_index_get_id(struct rds_report_index* s);
-void rds_report_index_set_request(struct rds_report_index* s, struct rds_report_request_index *request);
-struct rds_report_request_index *rds_report_index_get_request(struct rds_report_index* s);
+OSCAP_API struct rds_report_index* rds_report_index_new(void);
+OSCAP_API void rds_report_index_free(struct rds_report_index* s);
+OSCAP_API const char* rds_report_index_get_id(struct rds_report_index* s);
+OSCAP_API void rds_report_index_set_request(struct rds_report_index* s, struct rds_report_request_index *request);
+OSCAP_API struct rds_report_request_index *rds_report_index_get_request(struct rds_report_index* s);
 
 /**
  * @struct rds_report_request_index_iterator
@@ -356,11 +357,11 @@ struct rds_report_request_index *rds_report_index_get_request(struct rds_report_
 struct rds_report_request_index_iterator;
 
 /// @memberof rds_report_request_index_iterator
-struct rds_report_request_index *rds_report_request_index_iterator_next(struct rds_report_request_index_iterator *it);
+OSCAP_API struct rds_report_request_index *rds_report_request_index_iterator_next(struct rds_report_request_index_iterator *it);
 /// @memberof rds_report_request_index_iterator
-bool rds_report_request_index_iterator_has_more(struct rds_report_request_index_iterator *it);
+OSCAP_API bool rds_report_request_index_iterator_has_more(struct rds_report_request_index_iterator *it);
 /// @memberof rds_report_request_index_iterator
-void rds_report_request_index_iterator_free(struct rds_report_request_index_iterator *it);
+OSCAP_API void rds_report_request_index_iterator_free(struct rds_report_request_index_iterator *it);
 
 /**
  * @struct rds_asset_index_iterator
@@ -369,11 +370,11 @@ void rds_report_request_index_iterator_free(struct rds_report_request_index_iter
 struct rds_asset_index_iterator;
 
 /// @memberof rds_asset_index_iterator
-struct rds_asset_index *rds_asset_index_iterator_next(struct rds_asset_index_iterator *it);
+OSCAP_API struct rds_asset_index *rds_asset_index_iterator_next(struct rds_asset_index_iterator *it);
 /// @memberof rds_asset_index_iterator
-bool rds_asset_index_iterator_has_more(struct rds_asset_index_iterator *it);
+OSCAP_API bool rds_asset_index_iterator_has_more(struct rds_asset_index_iterator *it);
 /// @memberof rds_asset_index_iterator
-void rds_asset_index_iterator_free(struct rds_asset_index_iterator *it);
+OSCAP_API void rds_asset_index_iterator_free(struct rds_asset_index_iterator *it);
 
 /**
  * @struct rds_report_index_iterator
@@ -382,11 +383,11 @@ void rds_asset_index_iterator_free(struct rds_asset_index_iterator *it);
 struct rds_report_index_iterator;
 
 /// @memberof rds_report_index_iterator
-struct rds_report_index *rds_report_index_iterator_next(struct rds_report_index_iterator *it);
+OSCAP_API struct rds_report_index *rds_report_index_iterator_next(struct rds_report_index_iterator *it);
 /// @memberof rds_report_index_iterator
-bool rds_report_index_iterator_has_more(struct rds_report_index_iterator *it);
+OSCAP_API bool rds_report_index_iterator_has_more(struct rds_report_index_iterator *it);
 /// @memberof rds_report_index_iterator
-void rds_report_index_iterator_free(struct rds_report_index_iterator *it);
+OSCAP_API void rds_report_index_iterator_free(struct rds_report_index_iterator *it);
 
 /**
  * @struct rds_index
@@ -399,33 +400,33 @@ void rds_report_index_iterator_free(struct rds_report_index_iterator *it);
 struct rds_index;
 
 /// @memberof rds_index
-struct rds_index* rds_index_new(void);
+OSCAP_API struct rds_index* rds_index_new(void);
 /// @memberof rds_index
-void rds_index_free(struct rds_index *s);
+OSCAP_API void rds_index_free(struct rds_index *s);
 
 /// @memberof rds_index
-struct rds_report_request_index_iterator *rds_index_get_report_requests(struct rds_index *s);
+OSCAP_API struct rds_report_request_index_iterator *rds_index_get_report_requests(struct rds_index *s);
 /// @memberof rds_index
-struct rds_asset_index_iterator *rds_index_get_assets(struct rds_index *s);
+OSCAP_API struct rds_asset_index_iterator *rds_index_get_assets(struct rds_index *s);
 /// @memberof rds_index
-struct rds_report_index_iterator *rds_index_get_reports(struct rds_index *s);
+OSCAP_API struct rds_report_index_iterator *rds_index_get_reports(struct rds_index *s);
 
 /// @memberof rds_index
-struct rds_report_request_index *rds_index_get_report_request(struct rds_index *rds, const char *id);
+OSCAP_API struct rds_report_request_index *rds_index_get_report_request(struct rds_index *rds, const char *id);
 /// @memberof rds_index
-struct rds_asset_index *rds_index_get_asset(struct rds_index *rds, const char *id);
+OSCAP_API struct rds_asset_index *rds_index_get_asset(struct rds_index *rds, const char *id);
 /// @memberof rds_index
-struct rds_report_index *rds_index_get_report(struct rds_index *rds, const char *id);
+OSCAP_API struct rds_report_index *rds_index_get_report(struct rds_index *rds, const char *id);
 
 /**
  * @memberof rds_index
  * @deprecated This function has been deprecated. Make a use of ds_rds_session
  * instread. This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(struct rds_index *rds_index_import(const char *file));
+OSCAP_API OSCAP_DEPRECATED(struct rds_index *rds_index_import(const char *file));
 
 /// @memberof rds_index
-int rds_index_select_report(struct rds_index *s, const char **report_id);
+OSCAP_API int rds_index_select_report(struct rds_index *s, const char **report_id);
 
 /************************************************************/
 /** @} End of DS group */

--- a/src/OVAL/probes/SEAP/public/seap-command.h
+++ b/src/OVAL/probes/SEAP/public/seap-command.h
@@ -28,12 +28,13 @@
 #include <stdarg.h>
 #include <sexp-types.h>
 #include <seap-types.h>
+#include "oscap_export.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef SEXP_t * (*SEAP_cmdfn_t) (SEXP_t *, void *);
+OSCAP_API typedef SEXP_t * (*SEAP_cmdfn_t) (SEXP_t *, void *);
 
 typedef uint16_t SEAP_cmdcode_t;
 typedef uint16_t SEAP_cmdid_t;
@@ -46,8 +47,8 @@ typedef uint8_t  SEAP_cmdtype_t;
 #define SEAP_CMDREG_USEARG 0x00000002
 #define SEAP_CMDREG_THREAD 0x00000004
 
-int SEAP_cmd_register   (SEAP_CTX_t *ctx, SEAP_cmdcode_t code, uint32_t flags, SEAP_cmdfn_t func, ...);
-int SEAP_cmd_unregister (SEAP_CTX_t *ctx, SEAP_cmdcode_t code);
+OSCAP_API int SEAP_cmd_register   (SEAP_CTX_t *ctx, SEAP_cmdcode_t code, uint32_t flags, SEAP_cmdfn_t func, ...);
+OSCAP_API int SEAP_cmd_unregister (SEAP_CTX_t *ctx, SEAP_cmdcode_t code);
 
 #define SEAP_EXEC_LOCAL  0x01
 #define SEAP_EXEC_LONLY  0x02

--- a/src/OVAL/probes/SEAP/public/seap-message.h
+++ b/src/OVAL/probes/SEAP/public/seap-message.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <sexp-types.h>
+#include "oscap_export.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,23 +42,23 @@ typedef uint32_t SEAP_msgid_t;
 typedef struct SEAP_msg  SEAP_msg_t;
 typedef struct SEAP_attr SEAP_attr_t;
 
-SEAP_msg_t *SEAP_msg_new (void);
-SEAP_msg_t *SEAP_msg_clone (SEAP_msg_t *msg);
-void        SEAP_msg_free (SEAP_msg_t *msg);
+OSCAP_API SEAP_msg_t *SEAP_msg_new (void);
+OSCAP_API SEAP_msg_t *SEAP_msg_clone (SEAP_msg_t *msg);
+OSCAP_API void        SEAP_msg_free (SEAP_msg_t *msg);
 
-SEAP_msgid_t SEAP_msg_id (SEAP_msg_t *msg);
+OSCAP_API SEAP_msgid_t SEAP_msg_id (SEAP_msg_t *msg);
 
-int     SEAP_msg_set (SEAP_msg_t *msg, SEXP_t *sexp);
-void    SEAP_msg_unset (SEAP_msg_t *msg);
-SEXP_t *SEAP_msg_get (SEAP_msg_t *msg);
+OSCAP_API int     SEAP_msg_set (SEAP_msg_t *msg, SEXP_t *sexp);
+OSCAP_API void    SEAP_msg_unset (SEAP_msg_t *msg);
+OSCAP_API SEXP_t *SEAP_msg_get (SEAP_msg_t *msg);
 
-SEXP_t *SEAP_msgattr_get (SEAP_msg_t *msg, const char *name);
-int     SEAP_msgattr_set (SEAP_msg_t *msg, const char *name, SEXP_t *value);
-int     SEAP_msgattr_del (SEAP_msg_t *msg, const char *name);
-bool    SEAP_msgattr_exists (SEAP_msg_t *msg, const char *name);
+OSCAP_API SEXP_t *SEAP_msgattr_get (SEAP_msg_t *msg, const char *name);
+OSCAP_API int     SEAP_msgattr_set (SEAP_msg_t *msg, const char *name, SEXP_t *value);
+OSCAP_API int     SEAP_msgattr_del (SEAP_msg_t *msg, const char *name);
+OSCAP_API bool    SEAP_msgattr_exists (SEAP_msg_t *msg, const char *name);
 
 #include <stdio.h>
-void SEAP_msg_print (FILE *fp, SEAP_msg_t *msg);
+OSCAP_API void SEAP_msg_print (FILE *fp, SEAP_msg_t *msg);
 
 #ifdef __cplusplus
 }

--- a/src/OVAL/probes/SEAP/public/seap-packet.h
+++ b/src/OVAL/probes/SEAP/public/seap-packet.h
@@ -27,6 +27,7 @@
 #include <seap-message.h>
 #include <seap-command.h>
 #include <seap-error.h>
+#include "oscap_export.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,20 +41,20 @@ typedef struct SEAP_packet SEAP_packet_t;
 #define SEAP_PACKET_CMD 0x03 /* Command packet */
 #define SEAP_PACKET_RAW 0x04 /* Raw packet */
 
-SEAP_packet_t *SEAP_packet_new (void);
-void SEAP_packet_free (SEAP_packet_t *packet);
+OSCAP_API SEAP_packet_t *SEAP_packet_new (void);
+OSCAP_API void SEAP_packet_free (SEAP_packet_t *packet);
 
-void   *SEAP_packet_settype (SEAP_packet_t *packet, uint8_t type);
-uint8_t SEAP_packet_gettype (SEAP_packet_t *packet);
+OSCAP_API void   *SEAP_packet_settype (SEAP_packet_t *packet, uint8_t type);
+OSCAP_API uint8_t SEAP_packet_gettype (SEAP_packet_t *packet);
 
-SEAP_msg_t *SEAP_packet_msg (SEAP_packet_t *packet);
-SEAP_cmd_t *SEAP_packet_cmd (SEAP_packet_t *packet);
-SEAP_err_t *SEAP_packet_err (SEAP_packet_t *packet);
+OSCAP_API SEAP_msg_t *SEAP_packet_msg (SEAP_packet_t *packet);
+OSCAP_API SEAP_cmd_t *SEAP_packet_cmd (SEAP_packet_t *packet);
+OSCAP_API SEAP_err_t *SEAP_packet_err (SEAP_packet_t *packet);
 
-int SEAP_packet_recv (SEAP_CTX_t *ctx, int sd, SEAP_packet_t **packet);
-int SEAP_packet_recv_bytype (SEAP_CTX_t *ctx, int sd, SEAP_packet_t **packet, uint8_t type);
-int SEAP_packet_send (SEAP_CTX_t *ctx, int sd, SEAP_packet_t *packet);
-int SEAP_packet_enqueue (SEAP_CTX_t *ctx, int sd, SEAP_packet_t *packet);
+OSCAP_API int SEAP_packet_recv (SEAP_CTX_t *ctx, int sd, SEAP_packet_t **packet);
+OSCAP_API int SEAP_packet_recv_bytype (SEAP_CTX_t *ctx, int sd, SEAP_packet_t **packet, uint8_t type);
+OSCAP_API int SEAP_packet_send (SEAP_CTX_t *ctx, int sd, SEAP_packet_t *packet);
+OSCAP_API int SEAP_packet_enqueue (SEAP_CTX_t *ctx, int sd, SEAP_packet_t *packet);
 
 #ifdef __cplusplus
 }

--- a/src/OVAL/probes/SEAP/public/seap.h
+++ b/src/OVAL/probes/SEAP/public/seap.h
@@ -39,6 +39,7 @@ extern "C" {
 #include <seap-message.h>
 #include <seap-command.h>
 #include <seap-error.h>
+#include "oscap_export.h"
 
 #ifndef EOPNOTSUPP
 # define EOPNOTSUPP 1001
@@ -48,43 +49,43 @@ extern "C" {
 # define ECANCELED  1002
 #endif
 
-SEAP_CTX_t *SEAP_CTX_new  (void);
-void        SEAP_CTX_init (SEAP_CTX_t *ctx);
-void        SEAP_CTX_free (SEAP_CTX_t *ctx);
+OSCAP_API SEAP_CTX_t *SEAP_CTX_new  (void);
+OSCAP_API void        SEAP_CTX_init (SEAP_CTX_t *ctx);
+OSCAP_API void        SEAP_CTX_free (SEAP_CTX_t *ctx);
 
-int     SEAP_connect (SEAP_CTX_t *ctx, const char *uri, uint32_t flags);
-int     SEAP_listen (SEAP_CTX_t *ctx, int sd, uint32_t maxcli);
-int     SEAP_accept (SEAP_CTX_t *ctx, int sd);
+OSCAP_API int     SEAP_connect (SEAP_CTX_t *ctx, const char *uri, uint32_t flags);
+OSCAP_API int     SEAP_listen (SEAP_CTX_t *ctx, int sd, uint32_t maxcli);
+OSCAP_API int     SEAP_accept (SEAP_CTX_t *ctx, int sd);
 
-int     SEAP_open  (SEAP_CTX_t *ctx, const char *path, uint32_t flags);
-SEXP_t *SEAP_read  (SEAP_CTX_t *ctx, int sd);
-int     SEAP_write (SEAP_CTX_t *ctx, int sd, SEXP_t *sexp);
-int     SEAP_close (SEAP_CTX_t *ctx, int sd);
+OSCAP_API int     SEAP_open  (SEAP_CTX_t *ctx, const char *path, uint32_t flags);
+OSCAP_API SEXP_t *SEAP_read  (SEAP_CTX_t *ctx, int sd);
+OSCAP_API int     SEAP_write (SEAP_CTX_t *ctx, int sd, SEXP_t *sexp);
+OSCAP_API int     SEAP_close (SEAP_CTX_t *ctx, int sd);
 
-int SEAP_openfd (SEAP_CTX_t *ctx, int fd, uint32_t flags);
-int SEAP_openfd2 (SEAP_CTX_t *ctx, int ifd, int ofd, uint32_t flags);
+OSCAP_API int SEAP_openfd (SEAP_CTX_t *ctx, int fd, uint32_t flags);
+OSCAP_API int SEAP_openfd2 (SEAP_CTX_t *ctx, int ifd, int ofd, uint32_t flags);
 
-SEAP_msg_t *SEAP_msg_new (void);
-void        SEAP_msg_free (SEAP_msg_t *msg);
-int         SEAP_msg_set (SEAP_msg_t *msg, SEXP_t *sexp);
-SEXP_t     *SEAP_msg_get (SEAP_msg_t *msg);
+OSCAP_API SEAP_msg_t *SEAP_msg_new (void);
+OSCAP_API void        SEAP_msg_free (SEAP_msg_t *msg);
+OSCAP_API int         SEAP_msg_set (SEAP_msg_t *msg, SEXP_t *sexp);
+OSCAP_API SEXP_t     *SEAP_msg_get (SEAP_msg_t *msg);
 
-int     SEAP_msgattr_set (SEAP_msg_t *msg, const char *attr, SEXP_t *value);
-SEXP_t *SEAP_msgattr_get (SEAP_msg_t *msg, const char *name);
+OSCAP_API int     SEAP_msgattr_set (SEAP_msg_t *msg, const char *attr, SEXP_t *value);
+OSCAP_API SEXP_t *SEAP_msgattr_get (SEAP_msg_t *msg, const char *name);
 
-int SEAP_recvsexp (SEAP_CTX_t *ctx, int sd, SEXP_t **sexp);
-int SEAP_recvmsg  (SEAP_CTX_t *ctx, int sd, SEAP_msg_t **seap_msg);
+OSCAP_API int SEAP_recvsexp (SEAP_CTX_t *ctx, int sd, SEXP_t **sexp);
+OSCAP_API int SEAP_recvmsg  (SEAP_CTX_t *ctx, int sd, SEAP_msg_t **seap_msg);
 
-int SEAP_sendsexp (SEAP_CTX_t *ctx, int sd, SEXP_t *sexp);
-int SEAP_sendmsg  (SEAP_CTX_t *ctx, int sd, SEAP_msg_t *seap_msg);
+OSCAP_API int SEAP_sendsexp (SEAP_CTX_t *ctx, int sd, SEXP_t *sexp);
+OSCAP_API int SEAP_sendmsg  (SEAP_CTX_t *ctx, int sd, SEAP_msg_t *seap_msg);
 
-int SEAP_reply (SEAP_CTX_t *ctx, int sd, SEAP_msg_t *rep_msg, SEAP_msg_t *req_msg);
+OSCAP_API int SEAP_reply (SEAP_CTX_t *ctx, int sd, SEAP_msg_t *rep_msg, SEAP_msg_t *req_msg);
 
-int SEAP_senderr (SEAP_CTX_t *ctx, int sd, SEAP_err_t *err);
-int SEAP_recverr (SEAP_CTX_t *ctx, int sd, SEAP_err_t **err);
-int SEAP_recverr_byid (SEAP_CTX_t *ctx, int sd, SEAP_err_t **err, SEAP_msgid_t id);
+OSCAP_API int SEAP_senderr (SEAP_CTX_t *ctx, int sd, SEAP_err_t *err);
+OSCAP_API int SEAP_recverr (SEAP_CTX_t *ctx, int sd, SEAP_err_t **err);
+OSCAP_API int SEAP_recverr_byid (SEAP_CTX_t *ctx, int sd, SEAP_err_t **err, SEAP_msgid_t id);
 
-int SEAP_replyerr (SEAP_CTX_t *ctx, int sd, SEAP_msg_t *rep_msg, uint32_t e);
+OSCAP_API int SEAP_replyerr (SEAP_CTX_t *ctx, int sd, SEAP_msg_t *rep_msg, uint32_t e);
 
 #ifdef __cplusplus
 }

--- a/src/OVAL/probes/SEAP/public/sexp-ID.h
+++ b/src/OVAL/probes/SEAP/public/sexp-ID.h
@@ -24,13 +24,14 @@
 
 #include <stdint.h>
 #include "sexp-types.h"
+#include "oscap_export.h"
 
 typedef uint64_t SEXP_ID_t;
 
 /**
  * Compute an S-exp value identifier
  */
-SEXP_ID_t SEXP_ID_v(const SEXP_t *s);
-SEXP_ID_t SEXP_ID_v2(const SEXP_t *s);
+OSCAP_API SEXP_ID_t SEXP_ID_v(const SEXP_t *s);
+OSCAP_API SEXP_ID_t SEXP_ID_v2(const SEXP_t *s);
 
 #endif /* SEXP_ID_H */

--- a/src/OVAL/probes/SEAP/public/sexp-datatype.h
+++ b/src/OVAL/probes/SEAP/public/sexp-datatype.h
@@ -27,31 +27,32 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <sexp.h>
+#include "oscap_export.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef void (*SEXP_datatypeOP_t) (SEXP_t *, const SEXP_t *, void *);
+OSCAP_API typedef void (*SEXP_datatypeOP_t) (SEXP_t *, const SEXP_t *, void *);
 
 typedef struct SEXP_datatype    SEXP_datatype_t;
 typedef struct SEXP_datatypeTbl SEXP_datatypeTbl_t;
 
 extern SEXP_datatypeTbl_t g_datatypes;
 
-/* const char *SEXP_datatype (const SEXP_t *sexp); */
+OSCAP_API /* const char *SEXP_datatype (const SEXP_t *sexp); */
 
-int SEXP_datatype_register (SEXP_datatypeTbl_t *t, const char *datatype);
-/* int SEXP_datatype_unregister (void); */
+OSCAP_API int SEXP_datatype_register (SEXP_datatypeTbl_t *t, const char *datatype);
+OSCAP_API /* int SEXP_datatype_unregister (void); */
 
-int SEXP_datatype_op (uint8_t op, const SEXP_t *sexp, void *res, ...);
-int SEXP_datatype_op_safe (const char *datatype, uint8_t op, const SEXP_t *sexp, void *res, ...);
+OSCAP_API int SEXP_datatype_op (uint8_t op, const SEXP_t *sexp, void *res, ...);
+OSCAP_API int SEXP_datatype_op_safe (const char *datatype, uint8_t op, const SEXP_t *sexp, void *res, ...);
 
-SEXP_datatype_t *SEXP_datatype_new(void);
-int SEXP_datatype_setflag(SEXP_datatype_t **dp, uint16_t flag, ...);
-int SEXP_datatype_unsetflag(SEXP_datatype_t **dp, uint16_t flag);
-int SEXP_datatype_addop(SEXP_datatype_t **dp, int opnum, SEXP_datatypeOP_t *op);
-int SEXP_datatype_delop(SEXP_datatype_t **dp, int opnum);
+OSCAP_API SEXP_datatype_t *SEXP_datatype_new(void);
+OSCAP_API int SEXP_datatype_setflag(SEXP_datatype_t **dp, uint16_t flag, ...);
+OSCAP_API int SEXP_datatype_unsetflag(SEXP_datatype_t **dp, uint16_t flag);
+OSCAP_API int SEXP_datatype_addop(SEXP_datatype_t **dp, int opnum, SEXP_datatypeOP_t *op);
+OSCAP_API int SEXP_datatype_delop(SEXP_datatype_t **dp, int opnum);
 
 #ifdef __cplusplus
 }

--- a/src/OVAL/probes/SEAP/public/sexp-manip.h
+++ b/src/OVAL/probes/SEAP/public/sexp-manip.h
@@ -42,6 +42,7 @@
 #include <stdbool.h>
 #include <sexp-types.h>
 #include <helpers.h>
+#include "oscap_export.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,43 +57,43 @@ extern "C" {
  * @param t the desired number type
  * @param n pointer to the number value
  */
-SEXP_t *SEXP_number_new (SEXP_numtype_t t, const void *n) __attribute__ ((nonnull (2)));
+OSCAP_API SEXP_t *SEXP_number_new (SEXP_numtype_t t, const void *n) __attribute__ ((nonnull (2)));
 
 /**
  * Create a new sexp object from a boolean value.
  * @param n the boolean value to store
  */
-SEXP_t *SEXP_number_newb (bool n);
+OSCAP_API SEXP_t *SEXP_number_newb (bool n);
 
 /**
  * Create a new sexp object from an integer.
  * @param n the integer value to store
  */
-SEXP_t *SEXP_number_newi_8 (int8_t n);
+OSCAP_API SEXP_t *SEXP_number_newi_8 (int8_t n);
 
 /**
  * Create a new sexp object from an unsigned integer.
  * @param n the unsigned integer value to store
  */
-SEXP_t *SEXP_number_newu_8 (uint8_t n);
+OSCAP_API SEXP_t *SEXP_number_newu_8 (uint8_t n);
 
 /**
  * Get unsigned integer value from a sexp object.
  * @param s_exp the queried sexp object
  */
-uint8_t SEXP_number_getu_8 (const SEXP_t *s_exp);
+OSCAP_API uint8_t SEXP_number_getu_8 (const SEXP_t *s_exp);
 
 /**
  * Create a new sexp object from an integer.
  * @param n the integer value to store
  */
-SEXP_t *SEXP_number_newi_16 (int16_t n);
+OSCAP_API SEXP_t *SEXP_number_newi_16 (int16_t n);
 
 /**
  * Create a new sexp object from an unsigned integer.
  * @param n the unsigned integer value to store
  */
-SEXP_t *SEXP_number_newu_16 (uint16_t n);
+OSCAP_API SEXP_t *SEXP_number_newu_16 (uint16_t n);
 
 /**
  * Create a new sexp object from an integer.
@@ -104,7 +105,7 @@ SEXP_t *SEXP_number_newu_16 (uint16_t n);
  * Create a new sexp object from an integer.
  * @param n the integer value to store
  */
-SEXP_t *SEXP_number_newi_32 (int32_t n);
+OSCAP_API SEXP_t *SEXP_number_newi_32 (int32_t n);
 
 /**
  * Get integer value from a sexp object.
@@ -116,13 +117,13 @@ SEXP_t *SEXP_number_newi_32 (int32_t n);
  * Get integer value from a sexp object.
  * @param s_exp the queried sexp object
  */
-int32_t SEXP_number_geti_32 (const SEXP_t *s_exp);
+OSCAP_API int32_t SEXP_number_geti_32 (const SEXP_t *s_exp);
 
 /**
  * Get boolean value from a sexp object.
  * @param s_exp the queried sexp object
  */
-bool SEXP_number_getb (const SEXP_t *s_exp);
+OSCAP_API bool SEXP_number_getb (const SEXP_t *s_exp);
 
 /**
  * Create a new sexp object from an unsigned integer.
@@ -134,7 +135,7 @@ bool SEXP_number_getb (const SEXP_t *s_exp);
  * Create a new sexp object from an unsigned integer.
  * @param n the integer value to store
  */
-SEXP_t *SEXP_number_newu_32 (uint32_t n);
+OSCAP_API SEXP_t *SEXP_number_newu_32 (uint32_t n);
 
 /**
  * Get unsigned integer value from a sexp object.
@@ -146,43 +147,43 @@ SEXP_t *SEXP_number_newu_32 (uint32_t n);
  * Get unsigned integer value from a sexp object.
  * @param s_exp the queried sexp object
  */
-uint32_t SEXP_number_getu_32 (const SEXP_t *s_exp);
+OSCAP_API uint32_t SEXP_number_getu_32 (const SEXP_t *s_exp);
 
 /**
  * Create a new sexp object from an integer.
  * @param n the integer value to store
  */
-SEXP_t *SEXP_number_newi_64 (int64_t n);
+OSCAP_API SEXP_t *SEXP_number_newi_64 (int64_t n);
 
 /**
  * Get integer value from a sexp object.
  * @param s_exp the queried sexp object
  */
-int64_t SEXP_number_geti_64 (const SEXP_t *s_exp);
+OSCAP_API int64_t SEXP_number_geti_64 (const SEXP_t *s_exp);
 
 /**
  * Create a new sexp object from an unsigned integer.
  * @param n the integer value to store
  */
-SEXP_t *SEXP_number_newu_64 (uint64_t n);
+OSCAP_API SEXP_t *SEXP_number_newu_64 (uint64_t n);
 
 /**
  * Get unsigned integer value from a sexp object.
  * @param s_exp the queried sexp object
  */
-uint64_t SEXP_number_getu_64 (const SEXP_t *s_exp);
+OSCAP_API uint64_t SEXP_number_getu_64 (const SEXP_t *s_exp);
 
 /**
  * Create a new sexp object from an floating point value.
  * @param n the floating point value to store
  */
-SEXP_t *SEXP_number_newf (double n);
+OSCAP_API SEXP_t *SEXP_number_newf (double n);
 
 /**
  * Get floating point value from a sexp object.
  * @param s_exp the queried sexp object
  */
-double  SEXP_number_getf (const SEXP_t *s_exp);
+OSCAP_API double  SEXP_number_getf (const SEXP_t *s_exp);
 
 /**
  * Get a value from a sexp object according to a specified type
@@ -190,31 +191,31 @@ double  SEXP_number_getf (const SEXP_t *s_exp);
  * @param dst buffer for the value
  * @param type the desired number type
  */
-int SEXP_number_get (const SEXP_t *s_exp, void *dst, SEXP_numtype_t type);
+OSCAP_API int SEXP_number_get (const SEXP_t *s_exp, void *dst, SEXP_numtype_t type);
 
 /**
  * Get unsigned integer value from a sexp object.
  * @param s_exp the queried sexp object
  */
-uint16_t SEXP_number_getu_16 (const SEXP_t *s_exp);
+OSCAP_API uint16_t SEXP_number_getu_16 (const SEXP_t *s_exp);
 
 /**
  * Free the specified sexp object.
  * @param s_exp the object to be freed
  */
-void    SEXP_number_free (SEXP_t *s_exp);
+OSCAP_API void    SEXP_number_free (SEXP_t *s_exp);
 
 /**
  * Check whether the provided sexp object is a number.
  * @param s_exp the sexp object to be tested
  */
-bool    SEXP_numberp (const SEXP_t *s_exp);
+OSCAP_API bool    SEXP_numberp (const SEXP_t *s_exp);
 
 /**
  * Get the number type of an object.
  * @param sexp the queried sexp object
  */
-SEXP_numtype_t SEXP_number_type (const SEXP_t *sexp);
+OSCAP_API SEXP_numtype_t SEXP_number_type (const SEXP_t *sexp);
 
 /*
  * string
@@ -225,39 +226,39 @@ SEXP_numtype_t SEXP_number_type (const SEXP_t *sexp);
  * @param string the string to be stored
  * @param strlen the length of the string in bytes
  */
-SEXP_t *SEXP_string_new  (const void *string, size_t strlen) __attribute__ ((nonnull (1)));
+OSCAP_API SEXP_t *SEXP_string_new  (const void *string, size_t strlen) __attribute__ ((nonnull (1)));
 
 /**
  * Create a new sexp object from a format string.
  * @param format the format of the new string
  * @param ... arguments for the format
  */
-SEXP_t *SEXP_string_newf (const char *format, ...) __attribute__ ((format (printf, 1, 2), nonnull (1)));
+OSCAP_API SEXP_t *SEXP_string_newf (const char *format, ...) __attribute__ ((format (printf, 1, 2), nonnull (1)));
 
 /**
  * Free the specified sexp object.
  * @param s_exp the object to be freed
  */
-void SEXP_string_free (SEXP_t *s_exp);
+OSCAP_API void SEXP_string_free (SEXP_t *s_exp);
 
 /**
  * Check whether the provided sexp object is a string.
  * @param s_exp the sexp object to be tested
  */
-bool SEXP_stringp (const SEXP_t *s_exp);
+OSCAP_API bool SEXP_stringp (const SEXP_t *s_exp);
 
 /**
  * Get the length of a string in a sexp object.
  * @param s_exp the queried sexp object
  */
-size_t SEXP_string_length (const SEXP_t *s_exp);
+OSCAP_API size_t SEXP_string_length (const SEXP_t *s_exp);
 
 /**
  * Compare a string in a sexp object with a C string.
  * @param s_exp the sexp object to be compared
  * @param str the C string to be compared
  */
-int SEXP_strcmp (const SEXP_t *s_exp, const char *str) __attribute__ ((nonnull (2)));
+OSCAP_API int SEXP_strcmp (const SEXP_t *s_exp, const char *str) __attribute__ ((nonnull (2)));
 
 /**
  * Compare a string in a sexp object with a C string.
@@ -265,19 +266,19 @@ int SEXP_strcmp (const SEXP_t *s_exp, const char *str) __attribute__ ((nonnull (
  * @param str the C string to be compared
  * @param n compare at most n bytes
  */
-int SEXP_strncmp (const SEXP_t *s_exp, const char *str, size_t n) __attribute__ ((nonnull (2)));
+OSCAP_API int SEXP_strncmp (const SEXP_t *s_exp, const char *str, size_t n) __attribute__ ((nonnull (2)));
 
 /**
  * Get the n-th byte of a string.
  * @param s_exp the sexp object holding the string
  * @param n the index of the desired character
  */
-int SEXP_string_nth (const SEXP_t *s_exp, size_t n);
+OSCAP_API int SEXP_string_nth (const SEXP_t *s_exp, size_t n);
 
 /**
  * Get a C string from a sexp object.
  */
-char  *SEXP_string_cstr (const SEXP_t *s_exp);
+OSCAP_API char  *SEXP_string_cstr (const SEXP_t *s_exp);
 
 /**
  * Get a C string from a sexp object.
@@ -286,12 +287,12 @@ char  *SEXP_string_cstr (const SEXP_t *s_exp);
  * @param buf the buffer to store the name in
  * @param len the length of the buffer
  */
-size_t SEXP_string_cstr_r (const SEXP_t *s_exp, char *buf, size_t len) __attribute__ ((nonnull (2)));
+OSCAP_API size_t SEXP_string_cstr_r (const SEXP_t *s_exp, char *buf, size_t len) __attribute__ ((nonnull (2)));
 
 /**
  * Obsolete function.
  */
-char  *SEXP_string_cstrp (const SEXP_t *s_exp);
+OSCAP_API char  *SEXP_string_cstrp (const SEXP_t *s_exp);
 
 /**
  * Get a C substring from a sexp object.
@@ -299,20 +300,20 @@ char  *SEXP_string_cstrp (const SEXP_t *s_exp);
  * @param beg the position of the fisrt character of the substring
  * @param len the length of the substring
  */
-char *SEXP_string_subcstr (const SEXP_t *s_exp, size_t beg, size_t len);
+OSCAP_API char *SEXP_string_subcstr (const SEXP_t *s_exp, size_t beg, size_t len);
 
 /**
  * Compare two sexp strings.
  * @param str_a the first string to compare
  * @param str_b the second string to compare
  */
-int SEXP_string_cmp (const SEXP_t *str_a, const SEXP_t *str_b);
+OSCAP_API int SEXP_string_cmp (const SEXP_t *str_a, const SEXP_t *str_b);
 
 /**
  * Try to cast the supplied sexp string to a boolean.
  * @param s_ext the string to be cast
  */
-bool SEXP_string_getb (const SEXP_t *s_exp);
+OSCAP_API bool SEXP_string_getb (const SEXP_t *s_exp);
 
 /*
  * list
@@ -324,46 +325,46 @@ bool SEXP_string_getb (const SEXP_t *s_exp);
  * @param memb the first sexp object to be inserted into the new list. can be NULL.
  * @param ... arbitrary number of elements to be inserted
  */
-SEXP_t *SEXP_list_new (SEXP_t *memb, ...);
+OSCAP_API SEXP_t *SEXP_list_new (SEXP_t *memb, ...);
 
 /**
  * Free the specified sexp object.
  * @param s_exp the object to be freed
  */
-void    SEXP_list_free (SEXP_t *s_exp);
+OSCAP_API void    SEXP_list_free (SEXP_t *s_exp);
 
 /**
  * Check whether the provided sexp object is a list.
  * @param s_exp the sexp object to be tested
  */
-bool    SEXP_listp (const SEXP_t *s_exp);
+OSCAP_API bool    SEXP_listp (const SEXP_t *s_exp);
 
 /**
  * Get the length of the sexp list.
  * @param s_sexp the queried sexp object
  */
-size_t  SEXP_list_length (const SEXP_t *s_exp);
+OSCAP_API size_t  SEXP_list_length (const SEXP_t *s_exp);
 
 /**
  * Get the first element of a list.
  * This function increments element's reference count
  * @param list the queried sexp object
  */
-SEXP_t *SEXP_list_first (const SEXP_t *list);
+OSCAP_API SEXP_t *SEXP_list_first (const SEXP_t *list);
 
 /**
  * Get the rest of a list.
  * This function increments elements' reference count.
  * @param list the queried sexp object
  */
-SEXP_t *SEXP_list_rest  (const SEXP_t *list);
+OSCAP_API SEXP_t *SEXP_list_rest  (const SEXP_t *list);
 
 /**
  * Get the last element of a list.
  * This function increments element's reference count.
  * @param list the queried sexp object
  */
-SEXP_t *SEXP_list_last (const SEXP_t *list);
+OSCAP_API SEXP_t *SEXP_list_last (const SEXP_t *list);
 
 /**
  * Get the n-th element of a list.
@@ -371,7 +372,7 @@ SEXP_t *SEXP_list_last (const SEXP_t *list);
  * @param list the queried sexp object
  * @param n the position of the element in the list
  */
-SEXP_t *SEXP_list_nth (const SEXP_t *list, uint32_t n);
+OSCAP_API SEXP_t *SEXP_list_nth (const SEXP_t *list, uint32_t n);
 
 /**
  * Add an element to a list.
@@ -379,7 +380,7 @@ SEXP_t *SEXP_list_nth (const SEXP_t *list, uint32_t n);
  * @param list the modified sexp object
  * @param s_exp the element to be added
  */
-SEXP_t *SEXP_list_add (SEXP_t *list, const SEXP_t *s_exp);
+OSCAP_API SEXP_t *SEXP_list_add (SEXP_t *list, const SEXP_t *s_exp);
 
 /**
  * Create a new list containing the concatenated contents of two lists.
@@ -387,7 +388,7 @@ SEXP_t *SEXP_list_add (SEXP_t *list, const SEXP_t *s_exp);
  * @param list_a the first list to be contatenated
  * @param list_b the list to be attached to the first one
  */
-SEXP_t *SEXP_list_join (const SEXP_t *list_a, const SEXP_t *list_b);
+OSCAP_API SEXP_t *SEXP_list_join (const SEXP_t *list_a, const SEXP_t *list_b);
 
 /**
  * Push an element to the head of a list.
@@ -395,19 +396,19 @@ SEXP_t *SEXP_list_join (const SEXP_t *list_a, const SEXP_t *list_b);
  * @param list the modified sexp object
  * @param s_exp the element to be added
  */
-SEXP_t *SEXP_list_push (SEXP_t *list, const SEXP_t *s_exp);
+OSCAP_API SEXP_t *SEXP_list_push (SEXP_t *list, const SEXP_t *s_exp);
 
 /**
  * Extract the first element of a list.
  * This function increments element's reference count.
  * @param list the modified sexp object
  */
-SEXP_t *SEXP_list_pop (SEXP_t *list);
+OSCAP_API SEXP_t *SEXP_list_pop (SEXP_t *list);
 
 /**
  * Sort a list using `compare' as the comparison function.
  */
-SEXP_t *SEXP_list_sort(SEXP_t *list, int(*compare)(const SEXP_t *, const SEXP_t *));
+OSCAP_API SEXP_t *SEXP_list_sort(SEXP_t *list, int(*compare)(const SEXP_t *, const SEXP_t *));
 
 /**
  * Replace the n-th element of a list.
@@ -417,28 +418,28 @@ SEXP_t *SEXP_list_sort(SEXP_t *list, int(*compare)(const SEXP_t *, const SEXP_t 
  * @param s_exp the element to be added
  * @return the replaced element
  */
-SEXP_t *SEXP_list_replace (SEXP_t *list, uint32_t n, const SEXP_t *s_exp);
+OSCAP_API SEXP_t *SEXP_list_replace (SEXP_t *list, uint32_t n, const SEXP_t *s_exp);
 
 /**
  * Get the first element of a list.
  * This function creates a soft reference to the element.
  * @param list the queried sexp object
  */
-SEXP_t *SEXP_listref_first (SEXP_t *list);
+OSCAP_API SEXP_t *SEXP_listref_first (SEXP_t *list);
 
 /**
  * Get the rest of a list.
  * This function creates a soft reference to the list.
  * @param list the queried sexp object
  */
-SEXP_t *SEXP_listref_rest (SEXP_t *list);
+OSCAP_API SEXP_t *SEXP_listref_rest (SEXP_t *list);
 
 /**
  * Get the last element of a list.
  * This function creates a soft reference to the element.
  * @param list the queried sexp object
  */
-SEXP_t *SEXP_listref_last (SEXP_t *list);
+OSCAP_API SEXP_t *SEXP_listref_last (SEXP_t *list);
 
 /**
  * Get the n-th element of a list.
@@ -446,25 +447,25 @@ SEXP_t *SEXP_listref_last (SEXP_t *list);
  * @param list the queried sexp object
  * @param n the position of the element in the list
  */
-SEXP_t *SEXP_listref_nth (SEXP_t *list, uint32_t n);
+OSCAP_API SEXP_t *SEXP_listref_nth (SEXP_t *list, uint32_t n);
 
 typedef struct SEXP_it SEXP_it_t;
 
 #define SEXP_IT_RECURSIVE 0x01
 #define SEXP_IT_HARDREF   0x02
 
-SEXP_it_t *SEXP_listit_new (const SEXP_t *list, int flags);
-SEXP_t    *SEXP_listit_next(SEXP_it_t *it);
-SEXP_t    *SEXP_listit_prev (SEXP_it_t *it);
-SEXP_t    *SEXP_listit_length (SEXP_it_t *it);
-SEXP_t    *SEXP_listit_seek (SEXP_it_t *it, uint32_t n);
-void       SEXP_listit_free (SEXP_it_t *it);
+OSCAP_API SEXP_it_t *SEXP_listit_new (const SEXP_t *list, int flags);
+OSCAP_API SEXP_t    *SEXP_listit_next(SEXP_it_t *it);
+OSCAP_API SEXP_t    *SEXP_listit_prev (SEXP_it_t *it);
+OSCAP_API SEXP_t    *SEXP_listit_length (SEXP_it_t *it);
+OSCAP_API SEXP_t    *SEXP_listit_seek (SEXP_it_t *it, uint32_t n);
+OSCAP_API void       SEXP_listit_free (SEXP_it_t *it);
 
 typedef struct SEXP_list_it SEXP_list_it;
 
-SEXP_list_it *SEXP_list_it_new(const SEXP_t *list);
-SEXP_t *SEXP_list_it_next(SEXP_list_it *it);
-void SEXP_list_it_free(SEXP_list_it *it);
+OSCAP_API SEXP_list_it *SEXP_list_it_new(const SEXP_t *list);
+OSCAP_API SEXP_t *SEXP_list_it_next(SEXP_list_it *it);
+OSCAP_API void SEXP_list_it_free(SEXP_list_it *it);
 
 #if __STDC_VERSION__ >= 199901L
 # include <common/util.h>
@@ -486,7 +487,7 @@ void SEXP_list_it_free(SEXP_list_it *it);
  * @param end the index of the last element of the sublist
  */
 #define SEXP_sublist_foreach(var, list, beg, end)                       \
-        for (uint32_t OSCAP_CONCAT(i,__LINE__) = (beg); OSCAP_CONCAT(i,__LINE__) <= ((size_t)(end)) && ((var) = SEXP_list_nth (list, OSCAP_CONCAT(i,__LINE__))) != NULL; ++OSCAP_CONCAT(i,__LINE__), SEXP_free (var), (var) = NULL)
+OSCAP_API         for (uint32_t OSCAP_CONCAT(i,__LINE__) = (beg); OSCAP_CONCAT(i,__LINE__) <= ((size_t)(end)) && ((var) = SEXP_list_nth (list, OSCAP_CONCAT(i,__LINE__))) != NULL; ++OSCAP_CONCAT(i,__LINE__), SEXP_free (var), (var) = NULL)
 
 #define SEXP_LIST_END (UINT32_MAX - 1)
 
@@ -495,44 +496,44 @@ void SEXP_list_it_free(SEXP_list_it *it);
 /*
  * generic
  */
-SEXP_t *SEXP_new (void);
+OSCAP_API SEXP_t *SEXP_new (void);
 
-bool SEXP_emptyp(SEXP_t *sexp);
+OSCAP_API bool SEXP_emptyp(SEXP_t *sexp);
 
 /**
  * Create a new reference to a sexp object.
  * @param s_exp the object of which to increment the reference count
  */
-SEXP_t *SEXP_ref (const SEXP_t *s_exp);
+OSCAP_API SEXP_t *SEXP_ref (const SEXP_t *s_exp);
 
-SEXP_t *SEXP_unref (SEXP_t *s_exp_o);
+OSCAP_API SEXP_t *SEXP_unref (SEXP_t *s_exp_o);
 
 /**
  * Create a new soft reference to a sexp object.
  * @param s_exp the object to which create the soft reference
  */
-SEXP_t *SEXP_softref (SEXP_t *s_exp);
+OSCAP_API SEXP_t *SEXP_softref (SEXP_t *s_exp);
 
 /**
  * Check whether an S-exp reference is a "soft" reference
  * @param s_exp the S-exp reference
  */
-bool SEXP_softrefp(const SEXP_t *s_exp);
+OSCAP_API bool SEXP_softrefp(const SEXP_t *s_exp);
 
 /**
  * Return the value of the reference counter
  * @param ref
  */
-uint32_t SEXP_refs (const SEXP_t *ref);
+OSCAP_API uint32_t SEXP_refs (const SEXP_t *ref);
 
-bool SEXP_eq (const SEXP_t *a, const SEXP_t *b);
+OSCAP_API bool SEXP_eq (const SEXP_t *a, const SEXP_t *b);
 
 /**
  * Compare reference pointers.
  */
-int SEXP_refcmp(const SEXP_t *a, const SEXP_t *b);
+OSCAP_API int SEXP_refcmp(const SEXP_t *a, const SEXP_t *b);
 
-bool SEXP_deepcmp(const SEXP_t *a, const SEXP_t *b);
+OSCAP_API bool SEXP_deepcmp(const SEXP_t *a, const SEXP_t *b);
 
 #ifdef __COVERITY__
 /*
@@ -543,10 +544,10 @@ bool SEXP_deepcmp(const SEXP_t *a, const SEXP_t *b);
 # define SEXP_vfree_coverity(...) \
 	do { \
 		SEXP_t *__svf##__LINE__[] = { __VA_ARGS__ }; \
-		size_t __svfc##__LINE__ = sizeof (__svf##__LINE__)/sizeof(SEXP_t *); \
+OSCAP_API 		size_t __svfc##__LINE__ = sizeof (__svf##__LINE__)/sizeof(SEXP_t *); \
 		for (; __svfc##__LINE__ > 0; --__svfc##__LINE__) \
 			if (__svf##__LINE__[__svfc##__LINE__ - 1]) \
-				SEXP_free(__svf##__LINE__[__svfc##__LINE__ - 1]); \
+OSCAP_API 				SEXP_free(__svf##__LINE__[__svfc##__LINE__ - 1]); \
 	} while(0)
 #endif /* __COVERITY__ */
 
@@ -555,7 +556,7 @@ bool SEXP_deepcmp(const SEXP_t *a, const SEXP_t *b);
  * Free a sexp object.
  * @param s_exp the object to be freed
  */
-void     SEXP_free (SEXP_t *s_exp);
+OSCAP_API void     SEXP_free (SEXP_t *s_exp);
 
 /**
  * Free multiple sexp objects.
@@ -563,7 +564,7 @@ void     SEXP_free (SEXP_t *s_exp);
  * @param s_exp the object to be freed
  * @param ... arbitrary number of objects to be freed
  */
-void     __SEXP_vfree (int n, SEXP_t *s_exp, ...);
+OSCAP_API void     __SEXP_vfree (int n, SEXP_t *s_exp, ...);
 #ifdef __COVERITY__
 # define SEXP_vfree(...) SEXP_vfree_coverity(__VA_ARGS__)
 #else
@@ -571,26 +572,26 @@ void     __SEXP_vfree (int n, SEXP_t *s_exp, ...);
 #endif
 #else
 # define SEXP_free(ptr) __SEXP_free (ptr, __FILE__, __LINE__, __PRETTY_FUNCTION__)
-void     __SEXP_free (SEXP_t *s_exp, const char *file, uint32_t line, const char *func);
+OSCAP_API void     __SEXP_free (SEXP_t *s_exp, const char *file, uint32_t line, const char *func);
 #ifdef __COVERITY__
 # define SEXP_vfree(...) SEXP_vfree_coverity(__VA_ARGS__)
 #else
 # define SEXP_vfree(...) __SEXP_vfree (__FILE__, __LINE__, __PRETTY_FUNCTION__, PP_NARG(__VA_ARGS__), __VA_ARGS__)
 #endif
-void     __SEXP_vfree (const char *file, uint32_t line, const char *func, int n, SEXP_t *s_exp, ...);
+OSCAP_API void     __SEXP_vfree (const char *file, uint32_t line, const char *func, int n, SEXP_t *s_exp, ...);
 #endif
 
 /**
  * Get the user data type of a sexp object.
  * @param s_exp the object to be queried
  */
-const char *SEXP_datatype (const SEXP_t *s_exp);
+OSCAP_API const char *SEXP_datatype (const SEXP_t *s_exp);
 
 /**
  * Set the user data type of a sexp object.
  * @param s_exp the object to be modified
  */
-int SEXP_datatype_set (SEXP_t *s_exp, const char *name) __attribute__ ((nonnull (2)));
+OSCAP_API int SEXP_datatype_set (SEXP_t *s_exp, const char *name) __attribute__ ((nonnull (2)));
 
 /**
  * Set the user data type of the nth sexp object in a list.
@@ -598,29 +599,29 @@ int SEXP_datatype_set (SEXP_t *s_exp, const char *name) __attribute__ ((nonnull 
  * @param n the position of the object
  * @param name name of the user data type
  */
-int SEXP_datatype_set_nth (SEXP_t *list, uint32_t n, const char *name) __attribute__ ((nonnull (3)));
+OSCAP_API int SEXP_datatype_set_nth (SEXP_t *list, uint32_t n, const char *name) __attribute__ ((nonnull (3)));
 
 /**
  * Get the type of a sexp object.
  * @param s_exp the object to be queried
  */
-SEXP_type_t SEXP_typeof (const SEXP_t *s_exp);
+OSCAP_API SEXP_type_t SEXP_typeof (const SEXP_t *s_exp);
 
 /**
  * Get a text description of the sexp object's type.
  * @param s_exp the object to be queried
  */
-const char *SEXP_strtype (const SEXP_t *s_exp);
+OSCAP_API const char *SEXP_strtype (const SEXP_t *s_exp);
 
-SEXP_t *SEXP_build (const char *s_str, ...);
+OSCAP_API SEXP_t *SEXP_build (const char *s_str, ...);
 
-size_t SEXP_sizeof (const SEXP_t *s_exp);
+OSCAP_API size_t SEXP_sizeof (const SEXP_t *s_exp);
 
 #if !defined(NDEBUG)
 # define SEXP_VALIDATE(s) __SEXP_VALIDATE(s, __FILE__, __LINE__, __PRETTY_FUNCTION__)
 # include <stdlib.h>
 
-void __SEXP_VALIDATE(const SEXP_t *s_exp, const char *file, uint32_t line, const char *func);
+OSCAP_API void __SEXP_VALIDATE(const SEXP_t *s_exp, const char *file, uint32_t line, const char *func);
 
 #else
 # define SEXP_VALIDATE(s)

--- a/src/OVAL/probes/SEAP/public/sexp-manip_r.h
+++ b/src/OVAL/probes/SEAP/public/sexp-manip_r.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "sexp-types.h"
+#include "oscap_export.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,36 +41,36 @@ extern "C" {
 #define _GNUC_PRINTF( format_idx, arg_idx )
 #endif  /* __GNUC__ */
 
-SEXP_t *SEXP_init(SEXP_t *sexp_mem);
+OSCAP_API SEXP_t *SEXP_init(SEXP_t *sexp_mem);
 
-SEXP_t *SEXP_number_newb_r(SEXP_t *sexp_mem, bool n);
+OSCAP_API SEXP_t *SEXP_number_newb_r(SEXP_t *sexp_mem, bool n);
 #define SEXP_number_newi_r SEXP_number_newi_32_r
-SEXP_t *SEXP_number_newi_32_r(SEXP_t *sexp_mem, int32_t n);
-SEXP_t *SEXP_number_newu_32_r(SEXP_t *sexp_mem, uint32_t n);
-SEXP_t *SEXP_number_newu_64_r(SEXP_t *sexp_mem, uint64_t n);
-SEXP_t *SEXP_number_newi_64_r(SEXP_t *sexp_mem, int64_t n);
-SEXP_t *SEXP_number_newf_r(SEXP_t *sexp_mem, double n);
+OSCAP_API SEXP_t *SEXP_number_newi_32_r(SEXP_t *sexp_mem, int32_t n);
+OSCAP_API SEXP_t *SEXP_number_newu_32_r(SEXP_t *sexp_mem, uint32_t n);
+OSCAP_API SEXP_t *SEXP_number_newu_64_r(SEXP_t *sexp_mem, uint64_t n);
+OSCAP_API SEXP_t *SEXP_number_newi_64_r(SEXP_t *sexp_mem, int64_t n);
+OSCAP_API SEXP_t *SEXP_number_newf_r(SEXP_t *sexp_mem, double n);
 
-SEXP_t *SEXP_string_new_r(SEXP_t *sexp_mem, const void *string, size_t length);
-SEXP_t *SEXP_string_newf_r(SEXP_t *sexp_mem, const char *format, ...) _GNUC_PRINTF (2,3);
-SEXP_t *SEXP_string_newf_rv(SEXP_t *sexp_mem, const char *format, va_list ap);
+OSCAP_API SEXP_t *SEXP_string_new_r(SEXP_t *sexp_mem, const void *string, size_t length);
+OSCAP_API SEXP_t *SEXP_string_newf_r(SEXP_t *sexp_mem, const char *format, ...) _GNUC_PRINTF (2,3);
+OSCAP_API SEXP_t *SEXP_string_newf_rv(SEXP_t *sexp_mem, const char *format, va_list ap);
 
-SEXP_t *SEXP_list_new_rv(SEXP_t *sexp_mem, SEXP_t *memb, va_list alist);
-SEXP_t *SEXP_list_new_r(SEXP_t *sexp_mem, SEXP_t *memb, ...);
+OSCAP_API SEXP_t *SEXP_list_new_rv(SEXP_t *sexp_mem, SEXP_t *memb, va_list alist);
+OSCAP_API SEXP_t *SEXP_list_new_r(SEXP_t *sexp_mem, SEXP_t *memb, ...);
 
-SEXP_t *SEXP_list_rest_r (SEXP_t *rest, const SEXP_t *list);
+OSCAP_API SEXP_t *SEXP_list_rest_r (SEXP_t *rest, const SEXP_t *list);
 
-int SEXP_unref_r(SEXP_t *s_exp);
+OSCAP_API int SEXP_unref_r(SEXP_t *s_exp);
 
 #if defined(NDEBUG)
-void SEXP_free_r (SEXP_t *s_exp);
+OSCAP_API void SEXP_free_r (SEXP_t *s_exp);
 #else
 #include <stdint.h>
-void __SEXP_free_r(SEXP_t *s_exp, const char *file, uint32_t line, const char *func);
+OSCAP_API void __SEXP_free_r(SEXP_t *s_exp, const char *file, uint32_t line, const char *func);
 
 __attribute__ ((unused)) static void SEXP_free_r(SEXP_t *sexp)
 {
-        __SEXP_free_r(sexp, __FILE__, __LINE__, __PRETTY_FUNCTION__);
+OSCAP_API         __SEXP_free_r(sexp, __FILE__, __LINE__, __PRETTY_FUNCTION__);
 }
 
 #define SEXP_free_r(ptr) __SEXP_free_r(ptr, __FILE__, __LINE__, __PRETTY_FUNCTION__)

--- a/src/OVAL/probes/SEAP/public/sexp-output.h
+++ b/src/OVAL/probes/SEAP/public/sexp-output.h
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <sexp-types.h>
 #include <strbuf.h>
+#include "oscap_export.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,9 +36,9 @@ extern "C" {
 
 typedef struct SEXP_ostate SEXP_ostate_t;
 
-size_t SEXP_fprintfa (FILE *fp, const SEXP_t *s_exp);
+OSCAP_API size_t SEXP_fprintfa (FILE *fp, const SEXP_t *s_exp);
 
-int SEXP_sbprintf_t (SEXP_t *s_exp, strbuf_t *sb);
+OSCAP_API int SEXP_sbprintf_t (SEXP_t *s_exp, strbuf_t *sb);
 
 #ifdef __cplusplus
 }

--- a/src/OVAL/probes/SEAP/public/sexp-parser.h
+++ b/src/OVAL/probes/SEAP/public/sexp-parser.h
@@ -30,11 +30,12 @@ extern "C" {
 
 #include <stddef.h>
 #include <sexp-types.h>
+#include "oscap_export.h"
 
 typedef struct SEXP_psetup SEXP_psetup_t;
 
-SEXP_psetup_t *SEXP_psetup_new  (void);
-void           SEXP_psetup_free (SEXP_psetup_t *);
+OSCAP_API SEXP_psetup_t *SEXP_psetup_new  (void);
+OSCAP_API void           SEXP_psetup_free (SEXP_psetup_t *);
 
 typedef uint8_t SEXP_pflags_t;
 
@@ -42,18 +43,18 @@ typedef uint8_t SEXP_pflags_t;
 #define SEXP_PFLAG_FREEBUF 0x02
 #define SEXP_PFLAG_ALL     0x03
 
-int SEXP_psetup_setflags (SEXP_psetup_t *psetup, SEXP_pflags_t flags);
-int SEXP_psetup_unsetflags (SEXP_psetup_t *psetup, SEXP_pflags_t flags);
+OSCAP_API int SEXP_psetup_setflags (SEXP_psetup_t *psetup, SEXP_pflags_t flags);
+OSCAP_API int SEXP_psetup_unsetflags (SEXP_psetup_t *psetup, SEXP_pflags_t flags);
 
 typedef struct SEXP_pstate SEXP_pstate_t;
 
-SEXP_pstate_t *SEXP_pstate_new (void);
-void           SEXP_pstate_free (SEXP_pstate_t *);
-SEXP_pstate_t *SEXP_pstate_init (SEXP_pstate_t *);
+OSCAP_API SEXP_pstate_t *SEXP_pstate_new (void);
+OSCAP_API void           SEXP_pstate_free (SEXP_pstate_t *);
+OSCAP_API SEXP_pstate_t *SEXP_pstate_init (SEXP_pstate_t *);
 
-SEXP_t *SEXP_parse (const SEXP_psetup_t *psetup, char *buffer, size_t buflen, SEXP_pstate_t **pstate);
+OSCAP_API SEXP_t *SEXP_parse (const SEXP_psetup_t *psetup, char *buffer, size_t buflen, SEXP_pstate_t **pstate);
 
-bool SEXP_pstate_errorp(SEXP_pstate_t *pstate);
+OSCAP_API bool SEXP_pstate_errorp(SEXP_pstate_t *pstate);
 
 #ifdef __cplusplus
 }

--- a/src/OVAL/probes/SEAP/public/sm_alloc.h
+++ b/src/OVAL/probes/SEAP/public/sm_alloc.h
@@ -26,6 +26,7 @@
 
 #include "config.h"
 #include "src/common/debug_priv.h"
+#include "oscap_export.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,36 +36,36 @@ extern "C" {
 
 #if !defined(HAVE_POSIX_MEMALIGN)
 # if defined (HAVE_MEMALIGN)
-extern int posix_memalign (void ** __memptr, size_t __alignment, size_t __size);
+OSCAP_API extern int posix_memalign (void ** __memptr, size_t __alignment, size_t __size);
 
 # endif /* HAVE_MEMALIGN */
 #endif /* HAVE_POSIX_MEMALIGN */
 
 #if defined(NDEBUG)
-void *sm_alloc (size_t s);
-void *sm_calloc (size_t n, size_t s);
-void *sm_realloc (void *p, size_t s);
-void *sm_reallocf (void *p, size_t s);
-int   sm_memalign (void **p, size_t a, size_t s);
-void  sm_free (void *p);
+OSCAP_API void *sm_alloc (size_t s);
+OSCAP_API void *sm_calloc (size_t n, size_t s);
+OSCAP_API void *sm_realloc (void *p, size_t s);
+OSCAP_API void *sm_reallocf (void *p, size_t s);
+OSCAP_API int   sm_memalign (void **p, size_t a, size_t s);
+OSCAP_API void  sm_free (void *p);
 #else
-void *  __sm_alloc_dbg (size_t s, const char *f, size_t l);
-__ATTRIB void *sm_alloc     (size_t s) { return __sm_alloc_dbg (s, __FUNCTION__, 0); }
+OSCAP_API void *  __sm_alloc_dbg (size_t s, const char *f, size_t l);
+OSCAP_API __ATTRIB void *sm_alloc     (size_t s) { return __sm_alloc_dbg (s, __FUNCTION__, 0); }
 
-void *  __sm_calloc_dbg (size_t n, size_t s, const char *f, size_t l);
-__ATTRIB void *sm_calloc     (size_t n, size_t s) { return __sm_calloc_dbg (n, s, __FUNCTION__, 0); }
+OSCAP_API void *  __sm_calloc_dbg (size_t n, size_t s, const char *f, size_t l);
+OSCAP_API __ATTRIB void *sm_calloc     (size_t n, size_t s) { return __sm_calloc_dbg (n, s, __FUNCTION__, 0); }
 
-void *  __sm_realloc_dbg (void *p, size_t s, const char *f, size_t l);
-__ATTRIB void *sm_realloc     (void *p, size_t s) { return __sm_realloc_dbg (p, s, __FUNCTION__, 0); }
+OSCAP_API void *  __sm_realloc_dbg (void *p, size_t s, const char *f, size_t l);
+OSCAP_API __ATTRIB void *sm_realloc     (void *p, size_t s) { return __sm_realloc_dbg (p, s, __FUNCTION__, 0); }
 
-void *  __sm_reallocf_dbg (void *p, size_t s, const char *f, size_t l);
-__ATTRIB void *sm_reallocf     (void *p, size_t s) { return __sm_reallocf_dbg (p, s, __FUNCTION__, 0); }
+OSCAP_API void *  __sm_reallocf_dbg (void *p, size_t s, const char *f, size_t l);
+OSCAP_API __ATTRIB void *sm_reallocf     (void *p, size_t s) { return __sm_reallocf_dbg (p, s, __FUNCTION__, 0); }
 
-int     __sm_memalign_dbg (void **p, size_t a, size_t s, const char *f, size_t l);
-__ATTRIB int __sm_memalign     (void **p, size_t a, size_t s) { return __sm_memalign_dbg (p, a, s, __FUNCTION__, 0); }
+OSCAP_API int     __sm_memalign_dbg (void **p, size_t a, size_t s, const char *f, size_t l);
+OSCAP_API __ATTRIB int __sm_memalign     (void **p, size_t a, size_t s) { return __sm_memalign_dbg (p, a, s, __FUNCTION__, 0); }
 
-void   __sm_free_dbg (void *p, const char *f, size_t l);
-__ATTRIB void sm_free     (void *p) { __sm_free_dbg (p, __FUNCTION__, 0); }
+OSCAP_API void   __sm_free_dbg (void *p, const char *f, size_t l);
+OSCAP_API __ATTRIB void sm_free     (void *p) { __sm_free_dbg (p, __FUNCTION__, 0); }
 
 # define sm_alloc(s)          __sm_alloc_dbg (s, __PRETTY_FUNCTION__, __LINE__)
 # define sm_calloc(n, s)      __sm_calloc_dbg (n, s, __PRETTY_FUNCTION__, __LINE__)

--- a/src/OVAL/probes/SEAP/public/sm_alloc.h
+++ b/src/OVAL/probes/SEAP/public/sm_alloc.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #if !defined(HAVE_POSIX_MEMALIGN)
 # if defined (HAVE_MEMALIGN)
-OSCAP_API extern int posix_memalign (void ** __memptr, size_t __alignment, size_t __size);
+extern int posix_memalign (void ** __memptr, size_t __alignment, size_t __size);
 
 # endif /* HAVE_MEMALIGN */
 #endif /* HAVE_POSIX_MEMALIGN */

--- a/src/OVAL/probes/SEAP/public/strbuf.h
+++ b/src/OVAL/probes/SEAP/public/strbuf.h
@@ -27,6 +27,7 @@
 #include <stddef.h>
 #include <unistd.h>
 #include <stdio.h>
+#include "oscap_export.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,25 +49,25 @@ typedef struct {
         size_t         size;
 } strbuf_t;
 
-strbuf_t *strbuf_new  (size_t max);
-void      strbuf_free (strbuf_t *buf);
+OSCAP_API strbuf_t *strbuf_new  (size_t max);
+OSCAP_API void      strbuf_free (strbuf_t *buf);
 
-int strbuf_add   (strbuf_t *buf, const char *str, size_t len);
-int strbuf_addf  (strbuf_t *buf, char *str, size_t len);
-int strbuf_add0  (strbuf_t *buf, const char *str);
-int strbuf_add0f (strbuf_t *buf, char *str);
-int strbuf_addc (strbuf_t *buf, char ch);
+OSCAP_API int strbuf_add   (strbuf_t *buf, const char *str, size_t len);
+OSCAP_API int strbuf_addf  (strbuf_t *buf, char *str, size_t len);
+OSCAP_API int strbuf_add0  (strbuf_t *buf, const char *str);
+OSCAP_API int strbuf_add0f (strbuf_t *buf, char *str);
+OSCAP_API int strbuf_addc (strbuf_t *buf, char ch);
 
-size_t strbuf_size (strbuf_t *buf);
-int    strbuf_trunc  (strbuf_t *buf, size_t len);
-size_t strbuf_length (strbuf_t *buf);
+OSCAP_API size_t strbuf_size (strbuf_t *buf);
+OSCAP_API int    strbuf_trunc  (strbuf_t *buf, size_t len);
+OSCAP_API size_t strbuf_length (strbuf_t *buf);
 
-char *strbuf_cstr   (strbuf_t *buf);
-char *strbuf_cstr_r (strbuf_t *buf, char *str, size_t len);
-char *strbuf_copy (strbuf_t *buf, void *dst, size_t len);
+OSCAP_API char *strbuf_cstr   (strbuf_t *buf);
+OSCAP_API char *strbuf_cstr_r (strbuf_t *buf, char *str, size_t len);
+OSCAP_API char *strbuf_copy (strbuf_t *buf, void *dst, size_t len);
 
-size_t strbuf_fwrite (FILE *fp, strbuf_t *buf);
-ssize_t strbuf_write  (strbuf_t *buf, int fd);
+OSCAP_API size_t strbuf_fwrite (FILE *fp, strbuf_t *buf);
+OSCAP_API ssize_t strbuf_write  (strbuf_t *buf, int fd);
 
 #ifdef __cplusplus
 }

--- a/src/OVAL/probes/public/findfile.h
+++ b/src/OVAL/probes/public/findfile.h
@@ -33,6 +33,7 @@
 #include "seap.h"
 #include "probe-api.h"
 #include "fsdev.h"
+#include "oscap_export.h"
 
 #define MTAB_PATH "/etc/mtab"
 #define LOCAL_FILESYSTEMS { "btrfs",            \
@@ -56,7 +57,7 @@
  * @param arg an optional argument to the callback function
  */
 int find_files(SEXP_t *spath, SEXP_t *sfilename, SEXP_t *behaviors,
-	       int (*cb) (const char *, const char *, void *), void *arg);
+OSCAP_API 	       int (*cb) (const char *, const char *, void *), void *arg);
 
 #endif
 /// @}

--- a/src/OVAL/probes/public/fsdev.h
+++ b/src/OVAL/probes/public/fsdev.h
@@ -35,6 +35,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/stat.h>
+#include "oscap_export.h"
 
 /**
  * Filesystem device structure.
@@ -48,23 +49,23 @@ typedef struct {
  * Initialize the fsdev_t structure from an array of filesystem
  * names.
  */
-fsdev_t *fsdev_init(const char **fs, size_t fs_cnt);
+OSCAP_API fsdev_t *fsdev_init(const char **fs, size_t fs_cnt);
 
 /**
  * Initialize the fsdev_t structure from a string containing filesystem
  * names.
  */
-fsdev_t *fsdev_strinit(const char *fs_names);
+OSCAP_API fsdev_t *fsdev_strinit(const char *fs_names);
 
 /**
  * Free the fsdev_t structure.
  */
-void fsdev_free(fsdev_t * lfs);
+OSCAP_API void fsdev_free(fsdev_t * lfs);
 
 /**
  * Search an id in the fsdev_t structure.
  */
-int fsdev_search(fsdev_t * lfs, void *id);
+OSCAP_API int fsdev_search(fsdev_t * lfs, void *id);
 
 /**
  * Check whether a path points points to a place on any of the devices
@@ -75,7 +76,7 @@ int fsdev_search(fsdev_t * lfs, void *id);
  * @retval 0 otherwise
  * @retval -1 error
  */
-int fsdev_path(fsdev_t * lfs, const char *path);
+OSCAP_API int fsdev_path(fsdev_t * lfs, const char *path);
 
 /**
  * Check whether a file descriptor is associated with a file that resides
@@ -86,7 +87,7 @@ int fsdev_path(fsdev_t * lfs, const char *path);
  * @retval 0 otherwise
  * @retval -1 error
  */
-int fsdev_fd(fsdev_t * lfs, int fd);
+OSCAP_API int fsdev_fd(fsdev_t * lfs, int fd);
 
 #endif				/* FSDEV_H */
 /// @}

--- a/src/OVAL/probes/public/probe-api.h
+++ b/src/OVAL/probes/public/probe-api.h
@@ -67,6 +67,7 @@
 #include <oval_system_characteristics.h>
 #include <oval_results.h>
 #include <oval_types.h>
+#include "oscap_export.h"
 
 /*
  * items
@@ -76,9 +77,9 @@
  * Build a new item according to the specified format.
  * @param fmt the desired format
  */
-SEXP_t *probe_item_build(const char *fmt, ...);
+OSCAP_API SEXP_t *probe_item_build(const char *fmt, ...);
 
-/* SEXP_t *probe_item_creat (const char *name, SEXP_t *attrs, ...); */
+OSCAP_API /* SEXP_t *probe_item_creat (const char *name, SEXP_t *attrs, ...); */
 /**
  * Create a new item consisting of a name, optional attributes argument and an arbitrary number of entities.
  * Every entity is a triple:
@@ -90,14 +91,14 @@ SEXP_t *probe_item_build(const char *fmt, ...);
  * @param attrs optional item's attributes argument
  * @param ... arbitrary number of entity arguments
  */
-SEXP_t *probe_item_creat(const char *name, SEXP_t * attrs, ...);
+OSCAP_API SEXP_t *probe_item_creat(const char *name, SEXP_t * attrs, ...);
 
 /**
  * Create a new item with just a name and optional attributes argument.
  * @param name item's name
  * @param attrs optional attributes argument
  */
-SEXP_t *probe_item_new(const char *name, SEXP_t * attrs);
+OSCAP_API SEXP_t *probe_item_new(const char *name, SEXP_t * attrs);
 
 /**
  * Add a new attribute to an item.
@@ -106,7 +107,7 @@ SEXP_t *probe_item_new(const char *name, SEXP_t * attrs);
  * @param name name of the new attribute
  * @param val value of the new attribute
  */
-SEXP_t *probe_item_attr_add(SEXP_t * item, const char *name, SEXP_t * val);
+OSCAP_API SEXP_t *probe_item_attr_add(SEXP_t * item, const char *name, SEXP_t * val);
 
 /**
  * Add a new entity to an item.
@@ -116,14 +117,14 @@ SEXP_t *probe_item_attr_add(SEXP_t * item, const char *name, SEXP_t * val);
  * @param attrs optional attributes of the new entity
  * @param val value of the new entity
  */
-SEXP_t *probe_item_ent_add(SEXP_t * item, const char *name, SEXP_t * attrs, SEXP_t * val);
+OSCAP_API SEXP_t *probe_item_ent_add(SEXP_t * item, const char *name, SEXP_t * attrs, SEXP_t * val);
 
 /**
  * Set item's status.
  * @param obj the item to be modified
  * @param status the new status
  */
-int probe_item_setstatus(SEXP_t * obj, oval_syschar_status_t status);
+OSCAP_API int probe_item_setstatus(SEXP_t * obj, oval_syschar_status_t status);
 
 /**
  * Set status of an item's entity.
@@ -132,7 +133,7 @@ int probe_item_setstatus(SEXP_t * obj, oval_syschar_status_t status);
  * @param n select the n-th occurence of an entity with the specified name
  * @param status the new status
  */
-int probe_itement_setstatus(SEXP_t * obj, const char *name, uint32_t n, oval_syschar_status_t status);
+OSCAP_API int probe_itement_setstatus(SEXP_t * obj, const char *name, uint32_t n, oval_syschar_status_t status);
 
 /**
  *
@@ -144,13 +145,13 @@ struct id_desc_t;
  * @param id_desc pointer to a structure holding the global id context
  * @return a new id
  */
-SEXP_t *probe_item_newid(struct id_desc_t *id_desc);
+OSCAP_API SEXP_t *probe_item_newid(struct id_desc_t *id_desc);
 
 /**
  * Reset the item id generator.
  * @param id_desc pointer to a structure holding the global id context
  */
-void probe_item_resetidctr(struct id_desc_t *id_desc);
+OSCAP_API void probe_item_resetidctr(struct id_desc_t *id_desc);
 
 #define probe_item_getent(item, name, n) probe_obj_getent (item, name, n)
 
@@ -165,7 +166,7 @@ void probe_item_resetidctr(struct id_desc_t *id_desc);
  * @param val the value of the attribute
  * @param ... there can be an arbitrary number of name - value pairs
  */
-SEXP_t *probe_attr_creat(const char *name, const SEXP_t * val, ...);
+OSCAP_API SEXP_t *probe_attr_creat(const char *name, const SEXP_t * val, ...);
 
 /*
  * objects
@@ -175,7 +176,7 @@ SEXP_t *probe_attr_creat(const char *name, const SEXP_t * val, ...);
  * Build a new object according to the specified format.
  * @param fmt the desired format
  */
-SEXP_t *probe_obj_build(const char *fmt, ...);
+OSCAP_API SEXP_t *probe_obj_build(const char *fmt, ...);
 
 /**
  * Create a new object consisting of a name, optional attributes argument and an arbitrary number of entities.
@@ -188,7 +189,7 @@ SEXP_t *probe_obj_build(const char *fmt, ...);
  * @param attrs optional object's attributes argument
  * @param ... arbitrary number of entity arguments
  */
-SEXP_t *probe_obj_creat(const char *name, SEXP_t * attrs, ...);
+OSCAP_API SEXP_t *probe_obj_creat(const char *name, SEXP_t * attrs, ...);
 
 /**
  * Create a new object with just a name and optional attributes argument.
@@ -196,7 +197,7 @@ SEXP_t *probe_obj_creat(const char *name, SEXP_t * attrs, ...);
  * @param name object's name
  * @param attrs optional attributes argument
  */
-SEXP_t *probe_obj_new(const char *name, SEXP_t * attrs);
+OSCAP_API SEXP_t *probe_obj_new(const char *name, SEXP_t * attrs);
 
 /**
  * Get an entity from an object.
@@ -204,7 +205,7 @@ SEXP_t *probe_obj_new(const char *name, SEXP_t * attrs);
  * @param name the name of the entity
  * @param n select the n-th occurence of an entity with the specified name
  */
-SEXP_t *probe_obj_getent(const SEXP_t * obj, const char *name, uint32_t n);
+OSCAP_API SEXP_t *probe_obj_getent(const SEXP_t * obj, const char *name, uint32_t n);
 
 /**
  * Get the value of an object's entity.
@@ -213,7 +214,7 @@ SEXP_t *probe_obj_getent(const SEXP_t * obj, const char *name, uint32_t n);
  * @param name the name of the entity
  * @param n select the n-th occurence of an entity with the specified name
  */
-SEXP_t *probe_obj_getentval(const SEXP_t * obj, const char *name, uint32_t n);
+OSCAP_API SEXP_t *probe_obj_getentval(const SEXP_t * obj, const char *name, uint32_t n);
 
 /**
  * Get the list of values of an object's entity.
@@ -224,28 +225,28 @@ SEXP_t *probe_obj_getentval(const SEXP_t * obj, const char *name, uint32_t n);
  * @param res the resulting value list is stored in this argument
  * @return number of values in the list stored in the res argument
  */
-int probe_obj_getentvals(const SEXP_t * obj, const char *name, uint32_t n, SEXP_t ** res);
+OSCAP_API int probe_obj_getentvals(const SEXP_t * obj, const char *name, uint32_t n, SEXP_t ** res);
 
 /**
  * Get the value of an object's attribute.
  * @param obj the queried object
  * @param name the name of the attribute
  */
-SEXP_t *probe_obj_getattrval(const SEXP_t * obj, const char *name);
+OSCAP_API SEXP_t *probe_obj_getattrval(const SEXP_t * obj, const char *name);
 
 /**
  * Check whether the specified attribute exists.
  * @param obj the queried object
  * @param name the name of the attribute
  */
-bool probe_obj_attrexists(const SEXP_t * obj, const char *name);
+OSCAP_API bool probe_obj_attrexists(const SEXP_t * obj, const char *name);
 
 /**
  * Set objects's status.
  * @param obj the object to be modified
  * @param status the new status
  */
-int probe_obj_setstatus(SEXP_t * obj, oval_syschar_status_t status);
+OSCAP_API int probe_obj_setstatus(SEXP_t * obj, oval_syschar_status_t status);
 
 /**
  * Set status of an object's entity.
@@ -254,13 +255,13 @@ int probe_obj_setstatus(SEXP_t * obj, oval_syschar_status_t status);
  * @param n select the n-th occurence of an entity with the specified name
  * @param status the new status
  */
-int probe_objent_setstatus(SEXP_t * obj, const char *name, uint32_t n, oval_syschar_status_t status);
+OSCAP_API int probe_objent_setstatus(SEXP_t * obj, const char *name, uint32_t n, oval_syschar_status_t status);
 
 /**
  * Get the name of an object.
  * @param obj the queried object
  */
-char *probe_obj_getname(const SEXP_t * obj);
+OSCAP_API char *probe_obj_getname(const SEXP_t * obj);
 
 /**
  * Get the name of an object.
@@ -269,24 +270,24 @@ char *probe_obj_getname(const SEXP_t * obj);
  * @param buffer the buffer to store the name in
  * @param buflen the length of the buffer
  */
-size_t probe_obj_getname_r(const SEXP_t * obj, char *buffer, size_t buflen);
+OSCAP_API size_t probe_obj_getname_r(const SEXP_t * obj, char *buffer, size_t buflen);
 
 /*
  * collected objects
  */
 
-SEXP_t *probe_cobj_new(oval_syschar_collection_flag_t flag, SEXP_t *msg_list, SEXP_t *item_list, SEXP_t *mask_list);
-int probe_cobj_add_msg(SEXP_t *cobj, const SEXP_t *msg);
-SEXP_t *probe_cobj_get_msgs(const SEXP_t *cobj);
-SEXP_t *probe_cobj_get_mask(const SEXP_t *cobj);
-int probe_cobj_add_item(SEXP_t *cobj, const SEXP_t *item);
-SEXP_t *probe_cobj_get_items(const SEXP_t *cobj);
-void probe_cobj_set_flag(SEXP_t *cobj, oval_syschar_collection_flag_t flag);
-oval_syschar_collection_flag_t probe_cobj_get_flag(const SEXP_t *cobj);
+OSCAP_API SEXP_t *probe_cobj_new(oval_syschar_collection_flag_t flag, SEXP_t *msg_list, SEXP_t *item_list, SEXP_t *mask_list);
+OSCAP_API int probe_cobj_add_msg(SEXP_t *cobj, const SEXP_t *msg);
+OSCAP_API SEXP_t *probe_cobj_get_msgs(const SEXP_t *cobj);
+OSCAP_API SEXP_t *probe_cobj_get_mask(const SEXP_t *cobj);
+OSCAP_API int probe_cobj_add_item(SEXP_t *cobj, const SEXP_t *item);
+OSCAP_API SEXP_t *probe_cobj_get_items(const SEXP_t *cobj);
+OSCAP_API void probe_cobj_set_flag(SEXP_t *cobj, oval_syschar_collection_flag_t flag);
+OSCAP_API oval_syschar_collection_flag_t probe_cobj_get_flag(const SEXP_t *cobj);
 oval_syschar_collection_flag_t probe_cobj_combine_flags(oval_syschar_collection_flag_t f1,
 							oval_syschar_collection_flag_t f2,
 							oval_setobject_operation_t op);
-oval_syschar_collection_flag_t probe_cobj_compute_flag(SEXP_t *cobj);
+OSCAP_API oval_syschar_collection_flag_t probe_cobj_compute_flag(SEXP_t *cobj);
 
 /*
  * messages
@@ -297,7 +298,7 @@ oval_syschar_collection_flag_t probe_cobj_compute_flag(SEXP_t *cobj);
  * @param level the level associated with the new message
  * @param message the text of the new message
  */
-SEXP_t *probe_msg_creat(oval_message_level_t level, char *message);
+OSCAP_API SEXP_t *probe_msg_creat(oval_message_level_t level, char *message);
 
 /**
  * Create a new message that can be added to a collected object.
@@ -305,7 +306,7 @@ SEXP_t *probe_msg_creat(oval_message_level_t level, char *message);
  * @param fmt printf-like format string that produces the text of the new message
  * @param ... arguments for the format
  */
-SEXP_t *probe_msg_creatf(oval_message_level_t level, const char *fmt, ...) __attribute__((format(printf, 2, 3), nonnull(2)));
+OSCAP_API SEXP_t *probe_msg_creatf(oval_message_level_t level, const char *fmt, ...) __attribute__((format(printf, 2, 3), nonnull(2)));
 
 /*
  * entities
@@ -319,7 +320,7 @@ SEXP_t *probe_msg_creatf(oval_message_level_t level, const char *fmt, ...) __att
  * @param val the value of the entity
  * @param ... there can be an arbitrary number of name - attributes - value triples
  */
-SEXP_t *probe_ent_creat(const char *name, SEXP_t * attrs, SEXP_t * val, ...);
+OSCAP_API SEXP_t *probe_ent_creat(const char *name, SEXP_t * attrs, SEXP_t * val, ...);
 
 /**
  * Create a new entity.
@@ -328,7 +329,7 @@ SEXP_t *probe_ent_creat(const char *name, SEXP_t * attrs, SEXP_t * val, ...);
  * @param attrs optional entity's attributes argument
  * @param val the value of the entity
  */
-SEXP_t *probe_ent_creat1(const char *name, SEXP_t * attrs, SEXP_t * val);
+OSCAP_API SEXP_t *probe_ent_creat1(const char *name, SEXP_t * attrs, SEXP_t * val);
 
 /**
  * Add a new attribute to an entity.
@@ -337,14 +338,14 @@ SEXP_t *probe_ent_creat1(const char *name, SEXP_t * attrs, SEXP_t * val);
  * @param name name of the new attribute
  * @param val value of the new attribute
  */
-SEXP_t *probe_ent_attr_add(SEXP_t * ent, const char *name, SEXP_t * val);
+OSCAP_API SEXP_t *probe_ent_attr_add(SEXP_t * ent, const char *name, SEXP_t * val);
 
 /**
  * Get the value of an entity.
  * The function respects the var_ref attribute and returns the currently selected value.
  * @param ent the queried entity
  */
-SEXP_t *probe_ent_getval(const SEXP_t * ent);
+OSCAP_API SEXP_t *probe_ent_getval(const SEXP_t * ent);
 
 /**
  * Get the list of values of an entity.
@@ -353,66 +354,66 @@ SEXP_t *probe_ent_getval(const SEXP_t * ent);
  * @param res the resulting value list is stored in this argument
  * @return number of values in the list stored in the res argument
  */
-int probe_ent_getvals(const SEXP_t * ent, SEXP_t ** res);
+OSCAP_API int probe_ent_getvals(const SEXP_t * ent, SEXP_t ** res);
 
 /**
  * Get the value of an entity's attribute.
  * @param ent the queried entity
  * @param name the name of the attribute
  */
-SEXP_t *probe_ent_getattrval(const SEXP_t * ent, const char *name);
+OSCAP_API SEXP_t *probe_ent_getattrval(const SEXP_t * ent, const char *name);
 
 /**
  * Check whether the specified attribute exists.
  * @param ent the queried entity
  * @param name the name of the attribute
  */
-bool probe_ent_attrexists(const SEXP_t * ent, const char *name);
+OSCAP_API bool probe_ent_attrexists(const SEXP_t * ent, const char *name);
 
 /**
  * Set the OVAL data type of an entity.
  * @param ent the queried entity
  * @param type the new data type
  */
-int probe_ent_setdatatype(SEXP_t * ent, oval_datatype_t type);
+OSCAP_API int probe_ent_setdatatype(SEXP_t * ent, oval_datatype_t type);
 
 /**
  * Get the OVAL data type of an entity.
  * @param ent the queried entity
  */
-oval_datatype_t probe_ent_getdatatype(const SEXP_t * ent);
+OSCAP_API oval_datatype_t probe_ent_getdatatype(const SEXP_t * ent);
 
 /**
  * Set entity's mask.
  * @param ent the queried entity
  * @mask the new mask
  */
-int probe_ent_setmask(SEXP_t * ent, bool mask);
+OSCAP_API int probe_ent_setmask(SEXP_t * ent, bool mask);
 
 /**
  * Get entity's mask.
  * @param ent the queried entity
  */
-bool probe_ent_getmask(const SEXP_t * ent);
+OSCAP_API bool probe_ent_getmask(const SEXP_t * ent);
 
 /**
  * Set entity's status.
  * @param ent the entity to be modified
  * @param status the new status
  */
-int probe_ent_setstatus(SEXP_t * ent, oval_syschar_status_t status);
+OSCAP_API int probe_ent_setstatus(SEXP_t * ent, oval_syschar_status_t status);
 
 /**
  * Get entity status.
  * @param ent the queried entity
  */
-oval_syschar_status_t probe_ent_getstatus(const SEXP_t * ent);
+OSCAP_API oval_syschar_status_t probe_ent_getstatus(const SEXP_t * ent);
 
 /**
  * Get the name of an entity.
  * @param ent the queried entity
  */
-char *probe_ent_getname(const SEXP_t * ent);
+OSCAP_API char *probe_ent_getname(const SEXP_t * ent);
 
 /**
  * Get the name of an entity.
@@ -421,13 +422,13 @@ char *probe_ent_getname(const SEXP_t * ent);
  * @param buffer the buffer to store the name in
  * @param buflen the length of the buffer
  */
-size_t probe_ent_getname_r(const SEXP_t * ent, char *buffer, size_t buflen);
+OSCAP_API size_t probe_ent_getname_r(const SEXP_t * ent, char *buffer, size_t buflen);
 
 /**
  * Free the memory allocated by the probe_* functions.
  * @param obj the object to be freed
  */
-void probe_free(SEXP_t * obj);
+OSCAP_API void probe_free(SEXP_t * obj);
 
 /**
  * Set all of the missing attributes of the 'behaviors' entity
@@ -435,7 +436,7 @@ void probe_free(SEXP_t * obj);
  * a new entity is created and stored in the referenced pointer.
  * @param behaviors address of the pointer to the 'behaviors' entity, must not be NULL
  */
-void probe_filebehaviors_canonicalize(SEXP_t **behaviors);
+OSCAP_API void probe_filebehaviors_canonicalize(SEXP_t **behaviors);
 
 /**
  * Set all of the missing attributes of the 'behaviors' entity
@@ -443,7 +444,7 @@ void probe_filebehaviors_canonicalize(SEXP_t **behaviors);
  * a new entity is created and stored in the referenced pointer.
  * @param behaviors address of the pointer to the 'behaviors' entity, must not be NULL
  */
-void probe_tfc54behaviors_canonicalize(SEXP_t **behaviors);
+OSCAP_API void probe_tfc54behaviors_canonicalize(SEXP_t **behaviors);
 
 #define PROBE_EINVAL     1	/**< Invalid type/value/format */
 #define PROBE_ENOELM     2	/**< Missing element OBSOLETE: use ENOENT */
@@ -469,18 +470,18 @@ void probe_tfc54behaviors_canonicalize(SEXP_t **behaviors);
 #define PROBECMD_RESET     3 /**< Reset command code */
 
 
-void probe_offline_mode(void);
-void probe_preload(void);
-void *probe_init(void) __attribute__ ((unused));
-void probe_fini(void *) __attribute__ ((unused));
+OSCAP_API void probe_offline_mode(void);
+OSCAP_API void probe_preload(void);
+OSCAP_API void *probe_init(void) __attribute__ ((unused));
+OSCAP_API void probe_fini(void *) __attribute__ ((unused));
 
 typedef struct probe_ctx probe_ctx;
 
-int probe_main(probe_ctx *, void *) __attribute__ ((nonnull(1)));
+OSCAP_API int probe_main(probe_ctx *, void *) __attribute__ ((nonnull(1)));
 
-bool probe_item_filtered(const SEXP_t *item, const SEXP_t *filters);
+OSCAP_API bool probe_item_filtered(const SEXP_t *item, const SEXP_t *filters);
 
-int probe_result_additem(SEXP_t *result, SEXP_t *item);
+OSCAP_API int probe_result_additem(SEXP_t *result, SEXP_t *item);
 
 /**
  * Collect generated item (i.e. add it to the collected object)
@@ -489,7 +490,7 @@ int probe_result_additem(SEXP_t *result, SEXP_t *item);
  * calling this function). The implementation of this function
  * is placed in the `probe/icache.c' file.
  */
-int probe_item_collect(probe_ctx *ctx, SEXP_t *item);
+OSCAP_API int probe_item_collect(probe_ctx *ctx, SEXP_t *item);
 
 /**
  * Return reference to the input object. The reference counter
@@ -497,26 +498,26 @@ int probe_item_collect(probe_ctx *ctx, SEXP_t *item);
  * on the return value of this function). Implementation of this
  * function is placed in the `' file.
  */
-SEXP_t *probe_ctx_getobject(probe_ctx *ctx);
+OSCAP_API SEXP_t *probe_ctx_getobject(probe_ctx *ctx);
 
 /**
  * Return reference to the output object (aka collected object).
  * Reference counter is NOT incremented (see the description of
  * probe_ctx_getobject above).
  */
-SEXP_t *probe_ctx_getresult(probe_ctx *ctx);
+OSCAP_API SEXP_t *probe_ctx_getresult(probe_ctx *ctx);
 
 typedef struct {
         oval_datatype_t type;
         void           *value;
 } probe_elmatr_t;
 
-SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attributes[], ...);
+OSCAP_API SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attributes[], ...);
 
 #define PROBE_ENT_AREF(ent, dst, attr_name, invalid_exp)		\
 	do {								\
 		if (((dst) = probe_ent_getattrval(ent, attr_name)) == NULL) { \
-			dE("Attribute `%s' is missing!", attr_name);	\
+OSCAP_API 			dE("Attribute `%s' is missing!", attr_name);	\
 			invalid_exp					\
 		}               					\
 	} while(0)
@@ -526,20 +527,20 @@ SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attr
 		SEXP_t *___r;					\
 								\
 		if ((___r = probe_ent_getval(ent)) == NULL) {	\
-			dW("Entity has no value!");		\
+OSCAP_API 			dW("Entity has no value!");		\
 			invalid_exp				\
 		} else {					\
 			if (!SEXP_stringp(___r)) {		\
-				dE("Invalid type");		\
-				SEXP_free(___r);		\
+OSCAP_API 				dE("Invalid type");		\
+OSCAP_API 				SEXP_free(___r);		\
 				invalid_exp			\
 			}					\
 			else if (SEXP_string_length(___r) == 0) { \
-				SEXP_free(___r);		\
+OSCAP_API 				SEXP_free(___r);		\
 				zerolen_exp			\
 			} else {				\
-				SEXP_string_cstr_r(___r, dst, dstlen); \
-				SEXP_free(___r);		\
+OSCAP_API 				SEXP_string_cstr_r(___r, dst, dstlen); \
+OSCAP_API 				SEXP_free(___r);		\
 			}					\
 		}						\
 	} while (0)
@@ -549,36 +550,36 @@ SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attr
 		SEXP_t *___r;					\
 								\
 		if ((___r = probe_ent_getval(ent)) == NULL) {	\
-			dW("Entity has no value!");		\
+OSCAP_API 			dW("Entity has no value!");		\
 			nil_exp;				\
 		} else {					\
 			if (!SEXP_numberp(___r)) {		\
-				dE("Invalid type");		\
-				SEXP_free(___r);		\
+OSCAP_API 				dE("Invalid type");		\
+OSCAP_API 				SEXP_free(___r);		\
 				invalid_exp;			\
 			} else {				\
-				dst = SEXP_number_geti_32(___r);	\
-				SEXP_free(___r);                	\
+OSCAP_API 				dst = SEXP_number_geti_32(___r);	\
+OSCAP_API 				SEXP_free(___r);                	\
 			}						\
 		}							\
 	} while (0)
 
 #endif				/* PROBE_API_H */
 
-oval_operation_t probe_ent_getoperation(SEXP_t *entity, oval_operation_t op);
+OSCAP_API oval_operation_t probe_ent_getoperation(SEXP_t *entity, oval_operation_t op);
 
-int probe_item_add_msg(SEXP_t *item, oval_message_level_t msglvl, char *msgfmt, ...);
+OSCAP_API int probe_item_add_msg(SEXP_t *item, oval_message_level_t msglvl, char *msgfmt, ...);
 
-SEXP_t *probe_entval_from_cstr(oval_datatype_t type, const char *value, size_t vallen);
-SEXP_t *probe_ent_from_cstr(const char *name, oval_datatype_t type, const char *value, size_t vallen);
+OSCAP_API SEXP_t *probe_entval_from_cstr(oval_datatype_t type, const char *value, size_t vallen);
+OSCAP_API SEXP_t *probe_ent_from_cstr(const char *name, oval_datatype_t type, const char *value, size_t vallen);
 
-OSCAP_DEPRECATED(oval_version_t probe_obj_get_schema_version(const SEXP_t *obj));
-oval_schema_version_t probe_obj_get_platform_schema_version(const SEXP_t *obj);
+OSCAP_API OSCAP_DEPRECATED(oval_version_t probe_obj_get_schema_version(const SEXP_t *obj));
+OSCAP_API oval_schema_version_t probe_obj_get_platform_schema_version(const SEXP_t *obj);
 
 /**
  * Get object entity mask
  * @returns a list of masked entities
  */
-SEXP_t *probe_obj_getmask(SEXP_t *obj);
+OSCAP_API SEXP_t *probe_obj_getmask(SEXP_t *obj);
 
 /// @}

--- a/src/OVAL/public/oval_adt.h
+++ b/src/OVAL/public/oval_adt.h
@@ -40,6 +40,7 @@
 #define OVAL_ADT_H
 
 #include <stdbool.h>
+#include "oscap_export.h"
 
 /**
  * @struct oval_string_iterator
@@ -54,22 +55,22 @@ struct oval_string_iterator;
  * Returns <b>true</b> if the iterator is not exhausted.
  * @memberof oval_string_iterator
  */
-bool oval_string_iterator_has_more(struct oval_string_iterator *);
+OSCAP_API bool oval_string_iterator_has_more(struct oval_string_iterator *);
 /**
  * Returns the next instance of char *.
  * @memberof oval_string_iterator
  */
-char *oval_string_iterator_next(struct oval_string_iterator *);
+OSCAP_API char *oval_string_iterator_next(struct oval_string_iterator *);
 /**
  * Return number for remaining char * elements
  * @memberof oval_string_iterator
  */
-int oval_string_iterator_remaining(struct oval_string_iterator *);
+OSCAP_API int oval_string_iterator_remaining(struct oval_string_iterator *);
 /**
  * Frees the iterator.
  * @memberof oval_string_iterator
  */
-void oval_string_iterator_free(struct oval_string_iterator *);
+OSCAP_API void oval_string_iterator_free(struct oval_string_iterator *);
 /** @} */
 
 /**

--- a/src/OVAL/public/oval_agent_api.h
+++ b/src/OVAL/public/oval_agent_api.h
@@ -41,6 +41,7 @@
 #include "oval_system_characteristics.h"
 #include "oval_results.h"
 #include "oval_variables.h"
+#include "oscap_export.h"
 //#include "oval_probe.h"
 
 struct oval_agent_session;
@@ -57,12 +58,12 @@ typedef struct oval_agent_session oval_agent_session_t;
  * @param model OVAL Definition model
  * @param name Name of file that can be referenced from XCCDF Benchmark
  */
-oval_agent_session_t * oval_agent_new_session(struct oval_definition_model * model, const char * name);
+OSCAP_API oval_agent_session_t * oval_agent_new_session(struct oval_definition_model * model, const char * name);
 
 /**
  * Retrieves OVAL definition model associated with given session
  */
-struct oval_definition_model* oval_agent_get_definition_model(oval_agent_session_t* ag_sess);
+OSCAP_API struct oval_definition_model* oval_agent_get_definition_model(oval_agent_session_t* ag_sess);
 
 /**
  * Set a product name for the provided agent session. The
@@ -70,57 +71,57 @@ struct oval_definition_model* oval_agent_get_definition_model(oval_agent_session
  * there already are some models in the session, they are modified as
  * well.
  */
-void oval_agent_set_product_name(oval_agent_session_t *, char *);
+OSCAP_API void oval_agent_set_product_name(oval_agent_session_t *, char *);
 
 /**
  * Probe the system and evaluate specified definition
  * @return 0 on success; -1 error; 1 warning
  */
-int oval_agent_eval_definition(oval_agent_session_t *, const char *);
+OSCAP_API int oval_agent_eval_definition(oval_agent_session_t *, const char *);
 
 /**
  * Get the OVAL result of a definition from an agent session
  * @return 0 on success; -1 error
  */
-int oval_agent_get_definition_result(oval_agent_session_t *, const char *, oval_result_t *);
+OSCAP_API int oval_agent_get_definition_result(oval_agent_session_t *, const char *, oval_result_t *);
 
 /**
  * Get the OVAL result definition from an agent session
  * @return NULL if not found
  */
-struct oval_result_definition * oval_agent_get_result_definition(oval_agent_session_t *ag_sess, const char *id);
+OSCAP_API struct oval_result_definition * oval_agent_get_result_definition(oval_agent_session_t *ag_sess, const char *id);
 
 /**
  * Clean resuls that were generated in this agent session
  */
-int oval_agent_reset_session(oval_agent_session_t * ag_sess);
+OSCAP_API int oval_agent_reset_session(oval_agent_session_t * ag_sess);
 
 /**
  * Abort a running probe session
  */
-int oval_agent_abort_session(oval_agent_session_t *ag_sess);
+OSCAP_API int oval_agent_abort_session(oval_agent_session_t *ag_sess);
 
-typedef int (*agent_reporter)(const struct oval_result_definition * res_def, void *arg);
+OSCAP_API typedef int (*agent_reporter)(const struct oval_result_definition * res_def, void *arg);
 
 /**
  * Probe and evaluate all definitions from the content, call the callback functions upon single evaluation
  * @return 0 on success; -1 error; 1 warning
  */
-int oval_agent_eval_system(oval_agent_session_t * ag_sess, agent_reporter cb, void *arg);
+OSCAP_API int oval_agent_eval_system(oval_agent_session_t * ag_sess, agent_reporter cb, void *arg);
 
 /**
  * Get a result model from agent session
  */
-struct oval_results_model * oval_agent_get_results_model(oval_agent_session_t * ag_sess);
+OSCAP_API struct oval_results_model * oval_agent_get_results_model(oval_agent_session_t * ag_sess);
 /**
  * Get a filename under which was created
  */
-const char * oval_agent_get_filename(oval_agent_session_t * ag_sess);
+OSCAP_API const char * oval_agent_get_filename(oval_agent_session_t * ag_sess);
 
 /**
  * Finish OVAL agent session
  */
-void oval_agent_destroy_session(oval_agent_session_t * ag_sess);
+OSCAP_API void oval_agent_destroy_session(oval_agent_session_t * ag_sess);
 
 
 /**

--- a/src/OVAL/public/oval_agent_xccdf_api.h
+++ b/src/OVAL/public/oval_agent_xccdf_api.h
@@ -39,6 +39,7 @@
 #include <oscap.h>
 #include "oval_agent_api.h"
 #include "xccdf_policy.h"
+#include "oscap_export.h"
 
 /**
  * @param policy XCCDF Policy that is being evaluated
@@ -64,12 +65,12 @@ typedef xccdf_test_result_type_t (xccdf_policy_eval_rule_cb_t) (struct xccdf_pol
  * Next example shows common use of this function in evaluation proccess of XCCDF file.
  * \par
  * \code
- *  struct oval_definition_model * def_model = oval_definition_model_import(oval_file);
- *  struct xccdf_benchmark * benchmark = xccdf_benchmark_import(file);
- *  struct xccdf_policy_model * policy_model = xccdf_policy_model_new(benchmark);
- *  struct oval_agent_session * sess = oval_agent_new_session(def_model, "name-of-file");
+OSCAP_API  *  struct oval_definition_model * def_model = oval_definition_model_import(oval_file);
+OSCAP_API  *  struct xccdf_benchmark * benchmark = xccdf_benchmark_import(file);
+OSCAP_API  *  struct xccdf_policy_model * policy_model = xccdf_policy_model_new(benchmark);
+OSCAP_API  *  struct oval_agent_session * sess = oval_agent_new_session(def_model, "name-of-file");
  *  ...
- *  xccdf_policy_model_register_engine_and_query_callback(policy_model, "http://oval.mitre.org/XMLSchema/oval-definitions-5", oval_agent_eval_rule, (void *) sess, NULL);
+OSCAP_API  *  xccdf_policy_model_register_engine_and_query_callback(policy_model, "http://oval.mitre.org/XMLSchema/oval-definitions-5", oval_agent_eval_rule, (void *) sess, NULL);
  * \endcode
  * 
  */
@@ -86,7 +87,7 @@ xccdf_test_result_type_t oval_agent_eval_rule(struct xccdf_policy * policy, cons
  * \par Example
  * Example in oval_agent.c in function oval_agent_eval_rule
  */
-int oval_agent_resolve_variables(struct oval_agent_session * session, struct xccdf_value_binding_iterator *it);
+OSCAP_API int oval_agent_resolve_variables(struct oval_agent_session * session, struct xccdf_value_binding_iterator *it);
 
 
 /**
@@ -96,7 +97,7 @@ int oval_agent_resolve_variables(struct oval_agent_session * session, struct xcc
  * @memberof xccdf_policy_model
  * @return true if callback registered succesfully, false otherwise
  */
-bool xccdf_policy_model_register_engine_oval(struct xccdf_policy_model * model, struct oval_agent_session * sess);
+OSCAP_API bool xccdf_policy_model_register_engine_oval(struct xccdf_policy_model * model, struct oval_agent_session * sess);
 
 /**
  * @deprecated
@@ -106,7 +107,7 @@ bool xccdf_policy_model_register_engine_oval(struct xccdf_policy_model * model, 
  * @param session OVAL Agent session
  * @param ritem XCCDF Result
  */
-OSCAP_DEPRECATED(void oval_agent_export_sysinfo_to_xccdf_result(struct oval_agent_session * session, struct xccdf_result * ritem));
+OSCAP_API OSCAP_DEPRECATED(void oval_agent_export_sysinfo_to_xccdf_result(struct oval_agent_session * session, struct xccdf_result * ritem));
 
 /**
  * @} END OVALDEF

--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -46,6 +46,7 @@
 #include "oval_version.h"
 #include "oval_schema_version.h"
 #include <stdbool.h>
+#include "oscap_export.h"
 
 /**
  * Affected family enumeration.
@@ -248,21 +249,21 @@ typedef enum {
 /**
  * Get the family associated with a given subtype.
  */
-oval_family_t oval_subtype_get_family(oval_subtype_t);
-const char *oval_operator_get_text(oval_operator_t);
-const char *oval_subtype_get_text(oval_subtype_t);
-const char *oval_subtype_to_str(oval_subtype_t);
-const char *oval_family_get_text(oval_family_t);
-const char *oval_check_get_text(oval_check_t);
-const char *oval_existence_get_text(oval_existence_t);
-const char *oval_affected_family_get_text(oval_affected_family_t);
-const char *oval_datatype_get_text(oval_datatype_t);
-oval_datatype_t oval_datatype_from_text(const char *);
-const char *oval_operation_get_text(oval_operation_t);
-const char *oval_set_operation_get_text(oval_setobject_operation_t);
-const char *oval_datetime_format_get_text(oval_datetime_format_t);
-const char *oval_arithmetic_operation_get_text(oval_arithmetic_operation_t);
-const char *oval_filter_action_get_text(oval_filter_action_t);
+OSCAP_API oval_family_t oval_subtype_get_family(oval_subtype_t);
+OSCAP_API const char *oval_operator_get_text(oval_operator_t);
+OSCAP_API const char *oval_subtype_get_text(oval_subtype_t);
+OSCAP_API const char *oval_subtype_to_str(oval_subtype_t);
+OSCAP_API const char *oval_family_get_text(oval_family_t);
+OSCAP_API const char *oval_check_get_text(oval_check_t);
+OSCAP_API const char *oval_existence_get_text(oval_existence_t);
+OSCAP_API const char *oval_affected_family_get_text(oval_affected_family_t);
+OSCAP_API const char *oval_datatype_get_text(oval_datatype_t);
+OSCAP_API oval_datatype_t oval_datatype_from_text(const char *);
+OSCAP_API const char *oval_operation_get_text(oval_operation_t);
+OSCAP_API const char *oval_set_operation_get_text(oval_setobject_operation_t);
+OSCAP_API const char *oval_datetime_format_get_text(oval_datetime_format_t);
+OSCAP_API const char *oval_arithmetic_operation_get_text(oval_arithmetic_operation_t);
+OSCAP_API const char *oval_filter_action_get_text(oval_filter_action_t);
 
 
 /**
@@ -596,28 +597,28 @@ struct oval_component_iterator;
  */
 struct oval_generator;
 
-struct oval_generator *oval_generator_new(void);
-void oval_generator_free(struct oval_generator *generator);
-struct oval_generator *oval_generator_clone(struct oval_generator *old_generator);
-char *oval_generator_get_product_name(struct oval_generator *generator);
-char *oval_generator_get_product_version(struct oval_generator *generator);
-OSCAP_DEPRECATED(char *oval_generator_get_schema_version(struct oval_generator *generator));
-const char *oval_generator_get_core_schema_version(struct oval_generator *generator);
-char *oval_generator_get_timestamp(struct oval_generator *generator);
-const char *oval_generator_get_platform_schema_version (struct oval_generator *generator, const char *platform);
-void oval_generator_set_product_name(struct oval_generator *generator, const char *product_name);
-void oval_generator_set_product_version(struct oval_generator *generator, const char *product_version);
-OSCAP_DEPRECATED(void oval_generator_set_schema_version(struct oval_generator *generator, const char *schema_version));
-void oval_generator_set_core_schema_version(struct oval_generator *generator, const char *schema_version);
-void oval_generator_add_platform_schema_version(struct oval_generator *generator, const char *platform, const char *schema_version);
-void oval_generator_set_timestamp(struct oval_generator *generator, const char *timestamp);
-void oval_generator_update_timestamp(struct oval_generator *generator);
+OSCAP_API struct oval_generator *oval_generator_new(void);
+OSCAP_API void oval_generator_free(struct oval_generator *generator);
+OSCAP_API struct oval_generator *oval_generator_clone(struct oval_generator *old_generator);
+OSCAP_API char *oval_generator_get_product_name(struct oval_generator *generator);
+OSCAP_API char *oval_generator_get_product_version(struct oval_generator *generator);
+OSCAP_API OSCAP_DEPRECATED(char *oval_generator_get_schema_version(struct oval_generator *generator));
+OSCAP_API const char *oval_generator_get_core_schema_version(struct oval_generator *generator);
+OSCAP_API char *oval_generator_get_timestamp(struct oval_generator *generator);
+OSCAP_API const char *oval_generator_get_platform_schema_version (struct oval_generator *generator, const char *platform);
+OSCAP_API void oval_generator_set_product_name(struct oval_generator *generator, const char *product_name);
+OSCAP_API void oval_generator_set_product_version(struct oval_generator *generator, const char *product_version);
+OSCAP_API OSCAP_DEPRECATED(void oval_generator_set_schema_version(struct oval_generator *generator, const char *schema_version));
+OSCAP_API void oval_generator_set_core_schema_version(struct oval_generator *generator, const char *schema_version);
+OSCAP_API void oval_generator_add_platform_schema_version(struct oval_generator *generator, const char *platform, const char *schema_version);
+OSCAP_API void oval_generator_set_timestamp(struct oval_generator *generator, const char *timestamp);
+OSCAP_API void oval_generator_update_timestamp(struct oval_generator *generator);
 
 /**
  * Create an empty oval_definition_model.
  * @memberof oval_definition_model
  */
-struct oval_definition_model *oval_definition_model_new(void);
+OSCAP_API struct oval_definition_model *oval_definition_model_new(void);
 
 /**
  * Import the content of the oscap_source into the oval_definition_model
@@ -625,7 +626,7 @@ struct oval_definition_model *oval_definition_model_new(void);
  * @param source The oscap_source to import from
  * @returns newly build oval_definition_model, or NULL if something went wrong
  */
-struct oval_definition_model *oval_definition_model_import_source(struct oscap_source *source);
+OSCAP_API struct oval_definition_model *oval_definition_model_import_source(struct oscap_source *source);
 
 /**
  * Import the content from the file into an oval_definition_model.
@@ -635,7 +636,7 @@ struct oval_definition_model *oval_definition_model_import_source(struct oscap_s
  * @deprecated This function has been deprecated and it may be dropped from later
  * OpenSCAP releases. Please use oval_definition_model_import_source instead.
  */
-OSCAP_DEPRECATED(struct oval_definition_model *oval_definition_model_import(const char *file));
+OSCAP_API OSCAP_DEPRECATED(struct oval_definition_model *oval_definition_model_import(const char *file));
 
 /**
  * Merge the content from the file with specified oval_definition_model.
@@ -647,46 +648,46 @@ OSCAP_DEPRECATED(struct oval_definition_model *oval_definition_model_import(cons
  * @deprecated This function has been deprecated and it may be dropped from later
  * OpenSCAP releases.
  */
-OSCAP_DEPRECATED(int oval_definition_model_merge(struct oval_definition_model *model, const char *file));
+OSCAP_API OSCAP_DEPRECATED(int oval_definition_model_merge(struct oval_definition_model *model, const char *file));
 
 /**
  * Copy an oval_definition_model.
  * @return A copy of the specified @ref oval_definition_model.
  * @memberof oval_definition_model
  */
-struct oval_definition_model *oval_definition_model_clone(struct oval_definition_model *);
+OSCAP_API struct oval_definition_model *oval_definition_model_clone(struct oval_definition_model *);
 /**
  * Export an oval_definition_model into file.
  * @memberof oval_definition_model 
  *
  */
-int oval_definition_model_export(struct oval_definition_model *, const char *file);
+OSCAP_API int oval_definition_model_export(struct oval_definition_model *, const char *file);
 /**
  * Free OVAL object model and all binded variable models.
  * @memberof oval_definition_model
  */
-void oval_definition_model_free(struct oval_definition_model *model);
+OSCAP_API void oval_definition_model_free(struct oval_definition_model *model);
 
 /**
  * @name Setters
  * @{
  */
-void oval_definition_model_set_generator(struct oval_definition_model *model, struct oval_generator *generator);
+OSCAP_API void oval_definition_model_set_generator(struct oval_definition_model *model, struct oval_generator *generator);
 /**
  * Bind an oval_variable_model to the specified oval_definition_model.
  * @return zero on success or non zero value if an error occurred
  * @memberof oval_definition_model
  */
-int oval_definition_model_bind_variable_model(struct oval_definition_model *, struct oval_variable_model *);
+OSCAP_API int oval_definition_model_bind_variable_model(struct oval_definition_model *, struct oval_variable_model *);
 
-void oval_definition_model_clear_external_variables(struct oval_definition_model *);
+OSCAP_API void oval_definition_model_clear_external_variables(struct oval_definition_model *);
 /** @} */
 
 /**
  * @name Getters
  * @{
  */
-struct oval_generator *oval_definition_model_get_generator(struct oval_definition_model *model);
+OSCAP_API struct oval_generator *oval_definition_model_get_generator(struct oval_definition_model *model);
 /**
  * Returns the appended @ref oval_definition having the specified id.
  * IF the specified id does not resolve to an appended Oval_definition the method shall return NULL.
@@ -694,7 +695,7 @@ struct oval_generator *oval_definition_model_get_generator(struct oval_definitio
  * @param id the definition id.
  * @memberof oval_definition_model
  */
-struct oval_definition *oval_definition_model_get_definition(struct oval_definition_model *, const char *id);
+OSCAP_API struct oval_definition *oval_definition_model_get_definition(struct oval_definition_model *, const char *id);
 /**
  * Get oval test by ID.
  * Return a designated oval_test from the specified oval_definition_model.
@@ -703,7 +704,7 @@ struct oval_definition *oval_definition_model_get_definition(struct oval_definit
  * @param id the test id.
  * @memberof oval_definition_model
  */
-struct oval_test *oval_definition_model_get_test(struct oval_definition_model *model, const char *id);
+OSCAP_API struct oval_test *oval_definition_model_get_test(struct oval_definition_model *model, const char *id);
 /**
  * Get OVAL object by ID.
  * Return a designated oval_object from the specified oval_definition_model.
@@ -712,7 +713,7 @@ struct oval_test *oval_definition_model_get_test(struct oval_definition_model *m
  * @param id the object id.
  * @memberof oval_definition_model
  */
-struct oval_object *oval_definition_model_get_object(struct oval_definition_model *model, const char *id);
+OSCAP_API struct oval_object *oval_definition_model_get_object(struct oval_definition_model *model, const char *id);
 /**
  * Get OVAL state by ID.
  * Return a designated oval_state from the specified oval_definition_model.
@@ -721,7 +722,7 @@ struct oval_object *oval_definition_model_get_object(struct oval_definition_mode
  * @param id the state id.
  * @memberof oval_definition_model
  */
-struct oval_state *oval_definition_model_get_state(struct oval_definition_model *model, const char *id);
+OSCAP_API struct oval_state *oval_definition_model_get_state(struct oval_definition_model *model, const char *id);
 /**
  * Get OVAL variable by ID.
  * Return a designated oval_variable from the specified oval_definition_model.
@@ -730,53 +731,53 @@ struct oval_state *oval_definition_model_get_state(struct oval_definition_model 
  * @param id the variable id.
  * @memberof oval_definition_model
  */
-struct oval_variable *oval_definition_model_get_variable(struct oval_definition_model *model, const char *id);
+OSCAP_API struct oval_variable *oval_definition_model_get_variable(struct oval_definition_model *model, const char *id);
 /**
  * Returns all appended @ref oval_definition instances.
  * @memberof oval_definition_model
  */
-struct oval_definition_iterator *oval_definition_model_get_definitions(struct oval_definition_model *model);
+OSCAP_API struct oval_definition_iterator *oval_definition_model_get_definitions(struct oval_definition_model *model);
 /**
  * Get OVAL tests.
  * Return all oval_tests from the specified oval_definition_model.
  * @param model the queried model.
  * @memberof oval_definition_model
  */
-struct oval_test_iterator *oval_definition_model_get_tests(struct oval_definition_model *model);
+OSCAP_API struct oval_test_iterator *oval_definition_model_get_tests(struct oval_definition_model *model);
 /**
  * Get OVAL objects.
  * Return all oval_objects from the specified oval_definition_model.
  * @param model the queried model.
  * @memberof oval_definition_model
  */
-struct oval_object_iterator *oval_definition_model_get_objects(struct oval_definition_model *model);
+OSCAP_API struct oval_object_iterator *oval_definition_model_get_objects(struct oval_definition_model *model);
 /**
  * Get OVAL states.
  * Return all oval_states from the specified oval_definition_model.
  * @param model the queried model.
  * @memberof oval_definition_model
  */
-struct oval_state_iterator *oval_definition_model_get_states(struct oval_definition_model *model);
+OSCAP_API struct oval_state_iterator *oval_definition_model_get_states(struct oval_definition_model *model);
 /**
  * Get OVAL variables.
  * Return all oval_variables from the specified oval_definition_model.
  * @param model the queried model.
  * @memberof oval_definition_model
  */
-struct oval_variable_iterator *oval_definition_model_get_variables(struct oval_definition_model *model);
+OSCAP_API struct oval_variable_iterator *oval_definition_model_get_variables(struct oval_definition_model *model);
 
 /**
  * Get supported version of OVAL XML
  * @return version of XML file format
  * @memberof oval_definition_model
  */
-const char * oval_definition_model_supported(void);
+OSCAP_API const char * oval_definition_model_supported(void);
 /**
  * Return the list of variable models bound to the specified oval_definition_model.
  * @return iterator over oval_variable_model collection
  * @memberof oval_definition_model
  */
-struct oval_variable_model_iterator *oval_definition_model_get_variable_models(struct oval_definition_model *);
+OSCAP_API struct oval_variable_model_iterator *oval_definition_model_get_variable_models(struct oval_definition_model *);
 /** @} */
 
 /**
@@ -802,14 +803,14 @@ struct oval_variable_model_iterator *oval_definition_model_get_variable_models(s
  * @param id - (non-NULL) A copy of this string is bound to the id attribute of the created instance.
  * @memberof oval_definition
  */
-struct oval_definition *oval_definition_new(struct oval_definition_model *, const char *id);
+OSCAP_API struct oval_definition *oval_definition_new(struct oval_definition_model *, const char *id);
 
 /**
  * Clone instance of @ref oval_definition and add it to the specified @ref oval_definition_model.
  * @return A copy of the specified @ref oval_definition.
  * @memberof oval_definition
  */
-struct oval_definition *oval_definition_clone(struct oval_definition_model *new_model, struct oval_definition *old_definition);
+OSCAP_API struct oval_definition *oval_definition_clone(struct oval_definition_model *new_model, struct oval_definition *old_definition);
 
 /**
  * Release an instance of @ref oval_definition.
@@ -820,7 +821,7 @@ struct oval_definition *oval_definition_clone(struct oval_definition_model *new_
  * released.
  * @memberof oval_definition
  */
-void oval_definition_free(struct oval_definition *);
+OSCAP_API void oval_definition_free(struct oval_definition *);
 
 /**
  * @name Setters
@@ -833,7 +834,7 @@ void oval_definition_free(struct oval_definition *);
  * @param version - the required version
  * @memberof oval_definition
  */
-void oval_definition_set_version(struct oval_definition *, int version);
+OSCAP_API void oval_definition_set_version(struct oval_definition *, int version);
 /**
  * Set attribute @ref oval_definition->class.
  * This method shall overwrite a @ref OVAL_CLASS_UNKNOWN class attribute value with the value of the class parameter.
@@ -841,13 +842,13 @@ void oval_definition_set_version(struct oval_definition *, int version);
  * @param class - the required class
  * @memberof oval_definition
  */
-void oval_definition_set_class(struct oval_definition *, oval_definition_class_t);
+OSCAP_API void oval_definition_set_class(struct oval_definition *, oval_definition_class_t);
 /**
  * Set attribute @ref oval_definition->deprecated.
  * @param deprecated - the required deprecation toggle.
  * @memberof oval_definition
  */
-void oval_definition_set_deprecated(struct oval_definition *, bool deprecated);
+OSCAP_API void oval_definition_set_deprecated(struct oval_definition *, bool deprecated);
 /**
  * Set attribute @ref oval_definition->title.
  * This method shall overwrite a NULL title attribute value with a copy of the title parameter.
@@ -855,7 +856,7 @@ void oval_definition_set_deprecated(struct oval_definition *, bool deprecated);
  * @param title - the required title
  * @memberof oval_definition
  */
-void oval_definition_set_title(struct oval_definition *, char *title);
+OSCAP_API void oval_definition_set_title(struct oval_definition *, char *title);
 /**
  * Set attribute @ref oval_definition->description.
  * This method shall overwrite a NULL description attribute value with a copy of the description parameter.
@@ -863,7 +864,7 @@ void oval_definition_set_title(struct oval_definition *, char *title);
  * @param description - the required description
  * @memberof oval_definition
  */
-void oval_definition_set_description(struct oval_definition *, char *description);
+OSCAP_API void oval_definition_set_description(struct oval_definition *, char *description);
 /**
  * Append instance of @ref oval_affected to attribute @ref oval_definition->affected.
  * @note Instances of Oval_affected bound to Oval_definition by this method should not be subsequently freed by
@@ -874,7 +875,7 @@ void oval_definition_set_description(struct oval_definition *, char *description
  * @param affected - appended instance of Oval_affected.
  * @memberof oval_definition
  */
-void oval_definition_add_affected(struct oval_definition *, struct oval_affected *affected);
+OSCAP_API void oval_definition_add_affected(struct oval_definition *, struct oval_affected *affected);
 /**
  * Append instance of @ref oval_reference to attribute @ref oval_definition->references.
  * @note Instances of Oval_reference bound to Oval_definition by this method should not be subsequently freed by
@@ -885,13 +886,13 @@ void oval_definition_add_affected(struct oval_definition *, struct oval_affected
  * @param reference - appended instance of Oval_reference.
  * @memberof oval_definition
  */
-void oval_definition_add_reference(struct oval_definition *, struct oval_reference *reference);
+OSCAP_API void oval_definition_add_reference(struct oval_definition *, struct oval_reference *reference);
 /**
  * Append a copy of the note parameter to attribute @ref Oval_definition->notes.
  * @param note - the note text.
  * @memberof oval_definition
  */
-void oval_definition_add_note(struct oval_definition *, char *note);
+OSCAP_API void oval_definition_add_note(struct oval_definition *, char *note);
 /**
  * Set attribute @ref oval_definition->criteria.
  * This method shall overwrite a NULL criteria attribute value with the criteria parameter only if the criteria parameter is an instance of @ref Oval_criteria
@@ -905,7 +906,7 @@ void oval_definition_add_note(struct oval_definition *, char *note);
  * @param criteria - the required instance of Oval_criteria
  * @memberof oval_definition
  */
-void oval_definition_set_criteria(struct oval_definition *, struct oval_criteria_node *criteria);
+OSCAP_API void oval_definition_set_criteria(struct oval_definition *, struct oval_criteria_node *criteria);
 /** @} */
 
 /**
@@ -916,62 +917,62 @@ void oval_definition_set_criteria(struct oval_definition *, struct oval_criteria
  * Returns attribute @ref oval_definition->id (identifier).
  * @memberof oval_definition
  */
-char *oval_definition_get_id(struct oval_definition *);
+OSCAP_API char *oval_definition_get_id(struct oval_definition *);
 /**
  * Returns attribute @ref oval_definition->version.
  * @return A pointer to the id attribute of the specified @ref oval_definition.
  * @memberof oval_definition
  */
-int oval_definition_get_version(struct oval_definition *);
+OSCAP_API int oval_definition_get_version(struct oval_definition *);
 /**
  * Returns attribute @ref oval_definition->class.
  * @memberof oval_definition
  */
-oval_definition_class_t oval_definition_get_class(struct oval_definition *);
+OSCAP_API oval_definition_class_t oval_definition_get_class(struct oval_definition *);
 /**
  * Returns attribute @ref oval_definition->deprecated.
  * @memberof oval_definition
  */
-bool oval_definition_get_deprecated(struct oval_definition *);
+OSCAP_API bool oval_definition_get_deprecated(struct oval_definition *);
 /**
  * Returns attribute @ref oval_definition->title.
  * @return A pointer to the title attribute of the specified @ref oval_definition.
  * @memberof oval_definition
  */
-char *oval_definition_get_title(struct oval_definition *);
+OSCAP_API char *oval_definition_get_title(struct oval_definition *);
 /**
  * Returns attribute @ref oval_definition->description.
  * @return A pointer to the description attribute of the specified @ref oval_definition.
  * @memberof oval_definition
  */
-char *oval_definition_get_description(struct oval_definition *);
+OSCAP_API char *oval_definition_get_description(struct oval_definition *);
 /**
  * Returns attribute @ref oval_definition->affected.
  * @return A new iterator for the affected attribute of the specified @ref oval_definition.
  * It should be freed after use by the calling application.
  * @memberof oval_definition
  */
-struct oval_affected_iterator *oval_definition_get_affected(struct oval_definition *);
+OSCAP_API struct oval_affected_iterator *oval_definition_get_affected(struct oval_definition *);
 /**
  * Returns attribute @ref oval_definition->references.
  * @return A new iterator for the reference attribute of the specified @ref oval_definition.
  * It should be freed after use by the calling application.
  * @memberof oval_definition
  */
-struct oval_reference_iterator *oval_definition_get_references(struct oval_definition *);
+OSCAP_API struct oval_reference_iterator *oval_definition_get_references(struct oval_definition *);
 /**
  * Returns attribute @ref oval_definition->notes.
  * @return A new iterator for the notes attribute of the specified @ref oval_definition.
  * It should be freed after use by the calling application.
  * @memberof oval_definition
  */
-struct oval_string_iterator *oval_definition_get_notes(struct oval_definition *);
+OSCAP_API struct oval_string_iterator *oval_definition_get_notes(struct oval_definition *);
 /**
  * Returns attribute @ref oval_definition->criteria.
  * @return A pointer to the criteria attribute of the specified @ref oval_definition.
  * @memberof oval_definition
  */
-struct oval_criteria_node *oval_definition_get_criteria(struct oval_definition *);
+OSCAP_API struct oval_criteria_node *oval_definition_get_criteria(struct oval_definition *);
 /** @} */
 
 /**
@@ -988,18 +989,18 @@ struct oval_criteria_node *oval_definition_get_criteria(struct oval_definition *
  * Returns <b>true</b> if the iterator contains more instances of @ref oval_definition.
  * @memberof oval_definition_iterator
  */
-bool oval_definition_iterator_has_more(struct oval_definition_iterator *);
+OSCAP_API bool oval_definition_iterator_has_more(struct oval_definition_iterator *);
 /**
  * Returns the next iterated instance of @ref oval_definition.
  * NULL is returned if the iterator is exhausted (@ref oval_definition_iterator_has_more == <b>false</b>)
  * @memberof oval_definition_iterator
  */
-struct oval_definition *oval_definition_iterator_next(struct oval_definition_iterator *);
+OSCAP_API struct oval_definition *oval_definition_iterator_next(struct oval_definition_iterator *);
 /**
  * Free the iterator.
  * @memberof oval_definition_iterator
  */
-void oval_definition_iterator_free(struct oval_definition_iterator *);
+OSCAP_API void oval_definition_iterator_free(struct oval_definition_iterator *);
 /** @} */
 
 /**
@@ -1022,18 +1023,18 @@ void oval_definition_iterator_free(struct oval_definition_iterator *);
  * @param id - (Not NULL) the text of the required test id.
  * @memberof oval_test
  */
-struct oval_test *oval_test_new(struct oval_definition_model *, const char *id);
+OSCAP_API struct oval_test *oval_test_new(struct oval_definition_model *, const char *id);
 /**
  * Clone instance of @ref oval_test and add it to the specified @ref oval_definition_model.
  * @return A copy of the specified @ref oval_test.
  * @memberof oval_test
  */
-struct oval_test *oval_test_clone(struct oval_definition_model *new_model, struct oval_test *old_test);
+OSCAP_API struct oval_test *oval_test_clone(struct oval_definition_model *new_model, struct oval_test *old_test);
 /**
  * Destruct instance of @ref oval_test.
  * @memberof oval_test
  */
-void oval_test_free(struct oval_test *);
+OSCAP_API void oval_test_free(struct oval_test *);
 
 /**
  * @name Setters
@@ -1048,24 +1049,24 @@ void oval_test_free(struct oval_test *);
  * @param subtype - the required subtype value.
  * @memberof oval_test
  */
-void oval_test_set_subtype(struct oval_test *, oval_subtype_t subtype);
+OSCAP_API void oval_test_set_subtype(struct oval_test *, oval_subtype_t subtype);
 /**
  * Appends a copy of the note parameter to attribute @ref oval_test->notes.
  * @param note - (Not NULL) the text of the appended note.
  * @memberof oval_test
  */
-void oval_test_add_note(struct oval_test *, char *note);
+OSCAP_API void oval_test_add_note(struct oval_test *, char *note);
 /**
  * Sets a copy of the comment parameter to attribute @ref oval_test->comment.
  * @param comment - (Not NULL) the text of the comment.
  * @memberof oval_test
  */
-void oval_test_set_comment(struct oval_test *, char *comment);
+OSCAP_API void oval_test_set_comment(struct oval_test *, char *comment);
 /**
  * Sets attribute @ref oval_test->deprecated.
  * @memberof oval_test
  */
-void oval_test_set_deprecated(struct oval_test *, bool deprecated);
+OSCAP_API void oval_test_set_deprecated(struct oval_test *, bool deprecated);
 /**
  * Sets attribute @ref oval_test->version.
  * If Oval_test->version == 0 and parameter version >0,
@@ -1074,12 +1075,12 @@ void oval_test_set_deprecated(struct oval_test *, bool deprecated);
  * @param version - (>0) the required version
  * @memberof oval_test
  */
-void oval_test_set_version(struct oval_test *, int version);
+OSCAP_API void oval_test_set_version(struct oval_test *, int version);
 /**
  * Sets attribute @ref oval_test->state_operator.
  * @memberof oval_test
  */
-void oval_test_set_state_operator(struct oval_test *, oval_operator_t);
+OSCAP_API void oval_test_set_state_operator(struct oval_test *, oval_operator_t);
 /**
  * Sets attribute @ref oval_test->existence.
  * If Oval_test->existence == @ref OVAL_CHECK_UNKNOWN and parameter existence <> @ref OVAL_CHECK_UNKNOWN,
@@ -1088,7 +1089,7 @@ void oval_test_set_state_operator(struct oval_test *, oval_operator_t);
  * @param existence - (<> @ref OVAL_CHECK_UNKNOWN) the required existence
  * @memberof oval_test
  */
-void oval_test_set_existence(struct oval_test *, oval_existence_t);
+OSCAP_API void oval_test_set_existence(struct oval_test *, oval_existence_t);
 /**
  * Sets attribute @ref oval_test->check.
  * If Oval_test->check == @ref OVAL_CHECK_UNKNOWN and parameter check <> @ref OVAL_CHECK_UNKNOWN,
@@ -1098,7 +1099,7 @@ void oval_test_set_existence(struct oval_test *, oval_existence_t);
  * @param check - (<> @ref OVAL_CHECK_UNKNOWN) the required check
  * @memberof oval_test
  */
-void oval_test_set_check(struct oval_test *, oval_check_t);
+OSCAP_API void oval_test_set_check(struct oval_test *, oval_check_t);
 /**
  * Sets attribute @ref oval_test->object.
  * If Oval_test->object == NULL and parameter object <> NULL,
@@ -1107,13 +1108,13 @@ void oval_test_set_check(struct oval_test *, oval_check_t);
  * @param object - (<> NULL) the required object
  * @memberof oval_test
  */
-void oval_test_set_object(struct oval_test *, struct oval_object *);
+OSCAP_API void oval_test_set_object(struct oval_test *, struct oval_object *);
 /**
  * Add the specified state to the state list of the specified test.
  * @param state - (<> NULL) the required state
  * @memberof oval_test
  */
-void oval_test_add_state(struct oval_test *, struct oval_state *);
+OSCAP_API void oval_test_add_state(struct oval_test *, struct oval_state *);
 /** @} */
 
 /**
@@ -1124,69 +1125,69 @@ void oval_test_add_state(struct oval_test *, struct oval_state *);
  * Returns attribute @ref Oval_test->family
  * @memberof oval_test
  */
-oval_family_t oval_test_get_family(struct oval_test *);
+OSCAP_API oval_family_t oval_test_get_family(struct oval_test *);
 /**
  * Returns attribute @ref Oval_test->subtype
  * @memberof oval_test
  */
-oval_subtype_t oval_test_get_subtype(struct oval_test *);
+OSCAP_API oval_subtype_t oval_test_get_subtype(struct oval_test *);
 /**
  * Returns attribute @ref oval_test->notes.
  * @return A new iterator for the notes attribute of the specified @ref oval_test.
  * It should be freed after use by the calling application.
  * @memberof oval_test
  */
-struct oval_string_iterator *oval_test_get_notes(struct oval_test *);
+OSCAP_API struct oval_string_iterator *oval_test_get_notes(struct oval_test *);
 /**
  * Returns attribute @ref Oval_test->comment.
  * @return A pointer to the comment attribute of the specified @ref oval_test.
  * @memberof oval_test
  */
-char *oval_test_get_comment(struct oval_test *);
+OSCAP_API char *oval_test_get_comment(struct oval_test *);
 /**
  * Returns attribute @ref oval_test->id.
  * @return A pointer to the id attribute of the specified @ref oval_test.
  * @memberof oval_test
  */
-char *oval_test_get_id(struct oval_test *);
+OSCAP_API char *oval_test_get_id(struct oval_test *);
 /**
  * Returns attribute @ref oval_test->deprecated.
  * @memberof oval_test
  */
-bool oval_test_get_deprecated(struct oval_test *);
+OSCAP_API bool oval_test_get_deprecated(struct oval_test *);
 /**
  * Returns attribute @ref oval_test->version.
  * @memberof oval_test
  */
-int oval_test_get_version(struct oval_test *);
+OSCAP_API int oval_test_get_version(struct oval_test *);
 /**
  * Returns attribute @ref oval_test->state_operator.
  * @memberof oval_test
  */
-oval_operator_t oval_test_get_state_operator(struct oval_test *);
+OSCAP_API oval_operator_t oval_test_get_state_operator(struct oval_test *);
 /**
  * Returns attribute @ref oval_test->existence.
  * @memberof oval_test
  */
-oval_existence_t oval_test_get_existence(struct oval_test *);
+OSCAP_API oval_existence_t oval_test_get_existence(struct oval_test *);
 /**
  * Returns attribute @ref oval_test->check.
  * @memberof oval_test
  */
-oval_check_t oval_test_get_check(struct oval_test *);
+OSCAP_API oval_check_t oval_test_get_check(struct oval_test *);
 /**
  * Returns attribute @ref oval_test->object.
  * @return A pointer to the object attribute of the specified @ref oval_test.
  * @memberof oval_test
  */
-struct oval_object *oval_test_get_object(struct oval_test *);
+OSCAP_API struct oval_object *oval_test_get_object(struct oval_test *);
 /**
  * Returns attribute @ref oval_test->states.
  * @return A new iterator for the states attribute of the specified @ref oval_test.
  * It should be freed after use by the calling application.
  * @memberof oval_test
  */
-struct oval_state_iterator *oval_test_get_states(struct oval_test *);
+OSCAP_API struct oval_state_iterator *oval_test_get_states(struct oval_test *);
 
 /** @} */
 
@@ -1204,17 +1205,17 @@ struct oval_state_iterator *oval_test_get_states(struct oval_test *);
  * Returns <b>true</b> if the iterator is not exhausted.
  * @memberof oval_test_iterator
  */
-bool oval_test_iterator_has_more(struct oval_test_iterator *);
+OSCAP_API bool oval_test_iterator_has_more(struct oval_test_iterator *);
 /**
  * Returns the next instance of @ref oval_test.
  * @memberof oval_test_iterator
  */
-struct oval_test *oval_test_iterator_next(struct oval_test_iterator *);
+OSCAP_API struct oval_test *oval_test_iterator_next(struct oval_test_iterator *);
 /**
  * Frees the iterator.
  * @memberof oval_test_iterator
  */
-void oval_test_iterator_free(struct oval_test_iterator *);
+OSCAP_API void oval_test_iterator_free(struct oval_test_iterator *);
 /** @} */
 
 /**
@@ -1235,18 +1236,18 @@ void oval_test_iterator_free(struct oval_test_iterator *);
  * @param id - (Not NULL) the text of the required object id.
  * @memberof oval_object
  */
-struct oval_object *oval_object_new(struct oval_definition_model *, const char *id);
+OSCAP_API struct oval_object *oval_object_new(struct oval_definition_model *, const char *id);
 /**
  * Clone instance of @ref oval_object and add it to the specified @ref oval_definition_model.
  * @return A copy of the specified @ref oval_object.
  * @memberof oval_object
  */
-struct oval_object *oval_object_clone(struct oval_definition_model *new_model, struct oval_object *old_object);
+OSCAP_API struct oval_object *oval_object_clone(struct oval_definition_model *new_model, struct oval_object *old_object);
 /**
  * Free instance of @ref oval_object
  * @memberof oval_object
  */
-void oval_object_free(struct oval_object *);
+OSCAP_API void oval_object_free(struct oval_object *);
 
 /**
  * @name Setters
@@ -1261,26 +1262,26 @@ void oval_object_free(struct oval_object *);
  * @param subtype - the required subtype value.
  * @memberof oval_object
  */
-void oval_object_set_subtype(struct oval_object *, oval_subtype_t subtype);
+OSCAP_API void oval_object_set_subtype(struct oval_object *, oval_subtype_t subtype);
 /**
  * Appends a copy of the note parameter to attribute @ref oval_object->notes.
  * @param note - (Not NULL) the text of the appended note.
  * @memberof oval_object
  */
-void oval_object_add_note(struct oval_object *, char *note);
+OSCAP_API void oval_object_add_note(struct oval_object *, char *note);
 
 /**
  * Sets a copy of the comment parameter to attribute @ref oval_object->comment.
  * @param comment - (Not NULL) the text of the comment.
  * @memberof oval_object
  */
-void oval_object_set_comment(struct oval_object *, char *comment);
+OSCAP_API void oval_object_set_comment(struct oval_object *, char *comment);
 
 /**
  * Sets attribute @ref oval_object->deprecated.
  * @memberof oval_object
  */
-void oval_object_set_deprecated(struct oval_object *, bool deprecated);
+OSCAP_API void oval_object_set_deprecated(struct oval_object *, bool deprecated);
 /**
  * Sets attribute @ref oval_object->version.
  * If Oval_object->version == 0 and parameter version >0,
@@ -1289,7 +1290,7 @@ void oval_object_set_deprecated(struct oval_object *, bool deprecated);
  * @param version - (>0) the required version
  * @memberof oval_object
  */
-void oval_object_set_version(struct oval_object *, int version);
+OSCAP_API void oval_object_set_version(struct oval_object *, int version);
 /**
  * Append instance of @ref oval_object_content to attribute @ref oval_object->object_contents.
  *
@@ -1302,7 +1303,7 @@ void oval_object_set_version(struct oval_object *, int version);
  * @param content - (Not NULL) the Oval_object_content to be appended.
  * @memberof oval_object
  */
-void oval_object_add_object_content(struct oval_object *, struct oval_object_content *content);
+OSCAP_API void oval_object_add_object_content(struct oval_object *, struct oval_object_content *content);
 /**
  * Append instance of @ref oval_behavior to attribute @ref oval_object->behaviors.
  *
@@ -1315,7 +1316,7 @@ void oval_object_add_object_content(struct oval_object *, struct oval_object_con
  * @param behavior - (Not NULL) the Oval_behavior to be appended.
  * @memberof oval_object
  */
-void oval_object_add_behavior(struct oval_object *, struct oval_behavior *behavior);
+OSCAP_API void oval_object_add_behavior(struct oval_object *, struct oval_behavior *behavior);
 /** @} */
 
 /**
@@ -1326,59 +1327,59 @@ void oval_object_add_behavior(struct oval_object *, struct oval_behavior *behavi
  * Returns attribute @ref oval_object->family
  * @memberof oval_object
  */
-oval_family_t oval_object_get_family(struct oval_object *);
+OSCAP_API oval_family_t oval_object_get_family(struct oval_object *);
 /**
  * Returns the name of an @ref oval_object.
  * This is a convenience method that is equivalent to @ref oval_subtype_get_text (@ref oval_object_get_subtype)+"_object".
  * @memberof oval_object
  */
-const char *oval_object_get_name(struct oval_object *);
+OSCAP_API const char *oval_object_get_name(struct oval_object *);
 /**
  * Returns attribute @ref oval_object->subtype
  * @memberof oval_object
  */
-oval_subtype_t oval_object_get_subtype(struct oval_object *);
+OSCAP_API oval_subtype_t oval_object_get_subtype(struct oval_object *);
 /**
  * Returns attribute @ref oval_object->notes.
  * @return A new iterator for the notes attribute of the specified @ref oval_object.
  * It should be freed after use by the calling application.
  * @memberof oval_object
  */
-struct oval_string_iterator *oval_object_get_notes(struct oval_object *);
+OSCAP_API struct oval_string_iterator *oval_object_get_notes(struct oval_object *);
 /**
  * Returns attribute @ref oval_object->comment.
  * @return A pointer to the comment attribute of the specified @ref oval_object.
  * @memberof oval_object
  */
-char *oval_object_get_comment(struct oval_object *);
+OSCAP_API char *oval_object_get_comment(struct oval_object *);
 /**
  * Returns attribute @ref oval_object->id.
  * @return A pointer to the id attribute of the specified @ref oval_object.
  * @memberof oval_object
  */
-char *oval_object_get_id(struct oval_object *);
+OSCAP_API char *oval_object_get_id(struct oval_object *);
 
 /**
  * Returns attribute @ref oval_object->deprecated.
  * @memberof oval_object
  */
-bool oval_object_get_deprecated(struct oval_object *);
+OSCAP_API bool oval_object_get_deprecated(struct oval_object *);
 /**
  * Returns attribute @ref oval_object->version.
  * @memberof oval_object
  */
-int oval_object_get_version(struct oval_object *);
+OSCAP_API int oval_object_get_version(struct oval_object *);
 
 /**
  * Returns schema version of the associated definition model
  */
-OSCAP_DEPRECATED(oval_version_t oval_object_get_schema_version(struct oval_object *object));
+OSCAP_API OSCAP_DEPRECATED(oval_version_t oval_object_get_schema_version(struct oval_object *object));
 
 /**
  * Returns schema version of the associated platform extension definition model
  * @memberof oval_object
  */
-oval_schema_version_t oval_object_get_platform_schema_version(struct oval_object *object);
+OSCAP_API oval_schema_version_t oval_object_get_platform_schema_version(struct oval_object *object);
 
 /**
  * Returns attribute @ref oval_object->contents.
@@ -1386,14 +1387,14 @@ oval_schema_version_t oval_object_get_platform_schema_version(struct oval_object
  * It should be freed after use by the calling application.
  * @memberof oval_object
  */
-struct oval_object_content_iterator *oval_object_get_object_contents(struct oval_object *);
+OSCAP_API struct oval_object_content_iterator *oval_object_get_object_contents(struct oval_object *);
 /**
  * Returns attribute @ref oval_object->behaviors.
  * @return A new iterator for the behaviors attribute of the specified @ref oval_object.
  * It should be freed after use by the calling application.
  * @memberof oval_object
  */
-struct oval_behavior_iterator *oval_object_get_behaviors(struct oval_object *);
+OSCAP_API struct oval_behavior_iterator *oval_object_get_behaviors(struct oval_object *);
 /** @} */
 
 /**
@@ -1410,17 +1411,17 @@ struct oval_behavior_iterator *oval_object_get_behaviors(struct oval_object *);
  * Returns <b>true</b> if the iterator is not exhausted.
  * @memberof oval_object_iterator
  */
-bool oval_object_iterator_has_more(struct oval_object_iterator *);
+OSCAP_API bool oval_object_iterator_has_more(struct oval_object_iterator *);
 /**
  * Returns the next instance of @ref oval_object.
  * @memberof oval_object_iterator
  */
-struct oval_object *oval_object_iterator_next(struct oval_object_iterator *);
+OSCAP_API struct oval_object *oval_object_iterator_next(struct oval_object_iterator *);
 /**
  * Frees the iterator.
  * @memberof oval_object_iterator
  */
-void oval_object_iterator_free(struct oval_object_iterator *);
+OSCAP_API void oval_object_iterator_free(struct oval_object_iterator *);
 /** @} */
 
 /**
@@ -1441,18 +1442,18 @@ void oval_object_iterator_free(struct oval_object_iterator *);
  * @param id - (Not NULL) the text of the required state id.
  * @memberof oval_state
  */
-struct oval_state *oval_state_new(struct oval_definition_model *, const char *id);
+OSCAP_API struct oval_state *oval_state_new(struct oval_definition_model *, const char *id);
 /**
  * Clone instance of @ref oval_state and add it to the specified @ref oval_definition_model.
  * @return A copy of the specified @ref oval_state.
  * @memberof oval_state
  */
-struct oval_state *oval_state_clone(struct oval_definition_model *new_model, struct oval_state *old_state);
+OSCAP_API struct oval_state *oval_state_clone(struct oval_definition_model *new_model, struct oval_state *old_state);
 /**
  * Free instance of @ref oval_state
  * @memberof oval_state
  */
-void oval_state_free(struct oval_state *);
+OSCAP_API void oval_state_free(struct oval_state *);
 
 /**
  * @name Setters
@@ -1467,24 +1468,24 @@ void oval_state_free(struct oval_state *);
  * @param subtype - the required subtype value.
  * @memberof oval_state
  */
-void oval_state_set_subtype(struct oval_state *, oval_subtype_t subtype);
+OSCAP_API void oval_state_set_subtype(struct oval_state *, oval_subtype_t subtype);
 /**
  * Appends a copy of the note parameter to attribute @ref oval_state->notes.
  * @param note - (Not NULL) the text of the appended note.
  * @memberof oval_state
  */
-void oval_state_add_note(struct oval_state *, char *note);
+OSCAP_API void oval_state_add_note(struct oval_state *, char *note);
 /**
  * Sets a copy of the comment parameter to attribute @ref oval_state->comment.
  * @param comment - (Not NULL) the text of the comment.
  * @memberof oval_state
  */
-void oval_state_set_comment(struct oval_state *, char *comment);
+OSCAP_API void oval_state_set_comment(struct oval_state *, char *comment);
 /**
  * Sets attribute @ref oval_state->deprecated.
  * @memberof oval_state
  */
-void oval_state_set_deprecated(struct oval_state *, bool deprecated);
+OSCAP_API void oval_state_set_deprecated(struct oval_state *, bool deprecated);
 /**
  * Sets attribute @ref oval_state->version.
  * If oval_state->version == 0 and parameter version >0,
@@ -1493,12 +1494,12 @@ void oval_state_set_deprecated(struct oval_state *, bool deprecated);
  * @param version - (>0) the required version
  * @memberof oval_state
  */
-void oval_state_set_version(struct oval_state *, int version);
+OSCAP_API void oval_state_set_version(struct oval_state *, int version);
 /**
  * Sets attribute @ref oval_state->operator.
  * @memberof oval_state
  */
-void oval_state_set_operator(struct oval_state *, oval_operator_t);
+OSCAP_API void oval_state_set_operator(struct oval_state *, oval_operator_t);
 /**
  * Append instance of @ref oval_state_content to attribute @ref oval_state->state_contents.
  *
@@ -1511,7 +1512,7 @@ void oval_state_set_operator(struct oval_state *, oval_operator_t);
  * @param content - (Not NULL) the oval_state_content to be appended.
  * @memberof oval_state
  */
-void oval_state_add_content(struct oval_state *, struct oval_state_content *content);
+OSCAP_API void oval_state_add_content(struct oval_state *, struct oval_state_content *content);
 /** @} */
 
 /**
@@ -1522,59 +1523,59 @@ void oval_state_add_content(struct oval_state *, struct oval_state_content *cont
  * Returns attribute @ref oval_state->family
  * @memberof oval_state
  */
-oval_family_t oval_state_get_family(struct oval_state *);
+OSCAP_API oval_family_t oval_state_get_family(struct oval_state *);
 /**
  * Returns the name of an @ref oval_state.
  * This is a convenience method that is equivalent to @ref oval_subtype_get_text (@ref oval_state_get_subtype)+"_state".
  * @memberof oval_state
  */
-const char *oval_state_get_name(struct oval_state *);
+OSCAP_API const char *oval_state_get_name(struct oval_state *);
 /**
  * Returns attribute @ref oval_state->subtype
  * @memberof oval_state
  */
-oval_subtype_t oval_state_get_subtype(struct oval_state *);
+OSCAP_API oval_subtype_t oval_state_get_subtype(struct oval_state *);
 /**
  * Returns attribute @ref oval_state->notes.
  * @return A new iterator for the notes attribute of the specified @ref oval_state.
  * It should be freed after use by the calling application.
  * @memberof oval_state
  */
-struct oval_string_iterator *oval_state_get_notes(struct oval_state *);
+OSCAP_API struct oval_string_iterator *oval_state_get_notes(struct oval_state *);
 /**
  * Returns attribute @ref oval_state->comment.
  * @return A pointer to the comment attribute of the specified @ref oval_state.
  * @memberof oval_state
  */
-char *oval_state_get_comment(struct oval_state *);
+OSCAP_API char *oval_state_get_comment(struct oval_state *);
 /**
  * Returns attribute @ref oval_state->id.
  * @return A pointer to the id attribute of the specified @ref oval_state.
  * @memberof oval_state
  */
-char *oval_state_get_id(struct oval_state *);
+OSCAP_API char *oval_state_get_id(struct oval_state *);
 /**
  * Returns attribute @ref oval_state->deprecated.
  * @memberof oval_state
  */
-bool oval_state_get_deprecated(struct oval_state *);
+OSCAP_API bool oval_state_get_deprecated(struct oval_state *);
 /**
  * Returns attribute @ref oval_state->version.
  * @memberof oval_state
  */
-int oval_state_get_version(struct oval_state *);
+OSCAP_API int oval_state_get_version(struct oval_state *);
 /**
  * Returns attribute @ref oval_state->operator.
  * @memberof oval_state
  */
-int oval_state_get_operator(struct oval_state *);
+OSCAP_API int oval_state_get_operator(struct oval_state *);
 /**
  * Returns attribute @ref oval_state->contents.
  * @return A new iterator for the contents attribute of the specified @ref oval_state.
  * It should be freed after use by the calling application.
  * @memberof oval_state
  */
-struct oval_state_content_iterator *oval_state_get_contents(struct oval_state *);
+OSCAP_API struct oval_state_content_iterator *oval_state_get_contents(struct oval_state *);
 /** @} */
 
 /**
@@ -1585,17 +1586,17 @@ struct oval_state_content_iterator *oval_state_get_contents(struct oval_state *)
  * Returns <b>true</b> if the iterator is not exhausted.
  * @memberof oval_state_iterator
  */
-bool oval_state_iterator_has_more(struct oval_state_iterator *);
+OSCAP_API bool oval_state_iterator_has_more(struct oval_state_iterator *);
 /**
  * Returns the next instance of @ref oval_state.
  * @memberof oval_state_iterator
  */
-struct oval_state *oval_state_iterator_next(struct oval_state_iterator *);
+OSCAP_API struct oval_state *oval_state_iterator_next(struct oval_state_iterator *);
 /**
  * Frees the iterator.
  * @memberof oval_state_iterator
  */
-void oval_state_iterator_free(struct oval_state_iterator *);
+OSCAP_API void oval_state_iterator_free(struct oval_state_iterator *);
 /** @} */
 
 /**
@@ -1628,18 +1629,18 @@ void oval_state_iterator_free(struct oval_state_iterator *);
  * @param type - (Not @ref OVAL_VARIABLE_UNKNOWN) the required type.
  * @memberof oval_variable
  */
-struct oval_variable *oval_variable_new(struct oval_definition_model *model, const char *id, oval_variable_type_t type);
+OSCAP_API struct oval_variable *oval_variable_new(struct oval_definition_model *model, const char *id, oval_variable_type_t type);
 /**
  * Clone instance of @ref oval_variable and add it to the specified @ref oval_definition_model.
  * @return A copy of the specified @ref oval_variable.
  * @memberof oval_variable
  */
-struct oval_variable *oval_variable_clone(struct oval_definition_model *new_model, struct oval_variable *old_variable);
+OSCAP_API struct oval_variable *oval_variable_clone(struct oval_definition_model *new_model, struct oval_variable *old_variable);
 /**
  * Free instance of @ref oval_variable.
  * @memberof oval_variable
  */
-void oval_variable_free(struct oval_variable *);
+OSCAP_API void oval_variable_free(struct oval_variable *);
 
 /**
  * Construct new instance of possible_value element.
@@ -1647,25 +1648,25 @@ void oval_variable_free(struct oval_variable *);
  * @param value An expected value of an external variable
  * @memberof oval_variable_possible_value
  */
-struct oval_variable_possible_value *oval_variable_possible_value_new(const char *hint, const char *value);
+OSCAP_API struct oval_variable_possible_value *oval_variable_possible_value_new(const char *hint, const char *value);
 
 /**
  * Free instance of possible_value
  * @memberof oval_variable_possible_value
  */
-void oval_variable_possible_value_free(struct oval_variable_possible_value *pv);
+OSCAP_API void oval_variable_possible_value_free(struct oval_variable_possible_value *pv);
 
 /**
  * Get the hint of the possible_value
  * @memberof oval_variable_possible_value
  */
-char* oval_variable_possible_value_get_hint(struct oval_variable_possible_value* pv);
+OSCAP_API char* oval_variable_possible_value_get_hint(struct oval_variable_possible_value* pv);
 
 /**
  * Get the value of the possible value
  * @memberof oval_variable_possible_value
  */
-char* oval_variable_possible_value_get_value(struct oval_variable_possible_value* pv);
+OSCAP_API char* oval_variable_possible_value_get_value(struct oval_variable_possible_value* pv);
 
 /**
  * @name Iterators
@@ -1674,19 +1675,19 @@ char* oval_variable_possible_value_get_value(struct oval_variable_possible_value
 /**
  * @memberof oval_variable_possible_value_iterator
  */
-bool oval_variable_possible_value_iterator_has_more(struct oval_variable_possible_value_iterator*);
+OSCAP_API bool oval_variable_possible_value_iterator_has_more(struct oval_variable_possible_value_iterator*);
 /**
  * @memberof oval_variable_possible_value_iterator
  */
-struct oval_variable_possible_value *oval_variable_possible_value_iterator_next(struct oval_variable_possible_value_iterator*);
+OSCAP_API struct oval_variable_possible_value *oval_variable_possible_value_iterator_next(struct oval_variable_possible_value_iterator*);
 /**
  * @memberof oval_variable_possible_value_iterator
  */
-int oval_variable_possible_value_iterator_remaining(struct oval_variable_possible_value_iterator*);
+OSCAP_API int oval_variable_possible_value_iterator_remaining(struct oval_variable_possible_value_iterator*);
 /**
  * @memberof oval_variable_possible_value_iterator
  */
-void oval_variable_possible_value_iterator_free(struct oval_variable_possible_value_iterator*);
+OSCAP_API void oval_variable_possible_value_iterator_free(struct oval_variable_possible_value_iterator*);
 /** @} */
 
 
@@ -1696,14 +1697,14 @@ void oval_variable_possible_value_iterator_free(struct oval_variable_possible_va
  * @param hint A short description of what the value means or represents.
  * @memberof oval_variable_possible_restriction
  */
-struct oval_variable_possible_restriction *oval_variable_possible_restriction_new(oval_operator_t operator, const char *hint);
+OSCAP_API struct oval_variable_possible_restriction *oval_variable_possible_restriction_new(oval_operator_t operator, const char *hint);
 
 
 /**
  * Free instance of possible_restriction
  * @memberof oval_variable_possible_restriction
  */
-void oval_variable_possible_restriction_free(struct oval_variable_possible_restriction *pr);
+OSCAP_API void oval_variable_possible_restriction_free(struct oval_variable_possible_restriction *pr);
 
 
 /**
@@ -1713,19 +1714,19 @@ void oval_variable_possible_restriction_free(struct oval_variable_possible_restr
 /**
  * @memberof oval_variable_possible_restriction_iterator
  */
-bool oval_variable_possible_restriction_iterator_has_more(struct oval_variable_possible_restriction_iterator* iter);
+OSCAP_API bool oval_variable_possible_restriction_iterator_has_more(struct oval_variable_possible_restriction_iterator* iter);
 /**
  * @memberof oval_variable_possible_restriction_iterator
  */
-struct oval_variable_possible_restriction *oval_variable_possible_restriction_iterator_next(struct oval_variable_possible_restriction_iterator* iter);
+OSCAP_API struct oval_variable_possible_restriction *oval_variable_possible_restriction_iterator_next(struct oval_variable_possible_restriction_iterator* iter);
 /**
  * @memberof oval_variable_possible_restriction_iterator
  */
-int oval_variable_possible_restriction_iterator_remaining(struct oval_variable_possible_restriction_iterator* iter);
+OSCAP_API int oval_variable_possible_restriction_iterator_remaining(struct oval_variable_possible_restriction_iterator* iter);
 /**
  * @memberof oval_variable_possible_restriction_iterator
  */
-void oval_variable_possible_restriction_iterator_free(struct oval_variable_possible_restriction_iterator* iter);
+OSCAP_API void oval_variable_possible_restriction_iterator_free(struct oval_variable_possible_restriction_iterator* iter);
 /** @} */
 
 
@@ -1735,25 +1736,25 @@ void oval_variable_possible_restriction_iterator_free(struct oval_variable_possi
  * @param value Restriction placed on expected values for an external variable.
  * @memberof oval_variable_restriction
  */
-struct oval_variable_restriction *oval_variable_restriction_new(oval_operation_t operation, const char *value);
+OSCAP_API struct oval_variable_restriction *oval_variable_restriction_new(oval_operation_t operation, const char *value);
 
 /**
  * Free instance of restriction element.
  * @memberof oval_variable_restriction
  */
-void oval_variable_restriction_free(struct oval_variable_restriction *r);
+OSCAP_API void oval_variable_restriction_free(struct oval_variable_restriction *r);
 
 /**
  * Get the operation of a restriction element.
  * @memberof oval_variable_restriction
  */
-oval_operation_t oval_variable_restriction_get_operation(struct oval_variable_restriction* restriction);
+OSCAP_API oval_operation_t oval_variable_restriction_get_operation(struct oval_variable_restriction* restriction);
 
 /**
  * Get the value of a restriction element.
  * @memberof oval_variable_restriction
  */
-char* oval_variable_restriction_get_value(struct oval_variable_restriction* restriction);
+OSCAP_API char* oval_variable_restriction_get_value(struct oval_variable_restriction* restriction);
 
 /**
  * @name Iterators
@@ -1762,19 +1763,19 @@ char* oval_variable_restriction_get_value(struct oval_variable_restriction* rest
 /**
  * @memberof oval_variable_restriction_iterator
  */
-bool oval_variable_restriction_iterator_has_more(struct oval_variable_restriction_iterator*);
+OSCAP_API bool oval_variable_restriction_iterator_has_more(struct oval_variable_restriction_iterator*);
 /**
  * @memberof oval_variable_restriction_iterator
  */
-struct oval_variable_restriction *oval_variable_restriction_iterator_next(struct oval_variable_restriction_iterator*);
+OSCAP_API struct oval_variable_restriction *oval_variable_restriction_iterator_next(struct oval_variable_restriction_iterator*);
 /**
  * @memberof oval_variable_restriction_iterator
  */
-int oval_variable_restriction_iterator_remaining(struct oval_variable_restriction_iterator*);
+OSCAP_API int oval_variable_restriction_iterator_remaining(struct oval_variable_restriction_iterator*);
 /**
  * @memberof oval_variable_restriction_iterator
  */
-void oval_variable_restriction_iterator_free(struct oval_variable_restriction_iterator*);
+OSCAP_API void oval_variable_restriction_iterator_free(struct oval_variable_restriction_iterator*);
 /** @} */
 
 
@@ -1789,7 +1790,7 @@ void oval_variable_restriction_iterator_free(struct oval_variable_restriction_it
  * @param comm - (Not NULL) a copy of the comment parameter is set as  the comment attribute.
  * @memberof oval_variable
  */
-void oval_variable_set_comment(struct oval_variable *, char *comment);
+OSCAP_API void oval_variable_set_comment(struct oval_variable *, char *comment);
 /**
  * set attribute @ref oval_variable->version.
  * If attribute oval_variable->version == 0 this method shall overwrite the attribute with the version parameter.
@@ -1797,13 +1798,13 @@ void oval_variable_set_comment(struct oval_variable *, char *comment);
  * @param version - (>0) the required version.
  * @memberof oval_variable
  */
-void oval_variable_set_version(struct oval_variable *, int version);
+OSCAP_API void oval_variable_set_version(struct oval_variable *, int version);
 /**
  * set attribute @ref oval_variable->deprecated.
  * @param deprecated - the required deprecation toggle.
  * @memberof oval_variable
  */
-void oval_variable_set_deprecated(struct oval_variable *, bool deprecated);
+OSCAP_API void oval_variable_set_deprecated(struct oval_variable *, bool deprecated);
 /**
  * set attribute @ref oval_variable->datatype.
  * If attribute oval_variable->datatype == @ref OVAL_DATATYPE_UNKNOWN this method shall overwrite the attribute with the datatype parameter.
@@ -1811,7 +1812,7 @@ void oval_variable_set_deprecated(struct oval_variable *, bool deprecated);
  * @param datatype - (Not @ref OVAL_DATATYPE_UNKNOWN) a the required datatype.
  * @memberof oval_variable
  */
-void oval_variable_set_datatype(struct oval_variable *, oval_datatype_t);
+OSCAP_API void oval_variable_set_datatype(struct oval_variable *, oval_datatype_t);
 /**
  * Append an instance of @ref Oval_value to the attribute @ref Oval_constant->values.
  * If attribute type <> @ref OVAL_VARIABLE_CONSTANT or the value parameter is NULL the state of the oval_variable shall not be changed by this
@@ -1825,9 +1826,9 @@ void oval_variable_set_datatype(struct oval_variable *, oval_datatype_t);
  * @param value - the required value.
  * @memberof oval_variable
  */
-void oval_variable_add_value(struct oval_variable *, struct oval_value *);	//type==OVAL_VARIABLE_CONSTANT
+OSCAP_API void oval_variable_add_value(struct oval_variable *, struct oval_value *);	//type==OVAL_VARIABLE_CONSTANT
 
-void oval_variable_clear_values(struct oval_variable *);
+OSCAP_API void oval_variable_clear_values(struct oval_variable *);
 
 /**
  * Add a new possible value to an external variable.
@@ -1835,7 +1836,7 @@ void oval_variable_clear_values(struct oval_variable *);
  * @param pv The new possible_value.
  * @memberof oval_variable
  */
-void oval_variable_add_possible_value(struct oval_variable *variable, struct oval_variable_possible_value *pv);
+OSCAP_API void oval_variable_add_possible_value(struct oval_variable *variable, struct oval_variable_possible_value *pv);
 
 /**
  * Add a new possible restriction to an external variable.
@@ -1843,7 +1844,7 @@ void oval_variable_add_possible_value(struct oval_variable *variable, struct ova
  * @param pr The new possible_restriction.
  * @memberof oval_variable
  */
-void oval_variable_add_possible_restriction(struct oval_variable *variable, struct oval_variable_possible_restriction *pr);
+OSCAP_API void oval_variable_add_possible_restriction(struct oval_variable *variable, struct oval_variable_possible_restriction *pr);
 
 /**
  * Add a restriction to the list of possible restrictions.
@@ -1851,7 +1852,7 @@ void oval_variable_add_possible_restriction(struct oval_variable *variable, stru
  * @param r Restriction which will be added
  * @memberof oval_variable_possible_restriction
  */
-void oval_variable_possible_restriction_add_restriction(struct oval_variable_possible_restriction *pr, struct oval_variable_restriction *r);
+OSCAP_API void oval_variable_possible_restriction_add_restriction(struct oval_variable_possible_restriction *pr, struct oval_variable_restriction *r);
 
 /**
  * Bind an instance of @ref Oval_component to the attribute @ref Oval_local->component.
@@ -1865,7 +1866,7 @@ void oval_variable_possible_restriction_add_restriction(struct oval_variable_pos
  * @param component - the required component.
  * @memberof oval_variable
  */
-void oval_variable_set_component(struct oval_variable *, struct oval_component *component);	//type==OVAL_VARIABLE_LOCAL
+OSCAP_API void oval_variable_set_component(struct oval_variable *, struct oval_component *component);	//type==OVAL_VARIABLE_LOCAL
 /** @} */
 
 /**
@@ -1877,33 +1878,33 @@ void oval_variable_set_component(struct oval_variable *, struct oval_component *
  * @return A pointer to the id attribute of the specified @ref oval_variable.
  * @memberof oval_variable
  */
-char *oval_variable_get_id(struct oval_variable *);
+OSCAP_API char *oval_variable_get_id(struct oval_variable *);
 /**
  * Returns attribute @ref oval_variable->comment.
  * @return A pointer to the comment attribute of the specified @ref oval_variable.
  * @memberof oval_variable
  */
-char *oval_variable_get_comment(struct oval_variable *);
+OSCAP_API char *oval_variable_get_comment(struct oval_variable *);
 /**
  * Returns attribute @ref oval_variable->version.
  * @memberof oval_variable
  */
-int oval_variable_get_version(struct oval_variable *);
+OSCAP_API int oval_variable_get_version(struct oval_variable *);
 /**
  * Returns attribute @ref oval_variable->deprecated.
  * @memberof oval_variable
  */
-bool oval_variable_get_deprecated(struct oval_variable *);
+OSCAP_API bool oval_variable_get_deprecated(struct oval_variable *);
 /**
  * Returns attribute @ref oval_variable->type.
  * @memberof oval_variable
  */
-oval_variable_type_t oval_variable_get_type(struct oval_variable *);
+OSCAP_API oval_variable_type_t oval_variable_get_type(struct oval_variable *);
 /**
  * Returns attribute @ref oval_variable->datatype.
  * @memberof oval_variable
  */
-oval_datatype_t oval_variable_get_datatype(struct oval_variable *);
+OSCAP_API oval_datatype_t oval_variable_get_datatype(struct oval_variable *);
 /**
  * Returns attribute @ref Oval_external/@ref Oval_constant->values.
  * If attribute type == @ref OVAL_VARIABLE_LOCAL or @ref OVAL_VARIABLE_UNKNOWN, this method shall return NULL
@@ -1911,14 +1912,14 @@ oval_datatype_t oval_variable_get_datatype(struct oval_variable *);
  * It should be freed after use by the calling application.
  * @memberof oval_variable
  */
-struct oval_value_iterator *oval_variable_get_values(struct oval_variable *);	//type==OVAL_VARIABLE_CONSTANT
+OSCAP_API struct oval_value_iterator *oval_variable_get_values(struct oval_variable *);	//type==OVAL_VARIABLE_CONSTANT
 /**
  * Returns attribute @ref Oval_local->component.
  * If attribute type <> @ref OVAL_VARIABLE_LOCAL this method shall return NULL.
  * @return A pointer to the component attribute of the specified @ref oval_variable.
  * @memberof oval_variable
  */
-struct oval_component *oval_variable_get_component(struct oval_variable *);	//type==OVAL_VARIABLE_LOCAL
+OSCAP_API struct oval_component *oval_variable_get_component(struct oval_variable *);	//type==OVAL_VARIABLE_LOCAL
 
 /**
  * Get list of allowed values for an external variable.
@@ -1926,8 +1927,8 @@ struct oval_component *oval_variable_get_component(struct oval_variable *);	//ty
  * It should be freed after use by the calling application.
  * @memberof oval_variable
  */
-OSCAP_DEPRECATED(struct oval_iterator *oval_variable_get_possible_values(struct oval_variable *variable));
-struct oval_variable_possible_value_iterator *oval_variable_get_possible_values2(struct oval_variable *variable);
+OSCAP_API OSCAP_DEPRECATED(struct oval_iterator *oval_variable_get_possible_values(struct oval_variable *variable));
+OSCAP_API struct oval_variable_possible_value_iterator *oval_variable_get_possible_values2(struct oval_variable *variable);
 
 /**
  * Get list of constraints for an external variable.
@@ -1935,8 +1936,8 @@ struct oval_variable_possible_value_iterator *oval_variable_get_possible_values2
  * It should be freed after use by the calling application.
  * @memberof oval_variable
  */
-OSCAP_DEPRECATED(struct oval_iterator *oval_variable_get_possible_restrictions(struct oval_variable *variable));
-struct oval_variable_possible_restriction_iterator *oval_variable_get_possible_restrictions2(struct oval_variable *variable);
+OSCAP_API OSCAP_DEPRECATED(struct oval_iterator *oval_variable_get_possible_restrictions(struct oval_variable *variable));
+OSCAP_API struct oval_variable_possible_restriction_iterator *oval_variable_get_possible_restrictions2(struct oval_variable *variable);
 
 
 /**
@@ -1945,28 +1946,28 @@ struct oval_variable_possible_restriction_iterator *oval_variable_get_possible_r
  * It should be freed after use by the calling application.
  * @memberof oval_variable_possible_restriction
  */
-OSCAP_DEPRECATED(struct oval_iterator *oval_variable_possible_restriction_get_restrictions(struct oval_variable_possible_restriction *possible_restriction));
-struct oval_variable_restriction_iterator *oval_variable_possible_restriction_get_restrictions2(struct oval_variable_possible_restriction *possible_restriction);
+OSCAP_API OSCAP_DEPRECATED(struct oval_iterator *oval_variable_possible_restriction_get_restrictions(struct oval_variable_possible_restriction *possible_restriction));
+OSCAP_API struct oval_variable_restriction_iterator *oval_variable_possible_restriction_get_restrictions2(struct oval_variable_possible_restriction *possible_restriction);
 
 /**
  * Get operator of possible_restriction element
  * @return operator
  * @memberof oval_variable_possible_restriction
  */
-oval_operator_t oval_variable_possible_restriction_get_operator(struct oval_variable_possible_restriction *possible_restriction);
+OSCAP_API oval_operator_t oval_variable_possible_restriction_get_operator(struct oval_variable_possible_restriction *possible_restriction);
 
 /**
  * Get hint of possible_restriction element
  * @return hint
  * @memberof oval_variable_possible_restriction
  */
-char* oval_variable_possible_restriction_get_hint(struct oval_variable_possible_restriction* possible_restriction);
+OSCAP_API char* oval_variable_possible_restriction_get_hint(struct oval_variable_possible_restriction* possible_restriction);
 
 /**
  * Returns attribute @ref Oval_component_type->text.
  * @memberof oval_variable
  */
-const char *oval_component_type_get_text(oval_component_type_t type);
+OSCAP_API const char *oval_component_type_get_text(oval_component_type_t type);
 /** @} */
 
 /**
@@ -1977,17 +1978,17 @@ const char *oval_component_type_get_text(oval_component_type_t type);
  * Returns <b>true</b> if iterator not exhausted.
  * @memberof oval_variable_iterator
  */
-bool oval_variable_iterator_has_more(struct oval_variable_iterator *);
+OSCAP_API bool oval_variable_iterator_has_more(struct oval_variable_iterator *);
 /**
  * Returns next instance of @ref oval_variable.
  * @memberof oval_variable_iterator
  */
-struct oval_variable *oval_variable_iterator_next(struct oval_variable_iterator *);
+OSCAP_API struct oval_variable *oval_variable_iterator_next(struct oval_variable_iterator *);
 /**
  * Free iterator.
  * @memberof oval_variable_iterator
  */
-void oval_variable_iterator_free(struct oval_variable_iterator *);
+OSCAP_API void oval_variable_iterator_free(struct oval_variable_iterator *);
 /** @} */
 
 /**
@@ -2000,18 +2001,18 @@ void oval_variable_iterator_free(struct oval_variable_iterator *);
  * Construct instance of @ref oval_affected.
  * @memberof oval_affected
  */
-struct oval_affected *oval_affected_new(struct oval_definition_model *);
+OSCAP_API struct oval_affected *oval_affected_new(struct oval_definition_model *);
 /**
  * Clone instance of @ref oval_affected.
  * @return A copy of the specified @ref oval_affected.
  * @memberof oval_affected
  */
-struct oval_affected *oval_affected_clone(struct oval_definition_model *new_model, struct oval_affected *old_affected);
+OSCAP_API struct oval_affected *oval_affected_clone(struct oval_definition_model *new_model, struct oval_affected *old_affected);
 /**
  * Release instance of @ref oval_affected.
  * @memberof oval_affected
  */
-void oval_affected_free(struct oval_affected *);
+OSCAP_API void oval_affected_free(struct oval_affected *);
 
 /**
  * @name Setters
@@ -2021,17 +2022,17 @@ void oval_affected_free(struct oval_affected *);
  * Set @ref oval_affected family.
  * @memberof oval_affected
  */
-void oval_affected_set_family(struct oval_affected *, oval_affected_family_t family);
+OSCAP_API void oval_affected_set_family(struct oval_affected *, oval_affected_family_t family);
 /**
  * Append name to @ref oval_affected platform names.
  * @memberof oval_affected
  */
-void oval_affected_add_platform(struct oval_affected *, char *platform_name);
+OSCAP_API void oval_affected_add_platform(struct oval_affected *, char *platform_name);
 /**
  * Append name to @ref oval_affected product names.
  * @memberof oval_affected
  */
-void oval_affected_add_product(struct oval_affected *, char *product_name);
+OSCAP_API void oval_affected_add_product(struct oval_affected *, char *product_name);
 /** @} */
 
 /**
@@ -2044,7 +2045,7 @@ void oval_affected_add_product(struct oval_affected *, char *product_name);
  * other than one of the defined values is targeted.
  * @memberof oval_affected
  */
-oval_affected_family_t oval_affected_get_family(struct oval_affected *);
+OSCAP_API oval_affected_family_t oval_affected_get_family(struct oval_affected *);
 /**
  * Get member values @ref oval_affected platform_names.
  * If the returned iterator is empty, then the associated Oval_definition is not constrained to a specific platform choice.
@@ -2052,7 +2053,7 @@ oval_affected_family_t oval_affected_get_family(struct oval_affected *);
  * It should be freed after use by the calling application.
  * @memberof oval_affected
  */
-struct oval_string_iterator *oval_affected_get_platforms(struct oval_affected *);
+OSCAP_API struct oval_string_iterator *oval_affected_get_platforms(struct oval_affected *);
 /**
  * Get member values @ref oval_affected product_names.
  * If the returned iterator is empty, then the associated Oval_definition is not constrained to a specific product choice.
@@ -2060,7 +2061,7 @@ struct oval_string_iterator *oval_affected_get_platforms(struct oval_affected *)
  * It should be freed after use by the calling application.
  * @memberof oval_affected
  */
-struct oval_string_iterator *oval_affected_get_products(struct oval_affected *);
+OSCAP_API struct oval_string_iterator *oval_affected_get_products(struct oval_affected *);
 /** @} */
 
 /**
@@ -2077,33 +2078,33 @@ struct oval_string_iterator *oval_affected_get_products(struct oval_affected *);
  * Return <b>true</b> if iterator has more @ref oval_affected.
  * @memberof oval_affected_iterator
  */
-bool oval_affected_iterator_has_more(struct oval_affected_iterator *);
+OSCAP_API bool oval_affected_iterator_has_more(struct oval_affected_iterator *);
 /**
  * Return next instance of @ref oval_affected from iterator.
  * @memberof oval_affected_iterator
  */
-struct oval_affected *oval_affected_iterator_next(struct oval_affected_iterator *);
+OSCAP_API struct oval_affected *oval_affected_iterator_next(struct oval_affected_iterator *);
 /**
  * Release instance of @ref oval_affected_ iterator.
  * @memberof oval_affected_iterator
  */
-void oval_affected_iterator_free(struct oval_affected_iterator *);
+OSCAP_API void oval_affected_iterator_free(struct oval_affected_iterator *);
 /** @} */
 
 /**
  * @memberof oval_reference
  */
-struct oval_reference *oval_reference_new(struct oval_definition_model *);
+OSCAP_API struct oval_reference *oval_reference_new(struct oval_definition_model *);
 /**
  * @return A copy of the specified @ref oval_reference.
  * @memberof oval_reference
  */
-struct oval_reference *oval_reference_clone
-    (struct oval_definition_model *new_model, struct oval_reference *old_reference);
+OSCAP_API struct oval_reference *oval_reference_clone
+     (struct oval_definition_model *new_model, struct oval_reference *old_reference);
 /**
  * @memberof oval_reference
  */
-void oval_reference_free(struct oval_reference *);
+OSCAP_API void oval_reference_free(struct oval_reference *);
 
 /**
  * @name Setters
@@ -2114,15 +2115,15 @@ void oval_reference_free(struct oval_reference *);
  * Set OVAL reference source
  * @memberof oval_reference
  */
-void oval_reference_set_source(struct oval_reference *, char *);
+OSCAP_API void oval_reference_set_source(struct oval_reference *, char *);
 /**
  * @memberof oval_reference
  */
-void oval_reference_set_id(struct oval_reference *, char *);
+OSCAP_API void oval_reference_set_id(struct oval_reference *, char *);
 /**
  * @memberof oval_reference
  */
-void oval_reference_set_url(struct oval_reference *, char *);
+OSCAP_API void oval_reference_set_url(struct oval_reference *, char *);
 /** @} */
 
 /**
@@ -2134,19 +2135,19 @@ void oval_reference_set_url(struct oval_reference *, char *);
  * @return A pointer to the source attribute of the specified @ref oval_reference.
  * @memberof oval_reference
  */
-char *oval_reference_get_source(struct oval_reference *);
+OSCAP_API char *oval_reference_get_source(struct oval_reference *);
 /**
  * Get OVAL reference ID.
  * @return A pointer to the id attribute of the specified @ref oval_reference.
  * @memberof oval_reference
  */
-char *oval_reference_get_id(struct oval_reference *);
+OSCAP_API char *oval_reference_get_id(struct oval_reference *);
 /**
  * Get OVAL reference URL.
  * @return A pointer to the url attribute of the specified @ref oval_reference.
  * @memberof oval_reference
  */
-char *oval_reference_get_url(struct oval_reference *);
+OSCAP_API char *oval_reference_get_url(struct oval_reference *);
 /** @} */
 
 /**
@@ -2156,15 +2157,15 @@ char *oval_reference_get_url(struct oval_reference *);
 /**
  * @memberof oval_reference_iterator
  */
-bool oval_reference_iterator_has_more(struct oval_reference_iterator *);
+OSCAP_API bool oval_reference_iterator_has_more(struct oval_reference_iterator *);
 /**
  * @memberof oval_reference_iterator
  */
-struct oval_reference *oval_reference_iterator_next(struct oval_reference_iterator *);
+OSCAP_API struct oval_reference *oval_reference_iterator_next(struct oval_reference_iterator *);
 /**
  * @memberof oval_reference_iterator
  */
-void oval_reference_iterator_free(struct oval_reference_iterator *);
+OSCAP_API void oval_reference_iterator_free(struct oval_reference_iterator *);
 /** @} */
 
 /**
@@ -2193,19 +2194,19 @@ void oval_reference_iterator_free(struct oval_reference_iterator *);
  * @param type - the required node type.
  * @memberof oval_criteria_node
  */
-struct oval_criteria_node *oval_criteria_node_new(struct oval_definition_model *, oval_criteria_node_type_t type);
+OSCAP_API struct oval_criteria_node *oval_criteria_node_new(struct oval_definition_model *, oval_criteria_node_type_t type);
 /**
  * Clone an instance of @ref oval_criteria_node.
  * @return A copy of the specified @ref oval_criteria_node.
  * @memberof oval_criteria_node
  */
-struct oval_criteria_node *oval_criteria_node_clone
-    (struct oval_definition_model *new_model, struct oval_criteria_node *old_node);
+OSCAP_API struct oval_criteria_node *oval_criteria_node_clone
+     (struct oval_definition_model *new_model, struct oval_criteria_node *old_node);
 /**
  * Free an instance of @ref oval_criteria_node.
  * @memberof oval_criteria_node
  */
-void oval_criteria_node_free(struct oval_criteria_node *);
+OSCAP_API void oval_criteria_node_free(struct oval_criteria_node *);
 
 /**
  * @name Setters
@@ -2216,25 +2217,25 @@ void oval_criteria_node_free(struct oval_criteria_node *);
  * @param negate - the required value of the negate attribute
  * @memberof oval_criteria_node
  */
-void oval_criteria_node_set_negate(struct oval_criteria_node *, bool negate);
+OSCAP_API void oval_criteria_node_set_negate(struct oval_criteria_node *, bool negate);
 /**
  * Set attribute @ref Oval_criteria_node->applicability_check.
  * @param applicability_check - the required value of the applicability_check attribute
  * @memberof oval_criteria_node
  */
-void oval_criteria_node_set_applicability_check(struct oval_criteria_node *, bool applicability_check);
+OSCAP_API void oval_criteria_node_set_applicability_check(struct oval_criteria_node *, bool applicability_check);
 /**
  * Set attribute @ref Oval_criteria_node->type.
  * @param type - the required value of the type attribute
  * @memberof oval_criteria_node
  */
-void oval_criteria_set_node_type(struct oval_criteria_node *node, oval_criteria_node_type_t type);
+OSCAP_API void oval_criteria_set_node_type(struct oval_criteria_node *node, oval_criteria_node_type_t type);
 /**
  * set attribute @ref Oval_criteria_node->comment.
  * @param comm - (Not NULL) a copy of the comment parameter is set as  the comment attribute.
  * @memberof oval_criteria_node
  */
-void oval_criteria_node_set_comment(struct oval_criteria_node *, char *comment);
+OSCAP_API void oval_criteria_node_set_comment(struct oval_criteria_node *, char *comment);
 /**
  * Set attribute @ref Oval_criteria->operator.
  * If Oval_criteria_node->type == @ref OVAL_NODETYPE_CRITERIA and the value of the operator attribute is @ref OVAL_OPERATOR_UNKNOWN,
@@ -2242,7 +2243,7 @@ void oval_criteria_node_set_comment(struct oval_criteria_node *, char *comment);
  * Otherwise the Oval_criteria_node state shall not be changed by this method.
  * @memberof oval_criteria_node
  */
-void oval_criteria_node_set_operator(struct oval_criteria_node *, oval_operator_t op);
+OSCAP_API void oval_criteria_node_set_operator(struct oval_criteria_node *, oval_operator_t op);
 /**
  * Append instance of @ref Oval_criteria_node to attribute @ref Oval_criteria->subnodes.
  * If Oval_criteria_node->type <> @ref OVAL_NODETYPE_CRITERIA, this method shall return without changing the Oval_criteria_node state.
@@ -2253,7 +2254,7 @@ void oval_criteria_node_set_operator(struct oval_criteria_node *, oval_operator_
  * @param - (Not NULL) the subnode to be appended.
  * @memberof oval_criteria_node
  */
-void oval_criteria_node_add_subnode(struct oval_criteria_node *, struct oval_criteria_node *node);
+OSCAP_API void oval_criteria_node_add_subnode(struct oval_criteria_node *, struct oval_criteria_node *node);
 /**
  * Sets attribute @ref Oval_criterion->test.
  * If Oval_criteria_node->type == @ref OVAL_NODETYPE_CRITERION and the value of the test attribute is NULL,
@@ -2261,7 +2262,7 @@ void oval_criteria_node_add_subnode(struct oval_criteria_node *, struct oval_cri
  * Otherwise the Oval_criteria_node state shall not be changed by this method.
  * @memberof oval_criteria_node
  */
-void oval_criteria_node_set_test(struct oval_criteria_node *, struct oval_test *);
+OSCAP_API void oval_criteria_node_set_test(struct oval_criteria_node *, struct oval_test *);
 /**
  * Sets attribute @ref Oval_extends->definition.
  * If Oval_criteria_node->type == @ref OVAL_NODETYPE_EXTENDDEF and the value of the definition attribute is NULL,
@@ -2269,7 +2270,7 @@ void oval_criteria_node_set_test(struct oval_criteria_node *, struct oval_test *
  * Otherwise the Oval_criteria_node state shall not be changed by this method.
  * @memberof oval_criteria_node
  */
-void oval_criteria_node_set_definition(struct oval_criteria_node *, struct oval_definition *);	//type==NODETYPE_EXTENDDEF
+OSCAP_API void oval_criteria_node_set_definition(struct oval_criteria_node *, struct oval_definition *);	//type==NODETYPE_EXTENDDEF
 /** @} */
 
 /**
@@ -2280,30 +2281,30 @@ void oval_criteria_node_set_definition(struct oval_criteria_node *, struct oval_
  * Returns attribute @ref Oval_criteria_node->type.
  * @memberof oval_criteria_node
  */
-oval_criteria_node_type_t oval_criteria_node_get_type(struct oval_criteria_node *);
+OSCAP_API oval_criteria_node_type_t oval_criteria_node_get_type(struct oval_criteria_node *);
 /**
  * Returns attribute @ref Oval_criteria_node->negate.
  * @memberof oval_criteria_node
  */
-bool oval_criteria_node_get_negate(struct oval_criteria_node *);
+OSCAP_API bool oval_criteria_node_get_negate(struct oval_criteria_node *);
 /**
  * Returns attribute @ref Oval_criteria_node->applicability_check.
  * @memberof oval_criteria_node
  */
-bool oval_criteria_node_get_applicability_check(struct oval_criteria_node *);
+OSCAP_API bool oval_criteria_node_get_applicability_check(struct oval_criteria_node *);
 
 /**
  * Returns attribute @ref Oval_criteria_node->comment.
  * @return A pointer to the comment attribute of the specified @ref oval_criteria_node.
  * @memberof oval_criteria_node
  */
-char *oval_criteria_node_get_comment(struct oval_criteria_node *);
+OSCAP_API char *oval_criteria_node_get_comment(struct oval_criteria_node *);
 /**
  * Returns attribute @ref Oval_criteria->operator HOWDI.
  * @note If Oval_criteria_node->type <> @ref OVAL_NODETYPE_CRITERIA, this method shall return @ref OVAL_OPERATOR_UNKNOWN.
  * @memberof oval_criteria_node
  */
-oval_operator_t oval_criteria_node_get_operator(struct oval_criteria_node *);
+OSCAP_API oval_operator_t oval_criteria_node_get_operator(struct oval_criteria_node *);
 /**
  * Returns attribute @ref Oval_criteria_node->subnodes.
  * If Oval_criteria_node->type <> @ref OVAL_NODETYPE_CRITERIA, this method shall return NULL.
@@ -2311,21 +2312,21 @@ oval_operator_t oval_criteria_node_get_operator(struct oval_criteria_node *);
  * It should be freed after use by the calling application.
  * @memberof oval_criteria_node
  */
-struct oval_criteria_node_iterator *oval_criteria_node_get_subnodes(struct oval_criteria_node *);
+OSCAP_API struct oval_criteria_node_iterator *oval_criteria_node_get_subnodes(struct oval_criteria_node *);
 /**
  * Returns attribute @ref Oval_criterion->test.
  * If Oval_criteria_node->type <> @ref OVAL_NODETYPE_CRITERION, this method shall return NULL.
  * @return A pointer to the test attribute of the specified @ref oval_criteria_node.
  * @memberof oval_criteria_node
  */
-struct oval_test *oval_criteria_node_get_test(struct oval_criteria_node *);
+OSCAP_API struct oval_test *oval_criteria_node_get_test(struct oval_criteria_node *);
 /**
  * Returns attribute @ref Oval_extends->definition.
  * If Oval_criteria_node->type <> @ref OVAL_NODETYPE_EXTENDDEF, this method shall return NULL.
  * @return A pointer to the definition attribute of the specified @ref oval_criteria_node.
  * @memberof oval_criteria_node
  */
-struct oval_definition *oval_criteria_node_get_definition(struct oval_criteria_node *);
+OSCAP_API struct oval_definition *oval_criteria_node_get_definition(struct oval_criteria_node *);
 /** @} */
 
 /**
@@ -2336,18 +2337,18 @@ struct oval_definition *oval_criteria_node_get_definition(struct oval_criteria_n
  * Returns <b>true</b> if the iterator is not exhausted.
  * @memberof oval_criteria_node_iterator
  */
-bool oval_criteria_node_iterator_has_more(struct oval_criteria_node_iterator *);
+OSCAP_API bool oval_criteria_node_iterator_has_more(struct oval_criteria_node_iterator *);
 /**
  * Returns the next instance of @ref Oval_criteria_node from the iterator.
  * Returns NULL if the iterator is exhausted.
  * @memberof oval_criteria_node_iterator
  */
-struct oval_criteria_node *oval_criteria_node_iterator_next(struct oval_criteria_node_iterator *);
+OSCAP_API struct oval_criteria_node *oval_criteria_node_iterator_next(struct oval_criteria_node_iterator *);
 /**
  * Free the iterator.
  * @memberof oval_criteria_node_iterator
  */
-void oval_criteria_node_iterator_free(struct oval_criteria_node_iterator *);
+OSCAP_API void oval_criteria_node_iterator_free(struct oval_criteria_node_iterator *);
 /** @} */
 
 /**
@@ -2359,19 +2360,19 @@ void oval_criteria_node_iterator_free(struct oval_criteria_node_iterator *);
 /**
  * @memberof oval_object_content
  */
-struct oval_object_content *oval_object_content_new(struct oval_definition_model *model, oval_object_content_type_t type);
+OSCAP_API struct oval_object_content *oval_object_content_new(struct oval_definition_model *model, oval_object_content_type_t type);
 
 /**
  * @return A copy of the specified @ref oval_object_content.
  * @memberof oval_object_content
  */
-struct oval_object_content *oval_object_content_clone
-    (struct oval_definition_model *new_model, struct oval_object_content *old_content);
+OSCAP_API struct oval_object_content *oval_object_content_clone
+     (struct oval_definition_model *new_model, struct oval_object_content *old_content);
 
 /**
  * @memberof oval_object_content
  */
-void oval_object_content_free(struct oval_object_content *);
+OSCAP_API void oval_object_content_free(struct oval_object_content *);
 
 /**
  * @name Setters
@@ -2381,27 +2382,27 @@ void oval_object_content_free(struct oval_object_content *);
 /**
  * @memberof oval_object_content
  */
-void oval_object_content_set_type(struct oval_object_content *, oval_object_content_type_t);
+OSCAP_API void oval_object_content_set_type(struct oval_object_content *, oval_object_content_type_t);
 /**
  * @memberof oval_object_content
  */
-void oval_object_content_set_field_name(struct oval_object_content *, char *);
+OSCAP_API void oval_object_content_set_field_name(struct oval_object_content *, char *);
 /**
  * @memberof oval_object_content
  */
-void oval_object_content_set_entity(struct oval_object_content *, struct oval_entity *);	//type == OVAL_OBJECTCONTENT_ENTITY
+OSCAP_API void oval_object_content_set_entity(struct oval_object_content *, struct oval_entity *);	//type == OVAL_OBJECTCONTENT_ENTITY
 /**
  * @memberof oval_object_content
  */
-void oval_object_content_set_varCheck(struct oval_object_content *, oval_check_t);	//type == OVAL_OBJECTCONTENT_ENTITY
+OSCAP_API void oval_object_content_set_varCheck(struct oval_object_content *, oval_check_t);	//type == OVAL_OBJECTCONTENT_ENTITY
 /**
  * @memberof oval_object_content
  */
-void oval_object_content_set_setobject(struct oval_object_content *, struct oval_setobject *);	//type == OVAL_OBJECTCONTENT_SET
+OSCAP_API void oval_object_content_set_setobject(struct oval_object_content *, struct oval_setobject *);	//type == OVAL_OBJECTCONTENT_SET
 /**
  * @memberof oval_object_content
  */
-void oval_object_content_set_filter(struct oval_object_content *, struct oval_filter *);	//type == OVAL_OBJECTCONTENT_FILTER
+OSCAP_API void oval_object_content_set_filter(struct oval_object_content *, struct oval_filter *);	//type == OVAL_OBJECTCONTENT_FILTER
 /** @} */
 
 /**
@@ -2413,35 +2414,35 @@ void oval_object_content_set_filter(struct oval_object_content *, struct oval_fi
  * @return A pointer to the fieldName attribute of the specified @ref oval_object_content.
  * @memberof oval_object_content
  */
-char *oval_object_content_get_field_name(struct oval_object_content *);
+OSCAP_API char *oval_object_content_get_field_name(struct oval_object_content *);
 /**
  * Get type of a object content (entity or set).
  * @memberof oval_object_content
  */
-oval_object_content_type_t oval_object_content_get_type(struct oval_object_content *);
+OSCAP_API oval_object_content_type_t oval_object_content_get_type(struct oval_object_content *);
 /**
  * Get entity of a simple object content.
  * @return A pointer to the entity attribute of the specified @ref oval_object_content.
  * @memberof oval_object_content
  */
-struct oval_entity *oval_object_content_get_entity(struct oval_object_content *);	//type == OVAL_OBJECTCONTENT_ENTITY
+OSCAP_API struct oval_entity *oval_object_content_get_entity(struct oval_object_content *);	//type == OVAL_OBJECTCONTENT_ENTITY
 /**
  * Get varCheck of a simple object content.
  * @memberof oval_object_content
  */
-oval_check_t oval_object_content_get_varCheck(struct oval_object_content *);	//type == OVAL_OBJECTCONTENT_ENTITY
+OSCAP_API oval_check_t oval_object_content_get_varCheck(struct oval_object_content *);	//type == OVAL_OBJECTCONTENT_ENTITY
 /**
  * Get setobject of a set object content.
  * @return A pointer to the set attribute of the specified @ref oval_object_content.
  * @memberof oval_object_content
  */
-struct oval_setobject *oval_object_content_get_setobject(struct oval_object_content *);	//type == OVAL_OBJECTCONTENT_SET
+OSCAP_API struct oval_setobject *oval_object_content_get_setobject(struct oval_object_content *);	//type == OVAL_OBJECTCONTENT_SET
 /**
  * Get filter of a set object content.
  * @return A pointer to the filter attribute of the specified @ref oval_object_content.
  * @memberof oval_object_content
  */
-struct oval_filter *oval_object_content_get_filter(struct oval_object_content *content); //type == OVAL_OBJECTCONTENT_FILTER
+OSCAP_API struct oval_filter *oval_object_content_get_filter(struct oval_object_content *content); //type == OVAL_OBJECTCONTENT_FILTER
 /** @} */
 
 /**
@@ -2451,15 +2452,15 @@ struct oval_filter *oval_object_content_get_filter(struct oval_object_content *c
 /**
  * @memberof oval_object_content_iterator
  */
-bool oval_object_content_iterator_has_more(struct oval_object_content_iterator *);
+OSCAP_API bool oval_object_content_iterator_has_more(struct oval_object_content_iterator *);
 /**
  * @memberof oval_object_content_iterator
  */
-struct oval_object_content *oval_object_content_iterator_next(struct oval_object_content_iterator *);
+OSCAP_API struct oval_object_content *oval_object_content_iterator_next(struct oval_object_content_iterator *);
 /**
  * @memberof oval_object_content_iterator
  */
-void oval_object_content_iterator_free(struct oval_object_content_iterator *);
+OSCAP_API void oval_object_content_iterator_free(struct oval_object_content_iterator *);
 /** @} */
 
 /**
@@ -2471,17 +2472,17 @@ void oval_object_content_iterator_free(struct oval_object_content_iterator *);
 /**
  * @memberof oval_behavior
  */
-struct oval_behavior *oval_behavior_new(struct oval_definition_model *);
+OSCAP_API struct oval_behavior *oval_behavior_new(struct oval_definition_model *);
 
 /**
  * @return A copy of the specified @ref oval_behavior.
  * @memberof oval_behavior
  */
-struct oval_behavior *oval_behavior_clone(struct oval_definition_model *new_model, struct oval_behavior *old_behavior);
+OSCAP_API struct oval_behavior *oval_behavior_clone(struct oval_definition_model *new_model, struct oval_behavior *old_behavior);
 /**
  * @memberof oval_behavior
  */
-void oval_behavior_free(struct oval_behavior *);
+OSCAP_API void oval_behavior_free(struct oval_behavior *);
 
 /**
  * @name Setters
@@ -2490,7 +2491,7 @@ void oval_behavior_free(struct oval_behavior *);
 /**
  * @memberof oval_behavior
  */
-void oval_behavior_set_keyval(struct oval_behavior *behavior, const char *key, const char *value);
+OSCAP_API void oval_behavior_set_keyval(struct oval_behavior *behavior, const char *key, const char *value);
 /** @} */
 
 /**
@@ -2502,13 +2503,13 @@ void oval_behavior_set_keyval(struct oval_behavior *behavior, const char *key, c
  * @return A pointer to the key attribute of the specified @ref oval_behavior.
  * @memberof oval_behavior
  */
-char *oval_behavior_get_key(struct oval_behavior *);
+OSCAP_API char *oval_behavior_get_key(struct oval_behavior *);
 /**
  * Get OVAL behavior value.
  * @return A pointer to the value attribute of the specified @ref oval_behavior.
  * @memberof oval_behavior
  */
-char *oval_behavior_get_value(struct oval_behavior *);
+OSCAP_API char *oval_behavior_get_value(struct oval_behavior *);
 /** @} */
 
 /**
@@ -2518,15 +2519,15 @@ char *oval_behavior_get_value(struct oval_behavior *);
 /**
  * @memberof oval_behavior_iterator
  */
-bool oval_behavior_iterator_has_more(struct oval_behavior_iterator *);
+OSCAP_API bool oval_behavior_iterator_has_more(struct oval_behavior_iterator *);
 /**
  * @memberof oval_behavior_iterator
  */
-struct oval_behavior *oval_behavior_iterator_next(struct oval_behavior_iterator *);
+OSCAP_API struct oval_behavior *oval_behavior_iterator_next(struct oval_behavior_iterator *);
 /**
  * @memberof oval_behavior_iterator
  */
-void oval_behavior_iterator_free(struct oval_behavior_iterator *);
+OSCAP_API void oval_behavior_iterator_free(struct oval_behavior_iterator *);
 /** @} */
 
 /**
@@ -2538,16 +2539,16 @@ void oval_behavior_iterator_free(struct oval_behavior_iterator *);
 /**
  * @memberof oval_state_content
  */
-struct oval_state_content *oval_state_content_new(struct oval_definition_model *);
+OSCAP_API struct oval_state_content *oval_state_content_new(struct oval_definition_model *);
 /**
  * @return A copy of the specified @ref oval_state_content.
  * @memberof oval_state_content
  */
-struct oval_state_content *oval_state_content_clone (struct oval_definition_model *new_model, struct oval_state_content *old_content);
+OSCAP_API struct oval_state_content *oval_state_content_clone (struct oval_definition_model *new_model, struct oval_state_content *old_content);
 /**
  * @memberof oval_state_content
  */
-void oval_state_content_free(struct oval_state_content *);
+OSCAP_API void oval_state_content_free(struct oval_state_content *);
 
 /**
  * @name Setters
@@ -2556,26 +2557,26 @@ void oval_state_content_free(struct oval_state_content *);
 /**
  * @memberof oval_state_content
  */
-void oval_state_content_set_entity(struct oval_state_content *, struct oval_entity *);
+OSCAP_API void oval_state_content_set_entity(struct oval_state_content *, struct oval_entity *);
 /**
  * @memberof oval_state_content
  */
-void oval_state_content_add_record_field(struct oval_state_content *, struct oval_record_field *);
+OSCAP_API void oval_state_content_add_record_field(struct oval_state_content *, struct oval_record_field *);
 /**
  * @memberof oval_state_content
  */
-void oval_state_content_set_varcheck(struct oval_state_content *, oval_check_t);
+OSCAP_API void oval_state_content_set_varcheck(struct oval_state_content *, oval_check_t);
 /**
  * @memberof oval_state_content
  */
-void oval_state_content_set_entcheck(struct oval_state_content *, oval_check_t);
+OSCAP_API void oval_state_content_set_entcheck(struct oval_state_content *, oval_check_t);
 /**
  * Sets the "check_existence" attribute of an OVAL state entity
  * @param content An entity within the state element
  * @param existence New value of check_existence attribute of that entity
  * @memberof oval_state_content
  */
-void oval_state_content_set_check_existence(struct oval_state_content *content, oval_existence_t existence);
+OSCAP_API void oval_state_content_set_check_existence(struct oval_state_content *content, oval_existence_t existence);
 /** @} */
 
 /**
@@ -2587,28 +2588,28 @@ void oval_state_content_set_check_existence(struct oval_state_content *content, 
  * @return A pointer to the entity attribute of the specified @ref oval_state_content.
  * @memberof oval_state_content
  */
-struct oval_entity *oval_state_content_get_entity(struct oval_state_content *);
+OSCAP_API struct oval_entity *oval_state_content_get_entity(struct oval_state_content *);
 /**
  * @memberof oval_state_content
  */
-struct oval_record_field_iterator *oval_state_content_get_record_fields(struct oval_state_content *);
+OSCAP_API struct oval_record_field_iterator *oval_state_content_get_record_fields(struct oval_state_content *);
 /**
  * Get multipe variable values processing of a state content.
  * @memberof oval_state_content
  */
-oval_check_t oval_state_content_get_var_check(struct oval_state_content *);
+OSCAP_API oval_check_t oval_state_content_get_var_check(struct oval_state_content *);
 /**
  * Get multipe entities processing of a state content.
  * @memberof oval_state_content
  */
-oval_check_t oval_state_content_get_ent_check(struct oval_state_content *);
+OSCAP_API oval_check_t oval_state_content_get_ent_check(struct oval_state_content *);
 /**
  * Get "check_existence" attribute of an OVAL state entity
  * @param content An entity within the state element
  * @return Value of the check_existence attribute
  * @memberof oval_state_content
  */
-oval_existence_t oval_state_content_get_check_existence(struct oval_state_content *content);
+OSCAP_API oval_existence_t oval_state_content_get_check_existence(struct oval_state_content *content);
 /** @} */
 
 /**
@@ -2619,30 +2620,30 @@ oval_existence_t oval_state_content_get_check_existence(struct oval_state_conten
  * @ingroup oval_state_content_iterators
  * @memberof oval_state_content_iterator
  */
-bool oval_state_content_iterator_has_more(struct oval_state_content_iterator *);
+OSCAP_API bool oval_state_content_iterator_has_more(struct oval_state_content_iterator *);
 /**
  * @memberof oval_state_content_iterator
  */
-struct oval_state_content *oval_state_content_iterator_next(struct oval_state_content_iterator *);
+OSCAP_API struct oval_state_content *oval_state_content_iterator_next(struct oval_state_content_iterator *);
 /**
  * @memberof oval_state_content_iterator
  */
-void oval_state_content_iterator_free(struct oval_state_content_iterator *);
+OSCAP_API void oval_state_content_iterator_free(struct oval_state_content_iterator *);
 /** @} */
 
 /**
  * @memberof oval_value
  */
-struct oval_value *oval_value_new(oval_datatype_t datatype, char *text_value);
+OSCAP_API struct oval_value *oval_value_new(oval_datatype_t datatype, char *text_value);
 /**
  * @return A copy of the specified @ref oval_value.
  * @memberof oval_value
  */
-struct oval_value *oval_value_clone(struct oval_value *old_value);
+OSCAP_API struct oval_value *oval_value_clone(struct oval_value *old_value);
 /**
  * @memberof oval_value
  */
-void oval_value_free(struct oval_value *);
+OSCAP_API void oval_value_free(struct oval_value *);
 
 /**
  * @name Setters
@@ -2651,7 +2652,7 @@ void oval_value_free(struct oval_value *);
 /**
  * @memberof oval_value
  */
-void oval_value_set_datatype(struct oval_value *, oval_datatype_t);
+OSCAP_API void oval_value_set_datatype(struct oval_value *, oval_datatype_t);
 
 /**
  * @name Getters
@@ -2661,33 +2662,33 @@ void oval_value_set_datatype(struct oval_value *, oval_datatype_t);
  * Get OVAL value datatype.
  * @memberof oval_value
  */
-oval_datatype_t oval_value_get_datatype(struct oval_value *);
+OSCAP_API oval_datatype_t oval_value_get_datatype(struct oval_value *);
 /**
  * Get OVAL value as a text.
  * @return A pointer to the text attribute of the specified @ref oval_value.
  * @memberof oval_value
  */
-char *oval_value_get_text(struct oval_value *);
+OSCAP_API char *oval_value_get_text(struct oval_value *);
 /**
  * Get OVAL value as a piece of raw binary data.
  * @memberof oval_value
  */
-unsigned char *oval_value_get_binary(struct oval_value *);	//datatype==OVAL_DATATYPE_BINARY
+OSCAP_API unsigned char *oval_value_get_binary(struct oval_value *);	//datatype==OVAL_DATATYPE_BINARY
 /**
  * Get OVAL value as a boolean.
  * @memberof oval_value
  */
-bool oval_value_get_boolean(struct oval_value *);	//datatype==OVAL_DATATYPE_BOOLEAN
+OSCAP_API bool oval_value_get_boolean(struct oval_value *);	//datatype==OVAL_DATATYPE_BOOLEAN
 /**
  * Get OVAL value as a floating point number.
  * @memberof oval_value
  */
-float oval_value_get_float(struct oval_value *);	//datatype==OVAL_DATATYPE_FLOAT
+OSCAP_API float oval_value_get_float(struct oval_value *);	//datatype==OVAL_DATATYPE_FLOAT
 /**
  * Get OVAL value as an integer.
  * @memberof oval_value
  */
-long long oval_value_get_integer(struct oval_value *);	//datatype==OVAL_DATATYPE_INTEGER
+OSCAP_API long long oval_value_get_integer(struct oval_value *);	//datatype==OVAL_DATATYPE_INTEGER
 /** @} */
 
 /**
@@ -2697,19 +2698,19 @@ long long oval_value_get_integer(struct oval_value *);	//datatype==OVAL_DATATYPE
 /**
  * @memberof oval_value_iterator
  */
-bool oval_value_iterator_has_more(struct oval_value_iterator *);
+OSCAP_API bool oval_value_iterator_has_more(struct oval_value_iterator *);
 /**
  * @memberof oval_value_iterator
  */
-struct oval_value *oval_value_iterator_next(struct oval_value_iterator *);
+OSCAP_API struct oval_value *oval_value_iterator_next(struct oval_value_iterator *);
 /**
  * @memberof oval_value_iterator
  */
-int oval_value_iterator_remaining(struct oval_value_iterator *iterator);
+OSCAP_API int oval_value_iterator_remaining(struct oval_value_iterator *iterator);
 /**
  * @memberof oval_value_iterator
  */
-void oval_value_iterator_free(struct oval_value_iterator *);
+OSCAP_API void oval_value_iterator_free(struct oval_value_iterator *);
 /** @} */
 
 /**
@@ -2721,16 +2722,16 @@ void oval_value_iterator_free(struct oval_value_iterator *);
 /**
  * @memberof oval_entity
  */
-struct oval_entity *oval_entity_new(struct oval_definition_model *);
+OSCAP_API struct oval_entity *oval_entity_new(struct oval_definition_model *);
 /**
  * @return A copy of the specified @ref oval_entity.
  * @memberof oval_entity
  */
-struct oval_entity *oval_entity_clone(struct oval_definition_model *model, struct oval_entity *old_entity);
+OSCAP_API struct oval_entity *oval_entity_clone(struct oval_definition_model *model, struct oval_entity *old_entity);
 /**
  * @memberof oval_entity
  */
-void oval_entity_free(struct oval_entity *);
+OSCAP_API void oval_entity_free(struct oval_entity *);
 
 /**
  * @name Setters
@@ -2739,35 +2740,35 @@ void oval_entity_free(struct oval_entity *);
 /**
  * @memberof oval_entity
  */
-void oval_entity_set_type(struct oval_entity *, oval_entity_type_t);
+OSCAP_API void oval_entity_set_type(struct oval_entity *, oval_entity_type_t);
 /**
  * @memberof oval_entity
  */
-void oval_entity_set_datatype(struct oval_entity *, oval_datatype_t);
+OSCAP_API void oval_entity_set_datatype(struct oval_entity *, oval_datatype_t);
 /**
  * @memberof oval_entity
  */
-void oval_entity_set_mask(struct oval_entity *, int);
+OSCAP_API void oval_entity_set_mask(struct oval_entity *, int);
 /**
  * @memberof oval_entity
  */
-void oval_entity_set_varref_type(struct oval_entity *, oval_entity_varref_type_t);
+OSCAP_API void oval_entity_set_varref_type(struct oval_entity *, oval_entity_varref_type_t);
 /**
  * @memberof oval_entity
  */
-void oval_entity_set_variable(struct oval_entity *, struct oval_variable *);
+OSCAP_API void oval_entity_set_variable(struct oval_entity *, struct oval_variable *);
 /**
  * @memberof oval_entity
  */
-void oval_entity_set_value(struct oval_entity *, struct oval_value *);
+OSCAP_API void oval_entity_set_value(struct oval_entity *, struct oval_value *);
 /**
  * @memberof oval_entity
  */
-void oval_entity_set_name(struct oval_entity *, char *);
+OSCAP_API void oval_entity_set_name(struct oval_entity *, char *);
 /**
  * @memberof oval_entity
  */
-void oval_entity_set_operation(struct oval_entity *, oval_operation_t);
+OSCAP_API void oval_entity_set_operation(struct oval_entity *, oval_operation_t);
 /** @} */
 
 /**
@@ -2779,44 +2780,44 @@ void oval_entity_set_operation(struct oval_entity *, oval_operation_t);
  * @return A pointer to the name attribute of the specified @ref oval_entity.
  * @memberof oval_entity
  */
-char *oval_entity_get_name(struct oval_entity *);
+OSCAP_API char *oval_entity_get_name(struct oval_entity *);
 /**
  * Get OVAL entity type.
  * @memberof oval_entity
  */
-oval_entity_type_t oval_entity_get_type(struct oval_entity *);
+OSCAP_API oval_entity_type_t oval_entity_get_type(struct oval_entity *);
 /**
  * Get OVAL entity datatype.
  * @memberof oval_entity
  */
-oval_datatype_t oval_entity_get_datatype(struct oval_entity *);
+OSCAP_API oval_datatype_t oval_entity_get_datatype(struct oval_entity *);
 /**
  * Get OVAL entity operation type.
  * @memberof oval_entity
  */
-oval_operation_t oval_entity_get_operation(struct oval_entity *);
+OSCAP_API oval_operation_t oval_entity_get_operation(struct oval_entity *);
 /**
  * Get OVAL entity varref variable.
  * @return A pointer to the variable attribute of the specified @ref oval_entity.
  * @memberof oval_entity
  */
-struct oval_variable *oval_entity_get_variable(struct oval_entity *);
+OSCAP_API struct oval_variable *oval_entity_get_variable(struct oval_entity *);
 /**
  * Get OVAL entity value.
  * @return A pointer to the value attribute of the specified @ref oval_entity.
  * @memberof oval_entity
  */
-struct oval_value *oval_entity_get_value(struct oval_entity *);
+OSCAP_API struct oval_value *oval_entity_get_value(struct oval_entity *);
 /**
  * Get OVAL entity mask.
  * @memberof oval_entity
  */
-int oval_entity_get_mask(struct oval_entity *);
+OSCAP_API int oval_entity_get_mask(struct oval_entity *);
 /**
  * Get OVAL entity varref type.
  * @memberof oval_entity
  */
-oval_entity_varref_type_t oval_entity_get_varref_type(struct oval_entity *);
+OSCAP_API oval_entity_varref_type_t oval_entity_get_varref_type(struct oval_entity *);
 /** @} */
 
 /**
@@ -2826,15 +2827,15 @@ oval_entity_varref_type_t oval_entity_get_varref_type(struct oval_entity *);
 /**
  * @memberof oval_entity_iterator
  */
-bool oval_entity_iterator_has_more(struct oval_entity_iterator *);
+OSCAP_API bool oval_entity_iterator_has_more(struct oval_entity_iterator *);
 /**
  * @memberof oval_entity_iterator
  */
-struct oval_entity *oval_entity_iterator_next(struct oval_entity_iterator *);
+OSCAP_API struct oval_entity *oval_entity_iterator_next(struct oval_entity_iterator *);
 /**
  * @memberof oval_entity_iterator
  */
-void oval_entity_iterator_free(struct oval_entity_iterator *);
+OSCAP_API void oval_entity_iterator_free(struct oval_entity_iterator *);
 /** @} */
 
 /**
@@ -2846,15 +2847,15 @@ void oval_entity_iterator_free(struct oval_entity_iterator *);
 /**
  * @memberof oval_record_field
  */
-struct oval_record_field *oval_record_field_new(oval_record_field_type_t);
+OSCAP_API struct oval_record_field *oval_record_field_new(oval_record_field_type_t);
 /**
  * @memberof oval_record_field
  */
-struct oval_record_field *oval_record_field_clone(struct oval_record_field *);
+OSCAP_API struct oval_record_field *oval_record_field_clone(struct oval_record_field *);
 /**
  * @memberof oval_record_field
  */
-void oval_record_field_free(struct oval_record_field *);
+OSCAP_API void oval_record_field_free(struct oval_record_field *);
 
 /**
  * @name Setters
@@ -2863,35 +2864,35 @@ void oval_record_field_free(struct oval_record_field *);
 /**
  * @memberof oval_record_field
  */
-void oval_record_field_set_name(struct oval_record_field *, char *);
+OSCAP_API void oval_record_field_set_name(struct oval_record_field *, char *);
 /**
  * @memberof oval_record_field
  */
-void oval_record_field_set_value(struct oval_record_field *, char *);
+OSCAP_API void oval_record_field_set_value(struct oval_record_field *, char *);
 /**
  * @memberof oval_record_field
  */
-void oval_record_field_set_datatype(struct oval_record_field *, oval_datatype_t);
+OSCAP_API void oval_record_field_set_datatype(struct oval_record_field *, oval_datatype_t);
 /**
  * @memberof oval_record_field
  */
-void oval_record_field_set_mask(struct oval_record_field *, int);
+OSCAP_API void oval_record_field_set_mask(struct oval_record_field *, int);
 /**
  * @memberof oval_record_field
  */
-void oval_record_field_set_operation(struct oval_record_field *, oval_operation_t);
+OSCAP_API void oval_record_field_set_operation(struct oval_record_field *, oval_operation_t);
 /**
  * @memberof oval_record_field
  */
-void oval_record_field_set_variable(struct oval_record_field *, struct oval_variable *);
+OSCAP_API void oval_record_field_set_variable(struct oval_record_field *, struct oval_variable *);
 /**
  * @memberof oval_record_field
  */
-void oval_record_field_set_var_check(struct oval_record_field *, oval_check_t);
+OSCAP_API void oval_record_field_set_var_check(struct oval_record_field *, oval_check_t);
 /**
  * @memberof oval_record_field
  */
-void oval_record_field_set_ent_check(struct oval_record_field *, oval_check_t);
+OSCAP_API void oval_record_field_set_ent_check(struct oval_record_field *, oval_check_t);
 /** @} */
 
 /**
@@ -2901,39 +2902,39 @@ void oval_record_field_set_ent_check(struct oval_record_field *, oval_check_t);
 /**
  * @memberof oval_record_field
  */
-oval_record_field_type_t oval_record_field_get_type(struct oval_record_field *);
+OSCAP_API oval_record_field_type_t oval_record_field_get_type(struct oval_record_field *);
 /**
  * @memberof oval_record_field
  */
-char *oval_record_field_get_name(struct oval_record_field *);
+OSCAP_API char *oval_record_field_get_name(struct oval_record_field *);
 /**
  * @memberof oval_record_field
  */
-char *oval_record_field_get_value(struct oval_record_field *);
+OSCAP_API char *oval_record_field_get_value(struct oval_record_field *);
 /**
  * @memberof oval_record_field
  */
-oval_datatype_t oval_record_field_get_datatype(struct oval_record_field *);
+OSCAP_API oval_datatype_t oval_record_field_get_datatype(struct oval_record_field *);
 /**
  * @memberof oval_record_field
  */
-int oval_record_field_get_mask(struct oval_record_field *);
+OSCAP_API int oval_record_field_get_mask(struct oval_record_field *);
 /**
  * @memberof oval_record_field
  */
-oval_operation_t oval_record_field_get_operation(struct oval_record_field *);
+OSCAP_API oval_operation_t oval_record_field_get_operation(struct oval_record_field *);
 /**
  * @memberof oval_record_field
  */
-struct oval_variable *oval_record_field_get_variable(struct oval_record_field *);
+OSCAP_API struct oval_variable *oval_record_field_get_variable(struct oval_record_field *);
 /**
  * @memberof oval_record_field
  */
-oval_check_t oval_record_field_get_var_check(struct oval_record_field *);
+OSCAP_API oval_check_t oval_record_field_get_var_check(struct oval_record_field *);
 /**
  * @memberof oval_record_field
  */
-oval_check_t oval_record_field_get_ent_check(struct oval_record_field *);
+OSCAP_API oval_check_t oval_record_field_get_ent_check(struct oval_record_field *);
 /** @} */
 
 /**
@@ -2943,15 +2944,15 @@ oval_check_t oval_record_field_get_ent_check(struct oval_record_field *);
 /**
  * @memberof oval_record_field
  */
-bool oval_record_field_iterator_has_more(struct oval_record_field_iterator *);
+OSCAP_API bool oval_record_field_iterator_has_more(struct oval_record_field_iterator *);
 /**
  * @memberof oval_record_field
  */
-struct oval_record_field *oval_record_field_iterator_next(struct oval_record_field_iterator *);
+OSCAP_API struct oval_record_field *oval_record_field_iterator_next(struct oval_record_field_iterator *);
 /**
  * @memberof oval_record_field
  */
-void oval_record_field_iterator_free(struct oval_record_field_iterator *);
+OSCAP_API void oval_record_field_iterator_free(struct oval_record_field_iterator *);
 /** @} */
 
 /**
@@ -2963,15 +2964,15 @@ void oval_record_field_iterator_free(struct oval_record_field_iterator *);
 /**
  * @memberof oval_filter
  */
-struct oval_filter *oval_filter_new(struct oval_definition_model *);
+OSCAP_API struct oval_filter *oval_filter_new(struct oval_definition_model *);
 /**
  * @memberof oval_filter
  */
-void oval_filter_free(struct oval_filter *);
+OSCAP_API void oval_filter_free(struct oval_filter *);
 /**
  * @memberof oval_filter
  */
-struct oval_filter *oval_filter_clone(struct oval_definition_model *, struct oval_filter *);
+OSCAP_API struct oval_filter *oval_filter_clone(struct oval_definition_model *, struct oval_filter *);
 
 /**
  * @name Setters
@@ -2980,11 +2981,11 @@ struct oval_filter *oval_filter_clone(struct oval_definition_model *, struct ova
 /**
  * @memberof oval_filter
  */
-void oval_filter_set_state(struct oval_filter *, struct oval_state *);
+OSCAP_API void oval_filter_set_state(struct oval_filter *, struct oval_state *);
 /**
  * @memberof oval_filter
  */
-void oval_filter_set_filter_action(struct oval_filter *, oval_filter_action_t );
+OSCAP_API void oval_filter_set_filter_action(struct oval_filter *, oval_filter_action_t );
 /** @} */
 
 /**
@@ -2994,11 +2995,11 @@ void oval_filter_set_filter_action(struct oval_filter *, oval_filter_action_t );
 /**
  * @memberof oval_filter
  */
-struct oval_state *oval_filter_get_state(struct oval_filter *);
+OSCAP_API struct oval_state *oval_filter_get_state(struct oval_filter *);
 /**
  * @memberof oval_filter
  */
-oval_filter_action_t oval_filter_get_filter_action(struct oval_filter *);
+OSCAP_API oval_filter_action_t oval_filter_get_filter_action(struct oval_filter *);
 /** @} */
 
 /**
@@ -3008,15 +3009,15 @@ oval_filter_action_t oval_filter_get_filter_action(struct oval_filter *);
 /**
  * @memberof oval_filter
  */
-bool oval_filter_iterator_has_more(struct oval_filter_iterator *);
+OSCAP_API bool oval_filter_iterator_has_more(struct oval_filter_iterator *);
 /**
  * @memberof oval_filter
  */
-struct oval_filter *oval_filter_iterator_next(struct oval_filter_iterator *);
+OSCAP_API struct oval_filter *oval_filter_iterator_next(struct oval_filter_iterator *);
 /**
  * @memberof oval_filter
  */
-void oval_filter_iterator_free(struct oval_filter_iterator *);
+OSCAP_API void oval_filter_iterator_free(struct oval_filter_iterator *);
 /** @} */
 
 /**
@@ -3028,16 +3029,16 @@ void oval_filter_iterator_free(struct oval_filter_iterator *);
 /**
  * @memberof oval_setobject
  */
-struct oval_setobject *oval_setobject_new(struct oval_definition_model *);
+OSCAP_API struct oval_setobject *oval_setobject_new(struct oval_definition_model *);
 /**
  * @return A copy of the specified @ref oval_setobject.
  * @memberof oval_setobject
  */
-struct oval_setobject *oval_setobject_clone(struct oval_definition_model *new_model, struct oval_setobject *old_setobject);
+OSCAP_API struct oval_setobject *oval_setobject_clone(struct oval_definition_model *new_model, struct oval_setobject *old_setobject);
 /**
  * @memberof oval_setobject
  */
-void oval_setobject_free(struct oval_setobject *);
+OSCAP_API void oval_setobject_free(struct oval_setobject *);
 
 /**
  * @name Setters
@@ -3045,23 +3046,23 @@ void oval_setobject_free(struct oval_setobject *);
  */
 /**
  */
-void oval_setobject_set_type(struct oval_setobject *, oval_setobject_type_t);
+OSCAP_API void oval_setobject_set_type(struct oval_setobject *, oval_setobject_type_t);
 /**
  * @memberof oval_setobject
  */
-void oval_setobject_set_operation(struct oval_setobject *, oval_setobject_operation_t);
+OSCAP_API void oval_setobject_set_operation(struct oval_setobject *, oval_setobject_operation_t);
 /**
  * @memberof oval_setobject
  */
-void oval_setobject_add_subset(struct oval_setobject *, struct oval_setobject *);	//type==OVAL_SET_AGGREGATE;
+OSCAP_API void oval_setobject_add_subset(struct oval_setobject *, struct oval_setobject *);	//type==OVAL_SET_AGGREGATE;
 /**
  * @memberof oval_setobject
  */
-void oval_setobject_add_object(struct oval_setobject *, struct oval_object *);	//type==OVAL_SET_COLLECTIVE;
+OSCAP_API void oval_setobject_add_object(struct oval_setobject *, struct oval_object *);	//type==OVAL_SET_COLLECTIVE;
 /**
  * @memberof oval_setobject
  */
-void oval_setobject_add_filter(struct oval_setobject *, struct oval_filter *);	//type==OVAL_SET_COLLECTIVE;
+OSCAP_API void oval_setobject_add_filter(struct oval_setobject *, struct oval_filter *);	//type==OVAL_SET_COLLECTIVE;
 /** @} */
 
 /**
@@ -3072,12 +3073,12 @@ void oval_setobject_add_filter(struct oval_setobject *, struct oval_filter *);	/
  * Get OVAL set object type.
  * @memberof oval_setobject
  */
-oval_setobject_type_t oval_setobject_get_type(struct oval_setobject *);
+OSCAP_API oval_setobject_type_t oval_setobject_get_type(struct oval_setobject *);
 /**
  * Get OVAL set object operation type.
  * @memberof oval_setobject
  */
-oval_setobject_operation_t oval_setobject_get_operation(struct oval_setobject *);
+OSCAP_API oval_setobject_operation_t oval_setobject_get_operation(struct oval_setobject *);
 /**
  * Get OVAL set object subsets.
  * This works only with sets of OVAL_SET_AGGREGATE type.
@@ -3085,7 +3086,7 @@ oval_setobject_operation_t oval_setobject_get_operation(struct oval_setobject *)
  * It should be freed after use by the calling application.
  * @memberof oval_setobject
  */
-struct oval_setobject_iterator *oval_setobject_get_subsets(struct oval_setobject *);	//type==OVAL_SET_AGGREGATE;
+OSCAP_API struct oval_setobject_iterator *oval_setobject_get_subsets(struct oval_setobject *);	//type==OVAL_SET_AGGREGATE;
 /**
  * Get OVAL set object referenced objects.
  * This works only with sets of OVAL_SET_COLLECTIVE type.
@@ -3093,7 +3094,7 @@ struct oval_setobject_iterator *oval_setobject_get_subsets(struct oval_setobject
  * It should be freed after use by the calling application.
  * @memberof oval_setobject
  */
-struct oval_object_iterator *oval_setobject_get_objects(struct oval_setobject *);	//type==OVAL_SET_COLLECTIVE;
+OSCAP_API struct oval_object_iterator *oval_setobject_get_objects(struct oval_setobject *);	//type==OVAL_SET_COLLECTIVE;
 /**
  * Get OVAL set object filters.
  * This works only with sets of OVAL_SET_COLLECTIVE type.
@@ -3101,7 +3102,7 @@ struct oval_object_iterator *oval_setobject_get_objects(struct oval_setobject *)
  * It should be freed after use by the calling application.
  * @memberof oval_setobject
  */
-struct oval_filter_iterator *oval_setobject_get_filters(struct oval_setobject *);	//type==OVAL_SET_COLLECTIVE;
+OSCAP_API struct oval_filter_iterator *oval_setobject_get_filters(struct oval_setobject *);	//type==OVAL_SET_COLLECTIVE;
 /** @} */
 
 /**
@@ -3111,15 +3112,15 @@ struct oval_filter_iterator *oval_setobject_get_filters(struct oval_setobject *)
 /**
  * @memberof oval_setobject_iterator
  */
-bool oval_setobject_iterator_has_more(struct oval_setobject_iterator *);
+OSCAP_API bool oval_setobject_iterator_has_more(struct oval_setobject_iterator *);
 /**
  * @memberof oval_setobject_iterator
  */
-struct oval_setobject *oval_setobject_iterator_next(struct oval_setobject_iterator *);
+OSCAP_API struct oval_setobject *oval_setobject_iterator_next(struct oval_setobject_iterator *);
 /**
  * @memberof oval_setobject_iterator
  */
-void oval_setobject_iterator_free(struct oval_setobject_iterator *);
+OSCAP_API void oval_setobject_iterator_free(struct oval_setobject_iterator *);
 /** @} */
 
 /**
@@ -3171,7 +3172,7 @@ void oval_setobject_iterator_free(struct oval_setobject_iterator *);
  * @param type - the required component type.
  * @memberof oval_component
  */
-struct oval_component *oval_component_new(struct oval_definition_model *, oval_component_type_t type);
+OSCAP_API struct oval_component *oval_component_new(struct oval_definition_model *, oval_component_type_t type);
 /**
  * Clone instance of @ref Oval_component.
  * @return A copy of the specified @ref oval_component.
@@ -3183,7 +3184,7 @@ struct oval_component *oval_component_clone(struct oval_definition_model *new_mo
  * Free instance of @ref Oval_component
  * @memberof oval_component
  */
-void oval_component_free(struct oval_component *);
+OSCAP_API void oval_component_free(struct oval_component *);
 
 /**
  * @name Setters
@@ -3193,77 +3194,77 @@ void oval_component_free(struct oval_component *);
  * Set type of component @ref Oval_component->type
  * @memberof oval_component
  */
-void oval_component_set_type(struct oval_component *component, oval_component_type_t type);
+OSCAP_API void oval_component_set_type(struct oval_component *component, oval_component_type_t type);
 /**
  * set attribute @ref Oval_component_object->object.
  * IF component->type <> @ref OVAL_COMPONENT_OBJECTREF OR component->object <> NULL, this method does nothing .
  * @memberof oval_component
  */
-void oval_component_set_object(struct oval_component *, struct oval_object *object);
+OSCAP_API void oval_component_set_object(struct oval_component *, struct oval_object *object);
 /**
  * set attribute @ref Oval_component_object->item_field.
  * @memberof oval_component
  */
-void oval_component_set_item_field(struct oval_component *, char *);
+OSCAP_API void oval_component_set_item_field(struct oval_component *, char *);
 /**
  * set attribute @ref Oval_component_object->record_field.
  * @memberof oval_component
  */
-void oval_component_set_record_field(struct oval_component *, char *);
+OSCAP_API void oval_component_set_record_field(struct oval_component *, char *);
 /**
  * set attribute @ref Oval_component_object->variable.
  * IF component->type <> @ref OVAL_COMPONENT_OBJECTREF OR component->variable <> NULL, this method does nothing.
  * @memberof oval_component
  */
-void oval_component_set_variable(struct oval_component *, struct oval_variable *variable);
+OSCAP_API void oval_component_set_variable(struct oval_component *, struct oval_variable *variable);
 /**
  * @memberof oval_component
  */
-void oval_component_add_function_component(struct oval_component *, struct oval_component *);	//type==OVAL_COMPONENT_FUNCTION
+OSCAP_API void oval_component_add_function_component(struct oval_component *, struct oval_component *);	//type==OVAL_COMPONENT_FUNCTION
 /**
  * @memberof oval_component
  */
-void oval_component_set_arithmetic_operation(struct oval_component *, oval_arithmetic_operation_t);	//type==OVAL_COMPONENT_ARITHMETIC
+OSCAP_API void oval_component_set_arithmetic_operation(struct oval_component *, oval_arithmetic_operation_t);	//type==OVAL_COMPONENT_ARITHMETIC
 /**
  * @memberof oval_component
  */
-void oval_component_set_prefix(struct oval_component *, char *);	//type==OVAL_COMPONENT_BEGIN
+OSCAP_API void oval_component_set_prefix(struct oval_component *, char *);	//type==OVAL_COMPONENT_BEGIN
 /**
  * @memberof oval_component
  */
-void oval_component_set_suffix(struct oval_component *, char *);	//type==OVAL_COMPONENT_END
+OSCAP_API void oval_component_set_suffix(struct oval_component *, char *);	//type==OVAL_COMPONENT_END
 /**
  * @memberof oval_component
  */
-void oval_component_set_split_delimiter(struct oval_component *, char *);	//type==OVAL_COMPONENT_SPLIT
+OSCAP_API void oval_component_set_split_delimiter(struct oval_component *, char *);	//type==OVAL_COMPONENT_SPLIT
 /**
  * @memberof oval_component
  */
-void oval_component_set_glob_to_regex_glob_noescape(struct oval_component *, bool);	//type==OVAL_COMPONENT_GLOB
+OSCAP_API void oval_component_set_glob_to_regex_glob_noescape(struct oval_component *, bool);	//type==OVAL_COMPONENT_GLOB
 /**
  * @memberof oval_component
  */
-void oval_component_set_substring_start(struct oval_component *, int);	//type==OVAL_COMPONENT_SUBSTRING
+OSCAP_API void oval_component_set_substring_start(struct oval_component *, int);	//type==OVAL_COMPONENT_SUBSTRING
 /**
  * @memberof oval_component
  */
-void oval_component_set_substring_length(struct oval_component *, int);	//type==OVAL_COMPONENT_SUBSTRING
+OSCAP_API void oval_component_set_substring_length(struct oval_component *, int);	//type==OVAL_COMPONENT_SUBSTRING
 /**
  * @memberof oval_component
  */
-void oval_component_set_timedif_format_1(struct oval_component *, oval_datetime_format_t);	//type==OVAL_COMPONENT_TIMEDIF
+OSCAP_API void oval_component_set_timedif_format_1(struct oval_component *, oval_datetime_format_t);	//type==OVAL_COMPONENT_TIMEDIF
 /**
  * @memberof oval_component
  */
-void oval_component_set_timedif_format_2(struct oval_component *, oval_datetime_format_t);	//type==OVAL_COMPONENT_TIMEDIF
+OSCAP_API void oval_component_set_timedif_format_2(struct oval_component *, oval_datetime_format_t);	//type==OVAL_COMPONENT_TIMEDIF
 /**
  * @memberof oval_component
  */
-void oval_component_set_regex_pattern(struct oval_component *, char *);	//type==OVAL_COMPONENT_REGEX_CAPTURE
+OSCAP_API void oval_component_set_regex_pattern(struct oval_component *, char *);	//type==OVAL_COMPONENT_REGEX_CAPTURE
 /**
  * @memberof oval_component
  */
-void oval_component_set_literal_value(struct oval_component *, struct oval_value *);	//type==OVAL_COMPONENT_LITERAL
+OSCAP_API void oval_component_set_literal_value(struct oval_component *, struct oval_value *);	//type==OVAL_COMPONENT_LITERAL
 /** @} */
 
 /**
@@ -3274,7 +3275,7 @@ void oval_component_set_literal_value(struct oval_component *, struct oval_value
  * Returns attribute @ref Oval_component->type
  * @memberof oval_component
  */
-oval_component_type_t oval_component_get_type(struct oval_component *);
+OSCAP_API oval_component_type_t oval_component_get_type(struct oval_component *);
 /**
  * Returns attribute @ref Oval_component_object->object.
  * IF component->type <> @ref OVAL_COMPONENT_OBJECTREF, this method shall return NULL.
@@ -3282,21 +3283,21 @@ oval_component_type_t oval_component_get_type(struct oval_component *);
  * @note applications should not free the @ref Oval_object returned by this method
  * @memberof oval_component
  */
-struct oval_object *oval_component_get_object(struct oval_component *);	//type==OVAL_COMPONENT_OBJECTREF
+OSCAP_API struct oval_object *oval_component_get_object(struct oval_component *);	//type==OVAL_COMPONENT_OBJECTREF
 /**
  * Returns attribute @ref Oval_component_object->item_field.
  * @return A pointer to the item_field attribute of the specified @ref oval_component.
  * @note applications should not free the char* returned by this method
  * @memberof oval_component
  */
-char *oval_component_get_item_field(struct oval_component *);
+OSCAP_API char *oval_component_get_item_field(struct oval_component *);
 /**
  * Returns attribute @ref Oval_component_object->record_field.
  * @return A pointer to the record_field attribute of the specified @ref oval_component.
  * @note applications should not free the char* returned by this method
  * @memberof oval_component
  */
-char *oval_component_get_record_field(struct oval_component *);
+OSCAP_API char *oval_component_get_record_field(struct oval_component *);
 /**
  * Returns attribute @ref Oval_component_variable->variable.
  * IF component->type <> @ref OVAL_COMPONENT_VARREF, this method shall return NULL.
@@ -3304,7 +3305,7 @@ char *oval_component_get_record_field(struct oval_component *);
  * @note applications should not free the @ref Oval_variable returned by this method
  * @memberof oval_component
  */
-struct oval_variable *oval_component_get_variable(struct oval_component *);
+OSCAP_API struct oval_variable *oval_component_get_variable(struct oval_component *);
 /**
  * Returns attribute @ref Oval_function->components.
  * IF component->type < @ref OVAL_COMPONENT_FUNCTION, this method shall return NULL.
@@ -3312,13 +3313,13 @@ struct oval_variable *oval_component_get_variable(struct oval_component *);
  * It should be freed after use by the calling application.
  * @memberof oval_component
  */
-struct oval_component_iterator *oval_component_get_function_components(struct oval_component *);	//type==OVAL_COMPONENT_FUNCTION
+OSCAP_API struct oval_component_iterator *oval_component_get_function_components(struct oval_component *);	//type==OVAL_COMPONENT_FUNCTION
 /**
  * Returns attribute @ref Oval_function_ARITHMETIC->arithmetic_operation.
  * IF component->type <> @ref OVAL_FUNCTION_ARITHMETIC, this method shall return @ref OVAL_ARITHMETIC_UNKNOWN.
  * @memberof oval_component
  */
-oval_arithmetic_operation_t oval_component_get_arithmetic_operation(struct oval_component *);	//type==OVAL_COMPONENT_ARITHMETIC
+OSCAP_API oval_arithmetic_operation_t oval_component_get_arithmetic_operation(struct oval_component *);	//type==OVAL_COMPONENT_ARITHMETIC
 /**
  * Returns attribute @ref Oval_function_BEGIN->prefix.
  * IF component->type <> @ref OVAL_FUNCTION_BEGIN, this method shall return NULL
@@ -3326,7 +3327,7 @@ oval_arithmetic_operation_t oval_component_get_arithmetic_operation(struct oval_
  * @note applications should not free the char* returned by this method
  * @memberof oval_component
  */
-char *oval_component_get_prefix(struct oval_component *);	//type==OVAL_COMPONENT_BEGIN
+OSCAP_API char *oval_component_get_prefix(struct oval_component *);	//type==OVAL_COMPONENT_BEGIN
 /**
  * Returns attribute @ref Oval_function_END->suffix.
  * IF component->type <> @ref OVAL_FUNCTION_END, this method shall return NULL
@@ -3334,7 +3335,7 @@ char *oval_component_get_prefix(struct oval_component *);	//type==OVAL_COMPONENT
  * @note applications should not free the char* returned by this method
  * @memberof oval_component
  */
-char *oval_component_get_suffix(struct oval_component *);	//type==OVAL_COMPONENT_END
+OSCAP_API char *oval_component_get_suffix(struct oval_component *);	//type==OVAL_COMPONENT_END
 /**
  * Returns attribute @ref Oval_function_SPLIT->delimiter.
  * IF component->type <> @ref OVAL_FUNCTION_SPLIT, this method shall return NULL
@@ -3342,38 +3343,38 @@ char *oval_component_get_suffix(struct oval_component *);	//type==OVAL_COMPONENT
  * @note applications should not free the char* returned by this method
  * @memberof oval_component
  */
-char *oval_component_get_split_delimiter(struct oval_component *);	//type==OVAL_COMPONENT_SPLIT
+OSCAP_API char *oval_component_get_split_delimiter(struct oval_component *);	//type==OVAL_COMPONENT_SPLIT
 /**
  * Returns attribute @ref Oval_function_GLOB_TO_REGEX->glob_noescape.
  * IF component->type <> @ref OVAL_FUNCTION_GLOB_TO_REGEX, this method shall return false
  * @return An attribute of the specified @ref oval_component.
  * @memberof oval_component
  */
-bool oval_component_get_glob_to_regex_glob_noescape(struct oval_component *);	//type==OVAL_COMPONENT_GLOB
+OSCAP_API bool oval_component_get_glob_to_regex_glob_noescape(struct oval_component *);	//type==OVAL_COMPONENT_GLOB
 /**
  * Returns attribute @ref Oval_function_SUBSTRING->start.
  * IF component->type <> @ref OVAL_FUNCTION_SUBSTRING, this method shall return 0
  * @memberof oval_component
  */
-int oval_component_get_substring_start(struct oval_component *);	//type==OVAL_COMPONENT_SUBSTRING
+OSCAP_API int oval_component_get_substring_start(struct oval_component *);	//type==OVAL_COMPONENT_SUBSTRING
 /**
  * Returns attribute @ref Oval_function_SUBSTRING->length.
  * IF component->type <> @ref OVAL_FUNCTION_SUBSTRING, this method shall return 0
  * @memberof oval_component
  */
-int oval_component_get_substring_length(struct oval_component *);	//type==OVAL_COMPONENT_SUBSTRING
+OSCAP_API int oval_component_get_substring_length(struct oval_component *);	//type==OVAL_COMPONENT_SUBSTRING
 /**
  * Returns attribute @ref Oval_function_TIMEDIF->timedif_format_1.
  * IF component->type <> @ref OVAL_FUNCTION_TIMEDIF, this method shall return @ref OVAL_TIMEDATE_UNKNOWN
  * @memberof oval_component
  */
-oval_datetime_format_t oval_component_get_timedif_format_1(struct oval_component *);	//type==OVAL_COMPONENT_TIMEDIF
+OSCAP_API oval_datetime_format_t oval_component_get_timedif_format_1(struct oval_component *);	//type==OVAL_COMPONENT_TIMEDIF
 /**
  * Returns attribute @ref Oval_function_TIMEDIF->timedif_format_2.
  * IF component->type <> @ref OVAL_FUNCTION_TIMEDIF, this method shall return @ref OVAL_TIMEDATE_UNKNOWN
  * @memberof oval_component
  */
-oval_datetime_format_t oval_component_get_timedif_format_2(struct oval_component *);	//type==OVAL_COMPONENT_TIMEDIF
+OSCAP_API oval_datetime_format_t oval_component_get_timedif_format_2(struct oval_component *);	//type==OVAL_COMPONENT_TIMEDIF
 /**
  * Returns attribute @ref Oval_function_REGEX_CAPTURE->pattern.
  * IF component->type <> @ref OVAL_FUNCTION_REGEX_CAPTURE, this method shall return NULL
@@ -3381,7 +3382,7 @@ oval_datetime_format_t oval_component_get_timedif_format_2(struct oval_component
  * @note applications should not free the char* returned by this method
  * @memberof oval_component
  */
-char *oval_component_get_regex_pattern(struct oval_component *);	//type==OVAL_COMPONENT_REGEX_CAPTURE
+OSCAP_API char *oval_component_get_regex_pattern(struct oval_component *);	//type==OVAL_COMPONENT_REGEX_CAPTURE
 /**
  * Returns attribute @ref Oval_literal->literal.
  * IF component->type <> @ref OVAL_COMPONENT_LITERAL, this method shall return NULL
@@ -3389,7 +3390,7 @@ char *oval_component_get_regex_pattern(struct oval_component *);	//type==OVAL_CO
  * @note applications should not free the @ref Oval_value returned by this method
  * @memberof oval_component
  */
-struct oval_value *oval_component_get_literal_value(struct oval_component *);	//type==OVAL_COMPONENT_LITERAL
+OSCAP_API struct oval_value *oval_component_get_literal_value(struct oval_component *);	//type==OVAL_COMPONENT_LITERAL
 /** @} */
 
 /**
@@ -3400,23 +3401,23 @@ struct oval_value *oval_component_get_literal_value(struct oval_component *);	//
  * Return <b>true</b> if the iterator is not exhausted.
  * @memberof oval_component_iterator
  */
-bool oval_component_iterator_has_more(struct oval_component_iterator *);
+OSCAP_API bool oval_component_iterator_has_more(struct oval_component_iterator *);
 /**
  * return the next instance of @ref Oval_component.
  * If the iterator is exhausted this method shall return NULL.
  * @memberof oval_component_iterator
  */
-struct oval_component *oval_component_iterator_next(struct oval_component_iterator *);
+OSCAP_API struct oval_component *oval_component_iterator_next(struct oval_component_iterator *);
 /**
  * Free the iterator.
  * @memberof oval_component_iterator
  */
-void oval_component_iterator_free(struct oval_component_iterator *);
+OSCAP_API void oval_component_iterator_free(struct oval_component_iterator *);
 /**
  * How many remains.
  * @memberof oval_component_iterator
  */
-int oval_component_iterator_remaining(struct oval_component_iterator *);
+OSCAP_API int oval_component_iterator_remaining(struct oval_component_iterator *);
 /** @} */
 
 /**
@@ -3436,7 +3437,7 @@ int oval_component_iterator_remaining(struct oval_component_iterator *);
  * @deprecated This function has been deprecated by @ref oscap_source_get_schema_version.
  * This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(char *oval_determine_document_schema_version(const char *, oscap_document_type_t));
+OSCAP_API OSCAP_DEPRECATED(char *oval_determine_document_schema_version(const char *, oscap_document_type_t));
 
 /**
  * @} END OVAL

--- a/src/OVAL/public/oval_directives.h
+++ b/src/OVAL/public/oval_directives.h
@@ -40,6 +40,7 @@
 #include "oscap.h"
 #include "oscap_source.h"
 #include "oval_types.h"
+#include "oscap_export.h"
 
 /**
  * @typedef oval_result_directive_content_t
@@ -61,45 +62,45 @@ struct oval_directives_model;
 /**
  * @memberof oval_directives_model
  */
-struct oval_directives_model *oval_directives_model_new(void);
+OSCAP_API struct oval_directives_model *oval_directives_model_new(void);
 /**
  * @memberof oval_directives_model
  */
-void oval_directives_model_free(struct oval_directives_model *);
+OSCAP_API void oval_directives_model_free(struct oval_directives_model *);
 
 /**
  * Import the data from oscap_source to the directives model.
  * @memberof oval_directives_model
  */
-int oval_directives_model_import_source(struct oval_directives_model *model, struct oscap_source *source);
+OSCAP_API int oval_directives_model_import_source(struct oval_directives_model *model, struct oscap_source *source);
 
 /**
  * @memberof oval_directives_model
  * @deprecated This function has been deprecated and it may be dropped from later
  * OpenSCAP releases. Please use oval_directives_model_import_source instead.
  */
-OSCAP_DEPRECATED(int oval_directives_model_import(struct oval_directives_model *, char *));
+OSCAP_API OSCAP_DEPRECATED(int oval_directives_model_import(struct oval_directives_model *, char *));
 
 /**
  * @memberof oval_directives_model
  */
-struct oval_generator *oval_directives_model_get_generator(struct oval_directives_model *);
+OSCAP_API struct oval_generator *oval_directives_model_get_generator(struct oval_directives_model *);
 /**
  * @memberof oval_directives_model
  */
-struct oval_result_directives *oval_directives_model_get_defdirs(struct oval_directives_model *);
+OSCAP_API struct oval_result_directives *oval_directives_model_get_defdirs(struct oval_directives_model *);
 /**
  * @memberof oval_directives_model
  */
-struct oval_result_directives *oval_directives_model_get_classdir(struct oval_directives_model *, oval_definition_class_t);
+OSCAP_API struct oval_result_directives *oval_directives_model_get_classdir(struct oval_directives_model *, oval_definition_class_t);
 /**
  * @memberof oval_directives_model
  */
-struct oval_result_directives *oval_directives_model_get_new_classdir(struct oval_directives_model *, oval_definition_class_t);
+OSCAP_API struct oval_result_directives *oval_directives_model_get_new_classdir(struct oval_directives_model *, oval_definition_class_t);
 /**
  * @memberof oval_directives_model
  */
-int oval_directives_model_export(struct oval_directives_model *, const char *);
+OSCAP_API int oval_directives_model_export(struct oval_directives_model *, const char *);
 
 
 
@@ -112,37 +113,37 @@ struct oval_result_directives;
  * Create new OVAL Results Directives instance. Directives are setup to report FULL result by default.
  * @memberof oval_result_directives
  */
-struct oval_result_directives *oval_result_directives_new(void);
+OSCAP_API struct oval_result_directives *oval_result_directives_new(void);
 /**
  * @memberof oval_result_directives
  */
-void oval_result_directives_free(struct oval_result_directives *);
+OSCAP_API void oval_result_directives_free(struct oval_result_directives *);
 /**
  * Set (or unset) result types that are intended to be reported. Functions does not override previous settings.
  * @memberof oval_result_directives
  */
-void oval_result_directives_set_reported(struct oval_result_directives *, int flag, bool val);
+OSCAP_API void oval_result_directives_set_reported(struct oval_result_directives *, int flag, bool val);
 /**
  * Configure the depth of infomation.
  * @memberof oval_result_directives
  */
-void oval_result_directives_set_content(struct oval_result_directives *, int flag, oval_result_directive_content_t);
+OSCAP_API void oval_result_directives_set_content(struct oval_result_directives *, int flag, oval_result_directive_content_t);
 /**
  * @memberof oval_result_directives
  */
-void oval_result_directives_set_included(struct oval_result_directives *, bool);
+OSCAP_API void oval_result_directives_set_included(struct oval_result_directives *, bool);
 /**
  * @memberof oval_result_directives
  */
-bool oval_result_directives_get_reported(struct oval_result_directives *, oval_result_t);
+OSCAP_API bool oval_result_directives_get_reported(struct oval_result_directives *, oval_result_t);
 /**
  * @memberof oval_result_directives
  */
-bool oval_result_directives_get_included(struct oval_result_directives *);
+OSCAP_API bool oval_result_directives_get_included(struct oval_result_directives *);
 /**
  * @memberof oval_result_directives
  */
-oval_result_directive_content_t oval_result_directives_get_content(struct oval_result_directives *, oval_result_t);
+OSCAP_API oval_result_directive_content_t oval_result_directives_get_content(struct oval_result_directives *, oval_result_t);
 
 #endif				/* OVAL_DIRECTIVES_H_ */
 /// @}

--- a/src/OVAL/public/oval_probe.h
+++ b/src/OVAL/public/oval_probe.h
@@ -37,6 +37,7 @@
 #include "oval_definitions.h"
 #include "oval_system_characteristics.h"
 #include "oval_probe_session.h"
+#include "oscap_export.h"
 
 /*
  * probe session flags
@@ -54,14 +55,14 @@
  * @param sess probe session
  * @param out_sysinfo address of a pointer to hold the result
  */
-int oval_probe_query_sysinfo(oval_probe_session_t *sess, struct oval_sysinfo **out_sysinfo) __attribute__ ((nonnull(1, 2)));
+OSCAP_API int oval_probe_query_sysinfo(oval_probe_session_t *sess, struct oval_sysinfo **out_sysinfo) __attribute__ ((nonnull(1, 2)));
 
 /**
  * Evaluate an object
  * @param sess probe session
  * @param object the object to evaluate
  */
-int oval_probe_query_object(oval_probe_session_t *psess, struct oval_object *object, int flags, struct oval_syschar **out_syschar) __attribute__ ((nonnull(1, 2)));
+OSCAP_API int oval_probe_query_object(oval_probe_session_t *psess, struct oval_object *object, int flags, struct oval_syschar **out_syschar) __attribute__ ((nonnull(1, 2)));
 
 /**
  * Probe objects required for the evalatuation of the specified definition and update the system characteristics model associated with the session
@@ -69,7 +70,7 @@ int oval_probe_query_object(oval_probe_session_t *psess, struct oval_object *obj
  * @param id definition id
  * @return 0 on success; -1 on error; 1 warning
  */
-OSCAP_DEPRECATED(int oval_probe_query_definition(oval_probe_session_t *sess, const char *id)) __attribute__ ((nonnull(1, 2)));
+OSCAP_API OSCAP_DEPRECATED(int oval_probe_query_definition(oval_probe_session_t *sess, const char *id)) __attribute__ ((nonnull(1, 2)));
 
 /**
  * Query the specified variable and all its dependencies in order to compute the vector of its values
@@ -77,14 +78,14 @@ OSCAP_DEPRECATED(int oval_probe_query_definition(oval_probe_session_t *sess, con
  * @param variable the variable to query
  * @return 0 on success
  */
-int oval_probe_query_variable(oval_probe_session_t *sess, struct oval_variable *variable);
+OSCAP_API int oval_probe_query_variable(oval_probe_session_t *sess, struct oval_variable *variable);
 
 #define OVAL_PROBEMETA_LIST_VERBOSE 0x00000001 /**< Be verbose when listing supported probes */
 #define OVAL_PROBEMETA_LIST_DYNAMIC 0x00000002 /**< Perform additional checks when listing supported probes (i.e. list only existing external probes) */
 #define OVAL_PROBEMETA_LIST_OTYPE   0x00000004 /**< Show the otype / family type of the probe */
 
-void oval_probe_meta_list(FILE *output, int flags);
+OSCAP_API void oval_probe_meta_list(FILE *output, int flags);
 
-const char *oval_probe_ext_getdir(void);
+OSCAP_API const char *oval_probe_ext_getdir(void);
 #endif				/* OVAL_PROBE_H */
 /// @}

--- a/src/OVAL/public/oval_probe_handler.h
+++ b/src/OVAL/public/oval_probe_handler.h
@@ -31,6 +31,7 @@
 #define OVAL_PROBE_HANDLER
 
 #include "oval_definitions.h"
+#include "oscap_export.h"
 
 typedef struct oval_phtbl oval_phtbl_t;
 typedef struct oval_ph    oval_ph_t;
@@ -41,7 +42,7 @@ typedef struct oval_ph    oval_ph_t;
  * opening, evaluating, reseting and closing (whatever that means in
  * your particular case).
  */
-typedef int (oval_probe_handler_t)(oval_subtype_t, void *, int, ...);
+OSCAP_API typedef int (oval_probe_handler_t)(oval_subtype_t, void *, int, ...);
 
 #define PROBE_HANDLER_ACT_INIT  0
 #define PROBE_HANDLER_ACT_FREE  1

--- a/src/OVAL/public/oval_probe_session.h
+++ b/src/OVAL/public/oval_probe_session.h
@@ -34,18 +34,19 @@ typedef struct oval_probe_session oval_probe_session_t;
 
 #include "oval_probe_handler.h"
 #include "oval_system_characteristics.h"
+#include "oscap_export.h"
 
 /**
  * Create and initialize a new probe session
  * @param model system characteristics model
  */
-oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model);
+OSCAP_API oval_probe_session_t *oval_probe_session_new(struct oval_syschar_model *model);
 
 /**
  * Reinitialize already allocated probe session inplace
  * @param model system characteristics model
  */
-void oval_probe_session_reinit(oval_probe_session_t *sess, struct oval_syschar_model *model);
+OSCAP_API void oval_probe_session_reinit(oval_probe_session_t *sess, struct oval_syschar_model *model);
 
 /**
  * Destroy probe session. All state information created during the lifetime
@@ -53,14 +54,14 @@ void oval_probe_session_reinit(oval_probe_session_t *sess, struct oval_syschar_m
  * handler API.
  * @param sess pointer to the probe session structure
  */
-void oval_probe_session_destroy(oval_probe_session_t *sess);
+OSCAP_API void oval_probe_session_destroy(oval_probe_session_t *sess);
 
 /**
  * Send a close request to all probes. In case of external probes, the running
  * processes are shutdown - all cached results are lost.
  * @param sess pointer to the probe session structure
  */
-int oval_probe_session_close(oval_probe_session_t *sess);
+OSCAP_API int oval_probe_session_close(oval_probe_session_t *sess);
 
 /**
  * Reset the session. All state information created during the lifetime of the
@@ -68,12 +69,12 @@ int oval_probe_session_close(oval_probe_session_t *sess);
  * @param sess pointer to the probe session structure
  * @param sysch pointer to a new syschar model or NULL
  */
-int oval_probe_session_reset(oval_probe_session_t *sess, struct oval_syschar_model *sysch);
+OSCAP_API int oval_probe_session_reset(oval_probe_session_t *sess, struct oval_syschar_model *sysch);
 
 /**
  * Abort the session.
  */
-int oval_probe_session_abort(oval_probe_session_t *sess);
+OSCAP_API int oval_probe_session_abort(oval_probe_session_t *sess);
 
 /**
  * Set a new handler for an object of the specified type.
@@ -82,13 +83,13 @@ int oval_probe_session_abort(oval_probe_session_t *sess);
  * @param handler
  * @param ptr user pointer that will be passed to the handler on each invocation of the handler
  */
-int oval_probe_session_sethandler(oval_probe_session_t *sess, oval_subtype_t type, oval_probe_handler_t handler, void *ptr);
+OSCAP_API int oval_probe_session_sethandler(oval_probe_session_t *sess, oval_subtype_t type, oval_probe_handler_t handler, void *ptr);
 
 /**
  * Get system characteristics model from probe session.
  * @param sess pointer to the probe session structure
  */
-struct oval_syschar_model *oval_probe_session_getmodel(oval_probe_session_t *sess);
+OSCAP_API struct oval_syschar_model *oval_probe_session_getmodel(oval_probe_session_t *sess);
 
 #endif /* OVAL_PROBE_SESSION */
 /// @}

--- a/src/OVAL/public/oval_results.h
+++ b/src/OVAL/public/oval_results.h
@@ -49,9 +49,10 @@
 #include "oval_system_characteristics.h"
 #include "oval_directives.h"
 #include <stdbool.h>
+#include "oscap_export.h"
 
 
-const char *oval_result_get_text(oval_result_t);
+OSCAP_API const char *oval_result_get_text(oval_result_t);
 
 /**
  * @struct oval_results_model
@@ -117,7 +118,7 @@ struct oval_result_criteria_node_iterator;
  * @param syschar_model the array of specified oval_syschar_model(s) terminated by NULL.
  * @memberof oval_results_model
  */
-struct oval_results_model *oval_results_model_new(struct oval_definition_model *definition_model,
+OSCAP_API struct oval_results_model *oval_results_model_new(struct oval_definition_model *definition_model,
 						  struct oval_syschar_model **);
 
 /**
@@ -128,7 +129,7 @@ struct oval_results_model *oval_results_model_new(struct oval_definition_model *
  * @param source The oscap_source to import from
  * @return -1 if an error occurred
  */
-int oval_results_model_import_source(struct oval_results_model *model, struct oscap_source *source);
+OSCAP_API int oval_results_model_import_source(struct oval_results_model *model, struct oscap_source *source);
 
 /**
  * Import the content from the file into an oval_result_model.
@@ -140,28 +141,28 @@ int oval_results_model_import_source(struct oval_results_model *model, struct os
  * @deprecated This function has been deprecated and it may be dropped from later
  * OpenSCAP releases. Please use oval_results_model_import_source instead.
  */
-OSCAP_DEPRECATED(int oval_results_model_import(struct oval_results_model *model, const char *file));
+OSCAP_API OSCAP_DEPRECATED(int oval_results_model_import(struct oval_results_model *model, const char *file));
 /**
  * Copy an oval_results_model.
  * @return A copy of the specified @ref oval_results_model.
  * @memberof oval_results_model
  */
-struct oval_results_model *oval_results_model_clone(struct oval_results_model *);
+OSCAP_API struct oval_results_model *oval_results_model_clone(struct oval_results_model *);
 /**
  * @memberof oval_results_model
  */
-void oval_results_model_set_export_system_characteristics(struct oval_results_model *, bool export);
+OSCAP_API void oval_results_model_set_export_system_characteristics(struct oval_results_model *, bool export);
 
 /**
  * @memberof oval_results_model
  */
-bool oval_results_model_get_export_system_characteristics(struct oval_results_model *);
+OSCAP_API bool oval_results_model_get_export_system_characteristics(struct oval_results_model *);
 /**
  * Free memory allocated to a specified oval results model.
  * @param the specified oval_results model
  * @memberof oval_results_model
  */
-void oval_results_model_free(struct oval_results_model *model);
+OSCAP_API void oval_results_model_free(struct oval_results_model *model);
 /**
  * Export oval results into file.
  * @param model the oval_results_model
@@ -169,7 +170,7 @@ void oval_results_model_free(struct oval_results_model *model);
  * @param file filename
  * @memberof oval_results_model
  */
-int oval_results_model_export(struct oval_results_model *, struct oval_directives_model *, const char *file);
+OSCAP_API int oval_results_model_export(struct oval_results_model *, struct oval_directives_model *, const char *file);
 
 /**
  * Export OVAL results into oscap_source
@@ -179,40 +180,40 @@ int oval_results_model_export(struct oval_results_model *, struct oval_directive
  * This name may later be used when storing the oscap_source to disk drive.
  * @returns Newly created oscap_source or NULL in case of failure
  */
-struct oscap_source *oval_results_model_export_source(struct oval_results_model *results_model, struct oval_directives_model *directives_model, const char *name);
+OSCAP_API struct oscap_source *oval_results_model_export_source(struct oval_results_model *results_model, struct oval_directives_model *directives_model, const char *name);
 
 /**
  * @name Setters
  * @{
  */
-void oval_results_model_set_generator(struct oval_results_model *model, struct oval_generator *generator);
+OSCAP_API void oval_results_model_set_generator(struct oval_results_model *model, struct oval_generator *generator);
 /** @} */
 
 /**
  * @name Getters
  * @{
  */
-struct oval_generator *oval_results_model_get_generator(struct oval_results_model *model);
+OSCAP_API struct oval_generator *oval_results_model_get_generator(struct oval_results_model *model);
 
 /**
  * Return bound definition model from an oval_results_model.
  * @param model the specified oval_results_model.
  * @memberof oval_results_model
  */
-struct oval_definition_model *oval_results_model_get_definition_model(struct oval_results_model *model);
+OSCAP_API struct oval_definition_model *oval_results_model_get_definition_model(struct oval_results_model *model);
 
 /**
  * Return the OVAL directives model
  * @memberof oval_results_model
  */
-struct oval_directives_model *oval_results_model_get_directives_model(struct oval_results_model *model);
+OSCAP_API struct oval_directives_model *oval_results_model_get_directives_model(struct oval_results_model *model);
 
 /**
  * Return iterator over reporting systems.
  * @param model the specified results model
  * @memberof oval_results_model
  */
-struct oval_result_system_iterator *oval_results_model_get_systems(struct oval_results_model *);
+OSCAP_API struct oval_result_system_iterator *oval_results_model_get_systems(struct oval_results_model *);
 /** @} */
 
 /**
@@ -224,7 +225,7 @@ struct oval_result_system_iterator *oval_results_model_get_systems(struct oval_r
  * characteristics for evaluation were altready gathered. 
  * @return 0 on sucess and -1 on fail. Use \ref ERRORS mechanism to examine the error.
  */
-int oval_results_model_eval(struct oval_results_model *);
+OSCAP_API int oval_results_model_eval(struct oval_results_model *);
 /** @} */
 
 
@@ -235,7 +236,7 @@ int oval_results_model_eval(struct oval_results_model *);
 /**
  * @memberof oval_result_system
  */
-struct oval_result_system *oval_result_system_new(struct oval_results_model *, struct oval_syschar_model *);
+OSCAP_API struct oval_result_system *oval_result_system_new(struct oval_results_model *, struct oval_syschar_model *);
 /**
  * @return A copy of the specified @ref oval_result_system.
  * @memberof oval_result_system
@@ -245,7 +246,7 @@ struct oval_result_system *oval_result_system_clone(struct oval_results_model *n
 /**
  * @memberof oval_result_system
  */
-void oval_result_system_free(struct oval_result_system *);
+OSCAP_API void oval_result_system_free(struct oval_result_system *);
 
 /**
  * @name Setters
@@ -254,11 +255,11 @@ void oval_result_system_free(struct oval_result_system *);
 /**
  * @memberof oval_result_system
  */
-void oval_result_system_add_definition(struct oval_result_system *, struct oval_result_definition *);
+OSCAP_API void oval_result_system_add_definition(struct oval_result_system *, struct oval_result_definition *);
 /**
  * @memberof oval_result_system
  */
-void oval_result_system_add_test(struct oval_result_system *, struct oval_result_test *);
+OSCAP_API void oval_result_system_add_test(struct oval_result_system *, struct oval_result_test *);
 /** @} */
 
 /**
@@ -268,27 +269,27 @@ void oval_result_system_add_test(struct oval_result_system *, struct oval_result
 /**
  * @memberof oval_result_system
  */
-struct oval_results_model *oval_result_system_get_results_model(struct oval_result_system *);
+OSCAP_API struct oval_results_model *oval_result_system_get_results_model(struct oval_result_system *);
 /**
  * @memberof oval_result_system
  */
-struct oval_result_definition *oval_result_system_get_definition(struct oval_result_system *, const char *);
+OSCAP_API struct oval_result_definition *oval_result_system_get_definition(struct oval_result_system *, const char *);
 /**
  * @memberof oval_result_system
  */
-struct oval_result_definition_iterator *oval_result_system_get_definitions(struct oval_result_system *);
+OSCAP_API struct oval_result_definition_iterator *oval_result_system_get_definitions(struct oval_result_system *);
 /**
  * @memberof oval_result_system
  */
-struct oval_result_test_iterator *oval_result_system_get_tests(struct oval_result_system *);
+OSCAP_API struct oval_result_test_iterator *oval_result_system_get_tests(struct oval_result_system *);
 /**
  * @memberof oval_result_system
  */
-struct oval_syschar_model *oval_result_system_get_syschar_model(struct oval_result_system *);
+OSCAP_API struct oval_syschar_model *oval_result_system_get_syschar_model(struct oval_result_system *);
 /**
  * @memberof oval_result_system
  */
-struct oval_sysinfo *oval_result_system_get_sysinfo(struct oval_result_system *);
+OSCAP_API struct oval_sysinfo *oval_result_system_get_sysinfo(struct oval_result_system *);
 /** @} */
 
 /**
@@ -298,15 +299,15 @@ struct oval_sysinfo *oval_result_system_get_sysinfo(struct oval_result_system *)
 /**
  * @memberof oval_result_system_iterator
  */
-bool oval_result_system_iterator_has_more(struct oval_result_system_iterator *);
+OSCAP_API bool oval_result_system_iterator_has_more(struct oval_result_system_iterator *);
 /**
  * @memberof oval_result_system_iterator
  */
-struct oval_result_system *oval_result_system_iterator_next(struct oval_result_system_iterator *);
+OSCAP_API struct oval_result_system *oval_result_system_iterator_next(struct oval_result_system_iterator *);
 /**
  * @memberof oval_result_system_iterator
  */
-void oval_result_system_iterator_free(struct oval_result_system_iterator *);
+OSCAP_API void oval_result_system_iterator_free(struct oval_result_system_iterator *);
 /** @} */
 
 /**
@@ -320,7 +321,7 @@ void oval_result_system_iterator_free(struct oval_result_system_iterator *);
  * @param sys is result_system from result_model
  * @return 0 on sucess and -1 on fail. Use \ref ERRORS mechanism to examine the error.
  */
-int oval_result_system_eval(struct oval_result_system *sys);
+OSCAP_API int oval_result_system_eval(struct oval_result_system *sys);
 /**
  * Function evaluates specified OVAL definition in result_system. It assumes that all necessary system 
  * characteristics for evaluation were altready gathered.
@@ -329,7 +330,7 @@ int oval_result_system_eval(struct oval_result_system *sys);
  * @param id of the definition from definition_model from result_model
  * @return 0 on succeess, or non 0 if an error occurred. Use \ref ERRORS mechanism to examine the error.
  */
-int oval_result_system_eval_definition(struct oval_result_system *sys, const char *id);
+OSCAP_API int oval_result_system_eval_definition(struct oval_result_system *sys, const char *id);
 /** @} */
 
 
@@ -340,17 +341,17 @@ int oval_result_system_eval_definition(struct oval_result_system *sys, const cha
 /**
  * @memberof oval_result_definition
  */
-struct oval_result_definition *oval_result_definition_new(struct oval_result_system *, char *);
+OSCAP_API struct oval_result_definition *oval_result_definition_new(struct oval_result_system *, char *);
 /**
  * @return A copy of the specified @ref oval_result_definition.
  * @memberof oval_result_definition
  */
-struct oval_result_definition *oval_result_definition_clone
-    (struct oval_result_system *new_system, struct oval_result_definition *old_definition);
+OSCAP_API struct oval_result_definition *oval_result_definition_clone
+     (struct oval_result_system *new_system, struct oval_result_definition *old_definition);
 /**
  * @memberof oval_result_definition
  */
-void oval_result_definition_free(struct oval_result_definition *);
+OSCAP_API void oval_result_definition_free(struct oval_result_definition *);
 
 /**
  * @name Setters
@@ -359,19 +360,19 @@ void oval_result_definition_free(struct oval_result_definition *);
 /**
  * @memberof oval_result_definition
  */
-void oval_result_definition_set_result(struct oval_result_definition *, oval_result_t);
+OSCAP_API void oval_result_definition_set_result(struct oval_result_definition *, oval_result_t);
 /**
  * @memberof oval_result_definition
  */
-void oval_result_definition_set_instance(struct oval_result_definition *, int);
+OSCAP_API void oval_result_definition_set_instance(struct oval_result_definition *, int);
 /**
  * @memberof oval_result_definition
  */
-void oval_result_definition_set_criteria(struct oval_result_definition *, struct oval_result_criteria_node *);
+OSCAP_API void oval_result_definition_set_criteria(struct oval_result_definition *, struct oval_result_criteria_node *);
 /**
  * @memberof oval_result_definition
  */
-void oval_result_definition_add_message(struct oval_result_definition *, struct oval_message *);
+OSCAP_API void oval_result_definition_add_message(struct oval_result_definition *, struct oval_message *);
 /** @} */
 
 /**
@@ -381,36 +382,36 @@ void oval_result_definition_add_message(struct oval_result_definition *, struct 
 /**
  * @memberof oval_result_definition
  */
-struct oval_definition *oval_result_definition_get_definition(const struct oval_result_definition *);
+OSCAP_API struct oval_definition *oval_result_definition_get_definition(const struct oval_result_definition *);
 /**
  * Returns the @idref attribute of a given result definition
  * @memberof oval_result_definition
  */
-const char *oval_result_definition_get_id(const struct oval_result_definition *rslt_definition);
+OSCAP_API const char *oval_result_definition_get_id(const struct oval_result_definition *rslt_definition);
 /**
  * @memberof oval_result_definition
  */
-struct oval_result_system *oval_result_definition_get_system(const struct oval_result_definition *);
+OSCAP_API struct oval_result_system *oval_result_definition_get_system(const struct oval_result_definition *);
 /**
  * @memberof oval_result_definition
  */
-int oval_result_definition_get_instance(const struct oval_result_definition *);
+OSCAP_API int oval_result_definition_get_instance(const struct oval_result_definition *);
 /**
  * @memberof oval_result_definition
  */
-oval_result_t oval_result_definition_eval(struct oval_result_definition *);
+OSCAP_API oval_result_t oval_result_definition_eval(struct oval_result_definition *);
 /**
  * @memberof oval_result_definition
  */
-oval_result_t oval_result_definition_get_result(const struct oval_result_definition *);
+OSCAP_API oval_result_t oval_result_definition_get_result(const struct oval_result_definition *);
 /**
  * @memberof oval_result_definition
  */
-struct oval_message_iterator *oval_result_definition_get_messages(const struct oval_result_definition *);
+OSCAP_API struct oval_message_iterator *oval_result_definition_get_messages(const struct oval_result_definition *);
 /**
  * @memberof oval_result_definition
  */
-struct oval_result_criteria_node *oval_result_definition_get_criteria(const struct oval_result_definition *);
+OSCAP_API struct oval_result_criteria_node *oval_result_definition_get_criteria(const struct oval_result_definition *);
 /** @} */
 
 /**
@@ -420,15 +421,15 @@ struct oval_result_criteria_node *oval_result_definition_get_criteria(const stru
 /**
  * @memberof oval_result_definition_iterator
  */
-bool oval_result_definition_iterator_has_more(struct oval_result_definition_iterator *);
+OSCAP_API bool oval_result_definition_iterator_has_more(struct oval_result_definition_iterator *);
 /**
  * @memberof oval_result_definition_iterator
  */
-struct oval_result_definition *oval_result_definition_iterator_next(struct oval_result_definition_iterator *);
+OSCAP_API struct oval_result_definition *oval_result_definition_iterator_next(struct oval_result_definition_iterator *);
 /**
  * @memberof oval_result_definition_iterator
  */
-void oval_result_definition_iterator_free(struct oval_result_definition_iterator *);
+OSCAP_API void oval_result_definition_iterator_free(struct oval_result_definition_iterator *);
 /** @} */
 
 /**
@@ -445,17 +446,17 @@ void oval_result_definition_iterator_free(struct oval_result_definition_iterator
 /**
  * @memberof oval_result_test
  */
-struct oval_result_test *oval_result_test_new(struct oval_result_system *, char *);
+OSCAP_API struct oval_result_test *oval_result_test_new(struct oval_result_system *, char *);
 /**
  * @return A copy of the specified @ref oval_result_test.
  * @memberof oval_result_test
  */
-struct oval_result_test *oval_result_test_clone
-    (struct oval_result_system *new_system, struct oval_result_test *old_test);
+OSCAP_API struct oval_result_test *oval_result_test_clone
+     (struct oval_result_system *new_system, struct oval_result_test *old_test);
 /**
  * @memberof oval_result_test
  */
-void oval_result_test_free(struct oval_result_test *);
+OSCAP_API void oval_result_test_free(struct oval_result_test *);
 
 /**
  * @name Setters
@@ -464,23 +465,23 @@ void oval_result_test_free(struct oval_result_test *);
 /**
  * @memberof oval_result_test
  */
-void oval_result_test_set_result(struct oval_result_test *, oval_result_t);
+OSCAP_API void oval_result_test_set_result(struct oval_result_test *, oval_result_t);
 /**
  * @memberof oval_result_test
  */
-void oval_result_test_set_instance(struct oval_result_test *test, int instance);
+OSCAP_API void oval_result_test_set_instance(struct oval_result_test *test, int instance);
 /**
  * @memberof oval_result_test
  */
-void oval_result_test_add_message(struct oval_result_test *, struct oval_message *);
+OSCAP_API void oval_result_test_add_message(struct oval_result_test *, struct oval_message *);
 /**
  * @memberof oval_result_test
  */
-void oval_result_test_add_item(struct oval_result_test *, struct oval_result_item *);
+OSCAP_API void oval_result_test_add_item(struct oval_result_test *, struct oval_result_item *);
 /**
  * @memberof oval_result_test
  */
-void oval_result_test_add_binding(struct oval_result_test *, struct oval_variable_binding *);
+OSCAP_API void oval_result_test_add_binding(struct oval_result_test *, struct oval_variable_binding *);
 /** @} */
 
 /**
@@ -490,35 +491,35 @@ void oval_result_test_add_binding(struct oval_result_test *, struct oval_variabl
 /**
  * @memberof oval_result_test
  */
-struct oval_test *oval_result_test_get_test(struct oval_result_test *);
+OSCAP_API struct oval_test *oval_result_test_get_test(struct oval_result_test *);
 /**
  * @memberof oval_result_test
  */
-struct oval_result_system *oval_result_test_get_system(struct oval_result_test *);
+OSCAP_API struct oval_result_system *oval_result_test_get_system(struct oval_result_test *);
 /**
  * @memberof oval_result_test
  */
-oval_result_t oval_result_test_eval(struct oval_result_test *);
+OSCAP_API oval_result_t oval_result_test_eval(struct oval_result_test *);
 /**
  * @memberof oval_result_test
  */
-oval_result_t oval_result_test_get_result(struct oval_result_test *);
+OSCAP_API oval_result_t oval_result_test_get_result(struct oval_result_test *);
 /**
  * @memberof oval_result_test
  */
-int oval_result_test_get_instance(struct oval_result_test *);
+OSCAP_API int oval_result_test_get_instance(struct oval_result_test *);
 /**
  * @memberof oval_result_test
  */
-struct oval_message_iterator *oval_result_test_get_messages(struct oval_result_test *);
+OSCAP_API struct oval_message_iterator *oval_result_test_get_messages(struct oval_result_test *);
 /**
  * @memberof oval_result_test
  */
-struct oval_result_item_iterator *oval_result_test_get_items(struct oval_result_test *);
+OSCAP_API struct oval_result_item_iterator *oval_result_test_get_items(struct oval_result_test *);
 /**
  * @memberof oval_result_test
  */
-struct oval_variable_binding_iterator *oval_result_test_get_bindings(struct oval_result_test *);
+OSCAP_API struct oval_variable_binding_iterator *oval_result_test_get_bindings(struct oval_result_test *);
 /** @} */
 
 /**
@@ -528,15 +529,15 @@ struct oval_variable_binding_iterator *oval_result_test_get_bindings(struct oval
 /**
  * @memberof oval_result_test_iterator
  */
-bool oval_result_test_iterator_has_more(struct oval_result_test_iterator *);
+OSCAP_API bool oval_result_test_iterator_has_more(struct oval_result_test_iterator *);
 /**
  * @memberof oval_result_test_iterator
  */
-struct oval_result_test *oval_result_test_iterator_next(struct oval_result_test_iterator *);
+OSCAP_API struct oval_result_test *oval_result_test_iterator_next(struct oval_result_test_iterator *);
 /**
  * @memberof oval_result_test_iterator
  */
-void oval_result_test_iterator_free(struct oval_result_test_iterator *);
+OSCAP_API void oval_result_test_iterator_free(struct oval_result_test_iterator *);
 /** @} */
 
 /**
@@ -553,17 +554,17 @@ void oval_result_test_iterator_free(struct oval_result_test_iterator *);
 /**
  * @memberof oval_result_item
  */
-struct oval_result_item *oval_result_item_new(struct oval_result_system *, char *);
+OSCAP_API struct oval_result_item *oval_result_item_new(struct oval_result_system *, char *);
 /**
  * @return A copy of the specified @ref oval_result_item.
  * @memberof oval_result_item
  */
-struct oval_result_item *oval_result_item_clone
-    (struct oval_result_system *new_system, struct oval_result_item *old_item);
+OSCAP_API struct oval_result_item *oval_result_item_clone
+     (struct oval_result_system *new_system, struct oval_result_item *old_item);
 /**
  * @memberof oval_result_item
  */
-void oval_result_item_free(struct oval_result_item *);
+OSCAP_API void oval_result_item_free(struct oval_result_item *);
 
 /**
  * @name Setters
@@ -572,11 +573,11 @@ void oval_result_item_free(struct oval_result_item *);
 /**
  * @memberof oval_result_item
  */
-void oval_result_item_set_result(struct oval_result_item *, oval_result_t);
+OSCAP_API void oval_result_item_set_result(struct oval_result_item *, oval_result_t);
 /**
  * @memberof oval_result_item
  */
-void oval_result_item_add_message(struct oval_result_item *, struct oval_message *);
+OSCAP_API void oval_result_item_add_message(struct oval_result_item *, struct oval_message *);
 /** @} */
 
 /**
@@ -586,15 +587,15 @@ void oval_result_item_add_message(struct oval_result_item *, struct oval_message
 /**
  * @memberof oval_result_item
  */
-struct oval_sysitem *oval_result_item_get_sysitem(struct oval_result_item *);
+OSCAP_API struct oval_sysitem *oval_result_item_get_sysitem(struct oval_result_item *);
 /**
  * @memberof oval_result_item
  */
-oval_result_t oval_result_item_get_result(struct oval_result_item *);
+OSCAP_API oval_result_t oval_result_item_get_result(struct oval_result_item *);
 /**
  * @memberof oval_result_item
  */
-struct oval_message_iterator *oval_result_item_get_messages(struct oval_result_item *);
+OSCAP_API struct oval_message_iterator *oval_result_item_get_messages(struct oval_result_item *);
 /** @} */
 
 /**
@@ -604,15 +605,15 @@ struct oval_message_iterator *oval_result_item_get_messages(struct oval_result_i
 /**
  * @memberof oval_result_item_iterator
  */
-bool oval_result_item_iterator_has_more(struct oval_result_item_iterator *);
+OSCAP_API bool oval_result_item_iterator_has_more(struct oval_result_item_iterator *);
 /**
  * @memberof oval_result_item_iterator
  */
-struct oval_result_item *oval_result_item_iterator_next(struct oval_result_item_iterator *);
+OSCAP_API struct oval_result_item *oval_result_item_iterator_next(struct oval_result_item_iterator *);
 /**
  * @memberof oval_result_item_iterator
  */
-void oval_result_item_iterator_free(struct oval_result_item_iterator *);
+OSCAP_API void oval_result_item_iterator_free(struct oval_result_item_iterator *);
 /** @} */
 
 /**
@@ -636,12 +637,12 @@ struct oval_result_criteria_node *oval_result_criteria_node_new(struct oval_resu
  * @return A copy of the specified @ref oval_result_criteria_node.
  * @memberof oval_result_criteria_node
  */
-struct oval_result_criteria_node *oval_result_criteria_node_clone
-    (struct oval_result_system *new_system, struct oval_result_criteria_node *old_node);
+OSCAP_API struct oval_result_criteria_node *oval_result_criteria_node_clone
+     (struct oval_result_system *new_system, struct oval_result_criteria_node *old_node);
 /**
  * @memberof oval_result_criteria_node
  */
-void oval_result_criteria_node_free(struct oval_result_criteria_node *);
+OSCAP_API void oval_result_criteria_node_free(struct oval_result_criteria_node *);
 
 /**
  * @name Setters
@@ -650,31 +651,31 @@ void oval_result_criteria_node_free(struct oval_result_criteria_node *);
 /**
  * @memberof oval_result_criteria_node
  */
-void oval_result_criteria_node_set_result(struct oval_result_criteria_node *, oval_result_t);
+OSCAP_API void oval_result_criteria_node_set_result(struct oval_result_criteria_node *, oval_result_t);
 /**
  * @memberof oval_result_criteria_node
  */
-void oval_result_criteria_node_set_negate(struct oval_result_criteria_node *, bool);
+OSCAP_API void oval_result_criteria_node_set_negate(struct oval_result_criteria_node *, bool);
 /**
  * @memberof oval_result_criteria_node
  */
-void oval_result_criteria_node_set_applicability_check(struct oval_result_criteria_node *, bool);
+OSCAP_API void oval_result_criteria_node_set_applicability_check(struct oval_result_criteria_node *, bool);
 /**
  * @memberof oval_result_criteria_node
  */
-void oval_result_criteria_node_set_operator(struct oval_result_criteria_node *, oval_operator_t);	//type==NODETYPE_CRITERIA
+OSCAP_API void oval_result_criteria_node_set_operator(struct oval_result_criteria_node *, oval_operator_t);	//type==NODETYPE_CRITERIA
 /**
  * @memberof oval_result_criteria_node
  */
-void oval_result_criteria_node_add_subnode(struct oval_result_criteria_node *, struct oval_result_criteria_node *);	//type==NODETYPE_CRITERIA
+OSCAP_API void oval_result_criteria_node_add_subnode(struct oval_result_criteria_node *, struct oval_result_criteria_node *);	//type==NODETYPE_CRITERIA
 /**
  * @memberof oval_result_criteria_node
  */
-void oval_result_criteria_node_set_test(struct oval_result_criteria_node *, struct oval_result_test *);	//type==NODETYPE_CRITERION
+OSCAP_API void oval_result_criteria_node_set_test(struct oval_result_criteria_node *, struct oval_result_test *);	//type==NODETYPE_CRITERION
 /**
  * @memberof oval_result_criteria_node
  */
-void oval_result_criteria_node_set_extends(struct oval_result_criteria_node *, struct oval_result_definition *);	//type==NODETYPE_EXTENDDEF
+OSCAP_API void oval_result_criteria_node_set_extends(struct oval_result_criteria_node *, struct oval_result_definition *);	//type==NODETYPE_EXTENDDEF
 /** @} */
 
 /**
@@ -683,39 +684,39 @@ void oval_result_criteria_node_set_extends(struct oval_result_criteria_node *, s
  */
 /**
  */
-oval_criteria_node_type_t oval_result_criteria_node_get_type(struct oval_result_criteria_node *);
+OSCAP_API oval_criteria_node_type_t oval_result_criteria_node_get_type(struct oval_result_criteria_node *);
 /**
  * @memberof oval_result_criteria_node
  */
-oval_result_t oval_result_criteria_node_eval(struct oval_result_criteria_node *);
+OSCAP_API oval_result_t oval_result_criteria_node_eval(struct oval_result_criteria_node *);
 /**
  * @memberof oval_result_criteria_node
  */
-oval_result_t oval_result_criteria_node_get_result(struct oval_result_criteria_node *);
+OSCAP_API oval_result_t oval_result_criteria_node_get_result(struct oval_result_criteria_node *);
 /**
  * @memberof oval_result_criteria_node
  */
-bool oval_result_criteria_node_get_negate(struct oval_result_criteria_node *);
+OSCAP_API bool oval_result_criteria_node_get_negate(struct oval_result_criteria_node *);
 /**
  * @memberof oval_result_criteria_node
  */
-bool oval_result_criteria_node_get_applicability_check(struct oval_result_criteria_node *);
+OSCAP_API bool oval_result_criteria_node_get_applicability_check(struct oval_result_criteria_node *);
 /**
  * @memberof oval_result_criteria_node
  */
-oval_operator_t oval_result_criteria_node_get_operator(struct oval_result_criteria_node *);	//type==NODETYPE_CRITERIA
+OSCAP_API oval_operator_t oval_result_criteria_node_get_operator(struct oval_result_criteria_node *);	//type==NODETYPE_CRITERIA
 /**
  * @memberof oval_result_criteria_node
  */
-struct oval_result_criteria_node_iterator *oval_result_criteria_node_get_subnodes(struct oval_result_criteria_node *);	//type==NODETYPE_CRITERIA
+OSCAP_API struct oval_result_criteria_node_iterator *oval_result_criteria_node_get_subnodes(struct oval_result_criteria_node *);	//type==NODETYPE_CRITERIA
 /**
  * @memberof oval_result_criteria_node
  */
-struct oval_result_test *oval_result_criteria_node_get_test(struct oval_result_criteria_node *);	//type==NODETYPE_CRITERION
+OSCAP_API struct oval_result_test *oval_result_criteria_node_get_test(struct oval_result_criteria_node *);	//type==NODETYPE_CRITERION
 /**
  * @memberof oval_result_criteria_node
  */
-struct oval_result_definition *oval_result_criteria_node_get_extends(struct oval_result_criteria_node *);	//type==NODETYPE_EXTENDDEF
+OSCAP_API struct oval_result_definition *oval_result_criteria_node_get_extends(struct oval_result_criteria_node *);	//type==NODETYPE_EXTENDDEF
 /** @} */
 
 /**
@@ -725,15 +726,15 @@ struct oval_result_definition *oval_result_criteria_node_get_extends(struct oval
 /**
  * @memberof oval_result_criteria_node_iterator
  */
-bool oval_result_criteria_node_iterator_has_more(struct oval_result_criteria_node_iterator *);
+OSCAP_API bool oval_result_criteria_node_iterator_has_more(struct oval_result_criteria_node_iterator *);
 /**
  * @memberof oval_result_criteria_node_iterator
  */
-struct oval_result_criteria_node *oval_result_criteria_node_iterator_next(struct oval_result_criteria_node_iterator *);
+OSCAP_API struct oval_result_criteria_node *oval_result_criteria_node_iterator_next(struct oval_result_criteria_node_iterator *);
 /**
  * @memberof oval_result_criteria_node_iterator
  */
-void oval_result_criteria_node_iterator_free(struct oval_result_criteria_node_iterator *);
+OSCAP_API void oval_result_criteria_node_iterator_free(struct oval_result_criteria_node_iterator *);
 /** @} */
 
 /**

--- a/src/OVAL/public/oval_schema_version.h
+++ b/src/OVAL/public/oval_schema_version.h
@@ -23,6 +23,8 @@
 #ifndef OVAL_SCHEMA_VERSION_H
 #define OVAL_SCHEMA_VERSION_H
 
+#include "oscap_export.h"
+
 enum oval_schema_version_components {
 	OVAL_SCHEMA_VERSION_CORE_MAJOR = 0,
 	OVAL_SCHEMA_VERSION_CORE_MINOR,
@@ -45,7 +47,7 @@ typedef struct {
  * @param ver_str OVAL version as string
  * @return internal representation of OVAL schema version
  */
-oval_schema_version_t oval_schema_version_from_cstr(const char *ver_str);
+OSCAP_API oval_schema_version_t oval_schema_version_from_cstr(const char *ver_str);
 
 /**
  * Converts OVAL schema version from an internal representation to a string.
@@ -55,7 +57,7 @@ oval_schema_version_t oval_schema_version_from_cstr(const char *ver_str);
  * This function should have been declared to return non-const char*.
  * You need to free the result despite it being declared as const char*.
  */
-const char *oval_schema_version_to_cstr(oval_schema_version_t version);
+OSCAP_API const char *oval_schema_version_to_cstr(oval_schema_version_t version);
 
 /**
  * Compare two versions in the internal representation
@@ -64,6 +66,6 @@ const char *oval_schema_version_to_cstr(oval_schema_version_t version);
  *  <0 ... if 'v1' is older than 'v2'
  *  >0 ... if 'v1' is newer than 'v2'
  */
-int oval_schema_version_cmp(oval_schema_version_t v1, oval_schema_version_t v2);
+OSCAP_API int oval_schema_version_cmp(oval_schema_version_t v1, oval_schema_version_t v2);
 
 #endif

--- a/src/OVAL/public/oval_session.h
+++ b/src/OVAL/public/oval_session.h
@@ -37,6 +37,7 @@
 #ifndef OVAL_SESSION_H_
 #define OVAL_SESSION_H_
 #include "oscap_download_cb.h"
+#include "oscap_export.h"
 
 /**
  * @struct oval_session
@@ -55,7 +56,7 @@ struct oval_session;
  * @retval NULL in case of an error (use \ref oscap_err_desc or \ref
  * oscap_err_get_full_error to get more details)
  */
-struct oval_session *oval_session_new(const char *filename);
+OSCAP_API struct oval_session *oval_session_new(const char *filename);
 
 /**
  * Set OVAL Variables.
@@ -69,7 +70,7 @@ struct oval_session *oval_session_new(const char *filename);
  * @param session an \ref oval_session
  * @param filename a path to an OVAL Variables file
  */
-void oval_session_set_variables(struct oval_session *session, const char *filename);
+OSCAP_API void oval_session_set_variables(struct oval_session *session, const char *filename);
 
 /**
  * Set OVAL Directives
@@ -83,7 +84,7 @@ void oval_session_set_variables(struct oval_session *session, const char *filena
  * @param session an \ref oval_session
  * @param filename a path to an OVAL Directives file
  */
-void oval_session_set_directives(struct oval_session *session, const char *filename);
+OSCAP_API void oval_session_set_directives(struct oval_session *session, const char *filename);
 
 /**
  * Set XSD validation level.
@@ -93,7 +94,7 @@ void oval_session_set_directives(struct oval_session *session, const char *filen
  * @param validate false value indicates to skip any XSD validation
  * @param full_validation true value indicates that every possible step will be validated by XSD
  */
-void oval_session_set_validation(struct oval_session *session, bool validate, bool full_validation);
+OSCAP_API void oval_session_set_validation(struct oval_session *session, bool validate, bool full_validation);
 
 /**
  * Set ID of a specific OVAL Definition in an source datastream.
@@ -105,7 +106,7 @@ void oval_session_set_validation(struct oval_session *session, bool validate, bo
  * @param session an \ref oval_session
  * @param id an id of a definition
  */
-void oval_session_set_datastream_id(struct oval_session *session, const char *id);
+OSCAP_API void oval_session_set_datastream_id(struct oval_session *session, const char *id);
 
 /**
  * Set ID of a particular OVAL component if there are two OVALs in one
@@ -116,7 +117,7 @@ void oval_session_set_datastream_id(struct oval_session *session, const char *id
  * @param session an \ref oval_session
  * @param id an id of a definition
  */
-void oval_session_set_component_id(struct oval_session *session, const char *id);
+OSCAP_API void oval_session_set_component_id(struct oval_session *session, const char *id);
 
 /**
  * Set a name of the file that the the OVAL Results will be written into. If the
@@ -127,7 +128,7 @@ void oval_session_set_component_id(struct oval_session *session, const char *id)
  * @param session an \ref oval_session
  * @param filename a path to a new file
  */
-void oval_session_set_results_export(struct oval_session *session, const char *filename);
+OSCAP_API void oval_session_set_results_export(struct oval_session *session, const char *filename);
 
 /**
  * Set a name of the file that the the OVAL Results, converted to HTML format,
@@ -138,7 +139,7 @@ void oval_session_set_results_export(struct oval_session *session, const char *f
  * @param session an \ref oval_session
  * @param filename a path to a new file
  */
-void oval_session_set_report_export(struct oval_session *session, const char *filename);
+OSCAP_API void oval_session_set_report_export(struct oval_session *session, const char *filename);
 
 /**
  * Set XML validation reporter.
@@ -150,7 +151,7 @@ void oval_session_set_report_export(struct oval_session *session, const char *fi
  * @param session an \ref oval_session
  * @param fn pointer to XML reporter function
  */
-void oval_session_set_xml_reporter(struct oval_session *session, xml_reporter fn);
+OSCAP_API void oval_session_set_xml_reporter(struct oval_session *session, xml_reporter fn);
 
 /**
  * Load OVAL Definitions and bind OVAL Variables to it if provided. Validation
@@ -165,7 +166,7 @@ void oval_session_set_xml_reporter(struct oval_session *session, xml_reporter fn
  * @retval 1 on an internal error (use \ref oscap_err_desc or \ref
  * oscap_err_get_full_error to get more details)
  */
-int oval_session_load(struct oval_session *session);
+OSCAP_API int oval_session_load(struct oval_session *session);
 
 /**
  * Evaluate a specific OVAL Definition. The result of the evaluation will be
@@ -182,7 +183,7 @@ int oval_session_load(struct oval_session *session);
  * @retval 1 on an internal error (use \ref oscap_err_desc or \ref
  * oscap_err_get_full_error to get more details)
  */
-int oval_session_evaluate_id(struct oval_session *session, char *probe_root, const char *id, oval_result_t *result);
+OSCAP_API int oval_session_evaluate_id(struct oval_session *session, char *probe_root, const char *id, oval_result_t *result);
 
 /**
  * Evaluate OVAL Definitions. Optionally you can set a callback function which
@@ -201,7 +202,7 @@ int oval_session_evaluate_id(struct oval_session *session, char *probe_root, con
  * @retval 1 on an internal error (use \ref oscap_err_desc or \ref
  * oscap_err_get_full_error to get more details)
  */
-int oval_session_evaluate(struct oval_session *session, char *probe_root, agent_reporter fn, void *arg);
+OSCAP_API int oval_session_evaluate(struct oval_session *session, char *probe_root, agent_reporter fn, void *arg);
 
 /**
  * Export result to a file. Results can be represented as OVAL System
@@ -220,7 +221,7 @@ int oval_session_evaluate(struct oval_session *session, char *probe_root, agent_
  * @retval 1 on an internal error (use \ref oscap_err_desc or \ref
  * oscap_err_get_full_error to get more details)
  */
-int oval_session_export(struct oval_session *session);
+OSCAP_API int oval_session_export(struct oval_session *session);
 
 /**
  * Set exporting of system characteristics in OVAL results
@@ -230,7 +231,7 @@ int oval_session_export(struct oval_session *session);
  * @param session an \ref oval_session
  * @param export false values indicated no system_characteristics in OVAL Results
  */
-void oval_session_set_export_system_characteristics(struct oval_session *session, bool export);
+OSCAP_API void oval_session_set_export_system_characteristics(struct oval_session *session, bool export);
 
 /**
  * Set property of remote content.
@@ -240,13 +241,13 @@ void oval_session_set_export_system_characteristics(struct oval_session *session
  * @param callback used to notify user about download proceeds. This might be safely set
  * to NULL -- ignoring user notification.
  */
-void oval_session_set_remote_resources(struct oval_session *session, bool allowed, download_progress_calllback_t callback);
+OSCAP_API void oval_session_set_remote_resources(struct oval_session *session, bool allowed, download_progress_calllback_t callback);
 
 /**
  * Destructor of an \ref oval_session.
  * @memberof oval_session
  * @param session an \ref oval_session to destroy
  */
-void oval_session_free(struct oval_session *session);
+OSCAP_API void oval_session_free(struct oval_session *session);
 
 #endif

--- a/src/OVAL/public/oval_system_characteristics.h
+++ b/src/OVAL/public/oval_system_characteristics.h
@@ -44,6 +44,7 @@
 #include "oscap_source.h"
 #include "oval_types.h"
 #include "oval_definitions.h"
+#include "oscap_export.h"
 
 /// System characteristics result flag
 typedef enum {
@@ -75,9 +76,9 @@ typedef enum {
         OVAL_MESSAGE_LEVEL_FATAL = 5
 } oval_message_level_t;
 
-const char *oval_syschar_collection_flag_get_text(oval_syschar_collection_flag_t flag);
-const char *oval_syschar_status_get_text(oval_syschar_status_t status);
-const char *oval_message_level_text(oval_message_level_t);
+OSCAP_API const char *oval_syschar_collection_flag_get_text(oval_syschar_collection_flag_t flag);
+OSCAP_API const char *oval_syschar_status_get_text(oval_syschar_status_t status);
+OSCAP_API const char *oval_message_level_text(oval_message_level_t);
 
 
 
@@ -194,7 +195,7 @@ struct oval_variable_binding_iterator;
  * @param definition_model the specified oval_definition_model.
  * @memberof oval_syschar_model
  */
-struct oval_syschar_model *oval_syschar_model_new(struct oval_definition_model *definition_model);
+OSCAP_API struct oval_syschar_model *oval_syschar_model_new(struct oval_definition_model *definition_model);
 
 /**
  * Import the content from the oscap_source into an oval_syschar_model.
@@ -204,7 +205,7 @@ struct oval_syschar_model *oval_syschar_model_new(struct oval_definition_model *
  * @return zero on success or non zero value if an error occurred
  * @memberof oval_syschar_model
  */
-int oval_syschar_model_import_source(struct oval_syschar_model *model, struct oscap_source *source);
+OSCAP_API int oval_syschar_model_import_source(struct oval_syschar_model *model, struct oscap_source *source);
 
 /**
  * Import the content from the file into an oval_syschar_model.
@@ -217,65 +218,65 @@ int oval_syschar_model_import_source(struct oval_syschar_model *model, struct os
  * OpenSCAP releases. Please use oval_syschar_model_import_source instead.
  *
  */
-OSCAP_DEPRECATED(int oval_syschar_model_import(struct oval_syschar_model *model, const char *file));
+OSCAP_API OSCAP_DEPRECATED(int oval_syschar_model_import(struct oval_syschar_model *model, const char *file));
 /**
  * Copy an oval_syschar_model.
  * @return A copy of the specified @ref oval_syschar_model.
  * @memberof oval_syschar_model
  */
-struct oval_syschar_model *oval_syschar_model_clone(struct oval_syschar_model *);
+OSCAP_API struct oval_syschar_model *oval_syschar_model_clone(struct oval_syschar_model *);
 /**
  * Export system characteristics into file.
  * @memberof oval_syschar_model
  */
-int oval_syschar_model_export(struct oval_syschar_model *, const char *file);
+OSCAP_API int oval_syschar_model_export(struct oval_syschar_model *, const char *file);
 /**
  * Free memory allocated to a specified syschar model.
  * @param model the specified syschar model
  * @memberof oval_syschar_model
  */
-void oval_syschar_model_free(struct oval_syschar_model *model);
+OSCAP_API void oval_syschar_model_free(struct oval_syschar_model *model);
 
 /**
  * @name Setters
  * @{
  */
-void oval_syschar_model_set_generator(struct oval_syschar_model *model, struct oval_generator *generator);
+OSCAP_API void oval_syschar_model_set_generator(struct oval_syschar_model *model, struct oval_generator *generator);
 /**
  * Bind a variable model to the definitions bound to the syschar model.
  * @return zero on success or non zero value if an error occurred
  * @memberof oval_syschar_model
  */
-int oval_syschar_model_bind_variable_model(struct oval_syschar_model *, struct oval_variable_model *);
+OSCAP_API int oval_syschar_model_bind_variable_model(struct oval_syschar_model *, struct oval_variable_model *);
 /**
  * @memberof oval_syschar_model
  */
-void oval_syschar_model_set_sysinfo(struct oval_syschar_model *model, struct oval_sysinfo *sysinfo);
+OSCAP_API void oval_syschar_model_set_sysinfo(struct oval_syschar_model *model, struct oval_sysinfo *sysinfo);
 /** @} */
 
 /**
  * @name Getters
  * @{
  */
-struct oval_generator *oval_syschar_model_get_generator(struct oval_syschar_model *model);
+OSCAP_API struct oval_generator *oval_syschar_model_get_generator(struct oval_syschar_model *model);
 /**
  * Return related oval_definition_model from an oval_syschar_model.
  * @param model the specified oval_syschar_model.
  * @memberof oval_syschar_model
  */
-struct oval_definition_model *oval_syschar_model_get_definition_model(struct oval_syschar_model *model);
+OSCAP_API struct oval_definition_model *oval_syschar_model_get_definition_model(struct oval_syschar_model *model);
 /**
  * Return an iterator over the oval_sychar objects persisted by this model.
  * @param model the specified oval_syschar_model.
  * @memberof oval_syschar_model
  */
-struct oval_syschar_iterator *oval_syschar_model_get_syschars(struct oval_syschar_model *model);
+OSCAP_API struct oval_syschar_iterator *oval_syschar_model_get_syschars(struct oval_syschar_model *model);
 /**
  * Return default sysinfo bound to syschar model.
  * @param model the specified oval_syschar_model.
  * @memberof oval_syschar_model
  */
-struct oval_sysinfo *oval_syschar_model_get_sysinfo(struct oval_syschar_model *model);
+OSCAP_API struct oval_sysinfo *oval_syschar_model_get_sysinfo(struct oval_syschar_model *model);
 /**
  * Return the oval_syschar bound to a specified object_id.
  * Returns NULL if the object_id does not resolve to an oval_object in the bound oval_definition_model.
@@ -283,17 +284,17 @@ struct oval_sysinfo *oval_syschar_model_get_sysinfo(struct oval_syschar_model *m
  * @param object_id the specified object_id.
  * @memberof oval_syschar_model
  */
-struct oval_syschar *oval_syschar_model_get_syschar(struct oval_syschar_model *model, const char *object_id);
+OSCAP_API struct oval_syschar *oval_syschar_model_get_syschar(struct oval_syschar_model *model, const char *object_id);
 /**
  * Get the oval_values bound to a specified variable.
  * @memberof oval_syschar_model
  */
-int oval_syschar_model_compute_variable(struct oval_syschar_model *, struct oval_variable *);
-oval_syschar_collection_flag_t oval_variable_get_collection_flag(struct oval_variable *);
+OSCAP_API int oval_syschar_model_compute_variable(struct oval_syschar_model *, struct oval_variable *);
+OSCAP_API oval_syschar_collection_flag_t oval_variable_get_collection_flag(struct oval_variable *);
 /**
  * @memberof oval_syschar_model
  */
-struct oval_sysitem *oval_syschar_model_get_sysitem(struct oval_syschar_model *, const char *);
+OSCAP_API struct oval_sysitem *oval_syschar_model_get_sysitem(struct oval_syschar_model *, const char *);
 /** @} */
 
 /**
@@ -310,16 +311,16 @@ struct oval_sysitem *oval_syschar_model_get_sysitem(struct oval_syschar_model *,
 /**
  * @memberof oval_sysinfo
  */
-struct oval_sysinfo *oval_sysinfo_new(struct oval_syschar_model *);
+OSCAP_API struct oval_sysinfo *oval_sysinfo_new(struct oval_syschar_model *);
 /**
  * @return A copy of the specified @ref oval_sysinfo.
  * @memberof oval_sysinfo
  */
-struct oval_sysinfo *oval_sysinfo_clone(struct oval_syschar_model *new_model, struct oval_sysinfo *old_sysinfo);
+OSCAP_API struct oval_sysinfo *oval_sysinfo_clone(struct oval_syschar_model *new_model, struct oval_sysinfo *old_sysinfo);
 /**
  * @memberof oval_sysinfo
  */
-void oval_sysinfo_free(struct oval_sysinfo *);
+OSCAP_API void oval_sysinfo_free(struct oval_sysinfo *);
 
 /**
  * @name Setters
@@ -328,23 +329,23 @@ void oval_sysinfo_free(struct oval_sysinfo *);
 /**
  * @memberof oval_sysinfo
  */
-void oval_sysinfo_set_os_name(struct oval_sysinfo *, char *);
+OSCAP_API void oval_sysinfo_set_os_name(struct oval_sysinfo *, char *);
 /**
  * @memberof oval_sysinfo
  */
-void oval_sysinfo_set_os_version(struct oval_sysinfo *, char *);
+OSCAP_API void oval_sysinfo_set_os_version(struct oval_sysinfo *, char *);
 /**
  * @memberof oval_sysinfo
  */
-void oval_sysinfo_set_os_architecture(struct oval_sysinfo *, char *);
+OSCAP_API void oval_sysinfo_set_os_architecture(struct oval_sysinfo *, char *);
 /**
  * @memberof oval_sysinfo
  */
-void oval_sysinfo_set_primary_host_name(struct oval_sysinfo *, char *);
+OSCAP_API void oval_sysinfo_set_primary_host_name(struct oval_sysinfo *, char *);
 /**
  * @memberof oval_sysinfo
  */
-void oval_sysinfo_add_interface(struct oval_sysinfo *, struct oval_sysint *);
+OSCAP_API void oval_sysinfo_add_interface(struct oval_sysinfo *, struct oval_sysint *);
 /** @} */
 
 /**
@@ -355,31 +356,31 @@ void oval_sysinfo_add_interface(struct oval_sysinfo *, struct oval_sysint *);
  * Get operating system name.
  * @memberof oval_sysinfo
  */
-char *oval_sysinfo_get_os_name(struct oval_sysinfo *);
+OSCAP_API char *oval_sysinfo_get_os_name(struct oval_sysinfo *);
 
 /**
  * Get operating system version.
  * @memberof oval_sysinfo
  */
-char *oval_sysinfo_get_os_version(struct oval_sysinfo *);
+OSCAP_API char *oval_sysinfo_get_os_version(struct oval_sysinfo *);
 
 /**
  * Get operating system architecture.
  * @memberof oval_sysinfo
  */
-char *oval_sysinfo_get_os_architecture(struct oval_sysinfo *);
+OSCAP_API char *oval_sysinfo_get_os_architecture(struct oval_sysinfo *);
 
 /**
  * Get primary host name of the tested machine.
  * @memberof oval_sysinfo
  */
-char *oval_sysinfo_get_primary_host_name(struct oval_sysinfo *);
+OSCAP_API char *oval_sysinfo_get_primary_host_name(struct oval_sysinfo *);
 
 /**
  * Get an iterator to the list of network interfaces.
  * @memberof oval_sysinfo
  */
-struct oval_sysint_iterator *oval_sysinfo_get_interfaces(struct oval_sysinfo *);
+OSCAP_API struct oval_sysint_iterator *oval_sysinfo_get_interfaces(struct oval_sysinfo *);
 /** @} */
 
 /**
@@ -389,15 +390,15 @@ struct oval_sysint_iterator *oval_sysinfo_get_interfaces(struct oval_sysinfo *);
 /**
  * @memberof oval_sysinfo_iterator
  */
-bool oval_sysinfo_iterator_has_more(struct oval_sysinfo_iterator *);
+OSCAP_API bool oval_sysinfo_iterator_has_more(struct oval_sysinfo_iterator *);
 /**
  * @memberof oval_sysinfo_iterator
  */
-struct oval_sysinfo *oval_sysinfo_iterator_next(struct oval_sysinfo_iterator *);
+OSCAP_API struct oval_sysinfo *oval_sysinfo_iterator_next(struct oval_sysinfo_iterator *);
 /**
  * @memberof oval_sysinfo_iterator
  */
-void oval_sysinfo_iterator_free(struct oval_sysinfo_iterator *);
+OSCAP_API void oval_sysinfo_iterator_free(struct oval_sysinfo_iterator *);
 /** @} */
 
 /**
@@ -414,16 +415,16 @@ void oval_sysinfo_iterator_free(struct oval_sysinfo_iterator *);
 /**
  * @memberof oval_syschar
  */
-struct oval_syschar *oval_syschar_new(struct oval_syschar_model *, struct oval_object *);
+OSCAP_API struct oval_syschar *oval_syschar_new(struct oval_syschar_model *, struct oval_object *);
 /**
  * @return A copy of the specified @ref oval_syschar.
  * @memberof oval_syschar
  */
-struct oval_syschar *oval_syschar_clone(struct oval_syschar_model *new_model, struct oval_syschar *old_syschar);
+OSCAP_API struct oval_syschar *oval_syschar_clone(struct oval_syschar_model *new_model, struct oval_syschar *old_syschar);
 /**
  * @memberof oval_syschar
  */
-void oval_syschar_free(struct oval_syschar *);
+OSCAP_API void oval_syschar_free(struct oval_syschar *);
 
 /**
  * @name Setters
@@ -432,40 +433,40 @@ void oval_syschar_free(struct oval_syschar *);
 /**
  * @memberof oval_syschar
  */
-void oval_syschar_add_variable_binding(struct oval_syschar *, struct oval_variable_binding *);
+OSCAP_API void oval_syschar_add_variable_binding(struct oval_syschar *, struct oval_variable_binding *);
 /**
  * @memberof oval_syschar
  */
-void oval_syschar_set_flag(struct oval_syschar *model, oval_syschar_collection_flag_t flag);
+OSCAP_API void oval_syschar_set_flag(struct oval_syschar *model, oval_syschar_collection_flag_t flag);
 /**
  * @memberof oval_syschar
  */
-void oval_syschar_set_object(struct oval_syschar *, struct oval_object *);
+OSCAP_API void oval_syschar_set_object(struct oval_syschar *, struct oval_object *);
 /**
  * Gets the variable_instance attribute of the syschar.
  * @memberof oval_syschar
  * @returns currect variable_instance attribute assigned
  */
-int oval_syschar_get_variable_instance(const struct oval_syschar *syschar);
+OSCAP_API int oval_syschar_get_variable_instance(const struct oval_syschar *syschar);
 /**
  * Sets the variable_instance attribute of the syschar.
  * @memberof oval_syschar
  * @param syschar collected object
  * @param variable_instance_in new settings of variable_instance attribute
  */
-void oval_syschar_set_variable_instance(struct oval_syschar *syschar, int variable_instance_in);
+OSCAP_API void oval_syschar_set_variable_instance(struct oval_syschar *syschar, int variable_instance_in);
 /**
  * @memberof oval_syschar
  */
-void oval_syschar_add_sysitem(struct oval_syschar *, struct oval_sysitem *);
+OSCAP_API void oval_syschar_add_sysitem(struct oval_syschar *, struct oval_sysitem *);
 /**
  * @memberof oval_syschar
  */
-void oval_syschar_add_message(struct oval_syschar *syschar, struct oval_message *message);
+OSCAP_API void oval_syschar_add_message(struct oval_syschar *syschar, struct oval_message *message);
 /**
  * @memberof oval_syschar
  */
-void oval_syschar_add_new_message(struct oval_syschar *syschar, char *text, oval_message_level_t level);
+OSCAP_API void oval_syschar_add_new_message(struct oval_syschar *syschar, char *text, oval_message_level_t level);
 /** @} */
 
 /**
@@ -476,31 +477,31 @@ void oval_syschar_add_new_message(struct oval_syschar *syschar, char *text, oval
  * Get system characteristic flag.
  * @memberof oval_syschar
  */
-oval_syschar_collection_flag_t oval_syschar_get_flag(struct oval_syschar *);
+OSCAP_API oval_syschar_collection_flag_t oval_syschar_get_flag(struct oval_syschar *);
 
 /**
  * Get messages bound to this system characteristic.
  * @memberof oval_syschar
  */
-struct oval_message_iterator *oval_syschar_get_messages(struct oval_syschar *);
+OSCAP_API struct oval_message_iterator *oval_syschar_get_messages(struct oval_syschar *);
 
 /**
  * Get object associated with this system characteristic.
  * @memberof oval_syschar
  */
-struct oval_object *oval_syschar_get_object(struct oval_syschar *);
+OSCAP_API struct oval_object *oval_syschar_get_object(struct oval_syschar *);
 
 /**
  * Get system characteristic variable bindings.
  * @memberof oval_syschar
  */
-struct oval_variable_binding_iterator *oval_syschar_get_variable_bindings(struct oval_syschar *);
+OSCAP_API struct oval_variable_binding_iterator *oval_syschar_get_variable_bindings(struct oval_syschar *);
 
 /**
  * Get system characteristic data.
  * @memberof oval_syschar
  */
-struct oval_sysitem_iterator *oval_syschar_get_sysitem(struct oval_syschar *);
+OSCAP_API struct oval_sysitem_iterator *oval_syschar_get_sysitem(struct oval_syschar *);
 /** @} */
 
 /**
@@ -510,15 +511,15 @@ struct oval_sysitem_iterator *oval_syschar_get_sysitem(struct oval_syschar *);
 /**
  * @memberof oval_syschar_iterator
  */
-bool oval_syschar_iterator_has_more(struct oval_syschar_iterator *);
+OSCAP_API bool oval_syschar_iterator_has_more(struct oval_syschar_iterator *);
 /**
  * @memberof oval_syschar_iterator
  */
-struct oval_syschar *oval_syschar_iterator_next(struct oval_syschar_iterator *);
+OSCAP_API struct oval_syschar *oval_syschar_iterator_next(struct oval_syschar_iterator *);
 /**
  * @memberof oval_syschar_iterator
  */
-void oval_syschar_iterator_free(struct oval_syschar_iterator *);
+OSCAP_API void oval_syschar_iterator_free(struct oval_syschar_iterator *);
 /** @} */
 
 /**
@@ -535,16 +536,16 @@ void oval_syschar_iterator_free(struct oval_syschar_iterator *);
 /**
  * @memberof oval_sysint
  */
-struct oval_sysint *oval_sysint_new(struct oval_syschar_model *);
+OSCAP_API struct oval_sysint *oval_sysint_new(struct oval_syschar_model *);
 /**
  * @return A copy of the specified @ref oval_sysint.
  * @memberof oval_sysint
  */
-struct oval_sysint *oval_sysint_clone(struct oval_syschar_model *new_model, struct oval_sysint *old_sysint);
+OSCAP_API struct oval_sysint *oval_sysint_clone(struct oval_syschar_model *new_model, struct oval_sysint *old_sysint);
 /**
  * @memberof oval_sysint
  */
-void oval_sysint_free(struct oval_sysint *);
+OSCAP_API void oval_sysint_free(struct oval_sysint *);
 
 /**
  * @name Setters
@@ -553,15 +554,15 @@ void oval_sysint_free(struct oval_sysint *);
 /**
  * @memberof oval_sysint
  */
-void oval_sysint_set_name(struct oval_sysint *, char *);
+OSCAP_API void oval_sysint_set_name(struct oval_sysint *, char *);
 /**
  * @memberof oval_sysint
  */
-void oval_sysint_set_ip_address(struct oval_sysint *, char *);
+OSCAP_API void oval_sysint_set_ip_address(struct oval_sysint *, char *);
 /**
  * @memberof oval_sysint
  */
-void oval_sysint_set_mac_address(struct oval_sysint *, char *);
+OSCAP_API void oval_sysint_set_mac_address(struct oval_sysint *, char *);
 /** @} */
 
 /**
@@ -572,19 +573,19 @@ void oval_sysint_set_mac_address(struct oval_sysint *, char *);
  * Get interface name.
  * @memberof oval_sysint
  */
-char *oval_sysint_get_name(struct oval_sysint *);
+OSCAP_API char *oval_sysint_get_name(struct oval_sysint *);
 
 /**
  * Get interface IP address.
  * @memberof oval_sysint
  */
-char *oval_sysint_get_ip_address(struct oval_sysint *);
+OSCAP_API char *oval_sysint_get_ip_address(struct oval_sysint *);
 
 /**
  * Get interface MAC address.
  * @memberof oval_sysint
  */
-char *oval_sysint_get_mac_address(struct oval_sysint *);
+OSCAP_API char *oval_sysint_get_mac_address(struct oval_sysint *);
 /** @} */
 
 /**
@@ -594,15 +595,15 @@ char *oval_sysint_get_mac_address(struct oval_sysint *);
 /**
  * @memberof oval_sysint_iterator
  */
-bool oval_sysint_iterator_has_more(struct oval_sysint_iterator *);
+OSCAP_API bool oval_sysint_iterator_has_more(struct oval_sysint_iterator *);
 /**
  * @memberof oval_sysint_iterator
  */
-struct oval_sysint *oval_sysint_iterator_next(struct oval_sysint_iterator *);
+OSCAP_API struct oval_sysint *oval_sysint_iterator_next(struct oval_sysint_iterator *);
 /**
  * @memberof oval_sysint_iterator
  */
-void oval_sysint_iterator_free(struct oval_sysint_iterator *);
+OSCAP_API void oval_sysint_iterator_free(struct oval_sysint_iterator *);
 /** @} */
 
 /**
@@ -619,16 +620,16 @@ void oval_sysint_iterator_free(struct oval_sysint_iterator *);
 /**
  * @memberof oval_sysitem
  */
-struct oval_sysitem *oval_sysitem_new(struct oval_syschar_model *, const char *id);
+OSCAP_API struct oval_sysitem *oval_sysitem_new(struct oval_syschar_model *, const char *id);
 /**
  * @return A copy of the specified @ref oval_sysitem.
  * @memberof oval_sysitem
  */
-struct oval_sysitem *oval_sysitem_clone(struct oval_syschar_model *new_model, struct oval_sysitem *old_data);
+OSCAP_API struct oval_sysitem *oval_sysitem_clone(struct oval_syschar_model *new_model, struct oval_sysitem *old_data);
 /**
  * @memberof oval_sysitem
  */
-void oval_sysitem_free(struct oval_sysitem *);
+OSCAP_API void oval_sysitem_free(struct oval_sysitem *);
 
 /**
  * @name Setters
@@ -637,19 +638,19 @@ void oval_sysitem_free(struct oval_sysitem *);
 /**
  * @memberof oval_sysitem
  */
-void oval_sysitem_set_status(struct oval_sysitem *, oval_syschar_status_t);
+OSCAP_API void oval_sysitem_set_status(struct oval_sysitem *, oval_syschar_status_t);
 /**
  * @memberof oval_sysitem
  */
-void oval_sysitem_set_subtype(struct oval_sysitem *sysitem, oval_subtype_t subtype);
+OSCAP_API void oval_sysitem_set_subtype(struct oval_sysitem *sysitem, oval_subtype_t subtype);
 /**
  * @memberof oval_sysitem
  */
-void oval_sysitem_add_message(struct oval_sysitem *, struct oval_message *);
+OSCAP_API void oval_sysitem_add_message(struct oval_sysitem *, struct oval_message *);
 /**
  * @memberof oval_sysitem
  */
-void oval_sysitem_add_sysent(struct oval_sysitem *, struct oval_sysent *);
+OSCAP_API void oval_sysitem_add_sysent(struct oval_sysitem *, struct oval_sysent *);
 /** @} */
 
 /**
@@ -660,27 +661,27 @@ void oval_sysitem_add_sysent(struct oval_sysitem *, struct oval_sysent *);
  * Get system data ID.
  * @memberof oval_sysitem
  */
-char *oval_sysitem_get_id(struct oval_sysitem *);
+OSCAP_API char *oval_sysitem_get_id(struct oval_sysitem *);
 /**
  * Get system data status.
  * @memberof oval_sysitem
  */
-oval_syschar_status_t oval_sysitem_get_status(struct oval_sysitem *);
+OSCAP_API oval_syschar_status_t oval_sysitem_get_status(struct oval_sysitem *);
 /**
  * Get system data individual items.
  * @memberof oval_sysitem
  */
-struct oval_sysent_iterator *oval_sysitem_get_sysents(struct oval_sysitem *);
+OSCAP_API struct oval_sysent_iterator *oval_sysitem_get_sysents(struct oval_sysitem *);
 /**
  * Get system data message.
  * @memberof oval_sysitem
  */
-struct oval_message_iterator *oval_sysitem_get_messages(struct oval_sysitem *);
+OSCAP_API struct oval_message_iterator *oval_sysitem_get_messages(struct oval_sysitem *);
 /**
  * Get system data subtype.
  * @memberof oval_sysitem
  */
-oval_subtype_t oval_sysitem_get_subtype(struct oval_sysitem *);
+OSCAP_API oval_subtype_t oval_sysitem_get_subtype(struct oval_sysitem *);
 /** @} */
 
 /**
@@ -690,15 +691,15 @@ oval_subtype_t oval_sysitem_get_subtype(struct oval_sysitem *);
 /**
  * @memberof oval_sysitem_iterator
  */
-bool oval_sysitem_iterator_has_more(struct oval_sysitem_iterator *);
+OSCAP_API bool oval_sysitem_iterator_has_more(struct oval_sysitem_iterator *);
 /**
  * @memberof oval_sysitem_iterator
  */
-struct oval_sysitem *oval_sysitem_iterator_next(struct oval_sysitem_iterator *);
+OSCAP_API struct oval_sysitem *oval_sysitem_iterator_next(struct oval_sysitem_iterator *);
 /**
  * @memberof oval_sysitem_iterator
  */
-void oval_sysitem_iterator_free(struct oval_sysitem_iterator *);
+OSCAP_API void oval_sysitem_iterator_free(struct oval_sysitem_iterator *);
 /** @} */
 
 /**
@@ -715,16 +716,16 @@ void oval_sysitem_iterator_free(struct oval_sysitem_iterator *);
 /**
  * @memberof oval_sysent
  */
-struct oval_sysent *oval_sysent_new(struct oval_syschar_model *);
+OSCAP_API struct oval_sysent *oval_sysent_new(struct oval_syschar_model *);
 /**
  * @return A copy of the specified @ref oval_sysent.
  * @memberof oval_sysent
  */
-struct oval_sysent *oval_sysent_clone(struct oval_syschar_model *new_model, struct oval_sysent *old_item);
+OSCAP_API struct oval_sysent *oval_sysent_clone(struct oval_syschar_model *new_model, struct oval_sysent *old_item);
 /**
  * @memberof oval_sysent
  */
-void oval_sysent_free(struct oval_sysent *);
+OSCAP_API void oval_sysent_free(struct oval_sysent *);
 /**
  * @name Setters
  * @{
@@ -732,27 +733,27 @@ void oval_sysent_free(struct oval_sysent *);
 /**
  * @memberof oval_sysent
  */
-void oval_sysent_set_name(struct oval_sysent *sysent, char *name);
+OSCAP_API void oval_sysent_set_name(struct oval_sysent *sysent, char *name);
 /**
  * @memberof oval_sysent
  */
-void oval_sysent_set_value(struct oval_sysent *sysent, char *value);
+OSCAP_API void oval_sysent_set_value(struct oval_sysent *sysent, char *value);
 /**
  * @memberof oval_sysent
  */
-void oval_sysent_add_record_field(struct oval_sysent *, struct oval_record_field *);
+OSCAP_API void oval_sysent_add_record_field(struct oval_sysent *, struct oval_record_field *);
 /**
  * @memberof oval_sysent
  */
-void oval_sysent_set_status(struct oval_sysent *sysent, oval_syschar_status_t status);
+OSCAP_API void oval_sysent_set_status(struct oval_sysent *sysent, oval_syschar_status_t status);
 /**
  * @memberof oval_sysent
  */
-void oval_sysent_set_datatype(struct oval_sysent *sysent, oval_datatype_t type);
+OSCAP_API void oval_sysent_set_datatype(struct oval_sysent *sysent, oval_datatype_t type);
 /**
  * @memberof oval_sysent
  */
-void oval_sysent_set_mask(struct oval_sysent *sysent, int mask);
+OSCAP_API void oval_sysent_set_mask(struct oval_sysent *sysent, int mask);
 /** @} */
 
 /**
@@ -763,36 +764,36 @@ void oval_sysent_set_mask(struct oval_sysent *sysent, int mask);
  * Get system data item name.
  * @memberof oval_sysent
  */
-char *oval_sysent_get_name(struct oval_sysent *);
+OSCAP_API char *oval_sysent_get_name(struct oval_sysent *);
 
 /**
  * Get system data item value.
  * @memberof oval_sysent
  */
-char *oval_sysent_get_value(struct oval_sysent *);
+OSCAP_API char *oval_sysent_get_value(struct oval_sysent *);
 
 /**
  * @memberof oval_sysent
  */
-struct oval_record_field_iterator *oval_sysent_get_record_fields(struct oval_sysent *);
+OSCAP_API struct oval_record_field_iterator *oval_sysent_get_record_fields(struct oval_sysent *);
 
 /**
  * Get system data item status.
  * @memberof oval_sysent
  */
-oval_syschar_status_t oval_sysent_get_status(struct oval_sysent *);
+OSCAP_API oval_syschar_status_t oval_sysent_get_status(struct oval_sysent *);
 
 /**
  * Get system data item data type.
  * @memberof oval_sysent
  */
-oval_datatype_t oval_sysent_get_datatype(struct oval_sysent *);
+OSCAP_API oval_datatype_t oval_sysent_get_datatype(struct oval_sysent *);
 
 /**
  * Get system data item mask.
  * @memberof oval_sysent
  */
-int oval_sysent_get_mask(struct oval_sysent *);
+OSCAP_API int oval_sysent_get_mask(struct oval_sysent *);
 /** @} */
 
 /**
@@ -802,15 +803,15 @@ int oval_sysent_get_mask(struct oval_sysent *);
 /**
  * @memberof oval_sysent_iterator
  */
-bool oval_sysent_iterator_has_more(struct oval_sysent_iterator *);
+OSCAP_API bool oval_sysent_iterator_has_more(struct oval_sysent_iterator *);
 /**
  * @memberof oval_sysent_iterator
  */
-struct oval_sysent *oval_sysent_iterator_next(struct oval_sysent_iterator *);
+OSCAP_API struct oval_sysent *oval_sysent_iterator_next(struct oval_sysent_iterator *);
 /**
  * @memberof oval_sysent_iterator
  */
-void oval_sysent_iterator_free(struct oval_sysent_iterator *);
+OSCAP_API void oval_sysent_iterator_free(struct oval_sysent_iterator *);
 /** @} */
 
 /**
@@ -826,7 +827,7 @@ void oval_sysent_iterator_free(struct oval_sysent_iterator *);
 /**
  * @memberof oval_record_field
  */
-void oval_record_field_set_status(struct oval_record_field *, oval_syschar_status_t);
+OSCAP_API void oval_record_field_set_status(struct oval_record_field *, oval_syschar_status_t);
 /** @} */
 /**
  * @name Getters
@@ -835,22 +836,22 @@ void oval_record_field_set_status(struct oval_record_field *, oval_syschar_statu
 /**
  * @memberof oval_record_field
  */
-oval_syschar_status_t oval_record_field_get_status(struct oval_record_field *);
+OSCAP_API oval_syschar_status_t oval_record_field_get_status(struct oval_record_field *);
 /** @} */
 
 /**
  * @memberof oval_message
  */
-struct oval_message *oval_message_new(void);
+OSCAP_API struct oval_message *oval_message_new(void);
 /**
  * @return A copy of the specified @ref oval_message.
  * @memberof oval_message
  */
-struct oval_message *oval_message_clone(struct oval_message *old_message);
+OSCAP_API struct oval_message *oval_message_clone(struct oval_message *old_message);
 /**
  * @memberof oval_message
  */
-void oval_message_free(struct oval_message *);
+OSCAP_API void oval_message_free(struct oval_message *);
 
 /**
  * @name Setters
@@ -859,11 +860,11 @@ void oval_message_free(struct oval_message *);
 /**
  * @memberof oval_message
  */
-void oval_message_set_text(struct oval_message *, char *);
+OSCAP_API void oval_message_set_text(struct oval_message *, char *);
 /**
  * @memberof oval_message
  */
-void oval_message_set_level(struct oval_message *, oval_message_level_t);
+OSCAP_API void oval_message_set_level(struct oval_message *, oval_message_level_t);
 /** @} */
 
 /**
@@ -874,12 +875,12 @@ void oval_message_set_level(struct oval_message *, oval_message_level_t);
  * Get OVAL message text.
  * @memberof oval_message
  */
-char *oval_message_get_text(struct oval_message *message);
+OSCAP_API char *oval_message_get_text(struct oval_message *message);
 /**
  * Get OVAL message level.
  * @memberof oval_message
  */
-oval_message_level_t oval_message_get_level(struct oval_message *message);
+OSCAP_API oval_message_level_t oval_message_get_level(struct oval_message *message);
 /** @} */
 
 /**
@@ -889,22 +890,22 @@ oval_message_level_t oval_message_get_level(struct oval_message *message);
 /**
  * @memberof oval_message_iterator
  */
-bool oval_message_iterator_has_more(struct oval_message_iterator *oc_message);
+OSCAP_API bool oval_message_iterator_has_more(struct oval_message_iterator *oc_message);
 /**
  * @memberof oval_message_iterator
  */
-struct oval_message *oval_message_iterator_next(struct oval_message_iterator *oc_message);
+OSCAP_API struct oval_message *oval_message_iterator_next(struct oval_message_iterator *oc_message);
 /**
  * @memberof oval_message_iterator
  */
-void oval_message_iterator_free(struct oval_message_iterator *oc_message);
+OSCAP_API void oval_message_iterator_free(struct oval_message_iterator *oc_message);
 /** @} */
 
 
 /**
  * @memberof oval_variable_binding
  */
-struct oval_variable_binding *oval_variable_binding_new(struct oval_variable *, char *);
+OSCAP_API struct oval_variable_binding *oval_variable_binding_new(struct oval_variable *, char *);
 /**
  * @return A copy of the specified @ref oval_variable_binding.
  * @memberof oval_variable_binding
@@ -914,7 +915,7 @@ struct oval_variable_binding *oval_variable_binding_clone(struct oval_variable_b
 /**
  * @memberof oval_variable_binding
  */
-void oval_variable_binding_free(struct oval_variable_binding *);
+OSCAP_API void oval_variable_binding_free(struct oval_variable_binding *);
 
 /**
  * @name Setters
@@ -923,11 +924,11 @@ void oval_variable_binding_free(struct oval_variable_binding *);
 /**
  * @memberof oval_variable_binding
  */
-void oval_variable_binding_set_variable(struct oval_variable_binding *, struct oval_variable *);
+OSCAP_API void oval_variable_binding_set_variable(struct oval_variable_binding *, struct oval_variable *);
 /**
  * @memberof oval_variable_binding
  */
-void oval_variable_binding_add_value(struct oval_variable_binding *, char *);
+OSCAP_API void oval_variable_binding_add_value(struct oval_variable_binding *, char *);
 /** @} */
 
 /**
@@ -938,12 +939,12 @@ void oval_variable_binding_add_value(struct oval_variable_binding *, char *);
  * Get variable for this binding.
  * @memberof oval_variable_binding
  */
-struct oval_variable *oval_variable_binding_get_variable(struct oval_variable_binding *);
+OSCAP_API struct oval_variable *oval_variable_binding_get_variable(struct oval_variable_binding *);
 /**
  * Get value of this binding.
  * @memberof oval_variable_binding
  */
-struct oval_string_iterator *oval_variable_binding_get_values(struct oval_variable_binding *);
+OSCAP_API struct oval_string_iterator *oval_variable_binding_get_values(struct oval_variable_binding *);
 /** @} */
 
 /**
@@ -953,15 +954,15 @@ struct oval_string_iterator *oval_variable_binding_get_values(struct oval_variab
 /**
  * @memberof oval_variable_binding_iterator
  */
-bool oval_variable_binding_iterator_has_more(struct oval_variable_binding_iterator *);
+OSCAP_API bool oval_variable_binding_iterator_has_more(struct oval_variable_binding_iterator *);
 /**
  * @memberof oval_variable_binding_iterator
  */
-struct oval_variable_binding *oval_variable_binding_iterator_next(struct oval_variable_binding_iterator *);
+OSCAP_API struct oval_variable_binding *oval_variable_binding_iterator_next(struct oval_variable_binding_iterator *);
 /**
  * @memberof oval_variable_binding_iterator
  */
-void oval_variable_binding_iterator_free(struct oval_variable_binding_iterator *);
+OSCAP_API void oval_variable_binding_iterator_free(struct oval_variable_binding_iterator *);
 /** @} */
 
 /**

--- a/src/OVAL/public/oval_variables.h
+++ b/src/OVAL/public/oval_variables.h
@@ -39,12 +39,13 @@
 #include "oval_types.h"
 #include "oscap.h"
 #include "oscap_source.h"
+#include "oscap_export.h"
 
 /**
  * Create a new empty OVAL variable model
  * @memberof oval_variable_model
  */ 
-struct oval_variable_model *oval_variable_model_new(void);
+OSCAP_API struct oval_variable_model *oval_variable_model_new(void);
 
 /**
  * Import the content from the oscap_source into a new oval_variable_model.
@@ -52,7 +53,7 @@ struct oval_variable_model *oval_variable_model_new(void);
  * @return new oval_variable_model, or NULL if an error occurred
  * @memberof oval_variable_model
  */
-struct oval_variable_model *oval_variable_model_import_source(struct oscap_source *source);
+OSCAP_API struct oval_variable_model *oval_variable_model_import_source(struct oscap_source *source);
 
 /**
  * Import the content from the file into a new oval_variable_model.
@@ -63,32 +64,32 @@ struct oval_variable_model *oval_variable_model_import_source(struct oscap_sourc
  * OpenSCAP releases. Please use oval_variable_model_import_source instead.
  *
  */
-OSCAP_DEPRECATED(struct oval_variable_model *oval_variable_model_import(const char *file));
+OSCAP_API OSCAP_DEPRECATED(struct oval_variable_model *oval_variable_model_import(const char *file));
 
 /**
  * Clone an OVAL variable model
  * @return A copy of the specified @ref oval_variable_model.
  * @memberof oval_variable_model
  */ 
-struct oval_variable_model *oval_variable_model_clone(struct oval_variable_model *);
+OSCAP_API struct oval_variable_model *oval_variable_model_clone(struct oval_variable_model *);
 /**
  * Free memory allocated to a specified oval_variable_model
  * @param variable_model the specified oval_variable_model
  * @memberof oval_variable_model
  */ 
-void oval_variable_model_free(struct oval_variable_model *);
+OSCAP_API void oval_variable_model_free(struct oval_variable_model *);
 /**
  * Export the specified oval_variable_model into file
  * @memberof oval_variable_model
  */ 
-int oval_variable_model_export (struct oval_variable_model *, const char *file);
+OSCAP_API int oval_variable_model_export (struct oval_variable_model *, const char *file);
 
 
 /**
  * @name Setters
  * @{
  */
-void oval_variable_model_set_generator(struct oval_variable_model *model, struct oval_generator *generator);
+OSCAP_API void oval_variable_model_set_generator(struct oval_variable_model *model, struct oval_generator *generator);
 /**
  * Get the values bound to a specified external variable.
  * If the varid does not resolve to a managed external variable, this method returns NULL.
@@ -96,20 +97,20 @@ void oval_variable_model_set_generator(struct oval_variable_model *model, struct
  * @param varid the identifier of the required oval_variable.
  * @memberof oval_variable_model
  */ 
-void oval_variable_model_add(struct oval_variable_model *model, char *varid, const char *comment, oval_datatype_t datatype, char *value);
+OSCAP_API void oval_variable_model_add(struct oval_variable_model *model, char *varid, const char *comment, oval_datatype_t datatype, char *value);
 /** @} */
 
 /**
  * @name Getters
  * @{
  */
-struct oval_generator *oval_variable_model_get_generator(struct oval_variable_model *model);
+OSCAP_API struct oval_generator *oval_variable_model_get_generator(struct oval_variable_model *model);
 /**
  * Get all external variables managed by a specified oval_variable_model.
  * @param variable_model the specified oval_variable_model.
  * @memberof oval_variable_model
  */ 
-struct oval_string_iterator *oval_variable_model_get_variable_ids (struct oval_variable_model *);
+OSCAP_API struct oval_string_iterator *oval_variable_model_get_variable_ids (struct oval_variable_model *);
 
 /**
  * Return true if variable with ID is present in variable model, false otherwise
@@ -117,7 +118,7 @@ struct oval_string_iterator *oval_variable_model_get_variable_ids (struct oval_v
  * @param id ID of variable
  * @memberof oval_variable_model
  */
-bool oval_variable_model_has_variable(struct oval_variable_model *model, const char * id);
+OSCAP_API bool oval_variable_model_has_variable(struct oval_variable_model *model, const char * id);
 /**
  * Get a specified external variable datatype.
  * If the varid does not resolve to a managed external variable, this method returns 0.
@@ -125,7 +126,7 @@ bool oval_variable_model_has_variable(struct oval_variable_model *model, const c
  * @param varid the identifier of the required oval_variable.
  * @memberof oval_variable_model
  */ 
-oval_datatype_t oval_variable_model_get_datatype (struct oval_variable_model *, char *);
+OSCAP_API oval_datatype_t oval_variable_model_get_datatype (struct oval_variable_model *, char *);
 /**
  * Get a specified external variable comment.
  * If the varid does not resolve to a managed external variable, this method returns NULL.
@@ -133,7 +134,7 @@ oval_datatype_t oval_variable_model_get_datatype (struct oval_variable_model *, 
  * @param varid the identifier of the required oval_variable.
  * @memberof oval_variable_model
  */ 
-const char *oval_variable_model_get_comment (struct oval_variable_model *, char *);
+OSCAP_API const char *oval_variable_model_get_comment (struct oval_variable_model *, char *);
 /**
  * Get the values bound to a specified external variable.
  * If the varid does not resolve to a managed external variable, this method returns NULL.
@@ -141,7 +142,7 @@ const char *oval_variable_model_get_comment (struct oval_variable_model *, char 
  * @param varid the identifier of the required oval_variable.
  * @memberof oval_variable_model
  */ 
-struct oval_value_iterator *oval_variable_model_get_values(struct oval_variable_model *, char *);
+OSCAP_API struct oval_value_iterator *oval_variable_model_get_values(struct oval_variable_model *, char *);
 /** @} */
 
 /**
@@ -157,17 +158,17 @@ struct oval_variable_model_iterator;
  * Returns <b>true</b> if iterator not exhausted.
  * @memberof oval_variable_model_iterator
  */
-bool oval_variable_model_iterator_has_more(struct oval_variable_model_iterator *);
+OSCAP_API bool oval_variable_model_iterator_has_more(struct oval_variable_model_iterator *);
 /**
  * Returns next instance of @ref oval_variable_model.
  * @memberof oval_variable_model_iterator
  */
-struct oval_variable_model *oval_variable_model_iterator_next(struct oval_variable_model_iterator *);
+OSCAP_API struct oval_variable_model *oval_variable_model_iterator_next(struct oval_variable_model_iterator *);
 /**
  * Free iterator.
  * @memberof oval_variable_model_iterator
  */
-void oval_variable_model_iterator_free(struct oval_variable_model_iterator *);
+OSCAP_API void oval_variable_model_iterator_free(struct oval_variable_model_iterator *);
 /** @} */
 
 /**

--- a/src/OVAL/public/oval_version.h
+++ b/src/OVAL/public/oval_version.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <oscap.h>
+#include "oscap_export.h"
 
 typedef uint32_t oval_version_t;
 
@@ -16,7 +17,7 @@ typedef uint32_t oval_version_t;
  * OVAL_VERSION_INVALID ... if the string representation
  *                          is not a valid OVAL version
  */
-OSCAP_DEPRECATED(oval_version_t oval_version_from_cstr(const char *version_str));
+OSCAP_API OSCAP_DEPRECATED(oval_version_t oval_version_from_cstr(const char *version_str));
 
 #define OVAL_VERSION(v) oval_version_from_cstr(#v)
 
@@ -28,22 +29,22 @@ OSCAP_DEPRECATED(oval_version_t oval_version_from_cstr(const char *version_str))
  *  1 ... no major component
  * -1 ... insufficient buffer space
  */
-OSCAP_DEPRECATED(int oval_version_to_cstr(oval_version_t version, char *buffer, size_t buflen));
+OSCAP_API OSCAP_DEPRECATED(int oval_version_to_cstr(oval_version_t version, char *buffer, size_t buflen));
 
 /**
  * Get the major component of the version
  */
-OSCAP_DEPRECATED(uint8_t oval_version_major(oval_version_t version));
+OSCAP_API OSCAP_DEPRECATED(uint8_t oval_version_major(oval_version_t version));
 
 /**
  * Get the minor component of the version
  */
-OSCAP_DEPRECATED(uint8_t oval_version_minor(oval_version_t version));
+OSCAP_API OSCAP_DEPRECATED(uint8_t oval_version_minor(oval_version_t version));
 
 /**
  * Get the patch component of the version
  */
-OSCAP_DEPRECATED(uint8_t oval_version_patch(oval_version_t version));
+OSCAP_API OSCAP_DEPRECATED(uint8_t oval_version_patch(oval_version_t version));
 
 /**
  * Compare two versions in the internal representation
@@ -52,6 +53,6 @@ OSCAP_DEPRECATED(uint8_t oval_version_patch(oval_version_t version));
  *  <0 ... if `v1' is older than `v2'
  *  >0 ... if `v1' is newer than `v2'
  */
-OSCAP_DEPRECATED(int oval_version_cmp(oval_version_t v1, oval_version_t v2));
+OSCAP_API OSCAP_DEPRECATED(int oval_version_cmp(oval_version_t v1, oval_version_t v2));
 
 #endif /* OVAL_VERSION_H */

--- a/src/SCE/public/sce_engine_api.h
+++ b/src/SCE/public/sce_engine_api.h
@@ -27,40 +27,41 @@
 
 #include <xccdf_benchmark.h>
 #include <xccdf_policy.h>
+#include "oscap_export.h"
 
 /**
  * @memberof sce_check_result
  */
-struct sce_check_result* sce_check_result_new(void);
+OSCAP_API struct sce_check_result* sce_check_result_new(void);
 
 /**
  * @memberof sce_check_result
  */
-void sce_check_result_free(struct sce_check_result* v);
+OSCAP_API void sce_check_result_free(struct sce_check_result* v);
 
 /**
  * Sets the href used to execute the check that yielded given check result
  *
  * @memberof sce_check_result
  */
-void sce_check_result_set_href(struct sce_check_result* v, const char* href);
+OSCAP_API void sce_check_result_set_href(struct sce_check_result* v, const char* href);
 
 /**
  * @memberof sce_check_result
  */
-const char* sce_check_result_get_href(struct sce_check_result* v);
+OSCAP_API const char* sce_check_result_get_href(struct sce_check_result* v);
 
 /**
  * Sets basename of the script that was used for check evaluation
  *
  * @memberof sce_check_result
  */
-void sce_check_result_set_basename(struct sce_check_result* v, const char* basename);
+OSCAP_API void sce_check_result_set_basename(struct sce_check_result* v, const char* basename);
 
 /**
  * @memberof sce_check_result
  */
-const char* sce_check_result_get_basename(struct sce_check_result* v);
+OSCAP_API const char* sce_check_result_get_basename(struct sce_check_result* v);
 
 /**
  * Sets stdout that was captured while script was evaluating
@@ -68,12 +69,12 @@ const char* sce_check_result_get_basename(struct sce_check_result* v);
  * @param stdout should contain output only from stdout
  * @memberof sce_check_result
  */
-void sce_check_result_set_stdout(struct sce_check_result* v, const char* details);
+OSCAP_API void sce_check_result_set_stdout(struct sce_check_result* v, const char* details);
 
 /**
  * @memberof sce_check_result
  */
-const char* sce_check_result_get_stdout(struct sce_check_result* v);
+OSCAP_API const char* sce_check_result_get_stdout(struct sce_check_result* v);
 
 /**
  * Sets stderr that was captured while script was evaluating
@@ -81,30 +82,30 @@ const char* sce_check_result_get_stdout(struct sce_check_result* v);
  * @param stderr should contain output only from stderr
  * @memberof sce_check_result
  */
-void sce_check_result_set_stderr(struct sce_check_result* v, const char* details);
+OSCAP_API void sce_check_result_set_stderr(struct sce_check_result* v, const char* details);
 
 /**
  * @memberof sce_check_result
  */
-const char* sce_check_result_get_stderr(struct sce_check_result* v);
+OSCAP_API const char* sce_check_result_get_stderr(struct sce_check_result* v);
 
 /**
  * Sets exit code with which the script ended execution after evaluation
  * @memberof sce_check_result
  */
-void sce_check_result_set_exit_code(struct sce_check_result* v, int exit_code);
+OSCAP_API void sce_check_result_set_exit_code(struct sce_check_result* v, int exit_code);
 
 /**
  * @memberof sce_check_result
  */
-int sce_check_result_get_exit_code(struct sce_check_result* v);
+OSCAP_API int sce_check_result_get_exit_code(struct sce_check_result* v);
 
 /**
  * Clears the list of passed environment variables
  *
  * @memberof sce_check_result
  */
-void sce_check_result_reset_environment_variables(struct sce_check_result* v);
+OSCAP_API void sce_check_result_reset_environment_variables(struct sce_check_result* v);
 
 /**
  * Adds an environment variable entry to list of environment variables that
@@ -116,43 +117,43 @@ void sce_check_result_reset_environment_variables(struct sce_check_result* v);
  * @param var entry that will be added, in "VARIABLE_NAME=VARIABLE_VALUE" form
  * @memberof sce_check_result
  */
-void sce_check_result_add_environment_variable(struct sce_check_result* v, const char* var);
+OSCAP_API void sce_check_result_add_environment_variable(struct sce_check_result* v, const char* var);
 
 /**
  * Sets the final xccdf result (after exit code to xccdf mapping takes place)
  *
  * @memberof sce_check_result
  */
-void sce_check_result_set_xccdf_result(struct sce_check_result* v, xccdf_test_result_type_t result);
+OSCAP_API void sce_check_result_set_xccdf_result(struct sce_check_result* v, xccdf_test_result_type_t result);
 
 /**
  * @memberof sce_check_result
  */
-xccdf_test_result_type_t sce_check_result_get_xccdf_result(struct sce_check_result* v);
+OSCAP_API xccdf_test_result_type_t sce_check_result_get_xccdf_result(struct sce_check_result* v);
 
 /**
  * Exports details (in XML form) of given check result to given file
  *
  * @memberof sce_check_result
  */
-void sce_check_result_export(struct sce_check_result* v, const char* target_file);
+OSCAP_API void sce_check_result_export(struct sce_check_result* v, const char* target_file);
 
 /**
  * @memberof sce_session
  */
-struct sce_session* sce_session_new(void);
+OSCAP_API struct sce_session* sce_session_new(void);
 
 /**
  * @memberof sce_session
  */
-void sce_session_free(struct sce_session* s);
+OSCAP_API void sce_session_free(struct sce_session* s);
 
 /**
  * Removes all check results from the session
  *
  * @memberof sce_session
  */
-void sce_session_reset(struct sce_session* s);
+OSCAP_API void sce_session_reset(struct sce_session* s);
 
 /**
  * Adds a check result to the session
@@ -161,7 +162,7 @@ void sce_session_reset(struct sce_session* s);
  * @param result result to be added (the session takes ownership of it, don't deallocate it!)
  * @memberof sce_session
  */
-void sce_session_add_check_result(struct sce_session* s, struct sce_check_result* result);
+OSCAP_API void sce_session_add_check_result(struct sce_session* s, struct sce_check_result* result);
 
 /**
  * @struct sce_check_result_iterator
@@ -169,32 +170,32 @@ void sce_session_add_check_result(struct sce_session* s, struct sce_check_result
  * @see sce_check_result_iterator
  */
 struct sce_check_result_iterator;
-struct sce_check_result *sce_check_result_iterator_next(struct sce_check_result_iterator *it);
+OSCAP_API struct sce_check_result *sce_check_result_iterator_next(struct sce_check_result_iterator *it);
 /// @memberof sce_check_result_iterator
-bool sce_check_result_iterator_has_more(struct sce_check_result_iterator *it);
+OSCAP_API bool sce_check_result_iterator_has_more(struct sce_check_result_iterator *it);
 /// @memberof sce_check_result_iterator
-void sce_check_result_iterator_free(struct sce_check_result_iterator *it);
+OSCAP_API void sce_check_result_iterator_free(struct sce_check_result_iterator *it);
 /// @memberof sce_check_result_iterator
-void sce_check_result_iterator_reset(struct sce_check_result_iterator *it);
+OSCAP_API void sce_check_result_iterator_reset(struct sce_check_result_iterator *it);
 
-struct sce_check_result_iterator *sce_session_get_check_results(struct sce_session* s);
+OSCAP_API struct sce_check_result_iterator *sce_session_get_check_results(struct sce_session* s);
 
 /**
  * Exports all check results to given directory
  *
  * @memberof sce_session
  */
-void sce_session_export_to_directory(struct sce_session* s, const char* directory);
+OSCAP_API void sce_session_export_to_directory(struct sce_session* s, const char* directory);
 
 /**
  * @memberof sce_parameters
  */
-struct sce_parameters* sce_parameters_new(void);
+OSCAP_API struct sce_parameters* sce_parameters_new(void);
 
 /**
  * @memberof sce_parameters
  */
-void sce_parameters_free(struct sce_parameters* v);
+OSCAP_API void sce_parameters_free(struct sce_parameters* v);
 
 /**
  * Sets the directory that contains XCCDF that will reference SCE checks
@@ -202,12 +203,12 @@ void sce_parameters_free(struct sce_parameters* v);
  * @internal This is used to figure out where to look for the scripts
  * @memberof sce_parameters
  */
-void sce_parameters_set_xccdf_directory(struct sce_parameters* v, const char* value);
+OSCAP_API void sce_parameters_set_xccdf_directory(struct sce_parameters* v, const char* value);
 
 /**
  * @memberof sce_parameters
  */
-const char* sce_parameters_get_xccdf_directory(struct sce_parameters* v);
+OSCAP_API const char* sce_parameters_get_xccdf_directory(struct sce_parameters* v);
 
 /**
  * Sets SCE session to use for check results storage
@@ -216,12 +217,12 @@ const char* sce_parameters_get_xccdf_directory(struct sce_parameters* v);
  * @param value SCE session to use (sce_parameters take ownership of it, don't deallocate it!)
  * @memberof sce_parameters
  */
-void sce_parameters_set_session(struct sce_parameters* v, struct sce_session* value);
+OSCAP_API void sce_parameters_set_session(struct sce_parameters* v, struct sce_session* value);
 
 /**
  * @memberof sce_parameters
  */
-struct sce_session* sce_parameters_get_session(struct sce_parameters* v);
+OSCAP_API struct sce_session* sce_parameters_get_session(struct sce_parameters* v);
 
 /**
  * Just a convenience shortcut of setting a session to a newly allocated session
@@ -229,7 +230,7 @@ struct sce_session* sce_parameters_get_session(struct sce_parameters* v);
  * The session gets automatically freed when sce_parameters are freed, don't deallocate it!
  * @memberof sce_parameters
  */
-void sce_parameters_allocate_session(struct sce_parameters* v);
+OSCAP_API void sce_parameters_allocate_session(struct sce_parameters* v);
 
 /**
  * Internal rule evaluation callback, don't use directly
@@ -247,6 +248,6 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
  * @param model model to register SCE to
  * @param sce_parameters various parameters to be used with SCE (you are responsible to deallocate them!)
  */
-bool xccdf_policy_model_register_engine_sce(struct xccdf_policy_model * model, struct sce_parameters *sce_parameters);
+OSCAP_API bool xccdf_policy_model_register_engine_sce(struct xccdf_policy_model * model, struct sce_parameters *sce_parameters);
 
 #endif

--- a/src/XCCDF/public/xccdf_benchmark.h
+++ b/src/XCCDF/public/xccdf_benchmark.h
@@ -40,6 +40,7 @@
 #include <oscap_source.h>
 #include <oscap.h>
 #include "cpe_dict.h"
+#include "oscap_export.h"
 
 /*--------------------*\
 |     Enumerations     |
@@ -635,11 +636,11 @@ struct xccdf_plain_text_iterator;
 struct xccdf_version_info;
 
 /// @memberof xccdf_version_info
-const char* xccdf_version_info_get_version(const struct xccdf_version_info* v);
+OSCAP_API const char* xccdf_version_info_get_version(const struct xccdf_version_info* v);
 /// @memberof xccdf_version_info
-const char* xccdf_version_info_get_namespace_uri(const struct xccdf_version_info* v);
+OSCAP_API const char* xccdf_version_info_get_namespace_uri(const struct xccdf_version_info* v);
 /// @memberof xccdf_version_info
-const char* xccdf_version_info_get_cpe_version(const struct xccdf_version_info* v);
+OSCAP_API const char* xccdf_version_info_get_cpe_version(const struct xccdf_version_info* v);
 
 /**
  * Starts parsing given XCCDF benchmark file to detect its version,
@@ -649,15 +650,15 @@ const char* xccdf_version_info_get_cpe_version(const struct xccdf_version_info* 
  * @deprecated This function has been deprecated by @ref oscap_source_get_schema_version.
  * This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(char * xccdf_detect_version(const char* file));
+OSCAP_API OSCAP_DEPRECATED(char * xccdf_detect_version(const char* file));
 
 /************************************************************/
 
 /// @memberof xccdf_item
-void xccdf_item_free(struct xccdf_item *item);
+OSCAP_API void xccdf_item_free(struct xccdf_item *item);
 
 /// @memberof xccdf_item
-struct xccdf_item * xccdf_item_clone(const struct xccdf_item * old_item);
+OSCAP_API struct xccdf_item * xccdf_item_clone(const struct xccdf_item * old_item);
 
 /**
  * Convert the item to a benchmark.
@@ -665,7 +666,7 @@ struct xccdf_item * xccdf_item_clone(const struct xccdf_item * old_item);
  * @return Pointer to this item as the benchmark.
  * @retval NULL on faliure (e.g. item is not a benchmark)
  */
-struct xccdf_benchmark* xccdf_item_to_benchmark(struct xccdf_item* item);
+OSCAP_API struct xccdf_benchmark* xccdf_item_to_benchmark(struct xccdf_item* item);
 
 /**
  * Convert the item to a profile.
@@ -673,7 +674,7 @@ struct xccdf_benchmark* xccdf_item_to_benchmark(struct xccdf_item* item);
  * @return Pointer to this item as the profile.
  * @retval NULL on faliure (e.g. item is not a profile)
  */
-struct xccdf_profile* xccdf_item_to_profile(struct xccdf_item* item);
+OSCAP_API struct xccdf_profile* xccdf_item_to_profile(struct xccdf_item* item);
 
 /**
  * Convert the item to a rule.
@@ -681,7 +682,7 @@ struct xccdf_profile* xccdf_item_to_profile(struct xccdf_item* item);
  * @return Pointer to this item as the rule.
  * @retval NULL on faliure (e.g. item is not a rule)
  */
-struct xccdf_rule* xccdf_item_to_rule(struct xccdf_item* item);
+OSCAP_API struct xccdf_rule* xccdf_item_to_rule(struct xccdf_item* item);
 
 /**
  * Convert the item to a group.
@@ -689,7 +690,7 @@ struct xccdf_rule* xccdf_item_to_rule(struct xccdf_item* item);
  * @return Pointer to this item as the group.
  * @retval NULL on faliure (e.g. item is not a group)
  */
-struct xccdf_group* xccdf_item_to_group(struct xccdf_item* item);
+OSCAP_API struct xccdf_group* xccdf_item_to_group(struct xccdf_item* item);
 
 /**
  * Convert the item to a value.
@@ -697,7 +698,7 @@ struct xccdf_group* xccdf_item_to_group(struct xccdf_item* item);
  * @return Pointer to this item as the value.
  * @retval NULL on faliure (e.g. item is not a value)
  */
-struct xccdf_value* xccdf_item_to_value(struct xccdf_item* item);
+OSCAP_API struct xccdf_value* xccdf_item_to_value(struct xccdf_item* item);
 
 /**
  * Convert the item to a test result.
@@ -705,7 +706,7 @@ struct xccdf_value* xccdf_item_to_value(struct xccdf_item* item);
  * @return Pointer to this item as the test result.
  * @retval NULL on faliure (e.g. item is not a test result)
  */
-struct xccdf_result* xccdf_item_to_result(struct xccdf_item* item);
+OSCAP_API struct xccdf_result* xccdf_item_to_result(struct xccdf_item* item);
 
 /**
  * Import the content from a specified XML stream into a benchmark.
@@ -716,7 +717,7 @@ struct xccdf_result* xccdf_item_to_result(struct xccdf_item* item);
  * @deprecated This function has been deprecated by @ref xccdf_benchmark_import_source.
  * This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(struct xccdf_benchmark* xccdf_benchmark_import(const char *file));
+OSCAP_API OSCAP_DEPRECATED(struct xccdf_benchmark* xccdf_benchmark_import(const char *file));
 
 /**
  * Import the content from oscap_source into a benchmark
@@ -724,7 +725,7 @@ OSCAP_DEPRECATED(struct xccdf_benchmark* xccdf_benchmark_import(const char *file
  * @param source The oscap_source to import from
  * @returns newly created benchmark element or NULL
  */
-struct xccdf_benchmark* xccdf_benchmark_import_source(struct oscap_source *source);
+OSCAP_API struct xccdf_benchmark* xccdf_benchmark_import_source(struct oscap_source *source);
 
 /**
  * Export a benchmark to an XML stream
@@ -732,14 +733,14 @@ struct xccdf_benchmark* xccdf_benchmark_import_source(struct oscap_source *sourc
  * @return Integer
  * @retval -1 if error occurred
  */
-int xccdf_benchmark_export(struct xccdf_benchmark *benchmark, const char *file);
+OSCAP_API int xccdf_benchmark_export(struct xccdf_benchmark *benchmark, const char *file);
 
 /**
  * Export a benchmark to a source object
  * @memberof xccdf_benchmark
  * @returns newly created source object or NULL
  */
-struct oscap_source *xccdf_benchmark_export_source(struct xccdf_benchmark *benchmark, const char *filename);
+OSCAP_API struct oscap_source *xccdf_benchmark_export_source(struct xccdf_benchmark *benchmark, const char *filename);
 
 /**
  * Import the content of oscap_source into a xccdf_result
@@ -747,13 +748,13 @@ struct oscap_source *xccdf_benchmark_export_source(struct xccdf_benchmark *bench
  * @param source The oscap_source to import from
  * @returns newly created test-result element or NULL on error
  */
-struct xccdf_result *xccdf_result_import_source(struct oscap_source *source);
+OSCAP_API struct xccdf_result *xccdf_result_import_source(struct oscap_source *source);
 
 /**
  * Collect system info and store it in the TestResult.
  * @memberof xccdf_result
  */
-void xccdf_result_fill_sysinfo(struct xccdf_result *result);
+OSCAP_API void xccdf_result_fill_sysinfo(struct xccdf_result *result);
 
 /**
  * Export a TestResult to an XML stream
@@ -763,21 +764,21 @@ void xccdf_result_fill_sysinfo(struct xccdf_result *result);
  * @deprecated This function has been deprecated by @ref xccdf_benchmark_export_source.
  * This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(int xccdf_result_export(struct xccdf_result *result, const char *file));
+OSCAP_API OSCAP_DEPRECATED(int xccdf_result_export(struct xccdf_result *result, const char *file));
 
 /**
  * Export TestResult to oscap_source structure
  * @memberof xccdf_result
  * @returns newly created oscap_source or NULL on error
  */
-struct oscap_source *xccdf_result_export_source(struct xccdf_result *result, const char *filepath);
+OSCAP_API struct oscap_source *xccdf_result_export_source(struct xccdf_result *result, const char *filepath);
 
 /**
  * Export TestResult to oscap_source structure using STIG Rule IDs instead of the actual rule ids
  * @memberof xccdf_result
  * @returns newly created oscap_source or NULL on error
  */
-struct oscap_source *xccdf_result_stig_viewer_export_source(struct xccdf_result *result, const char *filepath);
+OSCAP_API struct oscap_source *xccdf_result_stig_viewer_export_source(struct xccdf_result *result, const char *filepath);
 
 /**
  * Resolve an benchmark.
@@ -785,198 +786,198 @@ struct oscap_source *xccdf_result_stig_viewer_export_source(struct xccdf_result 
  * @retval true on success
  * @retval false on dependency loop
  */
-bool xccdf_benchmark_resolve(struct xccdf_benchmark *benchmark);
+OSCAP_API bool xccdf_benchmark_resolve(struct xccdf_benchmark *benchmark);
 
 /// @memberof xccdf_benchmark
-struct xccdf_benchmark *xccdf_benchmark_new(void);
+OSCAP_API struct xccdf_benchmark *xccdf_benchmark_new(void);
 /// @memberof xccdf_benchmark
-void xccdf_benchmark_free(struct xccdf_benchmark *benchmark);
+OSCAP_API void xccdf_benchmark_free(struct xccdf_benchmark *benchmark);
 /// @memberof xccdf_benchmark
-struct xccdf_item *xccdf_benchmark_to_item(struct xccdf_benchmark *item);
+OSCAP_API struct xccdf_item *xccdf_benchmark_to_item(struct xccdf_benchmark *item);
 /// @memberof xccdf_benchmark
-struct xccdf_benchmark * xccdf_benchmark_clone( const struct  xccdf_benchmark * benchmark );
+OSCAP_API struct xccdf_benchmark * xccdf_benchmark_clone( const struct  xccdf_benchmark * benchmark );
 
 /**
  * Get supported version of XCCDF XML
  * @return version of XML file format
  * @memberof xccdf_benchmark
  */
-const char * xccdf_benchmark_supported(void);
+OSCAP_API const char * xccdf_benchmark_supported(void);
 
 /// @memberof xccdf_benchmark
-const struct xccdf_version_info *xccdf_benchmark_supported_schema_version(void);
+OSCAP_API const struct xccdf_version_info *xccdf_benchmark_supported_schema_version(void);
 
 /// @memberof xccdf_profile
-struct xccdf_profile *xccdf_profile_new(void);
+OSCAP_API struct xccdf_profile *xccdf_profile_new(void);
 /// @memberof xccdf_profile
-void xccdf_profile_free(struct xccdf_item *prof);
+OSCAP_API void xccdf_profile_free(struct xccdf_item *prof);
 /// @memberof xccdf_profile
-struct xccdf_item *xccdf_profile_to_item(struct xccdf_profile *item);
+OSCAP_API struct xccdf_item *xccdf_profile_to_item(struct xccdf_profile *item);
 /// @memberof xccdf_profile
-struct xccdf_profile * xccdf_profile_clone( const struct xccdf_profile * profile);
+OSCAP_API struct xccdf_profile * xccdf_profile_clone( const struct xccdf_profile * profile);
 
 /// @memberof xccdf_rule
-struct xccdf_rule *xccdf_rule_new(void);
+OSCAP_API struct xccdf_rule *xccdf_rule_new(void);
 /// @memberof xccdf_rule
-void xccdf_rule_free(struct xccdf_item *rule);
+OSCAP_API void xccdf_rule_free(struct xccdf_item *rule);
 /// @memberof xccdf_rule
-struct xccdf_item *xccdf_rule_to_item(struct xccdf_rule *item);
+OSCAP_API struct xccdf_item *xccdf_rule_to_item(struct xccdf_rule *item);
 /// @memberof xccdf_rule
-struct xccdf_rule * xccdf_rule_clone(const struct xccdf_rule * rule);
+OSCAP_API struct xccdf_rule * xccdf_rule_clone(const struct xccdf_rule * rule);
 
 /// @memberof xccdf_group
-struct xccdf_group *xccdf_group_new(void);
+OSCAP_API struct xccdf_group *xccdf_group_new(void);
 /// @memberof xccdf_group
-void xccdf_group_free(struct xccdf_item *group);
+OSCAP_API void xccdf_group_free(struct xccdf_item *group);
 /// @memberof xccdf_group
-struct xccdf_item *xccdf_group_to_item(struct xccdf_group *item);
+OSCAP_API struct xccdf_item *xccdf_group_to_item(struct xccdf_group *item);
 /// @memberof xccdf_group
-struct xccdf_group * xccdf_group_clone(const struct xccdf_group * group);
+OSCAP_API struct xccdf_group * xccdf_group_clone(const struct xccdf_group * group);
 
 /// @memberof xccdf_value
-struct xccdf_value *xccdf_value_new(xccdf_value_type_t type);
+OSCAP_API struct xccdf_value *xccdf_value_new(xccdf_value_type_t type);
 /// @memberof xccdf_value
-void xccdf_value_free(struct xccdf_item *val);
+OSCAP_API void xccdf_value_free(struct xccdf_item *val);
 /// @memberof xccdf_value
-struct xccdf_item *xccdf_value_to_item(struct xccdf_value *item);
+OSCAP_API struct xccdf_item *xccdf_value_to_item(struct xccdf_value *item);
 /// @memberof xccdf_value
-struct xccdf_value * xccdf_value_clone(const struct xccdf_value * value);
+OSCAP_API struct xccdf_value * xccdf_value_clone(const struct xccdf_value * value);
 
 /// @memberof xccdf_status
-struct xccdf_status *xccdf_status_new(void);
+OSCAP_API struct xccdf_status *xccdf_status_new(void);
 /// @memberof xccdf_status
-struct xccdf_status * xccdf_status_clone(const struct xccdf_status * old_status);
+OSCAP_API struct xccdf_status * xccdf_status_clone(const struct xccdf_status * old_status);
 /// @memberof xccdf_status
-struct xccdf_status *xccdf_status_new_fill(const char *status, const char *date);
+OSCAP_API struct xccdf_status *xccdf_status_new_fill(const char *status, const char *date);
 /// @memberof xccdf_status
-void xccdf_status_free(struct xccdf_status *status);
+OSCAP_API void xccdf_status_free(struct xccdf_status *status);
 /// @memberof xccdf_notice
-struct xccdf_notice *xccdf_notice_new(void);
+OSCAP_API struct xccdf_notice *xccdf_notice_new(void);
 /// @memberof xccdf_notice
-void xccdf_notice_free(struct xccdf_notice *notice);
+OSCAP_API void xccdf_notice_free(struct xccdf_notice *notice);
 /// @memberof xccdf_notice
-struct xccdf_notice * xccdf_notice_clone(const struct xccdf_notice * notice);
+OSCAP_API struct xccdf_notice * xccdf_notice_clone(const struct xccdf_notice * notice);
 
 /// @memberof xccdf_model
-struct xccdf_model *xccdf_model_new(void);
+OSCAP_API struct xccdf_model *xccdf_model_new(void);
 /// @memberof xccdf_model
-struct xccdf_model * xccdf_model_clone(const struct xccdf_model * old_model);
+OSCAP_API struct xccdf_model * xccdf_model_clone(const struct xccdf_model * old_model);
 /// @memberof xccdf_model
-void xccdf_model_free(struct xccdf_model *model);
+OSCAP_API void xccdf_model_free(struct xccdf_model *model);
 
 /// @memberof xccdf_ident
-struct xccdf_ident *xccdf_ident_new(void);
+OSCAP_API struct xccdf_ident *xccdf_ident_new(void);
 /// @memberof xccdf_ident
-struct xccdf_ident *xccdf_ident_new_fill(const char *id, const char *sys);
+OSCAP_API struct xccdf_ident *xccdf_ident_new_fill(const char *id, const char *sys);
 /// @memberof xccdf_ident
-struct xccdf_ident *xccdf_ident_clone(const struct xccdf_ident * ident);
+OSCAP_API struct xccdf_ident *xccdf_ident_clone(const struct xccdf_ident * ident);
 /// @memberof xccdf_ident
-void xccdf_ident_free(struct xccdf_ident *ident);
+OSCAP_API void xccdf_ident_free(struct xccdf_ident *ident);
 
 
 /// @memberof xccdf_check
-struct xccdf_check *xccdf_check_new(void);
+OSCAP_API struct xccdf_check *xccdf_check_new(void);
 /// @memberof xccdf_check
-void xccdf_check_free(struct xccdf_check *check);
+OSCAP_API void xccdf_check_free(struct xccdf_check *check);
 
 /// @memberof xccdf_check
-struct xccdf_check *xccdf_check_clone(const struct xccdf_check *old_check);
+OSCAP_API struct xccdf_check *xccdf_check_clone(const struct xccdf_check *old_check);
 /// @memberof xccdf_check_import
-struct xccdf_check_import *xccdf_check_import_clone(const struct xccdf_check_import *old_import);
+OSCAP_API struct xccdf_check_import *xccdf_check_import_clone(const struct xccdf_check_import *old_import);
 /// @memberof xccdf_check_export
-struct xccdf_check_export *xccdf_check_export_clone(const struct xccdf_check_export *old_export);
+OSCAP_API struct xccdf_check_export *xccdf_check_export_clone(const struct xccdf_check_export *old_export);
 /// @memberof xccdf_check_content_ref
-struct xccdf_check_content_ref *xccdf_check_content_ref_clone(const struct xccdf_check_content_ref *old_ref);
+OSCAP_API struct xccdf_check_content_ref *xccdf_check_content_ref_clone(const struct xccdf_check_content_ref *old_ref);
 
 /// @memberof xccdf_check_content_ref
-struct xccdf_check_content_ref *xccdf_check_content_ref_new(void);
+OSCAP_API struct xccdf_check_content_ref *xccdf_check_content_ref_new(void);
 /// @memberof xccdf_check_content_ref
-void xccdf_check_content_ref_free(struct xccdf_check_content_ref *ref);
+OSCAP_API void xccdf_check_content_ref_free(struct xccdf_check_content_ref *ref);
 
 /// @memberof xccdf_profile_note
-struct xccdf_profile_note *xccdf_profile_note_new(void);
+OSCAP_API struct xccdf_profile_note *xccdf_profile_note_new(void);
 /// @memberof xccdf_profile_note
-void xccdf_profile_note_free(struct xccdf_profile_note *note);
+OSCAP_API void xccdf_profile_note_free(struct xccdf_profile_note *note);
 
 /// @memberof xccdf_check_import
-struct xccdf_check_import *xccdf_check_import_new(void);
+OSCAP_API struct xccdf_check_import *xccdf_check_import_new(void);
 /// @memberof xccdf_check_import
-void xccdf_check_import_free(struct xccdf_check_import *item);
+OSCAP_API void xccdf_check_import_free(struct xccdf_check_import *item);
 
 /// @memberof xccdf_check_export
-struct xccdf_check_export *xccdf_check_export_new(void);
+OSCAP_API struct xccdf_check_export *xccdf_check_export_new(void);
 /// @memberof xccdf_check_export
-void xccdf_check_export_free(struct xccdf_check_export *item);
+OSCAP_API void xccdf_check_export_free(struct xccdf_check_export *item);
 
 /// @memberof xccdf_fix
-struct xccdf_fix *xccdf_fix_new(void);
+OSCAP_API struct xccdf_fix *xccdf_fix_new(void);
 /// @memberof xccdf_fix
-struct xccdf_fix *xccdf_fix_clone(const struct xccdf_fix *old_fix);
+OSCAP_API struct xccdf_fix *xccdf_fix_clone(const struct xccdf_fix *old_fix);
 /// @memberof xccdf_fix
-void xccdf_fix_free(struct xccdf_fix *item);
+OSCAP_API void xccdf_fix_free(struct xccdf_fix *item);
 
 /// @memberof xccdf_fixtext
-struct xccdf_fixtext *xccdf_fixtext_new(void);
+OSCAP_API struct xccdf_fixtext *xccdf_fixtext_new(void);
 /// @memberof xccdf_fixtext
-struct xccdf_fixtext * xccdf_fixtext_clone(const struct xccdf_fixtext * fixtext);
+OSCAP_API struct xccdf_fixtext * xccdf_fixtext_clone(const struct xccdf_fixtext * fixtext);
 /// @memberof xccdf_fixtext
-void xccdf_fixtext_free(struct xccdf_fixtext *item);
+OSCAP_API void xccdf_fixtext_free(struct xccdf_fixtext *item);
 
 /// @memberof xccdf_select
-void xccdf_select_free(struct xccdf_select *sel);
+OSCAP_API void xccdf_select_free(struct xccdf_select *sel);
 /// @memberof xccdf_select
-struct xccdf_select *xccdf_select_clone(const struct xccdf_select * select);
+OSCAP_API struct xccdf_select *xccdf_select_clone(const struct xccdf_select * select);
 /// @memberof xccdf_select
-struct xccdf_select *xccdf_select_new(void);
+OSCAP_API struct xccdf_select *xccdf_select_new(void);
 
 /// @memberof xccdf_warning
-struct xccdf_warning *xccdf_warning_new(void);
+OSCAP_API struct xccdf_warning *xccdf_warning_new(void);
 /// @memberof xccdf_warning
-struct xccdf_warning *xccdf_warning_clone(const struct xccdf_warning *old_warning);
+OSCAP_API struct xccdf_warning *xccdf_warning_clone(const struct xccdf_warning *old_warning);
 /// @memberof xccdf_warning
-void xccdf_warning_free(struct xccdf_warning * warn);
+OSCAP_API void xccdf_warning_free(struct xccdf_warning * warn);
 
 /// @memberof xccdf_refine_rule
-void xccdf_refine_rule_free(struct xccdf_refine_rule *obj);
+OSCAP_API void xccdf_refine_rule_free(struct xccdf_refine_rule *obj);
 
 /// @memberof xccdf_refine_value
-void xccdf_refine_value_free(struct xccdf_refine_value *rv);
+OSCAP_API void xccdf_refine_value_free(struct xccdf_refine_value *rv);
 
-void xccdf_setvalue_free(struct xccdf_setvalue *sv);
+OSCAP_API void xccdf_setvalue_free(struct xccdf_setvalue *sv);
 
 /// @memberof xccdf_tailoring
-struct xccdf_tailoring *xccdf_tailoring_new(void);
+OSCAP_API struct xccdf_tailoring *xccdf_tailoring_new(void);
 /// @memberof xccdf_tailoring
-void xccdf_tailoring_free(struct xccdf_tailoring *tailoring);
+OSCAP_API void xccdf_tailoring_free(struct xccdf_tailoring *tailoring);
 /// @memberof xccdf_tailoring
-int xccdf_tailoring_export(struct xccdf_tailoring *tailoring, const char *file, const struct xccdf_version_info *version_info);
+OSCAP_API int xccdf_tailoring_export(struct xccdf_tailoring *tailoring, const char *file, const struct xccdf_version_info *version_info);
 
 /**
  * Release library internal caches.
  * @deprecated Use @ref oscap_cleanup() instead.
  */
-OSCAP_DEPRECATED(void xccdf_cleanup(void));
+OSCAP_API OSCAP_DEPRECATED(void xccdf_cleanup(void));
 
 /**
  * Create a group and append it to the benchmark.
  * @param id - the identifier of the appended value.
  * @return the handle of the new group.
  */
-struct xccdf_group *xccdf_benchmark_append_new_group(struct xccdf_benchmark *, const char *id);
+OSCAP_API struct xccdf_group *xccdf_benchmark_append_new_group(struct xccdf_benchmark *, const char *id);
 
 /**
  * Create a value and append it to the benchmark.
  * @param id - the identifier of the appended value.
  * @return the handle of the new value.
  */
-struct xccdf_value *xccdf_benchmark_append_new_value(struct xccdf_benchmark *, const char *id, xccdf_value_type_t type);
+OSCAP_API struct xccdf_value *xccdf_benchmark_append_new_value(struct xccdf_benchmark *, const char *id, xccdf_value_type_t type);
 
 /**
  * Create a rule and append it to the benchmark.
  * @param id - the identifier of the appended rule.
  * @return the handle of the new rule.
  */
-struct xccdf_rule *xccdf_benchmark_append_new_rule(struct xccdf_benchmark *, const char *id);
+OSCAP_API struct xccdf_rule *xccdf_benchmark_append_new_rule(struct xccdf_benchmark *, const char *id);
 
 /**
  * Match a profile suffix agains profiles present in the given benchmark.
@@ -987,7 +988,7 @@ struct xccdf_rule *xccdf_benchmark_append_new_rule(struct xccdf_benchmark *, con
  * @returns The complete profile ID.
  * @retval NULL is returned in case of error. Details might be found through match_status
  */
-const char *xccdf_benchmark_match_profile_id(struct xccdf_benchmark *bench, const char *profile_suffix, int *match_status);
+OSCAP_API const char *xccdf_benchmark_match_profile_id(struct xccdf_benchmark *bench, const char *profile_suffix, int *match_status);
 
 /**
  * Match a profile suffix agains profiles present in the given benchmark.
@@ -998,84 +999,84 @@ const char *xccdf_benchmark_match_profile_id(struct xccdf_benchmark *bench, cons
  * @returns The complete profile ID.
  * @retval NULL is returned in case of error. Details might be found through match_status
  */
-const char *xccdf_tailoring_match_profile_id(struct xccdf_tailoring *tailoring, const char *profile_suffix, int *match_status);
+OSCAP_API const char *xccdf_tailoring_match_profile_id(struct xccdf_tailoring *tailoring, const char *profile_suffix, int *match_status);
 
 /// @memberof xccdf_plain_text
-struct xccdf_plain_text *xccdf_plain_text_new(void);
+OSCAP_API struct xccdf_plain_text *xccdf_plain_text_new(void);
 /// @memberof xccdf_plain_text
-struct xccdf_plain_text *xccdf_plain_text_new_fill(const char *id, const char *text);
+OSCAP_API struct xccdf_plain_text *xccdf_plain_text_new_fill(const char *id, const char *text);
 /// @memberof xccdf_plain_text
-void xccdf_plain_text_free(struct xccdf_plain_text *plain);
+OSCAP_API void xccdf_plain_text_free(struct xccdf_plain_text *plain);
 /// @memberof xccdf_plain_text
-struct xccdf_plain_text *xccdf_plain_text_clone(const struct xccdf_plain_text * pt);
+OSCAP_API struct xccdf_plain_text *xccdf_plain_text_clone(const struct xccdf_plain_text * pt);
 
 /// @memberof xccdf_result
-struct xccdf_result *xccdf_result_new(void);
+OSCAP_API struct xccdf_result *xccdf_result_new(void);
 /// @memberof xccdf_result
-void xccdf_result_free(struct xccdf_result *item);
+OSCAP_API void xccdf_result_free(struct xccdf_result *item);
 /// @memberof xccdf_result
-struct xccdf_item *xccdf_result_to_item(struct xccdf_result *item);
+OSCAP_API struct xccdf_item *xccdf_result_to_item(struct xccdf_result *item);
 /// @memberof xccdf_result
-struct xccdf_result * xccdf_result_clone(const struct xccdf_result * result);
+OSCAP_API struct xccdf_result * xccdf_result_clone(const struct xccdf_result * result);
 
 /// @memberof xccdf_rule_result
-struct xccdf_rule_result *xccdf_rule_result_new(void);
+OSCAP_API struct xccdf_rule_result *xccdf_rule_result_new(void);
 /// @memberof xccdf_rule_result
-struct xccdf_rule_result * xccdf_rule_result_clone(const struct xccdf_rule_result * result);
+OSCAP_API struct xccdf_rule_result * xccdf_rule_result_clone(const struct xccdf_rule_result * result);
 /// @memberof xccdf_rule_result
-void xccdf_rule_result_free(struct xccdf_rule_result *rr);
+OSCAP_API void xccdf_rule_result_free(struct xccdf_rule_result *rr);
 
 /// @memberof xccdf_identity
-struct xccdf_identity *xccdf_identity_new(void);
+OSCAP_API struct xccdf_identity *xccdf_identity_new(void);
 /// @memberof xccdf_identity
-struct xccdf_identity * xccdf_identity_clone(const struct xccdf_identity * identity);
+OSCAP_API struct xccdf_identity * xccdf_identity_clone(const struct xccdf_identity * identity);
 /// @memberof xccdf_identity
-void xccdf_identity_free(struct xccdf_identity *identity);
+OSCAP_API void xccdf_identity_free(struct xccdf_identity *identity);
 
 /// @memberof xccdf_score
-struct xccdf_score *xccdf_score_new(void);
+OSCAP_API struct xccdf_score *xccdf_score_new(void);
 /// @memberof xccdf_score
-struct xccdf_score * xccdf_score_clone(const struct xccdf_score * score);
+OSCAP_API struct xccdf_score * xccdf_score_clone(const struct xccdf_score * score);
 /// @memberof xccdf_score
-void xccdf_score_free(struct xccdf_score *score);
+OSCAP_API void xccdf_score_free(struct xccdf_score *score);
 
 /// @memberof xccdf_override
-struct xccdf_override *xccdf_override_new(void);
+OSCAP_API struct xccdf_override *xccdf_override_new(void);
 /// @memberof xccdf_override
-struct xccdf_override * xccdf_override_clone(const struct xccdf_override * override);
+OSCAP_API struct xccdf_override * xccdf_override_clone(const struct xccdf_override * override);
 /// @memberof xccdf_override
-void xccdf_override_free(struct xccdf_override *oride);
+OSCAP_API void xccdf_override_free(struct xccdf_override *oride);
 
 /// @memberof xccdf_message
-struct xccdf_message *xccdf_message_new(void);
+OSCAP_API struct xccdf_message *xccdf_message_new(void);
 /// @memberof xccdf_message
-struct xccdf_message * xccdf_message_clone(const struct xccdf_message * message);
+OSCAP_API struct xccdf_message * xccdf_message_clone(const struct xccdf_message * message);
 /// @memberof xccdf_message
-void xccdf_message_free(struct xccdf_message *msg);
+OSCAP_API void xccdf_message_free(struct xccdf_message *msg);
 
 /// @memberof xccdf_target_fact
-struct xccdf_target_fact *xccdf_target_fact_new(void);
+OSCAP_API struct xccdf_target_fact *xccdf_target_fact_new(void);
 /// @memberof xccdf_target_fact
-struct xccdf_target_fact * xccdf_target_fact_clone(const struct xccdf_target_fact * tf);
+OSCAP_API struct xccdf_target_fact * xccdf_target_fact_clone(const struct xccdf_target_fact * tf);
 /// @memberof xccdf_target_fact
-void xccdf_target_fact_free(struct xccdf_target_fact *fact);
+OSCAP_API void xccdf_target_fact_free(struct xccdf_target_fact *fact);
 
 /// @memberof xccdf_target_identifier
-struct xccdf_target_identifier *xccdf_target_identifier_new(void);
+OSCAP_API struct xccdf_target_identifier *xccdf_target_identifier_new(void);
 /// @memberof xccdf_target_identifier
-struct xccdf_target_identifier * xccdf_target_identifier_clone(const struct xccdf_target_identifier * ti);
+OSCAP_API struct xccdf_target_identifier * xccdf_target_identifier_clone(const struct xccdf_target_identifier * ti);
 /// @memberof xccdf_target_identifier
-void xccdf_target_identifier_free(struct xccdf_target_identifier *ti);
+OSCAP_API void xccdf_target_identifier_free(struct xccdf_target_identifier *ti);
 
 /// @memberof xccdf_instance
-struct xccdf_instance *xccdf_instance_new(void);
+OSCAP_API struct xccdf_instance *xccdf_instance_new(void);
 /// @memberof xccdf_instance
-struct xccdf_instance * xccdf_instance_clone(const struct xccdf_instance * instance);
+OSCAP_API struct xccdf_instance * xccdf_instance_clone(const struct xccdf_instance * instance);
 /// @memberof xccdf_instance
-void xccdf_instance_free(struct xccdf_instance *inst);
+OSCAP_API void xccdf_instance_free(struct xccdf_instance *inst);
 
 /// @memberof xccdf_value_instance
-struct oscap_string_iterator *xccdf_value_instance_get_choices(const struct xccdf_value_instance *item);
+OSCAP_API struct oscap_string_iterator *xccdf_value_instance_get_choices(const struct xccdf_value_instance *item);
 
 /************************************************************/
 /**
@@ -1087,659 +1088,659 @@ struct oscap_string_iterator *xccdf_value_instance_get_choices(const struct xccd
  * Return the next xccdf_item structure from the list and increment the iterator
  * @memberof xccdf_item_iterator
  */
-struct xccdf_item *xccdf_item_iterator_next(struct xccdf_item_iterator *it);
+OSCAP_API struct xccdf_item *xccdf_item_iterator_next(struct xccdf_item_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_item_iterator
  */
-bool xccdf_item_iterator_has_more(struct xccdf_item_iterator *it);
+OSCAP_API bool xccdf_item_iterator_has_more(struct xccdf_item_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_item_iterator
  */
-void xccdf_item_iterator_free(struct xccdf_item_iterator *it);
+OSCAP_API void xccdf_item_iterator_free(struct xccdf_item_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_item_iterator
  */
-void xccdf_item_iterator_reset(struct xccdf_item_iterator *it);
+OSCAP_API void xccdf_item_iterator_reset(struct xccdf_item_iterator *it);
 
 
 /**
  * Return the next xccdf_notice structure from the list and increment the iterator
  * @memberof xccdf_notice_iterator
  */
-struct xccdf_notice *xccdf_notice_iterator_next(struct xccdf_notice_iterator *it);
+OSCAP_API struct xccdf_notice *xccdf_notice_iterator_next(struct xccdf_notice_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_notice_iterator
  */
-bool xccdf_notice_iterator_has_more(struct xccdf_notice_iterator *it);
+OSCAP_API bool xccdf_notice_iterator_has_more(struct xccdf_notice_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_notice_iterator
  */
-void xccdf_notice_iterator_free(struct xccdf_notice_iterator *it);
+OSCAP_API void xccdf_notice_iterator_free(struct xccdf_notice_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_notice_iterator
  */
-void xccdf_notice_iterator_reset(struct xccdf_notice_iterator *it);
+OSCAP_API void xccdf_notice_iterator_reset(struct xccdf_notice_iterator *it);
 
 
 /**
  * Return the next xccdf_status structure from the list and increment the iterator
  * @memberof xccdf_status_iterator
  */
-struct xccdf_status *xccdf_status_iterator_next(struct xccdf_status_iterator *it);
+OSCAP_API struct xccdf_status *xccdf_status_iterator_next(struct xccdf_status_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_status_iterator
  */
-bool xccdf_status_iterator_has_more(struct xccdf_status_iterator *it);
+OSCAP_API bool xccdf_status_iterator_has_more(struct xccdf_status_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_status_iterator
  */
-void xccdf_status_iterator_free(struct xccdf_status_iterator *it);
+OSCAP_API void xccdf_status_iterator_free(struct xccdf_status_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_status_iterator
  */
-void xccdf_status_iterator_reset(struct xccdf_status_iterator *it);
+OSCAP_API void xccdf_status_iterator_reset(struct xccdf_status_iterator *it);
 
 
 /**
  * Return the next xccdf_model structure from the list and increment the iterator
  * @memberof xccdf_model_iterator
  */
-struct xccdf_model *xccdf_model_iterator_next(struct xccdf_model_iterator *it);
+OSCAP_API struct xccdf_model *xccdf_model_iterator_next(struct xccdf_model_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_model_iterator
  */
-bool xccdf_model_iterator_has_more(struct xccdf_model_iterator *it);
+OSCAP_API bool xccdf_model_iterator_has_more(struct xccdf_model_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_model_iterator
  */
-void xccdf_model_iterator_free(struct xccdf_model_iterator *it);
+OSCAP_API void xccdf_model_iterator_free(struct xccdf_model_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_model_iterator
  */
-void xccdf_model_iterator_reset(struct xccdf_model_iterator *it);
+OSCAP_API void xccdf_model_iterator_reset(struct xccdf_model_iterator *it);
 
 
 /**
  * Return the next xccdf_result structure from the list and increment the iterator
  * @memberof xccdf_result_iterator
  */
-struct xccdf_result *xccdf_result_iterator_next(struct xccdf_result_iterator *it);
+OSCAP_API struct xccdf_result *xccdf_result_iterator_next(struct xccdf_result_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_result_iterator
  */
-bool xccdf_result_iterator_has_more(struct xccdf_result_iterator *it);
+OSCAP_API bool xccdf_result_iterator_has_more(struct xccdf_result_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_result_iterator
  */
-void xccdf_result_iterator_free(struct xccdf_result_iterator *it);
+OSCAP_API void xccdf_result_iterator_free(struct xccdf_result_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_result_iterator
  */
-void xccdf_result_iterator_reset(struct xccdf_result_iterator *it);
+OSCAP_API void xccdf_result_iterator_reset(struct xccdf_result_iterator *it);
 
 
 /**
  * Return the next xccdf_profile structure from the list and increment the iterator
  * @memberof xccdf_profile_iterator
  */
-struct xccdf_profile *xccdf_profile_iterator_next(struct xccdf_profile_iterator *it);
+OSCAP_API struct xccdf_profile *xccdf_profile_iterator_next(struct xccdf_profile_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_profile_iterator
  */
-bool xccdf_profile_iterator_has_more(struct xccdf_profile_iterator *it);
+OSCAP_API bool xccdf_profile_iterator_has_more(struct xccdf_profile_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_profile_iterator
  */
-void xccdf_profile_iterator_free(struct xccdf_profile_iterator *it);
+OSCAP_API void xccdf_profile_iterator_free(struct xccdf_profile_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_profile_iterator
  */
-void xccdf_profile_iterator_reset(struct xccdf_profile_iterator *it);
+OSCAP_API void xccdf_profile_iterator_reset(struct xccdf_profile_iterator *it);
 
 
 /**
  * Return the next xccdf_select structure from the list and increment the iterator
  * @memberof xccdf_select_iterator
  */
-struct xccdf_select *xccdf_select_iterator_next(struct xccdf_select_iterator *it);
+OSCAP_API struct xccdf_select *xccdf_select_iterator_next(struct xccdf_select_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_select_iterator
  */
-bool xccdf_select_iterator_has_more(struct xccdf_select_iterator *it);
+OSCAP_API bool xccdf_select_iterator_has_more(struct xccdf_select_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_select_iterator
  */
-void xccdf_select_iterator_free(struct xccdf_select_iterator *it);
+OSCAP_API void xccdf_select_iterator_free(struct xccdf_select_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_select_iterator
  */
-void xccdf_select_iterator_reset(struct xccdf_select_iterator *it);
+OSCAP_API void xccdf_select_iterator_reset(struct xccdf_select_iterator *it);
 
 
 /**
  * Return the next xccdf_setvalue structure from the list and increment the iterator
  * @memberof xccdf_setvalue_iterator
  */
-struct xccdf_setvalue *xccdf_setvalue_iterator_next(struct xccdf_setvalue_iterator *it);
+OSCAP_API struct xccdf_setvalue *xccdf_setvalue_iterator_next(struct xccdf_setvalue_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_setvalue_iterator
  */
-bool xccdf_setvalue_iterator_has_more(struct xccdf_setvalue_iterator *it);
+OSCAP_API bool xccdf_setvalue_iterator_has_more(struct xccdf_setvalue_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_setvalue_iterator
  */
-void xccdf_setvalue_iterator_free(struct xccdf_setvalue_iterator *it);
+OSCAP_API void xccdf_setvalue_iterator_free(struct xccdf_setvalue_iterator *it);
 /**
  * Reset the iterator structure (it will point to the first item in the list)
  * @memberof xccdf_setvalue_iterator
  */
-void xccdf_setvalue_iterator_reset(struct xccdf_setvalue_iterator *it);
+OSCAP_API void xccdf_setvalue_iterator_reset(struct xccdf_setvalue_iterator *it);
 
 
 /**
  * Return the next xccdf_refine_value structure from the list and increment the iterator
  * @memberof xccdf_refine_value_iterator
  */
-struct xccdf_refine_value *xccdf_refine_value_iterator_next(struct xccdf_refine_value_iterator *it);
+OSCAP_API struct xccdf_refine_value *xccdf_refine_value_iterator_next(struct xccdf_refine_value_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_refine_value_iterator
  */
-bool xccdf_refine_value_iterator_has_more(struct xccdf_refine_value_iterator *it);
+OSCAP_API bool xccdf_refine_value_iterator_has_more(struct xccdf_refine_value_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_refine_value_iterator
  */
-void xccdf_refine_value_iterator_free(struct xccdf_refine_value_iterator *it);
+OSCAP_API void xccdf_refine_value_iterator_free(struct xccdf_refine_value_iterator *it);
 /**
  * Reset the iterator structure (it will point to the first item in the list)
  * @memberof xccdf_refine_value_iterator
  */
-void xccdf_refine_value_iterator_reset(struct xccdf_refine_value_iterator *it);
+OSCAP_API void xccdf_refine_value_iterator_reset(struct xccdf_refine_value_iterator *it);
 
 
 /**
  * Return the next xccdf_refine_rule structure from the list and increment the iterator
  * @memberof xccdf_refine_rule_iterator
  */
-struct xccdf_refine_rule *xccdf_refine_rule_iterator_next(struct xccdf_refine_rule_iterator *it);
+OSCAP_API struct xccdf_refine_rule *xccdf_refine_rule_iterator_next(struct xccdf_refine_rule_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_refine_rule_iterator
  */
-bool xccdf_refine_rule_iterator_has_more(struct xccdf_refine_rule_iterator *it);
+OSCAP_API bool xccdf_refine_rule_iterator_has_more(struct xccdf_refine_rule_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_refine_rule_iterator
  */
-void xccdf_refine_rule_iterator_free(struct xccdf_refine_rule_iterator *it);
+OSCAP_API void xccdf_refine_rule_iterator_free(struct xccdf_refine_rule_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_refine_rule_iterator
  */
-void xccdf_refine_rule_iterator_reset(struct xccdf_refine_rule_iterator *it);
+OSCAP_API void xccdf_refine_rule_iterator_reset(struct xccdf_refine_rule_iterator *it);
 
 
 /**
  * Return the next xccdf_ident structure from the list and increment the iterator
  * @memberof xccdf_ident_iterator
  */
-struct xccdf_ident *xccdf_ident_iterator_next(struct xccdf_ident_iterator *it);
+OSCAP_API struct xccdf_ident *xccdf_ident_iterator_next(struct xccdf_ident_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_ident_iterator
  */
-bool xccdf_ident_iterator_has_more(struct xccdf_ident_iterator *it);
+OSCAP_API bool xccdf_ident_iterator_has_more(struct xccdf_ident_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_ident_iterator
  */
-void xccdf_ident_iterator_free(struct xccdf_ident_iterator *it);
+OSCAP_API void xccdf_ident_iterator_free(struct xccdf_ident_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_ident_iterator
  */
-void xccdf_ident_iterator_reset(struct xccdf_ident_iterator *it);
+OSCAP_API void xccdf_ident_iterator_reset(struct xccdf_ident_iterator *it);
 
 
 /**
  * Return the next xccdf_check structure from the list and increment the iterator
  * @memberof xccdf_check_iterator
  */
-struct xccdf_check *xccdf_check_iterator_next(struct xccdf_check_iterator *it);
+OSCAP_API struct xccdf_check *xccdf_check_iterator_next(struct xccdf_check_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_check_iterator
  */
-bool xccdf_check_iterator_has_more(struct xccdf_check_iterator *it);
+OSCAP_API bool xccdf_check_iterator_has_more(struct xccdf_check_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_check_iterator
  */
-void xccdf_check_iterator_free(struct xccdf_check_iterator *it);
+OSCAP_API void xccdf_check_iterator_free(struct xccdf_check_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_check_iterator
  */
-void xccdf_check_iterator_reset(struct xccdf_check_iterator *it);
+OSCAP_API void xccdf_check_iterator_reset(struct xccdf_check_iterator *it);
 
 
 /**
  * Return the next xccdf_check_content_ref structure from the list and increment the iterator
  * @memberof xccdf_check_content_ref_iterator
  */
-struct xccdf_check_content_ref *xccdf_check_content_ref_iterator_next(struct xccdf_check_content_ref_iterator *it);
+OSCAP_API struct xccdf_check_content_ref *xccdf_check_content_ref_iterator_next(struct xccdf_check_content_ref_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_check_content_ref_iterator
  */
-bool xccdf_check_content_ref_iterator_has_more(struct xccdf_check_content_ref_iterator *it);
+OSCAP_API bool xccdf_check_content_ref_iterator_has_more(struct xccdf_check_content_ref_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_check_content_ref_iterator
  */
-void xccdf_check_content_ref_iterator_free(struct xccdf_check_content_ref_iterator *it);
+OSCAP_API void xccdf_check_content_ref_iterator_free(struct xccdf_check_content_ref_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_check_content_ref_iterator
  */
-void xccdf_check_content_ref_iterator_reset(struct xccdf_check_content_ref_iterator *it);
+OSCAP_API void xccdf_check_content_ref_iterator_reset(struct xccdf_check_content_ref_iterator *it);
 
 
 /**
  * Return the next xccdf_profile_note structure from the list and increment the iterator
  * @memberof xccdf_profile_note_iterator
  */
-struct xccdf_profile_note *xccdf_profile_note_iterator_next(struct xccdf_profile_note_iterator *it);
+OSCAP_API struct xccdf_profile_note *xccdf_profile_note_iterator_next(struct xccdf_profile_note_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_profile_note_iterator
  */
-bool xccdf_profile_note_iterator_has_more(struct xccdf_profile_note_iterator *it);
+OSCAP_API bool xccdf_profile_note_iterator_has_more(struct xccdf_profile_note_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_profile_note_iterator
  */
-void xccdf_profile_note_iterator_free(struct xccdf_profile_note_iterator *it);
+OSCAP_API void xccdf_profile_note_iterator_free(struct xccdf_profile_note_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_profile_note_iterator
  */
-void xccdf_profile_note_iterator_reset(struct xccdf_profile_note_iterator *it);
+OSCAP_API void xccdf_profile_note_iterator_reset(struct xccdf_profile_note_iterator *it);
 
 
 /**
  * Return the next xccdf_check_import structure from the list and increment the iterator
  * @memberof xccdf_check_import_iterator
  */
-struct xccdf_check_import *xccdf_check_import_iterator_next(struct xccdf_check_import_iterator *it);
+OSCAP_API struct xccdf_check_import *xccdf_check_import_iterator_next(struct xccdf_check_import_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_check_import_iterator
  */
-bool xccdf_check_import_iterator_has_more(struct xccdf_check_import_iterator *it);
+OSCAP_API bool xccdf_check_import_iterator_has_more(struct xccdf_check_import_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_check_import_iterator
  */
-void xccdf_check_import_iterator_free(struct xccdf_check_import_iterator *it);
+OSCAP_API void xccdf_check_import_iterator_free(struct xccdf_check_import_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_check_import_iterator
  */
-void xccdf_check_import_iterator_reset(struct xccdf_check_import_iterator *it);
+OSCAP_API void xccdf_check_import_iterator_reset(struct xccdf_check_import_iterator *it);
 
 
 /**
  * Return the next xccdf_check_export structure from the list and increment the iterator
  * @memberof xccdf_check_export_iterator
  */
-struct xccdf_check_export *xccdf_check_export_iterator_next(struct xccdf_check_export_iterator *it);
+OSCAP_API struct xccdf_check_export *xccdf_check_export_iterator_next(struct xccdf_check_export_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_check_export_iterator
  */
-bool xccdf_check_export_iterator_has_more(struct xccdf_check_export_iterator *it);
+OSCAP_API bool xccdf_check_export_iterator_has_more(struct xccdf_check_export_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_check_export_iterator
  */
-void xccdf_check_export_iterator_free(struct xccdf_check_export_iterator *it);
+OSCAP_API void xccdf_check_export_iterator_free(struct xccdf_check_export_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_check_export_iterator
  */
-void xccdf_check_export_iterator_reset(struct xccdf_check_export_iterator *it);
+OSCAP_API void xccdf_check_export_iterator_reset(struct xccdf_check_export_iterator *it);
 
 
 /**
  * Return the next xccdf_fix structure from the list and increment the iterator
  * @memberof xccdf_fix_iterator
  */
-struct xccdf_fix *xccdf_fix_iterator_next(struct xccdf_fix_iterator *it);
+OSCAP_API struct xccdf_fix *xccdf_fix_iterator_next(struct xccdf_fix_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_fix_iterator
  */
-bool xccdf_fix_iterator_has_more(struct xccdf_fix_iterator *it);
+OSCAP_API bool xccdf_fix_iterator_has_more(struct xccdf_fix_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_fix_iterator
  */
-void xccdf_fix_iterator_free(struct xccdf_fix_iterator *it);
+OSCAP_API void xccdf_fix_iterator_free(struct xccdf_fix_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_fix_iterator
  */
-void xccdf_fix_iterator_reset(struct xccdf_fix_iterator *it);
+OSCAP_API void xccdf_fix_iterator_reset(struct xccdf_fix_iterator *it);
 
 
 /**
  * Return the next xccdf_fixtext structure from the list and increment the iterator
  * @memberof xccdf_fixtext_iterator
  */
-struct xccdf_fixtext *xccdf_fixtext_iterator_next(struct xccdf_fixtext_iterator *it);
+OSCAP_API struct xccdf_fixtext *xccdf_fixtext_iterator_next(struct xccdf_fixtext_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_fixtext_iterator
  */
-bool xccdf_fixtext_iterator_has_more(struct xccdf_fixtext_iterator *it);
+OSCAP_API bool xccdf_fixtext_iterator_has_more(struct xccdf_fixtext_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_fixtext_iterator
  */
-void xccdf_fixtext_iterator_free(struct xccdf_fixtext_iterator *it);
+OSCAP_API void xccdf_fixtext_iterator_free(struct xccdf_fixtext_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_fixtext_iterator
  */
-void xccdf_fixtext_iterator_reset(struct xccdf_fixtext_iterator *it);
+OSCAP_API void xccdf_fixtext_iterator_reset(struct xccdf_fixtext_iterator *it);
 
 
 /**
  * Return the next xccdf_warning structure from the list and increment the iterator
  * @memberof xccdf_warning_iterator
  */
-struct xccdf_warning *xccdf_warning_iterator_next(struct xccdf_warning_iterator *it);
+OSCAP_API struct xccdf_warning *xccdf_warning_iterator_next(struct xccdf_warning_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_warning_iterator
  */
-bool xccdf_warning_iterator_has_more(struct xccdf_warning_iterator *it);
+OSCAP_API bool xccdf_warning_iterator_has_more(struct xccdf_warning_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_warning_iterator
  */
-void xccdf_warning_iterator_free(struct xccdf_warning_iterator *it);
+OSCAP_API void xccdf_warning_iterator_free(struct xccdf_warning_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the underlying list)
  * @memberof xccdf_warning_iterator
  */
-void xccdf_warning_iterator_reset(struct xccdf_warning_iterator *it);
+OSCAP_API void xccdf_warning_iterator_reset(struct xccdf_warning_iterator *it);
 
 
 /**
  * Return the next xccdf_instance structure from the list and increment the iterator
  * @memberof xccdf_instance_iterator
  */
-struct xccdf_instance *xccdf_instance_iterator_next(struct xccdf_instance_iterator *it);
+OSCAP_API struct xccdf_instance *xccdf_instance_iterator_next(struct xccdf_instance_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_instance_iterator
  */
-bool xccdf_instance_iterator_has_more(struct xccdf_instance_iterator *it);
+OSCAP_API bool xccdf_instance_iterator_has_more(struct xccdf_instance_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_instance_iterator
  */
-void xccdf_instance_iterator_free(struct xccdf_instance_iterator *it);
+OSCAP_API void xccdf_instance_iterator_free(struct xccdf_instance_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_instance_iterator
  */
-void xccdf_instance_iterator_reset(struct xccdf_instance_iterator *it);
+OSCAP_API void xccdf_instance_iterator_reset(struct xccdf_instance_iterator *it);
 
 
 /**
  * Return the next xccdf_message structure from the list and increment the iterator
  * @memberof xccdf_message_iterator
  */
-struct xccdf_message *xccdf_message_iterator_next(struct xccdf_message_iterator *it);
+OSCAP_API struct xccdf_message *xccdf_message_iterator_next(struct xccdf_message_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_message_iterator
  */
-bool xccdf_message_iterator_has_more(struct xccdf_message_iterator *it);
+OSCAP_API bool xccdf_message_iterator_has_more(struct xccdf_message_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_message_iterator
  */
-void xccdf_message_iterator_free(struct xccdf_message_iterator *it);
+OSCAP_API void xccdf_message_iterator_free(struct xccdf_message_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_message_iterator
  */
-void xccdf_message_iterator_reset(struct xccdf_message_iterator *it);
+OSCAP_API void xccdf_message_iterator_reset(struct xccdf_message_iterator *it);
 
 
 /**
  * Return the next xccdf_override structure from the list and increment the iterator
  * @memberof xccdf_override_iterator
  */
-struct xccdf_override *xccdf_override_iterator_next(struct xccdf_override_iterator *it);
+OSCAP_API struct xccdf_override *xccdf_override_iterator_next(struct xccdf_override_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_override_iterator
  */
-bool xccdf_override_iterator_has_more(struct xccdf_override_iterator *it);
+OSCAP_API bool xccdf_override_iterator_has_more(struct xccdf_override_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_override_iterator
  */
-void xccdf_override_iterator_free(struct xccdf_override_iterator *it);
+OSCAP_API void xccdf_override_iterator_free(struct xccdf_override_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_override_iterator
  */
-void xccdf_override_iterator_reset(struct xccdf_override_iterator *it);
+OSCAP_API void xccdf_override_iterator_reset(struct xccdf_override_iterator *it);
 
 
 /**
  * Return the next xccdf_identity structure from the list and increment the iterator
  * @memberof xccdf_identity_iterator
  */
-struct xccdf_identity *xccdf_identity_iterator_next(struct xccdf_identity_iterator *it);
+OSCAP_API struct xccdf_identity *xccdf_identity_iterator_next(struct xccdf_identity_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_identity_iterator
  */
-bool xccdf_identity_iterator_has_more(struct xccdf_identity_iterator *it);
+OSCAP_API bool xccdf_identity_iterator_has_more(struct xccdf_identity_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_identity_iterator
  */
-void xccdf_identity_iterator_free(struct xccdf_identity_iterator *it);
+OSCAP_API void xccdf_identity_iterator_free(struct xccdf_identity_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_identity_iterator
  */
-void xccdf_identity_iterator_reset(struct xccdf_identity_iterator *it);
+OSCAP_API void xccdf_identity_iterator_reset(struct xccdf_identity_iterator *it);
 
 
 /**
  * Return the next xccdf_rule_result structure from the list and increment the iterator
  * @memberof xccdf_rule_result_iterator
  */
-struct xccdf_rule_result *xccdf_rule_result_iterator_next(struct xccdf_rule_result_iterator *it);
+OSCAP_API struct xccdf_rule_result *xccdf_rule_result_iterator_next(struct xccdf_rule_result_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_rule_result_iterator
  */
-bool xccdf_rule_result_iterator_has_more(struct xccdf_rule_result_iterator *it);
+OSCAP_API bool xccdf_rule_result_iterator_has_more(struct xccdf_rule_result_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_rule_result_iterator
  */
-void xccdf_rule_result_iterator_free(struct xccdf_rule_result_iterator *it);
+OSCAP_API void xccdf_rule_result_iterator_free(struct xccdf_rule_result_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_rule_result_iterator
  */
-void xccdf_rule_result_iterator_reset(struct xccdf_rule_result_iterator *it);
+OSCAP_API void xccdf_rule_result_iterator_reset(struct xccdf_rule_result_iterator *it);
 
 
 /**
  * Return the next xccdf_value_instance structure from the list and increment the iterator
  * @memberof xccdf_value_instance_iterator
  */
-struct xccdf_value_instance *xccdf_value_instance_iterator_next(struct xccdf_value_instance_iterator *it);
+OSCAP_API struct xccdf_value_instance *xccdf_value_instance_iterator_next(struct xccdf_value_instance_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_value_instance_iterator
  */
-bool xccdf_value_instance_iterator_has_more(struct xccdf_value_instance_iterator *it);
+OSCAP_API bool xccdf_value_instance_iterator_has_more(struct xccdf_value_instance_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_value_instance_iterator
  */
-void xccdf_value_instance_iterator_free(struct xccdf_value_instance_iterator *it);
+OSCAP_API void xccdf_value_instance_iterator_free(struct xccdf_value_instance_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_value_instance_iterator
  */
-void xccdf_value_instance_iterator_reset(struct xccdf_value_instance_iterator *it);
+OSCAP_API void xccdf_value_instance_iterator_reset(struct xccdf_value_instance_iterator *it);
 
 
 /**
  * Return the next xccdf_score structure from the list and increment the iterator
  * @memberof xccdf_score_iterator
  */
-struct xccdf_score *xccdf_score_iterator_next(struct xccdf_score_iterator *it);
+OSCAP_API struct xccdf_score *xccdf_score_iterator_next(struct xccdf_score_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_score_iterator
  */
-bool xccdf_score_iterator_has_more(struct xccdf_score_iterator *it);
+OSCAP_API bool xccdf_score_iterator_has_more(struct xccdf_score_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_score_iterator
  */
-void xccdf_score_iterator_free(struct xccdf_score_iterator *it);
+OSCAP_API void xccdf_score_iterator_free(struct xccdf_score_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_score_iterator
  */
-void xccdf_score_iterator_reset(struct xccdf_score_iterator *it);
+OSCAP_API void xccdf_score_iterator_reset(struct xccdf_score_iterator *it);
 
 
 /**
  * Return the next xccdf_target_fact structure from the list and increment the iterator
  * @memberof xccdf_target_fact_iterator
  */
-struct xccdf_target_fact *xccdf_target_fact_iterator_next(struct xccdf_target_fact_iterator *it);
+OSCAP_API struct xccdf_target_fact *xccdf_target_fact_iterator_next(struct xccdf_target_fact_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_target_fact_iterator
  */
-bool xccdf_target_fact_iterator_has_more(struct xccdf_target_fact_iterator *it);
+OSCAP_API bool xccdf_target_fact_iterator_has_more(struct xccdf_target_fact_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_target_fact_iterator
  */
-void xccdf_target_fact_iterator_free(struct xccdf_target_fact_iterator *it);
+OSCAP_API void xccdf_target_fact_iterator_free(struct xccdf_target_fact_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_target_fact_iterator
  */
-void xccdf_target_fact_iterator_reset(struct xccdf_target_fact_iterator *it);
+OSCAP_API void xccdf_target_fact_iterator_reset(struct xccdf_target_fact_iterator *it);
 
 /**
  * Return the next xccdf_target_identifier structure from the list and increment the iterator
  * @memberof xccdf_target_identifier_iterator
  */
-struct xccdf_target_identifier *xccdf_target_identifier_iterator_next(struct xccdf_target_identifier_iterator *it);
+OSCAP_API struct xccdf_target_identifier *xccdf_target_identifier_iterator_next(struct xccdf_target_identifier_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_target_identifier_iterator
  */
-bool xccdf_target_identifier_iterator_has_more(struct xccdf_target_identifier_iterator *it);
+OSCAP_API bool xccdf_target_identifier_iterator_has_more(struct xccdf_target_identifier_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_target_identifier_iterator
  */
-void xccdf_target_identifier_iterator_free(struct xccdf_target_identifier_iterator *it);
+OSCAP_API void xccdf_target_identifier_iterator_free(struct xccdf_target_identifier_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_target_identifier_iterator
  */
-void xccdf_target_identifier_iterator_reset(struct xccdf_target_identifier_iterator *it);
+OSCAP_API void xccdf_target_identifier_iterator_reset(struct xccdf_target_identifier_iterator *it);
 
 
 /**
  * Return the next xccdf_plain_text structure from the list and increment the iterator
  * @memberof xccdf_plain_text_iterator
  */
-struct xccdf_plain_text *xccdf_plain_text_iterator_next(struct xccdf_plain_text_iterator *it);
+OSCAP_API struct xccdf_plain_text *xccdf_plain_text_iterator_next(struct xccdf_plain_text_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_plain_text_iterator
  */
-bool xccdf_plain_text_iterator_has_more(struct xccdf_plain_text_iterator *it);
+OSCAP_API bool xccdf_plain_text_iterator_has_more(struct xccdf_plain_text_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_plain_text_iterator
  */
-void xccdf_plain_text_iterator_free(struct xccdf_plain_text_iterator *it);
+OSCAP_API void xccdf_plain_text_iterator_free(struct xccdf_plain_text_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_plain_text_iterator
  */
-void xccdf_plain_text_iterator_reset(struct xccdf_plain_text_iterator *it);
+OSCAP_API void xccdf_plain_text_iterator_reset(struct xccdf_plain_text_iterator *it);
 
 
 /**
  * Return the next xccdf_value structure from the list and increment the iterator
  * @memberof xccdf_value_iterator
  */
-struct xccdf_value *xccdf_value_iterator_next(struct xccdf_value_iterator *it);
+OSCAP_API struct xccdf_value *xccdf_value_iterator_next(struct xccdf_value_iterator *it);
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_value_iterator
  */
-bool xccdf_value_iterator_has_more(struct xccdf_value_iterator *it);
+OSCAP_API bool xccdf_value_iterator_has_more(struct xccdf_value_iterator *it);
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_value_iterator
  */
-void xccdf_value_iterator_free(struct xccdf_value_iterator *it);
+OSCAP_API void xccdf_value_iterator_free(struct xccdf_value_iterator *it);
 /**
  * Reset the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_value_iterator
  */
-void xccdf_value_iterator_reset(struct xccdf_value_iterator *it);
+OSCAP_API void xccdf_value_iterator_reset(struct xccdf_value_iterator *it);
 
 /************************************************************
  ** @} End of Iterators group */
@@ -1755,86 +1756,86 @@ void xccdf_value_iterator_reset(struct xccdf_value_iterator *it);
 /**
  * @memberof xccdf_item
  */
-xccdf_type_t xccdf_item_get_type(const struct xccdf_item *item);
+OSCAP_API xccdf_type_t xccdf_item_get_type(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-const char *xccdf_item_get_id(const struct xccdf_item *item);
+OSCAP_API const char *xccdf_item_get_id(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-struct oscap_text_iterator *xccdf_item_get_title(const struct xccdf_item *item);
+OSCAP_API struct oscap_text_iterator *xccdf_item_get_title(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-struct oscap_text_iterator *xccdf_item_get_description(const struct xccdf_item *item);
+OSCAP_API struct oscap_text_iterator *xccdf_item_get_description(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-const char *xccdf_item_get_version(const struct xccdf_item *item);
+OSCAP_API const char *xccdf_item_get_version(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-const char *xccdf_item_get_extends(const struct xccdf_item *item);
+OSCAP_API const char *xccdf_item_get_extends(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-struct xccdf_status_iterator *xccdf_item_get_statuses(const struct xccdf_item *item);
+OSCAP_API struct xccdf_status_iterator *xccdf_item_get_statuses(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-struct oscap_reference_iterator *xccdf_item_get_dc_statuses(const struct xccdf_item *item);
+OSCAP_API struct oscap_reference_iterator *xccdf_item_get_dc_statuses(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-struct oscap_reference_iterator *xccdf_item_get_references(const struct xccdf_item *item);
+OSCAP_API struct oscap_reference_iterator *xccdf_item_get_references(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-struct oscap_string_iterator *xccdf_item_get_conflicts(const struct xccdf_item* item);
+OSCAP_API struct oscap_string_iterator *xccdf_item_get_conflicts(const struct xccdf_item* item);
 /**
  * @memberof xccdf_item
  */
-struct oscap_stringlist_iterator *xccdf_item_get_requires(const struct xccdf_item* item);
+OSCAP_API struct oscap_stringlist_iterator *xccdf_item_get_requires(const struct xccdf_item* item);
 /**
  * @memberof xccdf_item
  */
-struct xccdf_status * xccdf_item_get_current_status(const struct xccdf_item *item);
+OSCAP_API struct xccdf_status * xccdf_item_get_current_status(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-bool xccdf_item_get_hidden(const struct xccdf_item *item);
+OSCAP_API bool xccdf_item_get_hidden(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-bool xccdf_item_get_selected(const struct xccdf_item *item);
+OSCAP_API bool xccdf_item_get_selected(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-bool xccdf_item_get_prohibit_changes(const struct xccdf_item *item);
+OSCAP_API bool xccdf_item_get_prohibit_changes(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-bool xccdf_item_get_abstract(const struct xccdf_item *item);
+OSCAP_API bool xccdf_item_get_abstract(const struct xccdf_item *item);
 /**
  * @memberof xccdf_item
  */
-struct xccdf_item_iterator *xccdf_item_get_content(const struct xccdf_item *item);
+OSCAP_API struct xccdf_item_iterator *xccdf_item_get_content(const struct xccdf_item *item);
 /**
  * @memberof xccdf_test_result
  */
-const char * xccdf_test_result_type_get_text(xccdf_test_result_type_t id);
+OSCAP_API const char * xccdf_test_result_type_get_text(xccdf_test_result_type_t id);
 /**
  * @memberof xccdf_result
  */
-struct xccdf_rule_result * xccdf_result_get_rule_result_by_id(struct xccdf_result * result, const char * id);
+OSCAP_API struct xccdf_rule_result * xccdf_result_get_rule_result_by_id(struct xccdf_result * result, const char * id);
 
 /**
  * Return item's parent in the grouping hierarchy.
  * Returned item will be either a group or a benchmark.
  * @memberof xccdf_item
  */
-struct xccdf_item *xccdf_item_get_parent(const struct xccdf_item *item);
+OSCAP_API struct xccdf_item *xccdf_item_get_parent(const struct xccdf_item *item);
 
 /**
  * Retrieves the XCCDF version of top-level benchmark item.
@@ -1845,93 +1846,93 @@ struct xccdf_item *xccdf_item_get_parent(const struct xccdf_item *item);
  * Don't deallocate the returned buffer!
  * @memberof xccdf_item
  */
-const struct xccdf_version_info* xccdf_item_get_schema_version(struct xccdf_item* item);
+OSCAP_API const struct xccdf_version_info* xccdf_item_get_schema_version(struct xccdf_item* item);
 
 /**
  * @memberof xccdf_item
  */
-struct oscap_string_iterator *xccdf_item_get_metadata(const struct xccdf_item *item);
+OSCAP_API struct oscap_string_iterator *xccdf_item_get_metadata(const struct xccdf_item *item);
 
 /**
  * @memberof xccdf_benchmark
  */
-struct xccdf_profile *xccdf_benchmark_get_profile_by_id(struct xccdf_benchmark *benchmark, const char *profile_id);
+OSCAP_API struct xccdf_profile *xccdf_benchmark_get_profile_by_id(struct xccdf_benchmark *benchmark, const char *profile_id);
 /**
  * @memberof xccdf_benchmark
  */
-const char *xccdf_benchmark_get_id(const struct xccdf_benchmark *benchmark);
+OSCAP_API const char *xccdf_benchmark_get_id(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-bool xccdf_benchmark_get_resolved(const struct xccdf_benchmark *benchmark);
+OSCAP_API bool xccdf_benchmark_get_resolved(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-struct oscap_text_iterator *xccdf_benchmark_get_title(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct oscap_text_iterator *xccdf_benchmark_get_title(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-struct oscap_text_iterator *xccdf_benchmark_get_description(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct oscap_text_iterator *xccdf_benchmark_get_description(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-const char *xccdf_benchmark_get_version(const struct xccdf_benchmark *benchmark);
+OSCAP_API const char *xccdf_benchmark_get_version(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-const struct xccdf_version_info* xccdf_benchmark_get_schema_version(const struct xccdf_benchmark* item);
+OSCAP_API const struct xccdf_version_info* xccdf_benchmark_get_schema_version(const struct xccdf_benchmark* item);
 /**
  * @memberof xccdf_benchmark
  */
-const char *xccdf_benchmark_get_style(const struct xccdf_benchmark *benchmark);
+OSCAP_API const char *xccdf_benchmark_get_style(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-const char *xccdf_benchmark_get_style_href(const struct xccdf_benchmark *benchmark);
+OSCAP_API const char *xccdf_benchmark_get_style_href(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-struct oscap_text_iterator *xccdf_benchmark_get_front_matter(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct oscap_text_iterator *xccdf_benchmark_get_front_matter(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-struct oscap_text_iterator *xccdf_benchmark_get_rear_matter(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct oscap_text_iterator *xccdf_benchmark_get_rear_matter(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-struct xccdf_status_iterator *xccdf_benchmark_get_statuses(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct xccdf_status_iterator *xccdf_benchmark_get_statuses(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-struct oscap_reference_iterator *xccdf_benchmark_get_dc_statuses(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct oscap_reference_iterator *xccdf_benchmark_get_dc_statuses(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-struct oscap_reference_iterator *xccdf_benchmark_get_references(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct oscap_reference_iterator *xccdf_benchmark_get_references(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-struct oscap_string_iterator *xccdf_benchmark_get_platforms(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct oscap_string_iterator *xccdf_benchmark_get_platforms(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-struct xccdf_status * xccdf_benchmark_get_status_current(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct xccdf_status * xccdf_benchmark_get_status_current(const struct xccdf_benchmark *benchmark);
 /**
  * @memberof xccdf_benchmark
  */
-struct xccdf_plain_text_iterator *xccdf_benchmark_get_plain_texts(const struct xccdf_benchmark *item);
+OSCAP_API struct xccdf_plain_text_iterator *xccdf_benchmark_get_plain_texts(const struct xccdf_benchmark *item);
 /**
  * @memberof xccdf_benchmark
  */
-struct xccdf_result_iterator* xccdf_benchmark_get_results(const struct xccdf_benchmark *bench);
+OSCAP_API struct xccdf_result_iterator* xccdf_benchmark_get_results(const struct xccdf_benchmark *bench);
 /**
  * @memberof xccdf_benchmark
  */
-struct xccdf_value_iterator *xccdf_benchmark_get_values(const struct xccdf_benchmark *item);
+OSCAP_API struct xccdf_value_iterator *xccdf_benchmark_get_values(const struct xccdf_benchmark *item);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_set_lang(struct xccdf_benchmark *item, const char *newval);
+OSCAP_API bool xccdf_benchmark_set_lang(struct xccdf_benchmark *item, const char *newval);
 /// @memberof xccdf_benchmark
-const char *xccdf_benchmark_get_lang(const struct xccdf_benchmark *item);
+OSCAP_API const char *xccdf_benchmark_get_lang(const struct xccdf_benchmark *item);
 
 /**
  * Get a plain text by ID.
@@ -1940,7 +1941,7 @@ const char *xccdf_benchmark_get_lang(const struct xccdf_benchmark *item);
  * @return Plain text content.
  * @retval NULL if given plain text does not exist
  */
-const char *xccdf_benchmark_get_plain_text(const struct xccdf_benchmark *benchmark, const char *id);
+OSCAP_API const char *xccdf_benchmark_get_plain_text(const struct xccdf_benchmark *benchmark, const char *id);
 
 /**
  * Get benchmark xccdf:Item by ID.
@@ -1949,7 +1950,7 @@ const char *xccdf_benchmark_get_plain_text(const struct xccdf_benchmark *benchma
  * @return Item with given ID
  * @retval NULL if no such item exists
  */
-struct xccdf_item *xccdf_benchmark_get_item(const struct xccdf_benchmark *benchmark, const char *id);
+OSCAP_API struct xccdf_item *xccdf_benchmark_get_item(const struct xccdf_benchmark *benchmark, const char *id);
 
 /**
  * Get a registered member of xccdf_benchmakr by ID.
@@ -1958,28 +1959,28 @@ struct xccdf_item *xccdf_benchmark_get_item(const struct xccdf_benchmark *benchm
  * @return xccdf_item with given ID and type
  * @return NULL if no such member exists
  */
-struct xccdf_item *xccdf_benchmark_get_member(const struct xccdf_benchmark *benchmark, xccdf_type_t type, const char *key);
+OSCAP_API struct xccdf_item *xccdf_benchmark_get_member(const struct xccdf_benchmark *benchmark, xccdf_type_t type, const char *key);
 
 /**
  * Get an iterator to the benchmark legal notices.
  * @memberof xccdf_benchmark
  * @see xccdf_notice
  */
-struct xccdf_notice_iterator *xccdf_benchmark_get_notices(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct xccdf_notice_iterator *xccdf_benchmark_get_notices(const struct xccdf_benchmark *benchmark);
 
 /**
  * Get an iterator to the benchmark scoring models.
  * @memberof xccdf_benchmark
  * @see xccdf_model
  */
-struct xccdf_model_iterator *xccdf_benchmark_get_models(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct xccdf_model_iterator *xccdf_benchmark_get_models(const struct xccdf_benchmark *benchmark);
 
 /**
  * Get an iterator to the benchmark XCCDF profiles.
  * @memberof xccdf_benchmark
  * @see xccdf_profile
  */
-struct xccdf_profile_iterator *xccdf_benchmark_get_profiles(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct xccdf_profile_iterator *xccdf_benchmark_get_profiles(const struct xccdf_benchmark *benchmark);
 
 /**
  * Get an iterator to the bencmark content. The items are either groups or rules.
@@ -1988,238 +1989,238 @@ struct xccdf_profile_iterator *xccdf_benchmark_get_profiles(const struct xccdf_b
  * @see xccdf_group
  * @see xccdf_item
  */
-struct xccdf_item_iterator *xccdf_benchmark_get_content(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct xccdf_item_iterator *xccdf_benchmark_get_content(const struct xccdf_benchmark *benchmark);
 
 /**
  * @memberof xccdf_benchmark
  */
-struct oscap_string_iterator *xccdf_benchmark_get_metadata(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct oscap_string_iterator *xccdf_benchmark_get_metadata(const struct xccdf_benchmark *benchmark);
 
 /**
  * @memberof xccdf_benchmark
  */
-struct cpe_dict_model *xccdf_benchmark_get_cpe_list(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct cpe_dict_model *xccdf_benchmark_get_cpe_list(const struct xccdf_benchmark *benchmark);
 
 /**
  * @memberof xccdf_benchmark
  */
-struct cpe_lang_model *xccdf_benchmark_get_cpe_lang_model(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct cpe_lang_model *xccdf_benchmark_get_cpe_lang_model(const struct xccdf_benchmark *benchmark);
 
 /**
  * @memberof xccdf_profile
  */
-const char *xccdf_profile_get_id(const struct xccdf_profile *profile);
+OSCAP_API const char *xccdf_profile_get_id(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct oscap_text_iterator *xccdf_profile_get_title(const struct xccdf_profile *profile);
+OSCAP_API struct oscap_text_iterator *xccdf_profile_get_title(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct oscap_text_iterator *xccdf_profile_get_description(const struct xccdf_profile *profile);
+OSCAP_API struct oscap_text_iterator *xccdf_profile_get_description(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-const char *xccdf_profile_get_version(const struct xccdf_profile *profile);
+OSCAP_API const char *xccdf_profile_get_version(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-const char *xccdf_profile_get_extends(const struct xccdf_profile *profile);
+OSCAP_API const char *xccdf_profile_get_extends(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct xccdf_benchmark *xccdf_profile_get_benchmark(const struct xccdf_profile *profile);
+OSCAP_API struct xccdf_benchmark *xccdf_profile_get_benchmark(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-bool xccdf_profile_get_abstract(const struct xccdf_profile *profile);
+OSCAP_API bool xccdf_profile_get_abstract(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-bool xccdf_profile_get_prohibit_changes(const struct xccdf_profile *profile);
+OSCAP_API bool xccdf_profile_get_prohibit_changes(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct oscap_string_iterator *xccdf_profile_get_platforms(const struct xccdf_profile *profile);
+OSCAP_API struct oscap_string_iterator *xccdf_profile_get_platforms(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct xccdf_status_iterator *xccdf_profile_get_statuses(const struct xccdf_profile *profile);
+OSCAP_API struct xccdf_status_iterator *xccdf_profile_get_statuses(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct oscap_reference_iterator *xccdf_profile_get_dc_statuses(const struct xccdf_profile *profile);
+OSCAP_API struct oscap_reference_iterator *xccdf_profile_get_dc_statuses(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct oscap_reference_iterator *xccdf_profile_get_references(const struct xccdf_profile *profile);
+OSCAP_API struct oscap_reference_iterator *xccdf_profile_get_references(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct xccdf_status * xccdf_profile_get_status_current(const struct xccdf_profile *profile);
+OSCAP_API struct xccdf_status * xccdf_profile_get_status_current(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct xccdf_select_iterator *xccdf_profile_get_selects(const struct xccdf_profile *profile);
+OSCAP_API struct xccdf_select_iterator *xccdf_profile_get_selects(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct xccdf_setvalue_iterator *xccdf_profile_get_setvalues(const struct xccdf_profile *profile);
+OSCAP_API struct xccdf_setvalue_iterator *xccdf_profile_get_setvalues(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct xccdf_refine_value_iterator *xccdf_profile_get_refine_values(const struct xccdf_profile *profile);
+OSCAP_API struct xccdf_refine_value_iterator *xccdf_profile_get_refine_values(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct xccdf_refine_rule_iterator *xccdf_profile_get_refine_rules(const struct xccdf_profile *profile);
+OSCAP_API struct xccdf_refine_rule_iterator *xccdf_profile_get_refine_rules(const struct xccdf_profile *profile);
 /**
  * @memberof xccdf_profile
  */
-struct oscap_string_iterator *xccdf_profile_get_metadata(const struct xccdf_profile *profile);
+OSCAP_API struct oscap_string_iterator *xccdf_profile_get_metadata(const struct xccdf_profile *profile);
 
 /**
  * Return rule's parent in the grouping hierarchy.
  * Returned item will be either a group or a benchmark.
  * @memberof xccdf_rule
  */
-struct xccdf_item *xccdf_rule_get_parent(const struct xccdf_rule *rule);
+OSCAP_API struct xccdf_item *xccdf_rule_get_parent(const struct xccdf_rule *rule);
 
 /**
  * @memberof xccdf_rule
  */
-const char *xccdf_rule_get_id(const struct xccdf_rule *rule);
+OSCAP_API const char *xccdf_rule_get_id(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct oscap_text_iterator *xccdf_rule_get_title(const struct xccdf_rule *rule);
+OSCAP_API struct oscap_text_iterator *xccdf_rule_get_title(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct oscap_text_iterator *xccdf_rule_get_description(const struct xccdf_rule *rule);
+OSCAP_API struct oscap_text_iterator *xccdf_rule_get_description(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-const char *xccdf_rule_get_version(const struct xccdf_rule *rule);
+OSCAP_API const char *xccdf_rule_get_version(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct oscap_text_iterator *xccdf_rule_get_question(const struct xccdf_rule *rule);
+OSCAP_API struct oscap_text_iterator *xccdf_rule_get_question(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct xccdf_warning_iterator *xccdf_rule_get_warnings(const struct xccdf_rule *rule);
+OSCAP_API struct xccdf_warning_iterator *xccdf_rule_get_warnings(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct oscap_text_iterator *xccdf_rule_get_rationale(const struct xccdf_rule *rule);
+OSCAP_API struct oscap_text_iterator *xccdf_rule_get_rationale(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-const char *xccdf_rule_get_cluster_id(const struct xccdf_rule *rule);
+OSCAP_API const char *xccdf_rule_get_cluster_id(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-float xccdf_rule_get_weight(const struct xccdf_rule *rule);
+OSCAP_API float xccdf_rule_get_weight(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-bool xccdf_rule_set_weight(struct xccdf_rule *item, xccdf_numeric newval);
+OSCAP_API bool xccdf_rule_set_weight(struct xccdf_rule *item, xccdf_numeric newval);
 /**
  * @memberof xccdf_rule
  */
-const char *xccdf_rule_get_extends(const struct xccdf_rule *rule);
+OSCAP_API const char *xccdf_rule_get_extends(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-bool xccdf_rule_get_abstract(const struct xccdf_rule *rule);
+OSCAP_API bool xccdf_rule_get_abstract(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-bool xccdf_rule_get_prohibit_changes(const struct xccdf_rule *rule);
+OSCAP_API bool xccdf_rule_get_prohibit_changes(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-bool xccdf_rule_get_hidden(const struct xccdf_rule *rule);
+OSCAP_API bool xccdf_rule_get_hidden(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-bool xccdf_rule_get_selected(const struct xccdf_rule *rule);
+OSCAP_API bool xccdf_rule_get_selected(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-bool xccdf_rule_get_multiple(const struct xccdf_rule *rule);
+OSCAP_API bool xccdf_rule_get_multiple(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct oscap_string_iterator *xccdf_rule_get_platforms(const struct xccdf_rule *rule);
+OSCAP_API struct oscap_string_iterator *xccdf_rule_get_platforms(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct xccdf_status_iterator *xccdf_rule_get_statuses(const struct xccdf_rule *rule);
+OSCAP_API struct xccdf_status_iterator *xccdf_rule_get_statuses(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct oscap_reference_iterator *xccdf_rule_get_dc_statuses(const struct xccdf_rule *rule);
+OSCAP_API struct oscap_reference_iterator *xccdf_rule_get_dc_statuses(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct oscap_reference_iterator *xccdf_rule_get_references(const struct xccdf_rule *rule);
+OSCAP_API struct oscap_reference_iterator *xccdf_rule_get_references(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct xccdf_status * xccdf_rule_get_status_current(const struct xccdf_rule *rule);
+OSCAP_API struct xccdf_status * xccdf_rule_get_status_current(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-const char *xccdf_rule_get_impact_metric(const struct xccdf_rule *rule);
+OSCAP_API const char *xccdf_rule_get_impact_metric(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-xccdf_role_t xccdf_rule_get_role(const struct xccdf_rule *rule);
+OSCAP_API xccdf_role_t xccdf_rule_get_role(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-xccdf_level_t xccdf_rule_get_severity(const struct xccdf_rule *rule);
+OSCAP_API xccdf_level_t xccdf_rule_get_severity(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct xccdf_ident_iterator *xccdf_rule_get_idents(const struct xccdf_rule *rule);
+OSCAP_API struct xccdf_ident_iterator *xccdf_rule_get_idents(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct xccdf_check_iterator *xccdf_rule_get_checks(const struct xccdf_rule *rule);
+OSCAP_API struct xccdf_check_iterator *xccdf_rule_get_checks(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct xccdf_profile_note_iterator *xccdf_rule_get_profile_notes(const struct xccdf_rule *rule);
+OSCAP_API struct xccdf_profile_note_iterator *xccdf_rule_get_profile_notes(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct xccdf_fix_iterator *xccdf_rule_get_fixes(const struct xccdf_rule *rule);
+OSCAP_API struct xccdf_fix_iterator *xccdf_rule_get_fixes(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct xccdf_fixtext_iterator *xccdf_rule_get_fixtexts(const struct xccdf_rule *rule);
+OSCAP_API struct xccdf_fixtext_iterator *xccdf_rule_get_fixtexts(const struct xccdf_rule *rule);
 /**
  * @memberof xccdf_rule
  */
-struct oscap_string_iterator *xccdf_rule_get_conflicts(const struct xccdf_rule* rule);
+OSCAP_API struct oscap_string_iterator *xccdf_rule_get_conflicts(const struct xccdf_rule* rule);
 /**
  * @memberof xccdf_rule
  */
-struct oscap_stringlist_iterator *xccdf_rule_get_requires(const struct xccdf_rule* rule);
+OSCAP_API struct oscap_stringlist_iterator *xccdf_rule_get_requires(const struct xccdf_rule* rule);
 /**
  * @memberof xccdf_rule
  */
-struct oscap_string_iterator *xccdf_rule_get_metadata(const struct xccdf_rule *rule);
+OSCAP_API struct oscap_string_iterator *xccdf_rule_get_metadata(const struct xccdf_rule *rule);
 
 /*
  * Return group's parent in the grouping hierarchy.
  * Returned item will be either a group or a benchmark.
  * @memberof xccdf_group
  */
-struct xccdf_item *xccdf_group_get_parent(const struct xccdf_group *group);
+OSCAP_API struct xccdf_item *xccdf_group_get_parent(const struct xccdf_group *group);
 
 /**
  * Get an iterator to the group content. The items are either groups or rules.
@@ -2228,201 +2229,201 @@ struct xccdf_item *xccdf_group_get_parent(const struct xccdf_group *group);
  * @see xccdf_group
  * @see xccdf_item
  */
-struct xccdf_item_iterator *xccdf_group_get_content(const struct xccdf_group *group);
+OSCAP_API struct xccdf_item_iterator *xccdf_group_get_content(const struct xccdf_group *group);
 
 /// @memberof xccdf_group
-struct xccdf_value_iterator *xccdf_group_get_values(const struct xccdf_group *group);
+OSCAP_API struct xccdf_value_iterator *xccdf_group_get_values(const struct xccdf_group *group);
 
 /// @memberof xccdf_group
-const char *xccdf_group_get_id(const struct xccdf_group *group);
+OSCAP_API const char *xccdf_group_get_id(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct oscap_text_iterator *xccdf_group_get_title(const struct xccdf_group *group);
+OSCAP_API struct oscap_text_iterator *xccdf_group_get_title(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct oscap_text_iterator *xccdf_group_get_description(const struct xccdf_group *group);
+OSCAP_API struct oscap_text_iterator *xccdf_group_get_description(const struct xccdf_group *group);
 /// @memberof xccdf_group
-const char *xccdf_group_get_version(const struct xccdf_group *group);
+OSCAP_API const char *xccdf_group_get_version(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct oscap_text_iterator *xccdf_group_get_question(const struct xccdf_group *group);
+OSCAP_API struct oscap_text_iterator *xccdf_group_get_question(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct xccdf_warning_iterator *xccdf_group_get_warnings(const struct xccdf_group *group);
+OSCAP_API struct xccdf_warning_iterator *xccdf_group_get_warnings(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct oscap_text_iterator *xccdf_group_get_rationale(const struct xccdf_group *group);
+OSCAP_API struct oscap_text_iterator *xccdf_group_get_rationale(const struct xccdf_group *group);
 /// @memberof xccdf_group
-const char *xccdf_group_get_cluster_id(const struct xccdf_group *group);
+OSCAP_API const char *xccdf_group_get_cluster_id(const struct xccdf_group *group);
 /// @memberof xccdf_group
-float xccdf_group_get_weight(const struct xccdf_group *group);
+OSCAP_API float xccdf_group_get_weight(const struct xccdf_group *group);
 /// @memberof xccdf_group
-bool xccdf_group_set_weight(struct xccdf_group *item, xccdf_numeric newval);
+OSCAP_API bool xccdf_group_set_weight(struct xccdf_group *item, xccdf_numeric newval);
 /// @memberof xccdf_group
-const char *xccdf_group_get_extends(const struct xccdf_group *group);
+OSCAP_API const char *xccdf_group_get_extends(const struct xccdf_group *group);
 /// @memberof xccdf_group
-bool xccdf_group_get_abstract(const struct xccdf_group *group);
+OSCAP_API bool xccdf_group_get_abstract(const struct xccdf_group *group);
 /// @memberof xccdf_group
-bool xccdf_group_get_prohibit_changes(const struct xccdf_group *group);
+OSCAP_API bool xccdf_group_get_prohibit_changes(const struct xccdf_group *group);
 /// @memberof xccdf_group
-bool xccdf_group_get_hidden(const struct xccdf_group *group);
+OSCAP_API bool xccdf_group_get_hidden(const struct xccdf_group *group);
 /// @memberof xccdf_group
-bool xccdf_group_get_selected(const struct xccdf_group *group);
+OSCAP_API bool xccdf_group_get_selected(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct oscap_string_iterator *xccdf_group_get_platforms(const struct xccdf_group *group);
+OSCAP_API struct oscap_string_iterator *xccdf_group_get_platforms(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct xccdf_status_iterator *xccdf_group_get_statuses(const struct xccdf_group *group);
+OSCAP_API struct xccdf_status_iterator *xccdf_group_get_statuses(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct oscap_reference_iterator *xccdf_group_get_dc_statuses(const struct xccdf_group *group);
+OSCAP_API struct oscap_reference_iterator *xccdf_group_get_dc_statuses(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct oscap_reference_iterator *xccdf_group_get_references(const struct xccdf_group *group);
+OSCAP_API struct oscap_reference_iterator *xccdf_group_get_references(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct xccdf_status * xccdf_group_get_status_current(const struct xccdf_group *group);
+OSCAP_API struct xccdf_status * xccdf_group_get_status_current(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct oscap_string_iterator *xccdf_group_get_conflicts(const struct xccdf_group* group);
+OSCAP_API struct oscap_string_iterator *xccdf_group_get_conflicts(const struct xccdf_group* group);
 /// @memberof xccdf_group
-struct oscap_stringlist_iterator *xccdf_group_get_requires(const struct xccdf_group* group);
+OSCAP_API struct oscap_stringlist_iterator *xccdf_group_get_requires(const struct xccdf_group* group);
 /// @memberof xccdf_group
-struct oscap_string_iterator *xccdf_group_get_metadata(const struct xccdf_group *group);
+OSCAP_API struct oscap_string_iterator *xccdf_group_get_metadata(const struct xccdf_group *group);
 
 /// @memberof xccdf_value
-struct oscap_text_iterator *xccdf_value_get_title(const struct xccdf_value *value);
+OSCAP_API struct oscap_text_iterator *xccdf_value_get_title(const struct xccdf_value *value);
 /// @memberof xccdf_value
-const char *xccdf_value_get_id(const struct xccdf_value *value);
+OSCAP_API const char *xccdf_value_get_id(const struct xccdf_value *value);
 /// @memberof xccdf_value
-struct oscap_text_iterator *xccdf_value_get_description(const struct xccdf_value *value);
+OSCAP_API struct oscap_text_iterator *xccdf_value_get_description(const struct xccdf_value *value);
 /// @memberof xccdf_value
-const char *xccdf_value_get_extends(const struct xccdf_value *value);
+OSCAP_API const char *xccdf_value_get_extends(const struct xccdf_value *value);
 /// @memberof xccdf_value
-bool xccdf_value_get_abstract(const struct xccdf_value *value);
+OSCAP_API bool xccdf_value_get_abstract(const struct xccdf_value *value);
 /// @memberof xccdf_value
-bool xccdf_value_get_prohibit_changes(const struct xccdf_value *value);
+OSCAP_API bool xccdf_value_get_prohibit_changes(const struct xccdf_value *value);
 /// @memberof xccdf_value
-bool xccdf_value_get_hidden(const struct xccdf_value *value);
+OSCAP_API bool xccdf_value_get_hidden(const struct xccdf_value *value);
 /// @memberof xccdf_value
-bool xccdf_value_get_interactive(const struct xccdf_value *value);
+OSCAP_API bool xccdf_value_get_interactive(const struct xccdf_value *value);
 /// @memberof xccdf_value
-struct xccdf_status_iterator *xccdf_value_get_statuses(const struct xccdf_value *value);
+OSCAP_API struct xccdf_status_iterator *xccdf_value_get_statuses(const struct xccdf_value *value);
 /// @memberof xccdf_value
-struct oscap_reference_iterator *xccdf_value_get_dc_statuses(const struct xccdf_value *value);
+OSCAP_API struct oscap_reference_iterator *xccdf_value_get_dc_statuses(const struct xccdf_value *value);
 /// @memberof xccdf_value
-struct oscap_reference_iterator *xccdf_value_get_references(const struct xccdf_value *value);
+OSCAP_API struct oscap_reference_iterator *xccdf_value_get_references(const struct xccdf_value *value);
 /// @memberof xccdf_value
-struct xccdf_status * xccdf_value_get_status_current(const struct xccdf_value *value);
+OSCAP_API struct xccdf_status * xccdf_value_get_status_current(const struct xccdf_value *value);
 /// @memberof xccdf_value
-xccdf_value_type_t xccdf_value_get_type(const struct xccdf_value *value);
+OSCAP_API xccdf_value_type_t xccdf_value_get_type(const struct xccdf_value *value);
 /// @memberof xccdf_value
-xccdf_interface_hint_t xccdf_value_get_interface_hint(const struct xccdf_value *value);
+OSCAP_API xccdf_interface_hint_t xccdf_value_get_interface_hint(const struct xccdf_value *value);
 /// @memberof xccdf_value
-xccdf_operator_t xccdf_value_get_oper(const struct xccdf_value *value);
+OSCAP_API xccdf_operator_t xccdf_value_get_oper(const struct xccdf_value *value);
 /// @memberof xccdf_value
-struct xccdf_value_instance *xccdf_value_get_instance_by_selector(const struct xccdf_value *value, const char *selector);
+OSCAP_API struct xccdf_value_instance *xccdf_value_get_instance_by_selector(const struct xccdf_value *value, const char *selector);
 /// @memberof xccdf_value
-bool xccdf_value_add_instance(struct xccdf_value *value, struct xccdf_value_instance *instance);
+OSCAP_API bool xccdf_value_add_instance(struct xccdf_value *value, struct xccdf_value_instance *instance);
 /// @memberof xccdf_value
-struct xccdf_value_instance_iterator *xccdf_value_get_instances(const struct xccdf_value *item);
+OSCAP_API struct xccdf_value_instance_iterator *xccdf_value_get_instances(const struct xccdf_value *item);
 /// @memberof xccdf_value
-struct oscap_string_iterator *xccdf_value_get_metadata(const struct xccdf_value *value);
+OSCAP_API struct oscap_string_iterator *xccdf_value_get_metadata(const struct xccdf_value *value);
 
 /// @memberof xccdf_value_instance
-void xccdf_value_instance_free(struct xccdf_value_instance *inst);
+OSCAP_API void xccdf_value_instance_free(struct xccdf_value_instance *inst);
 /// @memberof xccdf_value
-struct xccdf_value_instance *xccdf_value_new_instance(struct xccdf_value *val);
+OSCAP_API struct xccdf_value_instance *xccdf_value_new_instance(struct xccdf_value *val);
 /// @memberof xccdf_value_instance
-const char *xccdf_value_instance_get_selector(const struct xccdf_value_instance *item);
+OSCAP_API const char *xccdf_value_instance_get_selector(const struct xccdf_value_instance *item);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_set_selector(struct xccdf_value_instance *obj, const char *newval);
+OSCAP_API bool xccdf_value_instance_set_selector(struct xccdf_value_instance *obj, const char *newval);
 /// @memberof xccdf_value_instance
-xccdf_value_type_t xccdf_value_instance_get_type(const struct xccdf_value_instance *item);
+OSCAP_API xccdf_value_type_t xccdf_value_instance_get_type(const struct xccdf_value_instance *item);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_get_must_match(const struct xccdf_value_instance *item);
+OSCAP_API bool xccdf_value_instance_get_must_match(const struct xccdf_value_instance *item);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_set_must_match(struct xccdf_value_instance *obj, bool newval);
+OSCAP_API bool xccdf_value_instance_set_must_match(struct xccdf_value_instance *obj, bool newval);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_get_value_boolean(const struct xccdf_value_instance *inst);
+OSCAP_API bool xccdf_value_instance_get_value_boolean(const struct xccdf_value_instance *inst);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_set_value_boolean(struct xccdf_value_instance *inst, bool newval);
+OSCAP_API bool xccdf_value_instance_set_value_boolean(struct xccdf_value_instance *inst, bool newval);
 /// @memberof xccdf_value_instance
-xccdf_numeric xccdf_value_instance_get_value_number(const struct xccdf_value_instance *inst);
+OSCAP_API xccdf_numeric xccdf_value_instance_get_value_number(const struct xccdf_value_instance *inst);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_set_value_number(struct xccdf_value_instance *inst, xccdf_numeric newval);
+OSCAP_API bool xccdf_value_instance_set_value_number(struct xccdf_value_instance *inst, xccdf_numeric newval);
 /// @memberof xccdf_value_instance
-const char *xccdf_value_instance_get_value_string(const struct xccdf_value_instance *inst);
+OSCAP_API const char *xccdf_value_instance_get_value_string(const struct xccdf_value_instance *inst);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_set_value_string(struct xccdf_value_instance *inst, const char *newval);
+OSCAP_API bool xccdf_value_instance_set_value_string(struct xccdf_value_instance *inst, const char *newval);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_get_defval_boolean(const struct xccdf_value_instance *inst);
+OSCAP_API bool xccdf_value_instance_get_defval_boolean(const struct xccdf_value_instance *inst);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_set_defval_boolean(struct xccdf_value_instance *inst, bool newval);
+OSCAP_API bool xccdf_value_instance_set_defval_boolean(struct xccdf_value_instance *inst, bool newval);
 /// @memberof xccdf_value_instance
-xccdf_numeric xccdf_value_instance_get_defval_number(const struct xccdf_value_instance *inst);
+OSCAP_API xccdf_numeric xccdf_value_instance_get_defval_number(const struct xccdf_value_instance *inst);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_set_defval_number(struct xccdf_value_instance *inst, xccdf_numeric newval);
+OSCAP_API bool xccdf_value_instance_set_defval_number(struct xccdf_value_instance *inst, xccdf_numeric newval);
 /// @memberof xccdf_value_instance
-const char *xccdf_value_instance_get_defval_string(const struct xccdf_value_instance *inst);
+OSCAP_API const char *xccdf_value_instance_get_defval_string(const struct xccdf_value_instance *inst);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_set_defval_string(struct xccdf_value_instance *inst, const char *newval);
+OSCAP_API bool xccdf_value_instance_set_defval_string(struct xccdf_value_instance *inst, const char *newval);
 /// @memberof xccdf_value_instance
-xccdf_numeric xccdf_value_instance_get_lower_bound(const struct xccdf_value_instance *inst);
+OSCAP_API xccdf_numeric xccdf_value_instance_get_lower_bound(const struct xccdf_value_instance *inst);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_set_lower_bound(struct xccdf_value_instance *inst, xccdf_numeric newval);
+OSCAP_API bool xccdf_value_instance_set_lower_bound(struct xccdf_value_instance *inst, xccdf_numeric newval);
 /// @memberof xccdf_value_instance
-xccdf_numeric xccdf_value_instance_get_upper_bound(const struct xccdf_value_instance *inst);
+OSCAP_API xccdf_numeric xccdf_value_instance_get_upper_bound(const struct xccdf_value_instance *inst);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_set_upper_bound(struct xccdf_value_instance *inst, xccdf_numeric newval);
+OSCAP_API bool xccdf_value_instance_set_upper_bound(struct xccdf_value_instance *inst, xccdf_numeric newval);
 /// @memberof xccdf_value_instance
-const char *xccdf_value_instance_get_match(const struct xccdf_value_instance *inst);
+OSCAP_API const char *xccdf_value_instance_get_match(const struct xccdf_value_instance *inst);
 /// @memberof xccdf_value_instance
-bool xccdf_value_instance_set_match(struct xccdf_value_instance *inst, const char *newval);
+OSCAP_API bool xccdf_value_instance_set_match(struct xccdf_value_instance *inst, const char *newval);
 /// @memberof xccdf_value_instance
-const char *  xccdf_value_instance_get_value(const struct xccdf_value_instance * val);
+OSCAP_API const char *  xccdf_value_instance_get_value(const struct xccdf_value_instance * val);
 
 /**
  * Return value's parent in the grouping hierarchy.
  * Returned item will be either a value or a benchmark.
  * @memberof xccdf_value
  */
-struct xccdf_item *xccdf_value_get_parent(const struct xccdf_value *value);
+OSCAP_API struct xccdf_item *xccdf_value_get_parent(const struct xccdf_value *value);
 
 
 /// @memberof xccdf_status
-time_t xccdf_status_get_date(const struct xccdf_status *status);
+OSCAP_API time_t xccdf_status_get_date(const struct xccdf_status *status);
 /// @memberof xccdf_status
-xccdf_status_type_t xccdf_status_get_status(const struct xccdf_status *status);
+OSCAP_API xccdf_status_type_t xccdf_status_get_status(const struct xccdf_status *status);
 /// @memberof xccdf_status
-const char *xccdf_status_type_to_text(xccdf_status_type_t id);
+OSCAP_API const char *xccdf_status_type_to_text(xccdf_status_type_t id);
 
 /// @memberof xccdf_notice
-const char *xccdf_notice_get_id(const struct xccdf_notice *notice);
+OSCAP_API const char *xccdf_notice_get_id(const struct xccdf_notice *notice);
 /// @memberof xccdf_notice
-struct oscap_text *xccdf_notice_get_text(const struct xccdf_notice *notice);
+OSCAP_API struct oscap_text *xccdf_notice_get_text(const struct xccdf_notice *notice);
 /// @memberof xccdf_model
-const char *xccdf_model_get_system(const struct xccdf_model *model);
+OSCAP_API const char *xccdf_model_get_system(const struct xccdf_model *model);
 /// @memberof xccdf_ident
-const char *xccdf_ident_get_id(const struct xccdf_ident *ident);
+OSCAP_API const char *xccdf_ident_get_id(const struct xccdf_ident *ident);
 /// @memberof xccdf_ident
-const char *xccdf_ident_get_system(const struct xccdf_ident *ident);
+OSCAP_API const char *xccdf_ident_get_system(const struct xccdf_ident *ident);
 /// @memberof xccdf_check
-const char *xccdf_check_get_id(const struct xccdf_check *check);
+OSCAP_API const char *xccdf_check_get_id(const struct xccdf_check *check);
 
 /**
  * True if the check is a complex check.
  * @memberof xccdf_check
  * @see xccdf_check_get_children
  */
-bool xccdf_check_get_complex(const struct xccdf_check *check);
+OSCAP_API bool xccdf_check_get_complex(const struct xccdf_check *check);
 
 /**
  * Get an operator to be applied no children of the complex check.
  * @memberof xccdf_check
  * @see xccdf_check_get_children
  */
-xccdf_bool_operator_t xccdf_check_get_oper(const struct xccdf_check *check);
+OSCAP_API xccdf_bool_operator_t xccdf_check_get_oper(const struct xccdf_check *check);
 /// @memberof xccdf_check
-const char *xccdf_check_get_system(const struct xccdf_check *check);
+OSCAP_API const char *xccdf_check_get_system(const struct xccdf_check *check);
 /// @memberof xccdf_check
-const char *xccdf_check_get_selector(const struct xccdf_check *check);
+OSCAP_API const char *xccdf_check_get_selector(const struct xccdf_check *check);
 /// @memberof xccdf_check
-const char *xccdf_check_get_content(const struct xccdf_check *check);
+OSCAP_API const char *xccdf_check_get_content(const struct xccdf_check *check);
 /// @memberof xccdf_check
-bool xccdf_check_get_multicheck(const struct xccdf_check *check);
+OSCAP_API bool xccdf_check_get_multicheck(const struct xccdf_check *check);
 /// @memberof xccdf_check
-bool xccdf_check_get_negate(const struct xccdf_check *check);
+OSCAP_API bool xccdf_check_get_negate(const struct xccdf_check *check);
 /// @memberof xccdf_check
 //struct xccdf_rule *xccdf_check_get_parent(const struct xccdf_check *check);
 /**
@@ -2430,217 +2431,217 @@ bool xccdf_check_get_negate(const struct xccdf_check *check);
  * @memberof xccdf_check
  * @see xccdf_check_get_export
  */
-struct xccdf_check_iterator *xccdf_check_get_children(const struct xccdf_check *check);
+OSCAP_API struct xccdf_check_iterator *xccdf_check_get_children(const struct xccdf_check *check);
 
 /// @memberof xccdf_check_content_ref
-const char *xccdf_check_content_ref_get_href(const struct xccdf_check_content_ref *ref);
+OSCAP_API const char *xccdf_check_content_ref_get_href(const struct xccdf_check_content_ref *ref);
 /// @memberof xccdf_check_content_ref
-const char *xccdf_check_content_ref_get_name(const struct xccdf_check_content_ref *ref);
+OSCAP_API const char *xccdf_check_content_ref_get_name(const struct xccdf_check_content_ref *ref);
 /// @memberof xccdf_profile_note
-const char *xccdf_profile_note_get_reftag(const struct xccdf_profile_note *note);
+OSCAP_API const char *xccdf_profile_note_get_reftag(const struct xccdf_profile_note *note);
 /// @memberof xccdf_profile_note
-struct oscap_text *xccdf_profile_note_get_text(const struct xccdf_profile_note *note);
+OSCAP_API struct oscap_text *xccdf_profile_note_get_text(const struct xccdf_profile_note *note);
 /// @memberof xccdf_check_import
-const char *xccdf_check_import_get_name(const struct xccdf_check_import *item);
+OSCAP_API const char *xccdf_check_import_get_name(const struct xccdf_check_import *item);
 /// @memberof xccdf_check_import
-const char *xccdf_check_import_get_xpath(const struct xccdf_check_import *item);
+OSCAP_API const char *xccdf_check_import_get_xpath(const struct xccdf_check_import *item);
 /// @memberof xccdf_check_import
-const char *xccdf_check_import_get_content(const struct xccdf_check_import *item);
+OSCAP_API const char *xccdf_check_import_get_content(const struct xccdf_check_import *item);
 /// @memberof xccdf_check_export
-const char *xccdf_check_export_get_value(const struct xccdf_check_export *item);
+OSCAP_API const char *xccdf_check_export_get_value(const struct xccdf_check_export *item);
 /// @memberof xccdf_check_export
-const char *xccdf_check_export_get_name(const struct xccdf_check_export *item);
+OSCAP_API const char *xccdf_check_export_get_name(const struct xccdf_check_export *item);
 
 /// @memberof xccdf_fix
-const char *xccdf_fix_get_content(const struct xccdf_fix *fix);
+OSCAP_API const char *xccdf_fix_get_content(const struct xccdf_fix *fix);
 /// @memberof xccdf_fix
-bool xccdf_fix_get_reboot(const struct xccdf_fix *fix);
+OSCAP_API bool xccdf_fix_get_reboot(const struct xccdf_fix *fix);
 /// @memberof xccdf_fix
-xccdf_strategy_t xccdf_fix_get_strategy(const struct xccdf_fix *fix);
+OSCAP_API xccdf_strategy_t xccdf_fix_get_strategy(const struct xccdf_fix *fix);
 /// @memberof xccdf_fix
-xccdf_level_t xccdf_fix_get_complexity(const struct xccdf_fix *fix);
+OSCAP_API xccdf_level_t xccdf_fix_get_complexity(const struct xccdf_fix *fix);
 /// @memberof xccdf_fix
-xccdf_level_t xccdf_fix_get_disruption(const struct xccdf_fix *fix);
+OSCAP_API xccdf_level_t xccdf_fix_get_disruption(const struct xccdf_fix *fix);
 /// @memberof xccdf_fix
-const char *xccdf_fix_get_id(const struct xccdf_fix *fix);
+OSCAP_API const char *xccdf_fix_get_id(const struct xccdf_fix *fix);
 /// @memberof xccdf_fix
-const char *xccdf_fix_get_system(const struct xccdf_fix *fix);
+OSCAP_API const char *xccdf_fix_get_system(const struct xccdf_fix *fix);
 /// @memberof xccdf_fix
-const char *xccdf_fix_get_platform(const struct xccdf_fix *fix);
+OSCAP_API const char *xccdf_fix_get_platform(const struct xccdf_fix *fix);
 /// @memberof xccdf_fixtext
-bool xccdf_fixtext_get_reboot(const struct xccdf_fixtext *fixtext);
+OSCAP_API bool xccdf_fixtext_get_reboot(const struct xccdf_fixtext *fixtext);
 /// @memberof xccdf_fixtext
-xccdf_strategy_t xccdf_fixtext_get_strategy(const struct xccdf_fixtext *fixtext);
+OSCAP_API xccdf_strategy_t xccdf_fixtext_get_strategy(const struct xccdf_fixtext *fixtext);
 /// @memberof xccdf_fixtext
-xccdf_level_t xccdf_fixtext_get_complexity(const struct xccdf_fixtext *fixtext);
+OSCAP_API xccdf_level_t xccdf_fixtext_get_complexity(const struct xccdf_fixtext *fixtext);
 /// @memberof xccdf_fixtext
-xccdf_level_t xccdf_fixtext_get_disruption(const struct xccdf_fixtext *fixtext);
+OSCAP_API xccdf_level_t xccdf_fixtext_get_disruption(const struct xccdf_fixtext *fixtext);
 /// @memberof xccdf_fixtext
-const char *xccdf_fixtext_get_fixref(const struct xccdf_fixtext *fixtext);
+OSCAP_API const char *xccdf_fixtext_get_fixref(const struct xccdf_fixtext *fixtext);
 /// @memberof xccdf_fixtext
-struct oscap_text *xccdf_fixtext_get_text(const struct xccdf_fixtext *fixtext);
+OSCAP_API struct oscap_text *xccdf_fixtext_get_text(const struct xccdf_fixtext *fixtext);
 /// @memberof xccdf_value
-const char *xccdf_value_get_version(const struct xccdf_value *value);
+OSCAP_API const char *xccdf_value_get_version(const struct xccdf_value *value);
 /// @memberof xccdf_value
-struct oscap_text_iterator *xccdf_value_get_question(const struct xccdf_value *value);
+OSCAP_API struct oscap_text_iterator *xccdf_value_get_question(const struct xccdf_value *value);
 /// @memberof xccdf_value
-struct xccdf_warning_iterator *xccdf_value_get_warnings(const struct xccdf_value *value);
+OSCAP_API struct xccdf_warning_iterator *xccdf_value_get_warnings(const struct xccdf_value *value);
 /// @memberof xccdf_value
-const char *xccdf_value_get_version_update(const struct xccdf_value *value);
+OSCAP_API const char *xccdf_value_get_version_update(const struct xccdf_value *value);
 /// @memberof xccdf_value
-const char *xccdf_value_get_version_time(const struct xccdf_value *value);
+OSCAP_API const char *xccdf_value_get_version_time(const struct xccdf_value *value);
 /// @memberof xccdf_value
-struct xccdf_benchmark *xccdf_value_get_benchmark(const struct xccdf_value *value);
+OSCAP_API struct xccdf_benchmark *xccdf_value_get_benchmark(const struct xccdf_value *value);
 /// @memberof xccdf_value
-struct oscap_string_iterator *xccdf_value_get_sources(const struct xccdf_value *value);
+OSCAP_API struct oscap_string_iterator *xccdf_value_get_sources(const struct xccdf_value *value);
 /// @memberof xccdf_value
-const char *xccdf_value_get_cluster_id(const struct xccdf_value *value);
+OSCAP_API const char *xccdf_value_get_cluster_id(const struct xccdf_value *value);
 
 /// @memberof xccdf_item
-struct oscap_text_iterator *xccdf_item_get_question(const struct xccdf_item *item);
+OSCAP_API struct oscap_text_iterator *xccdf_item_get_question(const struct xccdf_item *item);
 /// @memberof xccdf_item
-struct xccdf_warning_iterator *xccdf_item_get_warnings(const struct xccdf_item *item);
+OSCAP_API struct xccdf_warning_iterator *xccdf_item_get_warnings(const struct xccdf_item *item);
 /// @memberof xccdf_item
-struct oscap_text_iterator *xccdf_item_get_rationale(const struct xccdf_item *item);
+OSCAP_API struct oscap_text_iterator *xccdf_item_get_rationale(const struct xccdf_item *item);
 /// @memberof xccdf_item
-const char *xccdf_item_get_cluster_id(const struct xccdf_item *item);
+OSCAP_API const char *xccdf_item_get_cluster_id(const struct xccdf_item *item);
 /// @memberof xccdf_item
-const char *xccdf_item_get_version_update(const struct xccdf_item *item);
+OSCAP_API const char *xccdf_item_get_version_update(const struct xccdf_item *item);
 /// @memberof xccdf_item
-const char *xccdf_item_get_version_time(const struct xccdf_item *item);
+OSCAP_API const char *xccdf_item_get_version_time(const struct xccdf_item *item);
 /// @memberof xccdf_item
-float xccdf_item_get_weight(const struct xccdf_item *item);
+OSCAP_API float xccdf_item_get_weight(const struct xccdf_item *item);
 /// @memberof xccdf_item
-struct xccdf_benchmark *xccdf_item_get_benchmark(const struct xccdf_item *item);
+OSCAP_API struct xccdf_benchmark *xccdf_item_get_benchmark(const struct xccdf_item *item);
 /// @memberof xccdf_item
-struct oscap_string_iterator *xccdf_item_get_platforms(const struct xccdf_item *item);
+OSCAP_API struct oscap_string_iterator *xccdf_item_get_platforms(const struct xccdf_item *item);
 
 /// @memberof xccdf_benchmark
-struct xccdf_warning_iterator *xccdf_benchmark_get_warnings(const struct xccdf_benchmark *benchmark);
+OSCAP_API struct xccdf_warning_iterator *xccdf_benchmark_get_warnings(const struct xccdf_benchmark *benchmark);
 /// @memberof xccdf_benchmark
-const char *xccdf_benchmark_get_version_update(const struct xccdf_benchmark *benchmark);
+OSCAP_API const char *xccdf_benchmark_get_version_update(const struct xccdf_benchmark *benchmark);
 /// @memberof xccdf_benchmark
-const char *xccdf_benchmark_get_version_time(const struct xccdf_benchmark *benchmark);
+OSCAP_API const char *xccdf_benchmark_get_version_time(const struct xccdf_benchmark *benchmark);
 
 /// @memberof xccdf_profile
-const char *xccdf_profile_get_version_update(const struct xccdf_profile *profile);
+OSCAP_API const char *xccdf_profile_get_version_update(const struct xccdf_profile *profile);
 /// @memberof xccdf_profile
-const char *xccdf_profile_get_version_time(const struct xccdf_profile *profile);
+OSCAP_API const char *xccdf_profile_get_version_time(const struct xccdf_profile *profile);
 /// @memberof xccdf_profile
-bool xccdf_profile_get_tailoring(const struct xccdf_profile *profile);
+OSCAP_API bool xccdf_profile_get_tailoring(const struct xccdf_profile *profile);
 /// @memberof xccdf_profile
-const char *xccdf_profile_get_note_tag(const struct xccdf_profile *profile);
+OSCAP_API const char *xccdf_profile_get_note_tag(const struct xccdf_profile *profile);
 
 /// @memberof xccdf_rule
-const char *xccdf_rule_get_version_update(const struct xccdf_rule *rule);
+OSCAP_API const char *xccdf_rule_get_version_update(const struct xccdf_rule *rule);
 /// @memberof xccdf_rule
-const char *xccdf_rule_get_version_time(const struct xccdf_rule *rule);
+OSCAP_API const char *xccdf_rule_get_version_time(const struct xccdf_rule *rule);
 /// @memberof xccdf_rule
-struct xccdf_benchmark *xccdf_rule_get_benchmark(const struct xccdf_rule *rule);
+OSCAP_API struct xccdf_benchmark *xccdf_rule_get_benchmark(const struct xccdf_rule *rule);
 
 /// @memberof xccdf_group
-const char *xccdf_group_get_version_time(const struct xccdf_group *group);
+OSCAP_API const char *xccdf_group_get_version_time(const struct xccdf_group *group);
 /// @memberof xccdf_group
-const char *xccdf_group_get_version_update(const struct xccdf_group *group);
+OSCAP_API const char *xccdf_group_get_version_update(const struct xccdf_group *group);
 /// @memberof xccdf_group
-struct xccdf_benchmark *xccdf_group_get_benchmark(const struct xccdf_group *group);
+OSCAP_API struct xccdf_benchmark *xccdf_group_get_benchmark(const struct xccdf_group *group);
 
 /// @memberof xccdf_check
-struct xccdf_check_import_iterator *xccdf_check_get_imports(const struct xccdf_check *check);
+OSCAP_API struct xccdf_check_import_iterator *xccdf_check_get_imports(const struct xccdf_check *check);
 /// @memberof xccdf_check
-struct xccdf_check_export_iterator *xccdf_check_get_exports(const struct xccdf_check *check);
+OSCAP_API struct xccdf_check_export_iterator *xccdf_check_get_exports(const struct xccdf_check *check);
 /// @memberof xccdf_check
-struct xccdf_check_content_ref_iterator *xccdf_check_get_content_refs(const struct xccdf_check *check);
+OSCAP_API struct xccdf_check_content_ref_iterator *xccdf_check_get_content_refs(const struct xccdf_check *check);
 
 /// @memberof xccdf_select
-bool xccdf_select_get_selected(const struct xccdf_select *select);
+OSCAP_API bool xccdf_select_get_selected(const struct xccdf_select *select);
 /// @memberof xccdf_select
-const char *xccdf_select_get_item(const struct xccdf_select *select);
+OSCAP_API const char *xccdf_select_get_item(const struct xccdf_select *select);
 /// @memberof xccdf_select
-struct oscap_text_iterator *xccdf_select_get_remarks(const struct xccdf_select *select);
+OSCAP_API struct oscap_text_iterator *xccdf_select_get_remarks(const struct xccdf_select *select);
 
 /// @memberof xccdf_warning
-xccdf_warning_category_t xccdf_warning_get_category(const struct xccdf_warning *warning);
+OSCAP_API xccdf_warning_category_t xccdf_warning_get_category(const struct xccdf_warning *warning);
 /// @memberof xccdf_warning
-struct oscap_text *xccdf_warning_get_text(const struct xccdf_warning *warning);
+OSCAP_API struct oscap_text *xccdf_warning_get_text(const struct xccdf_warning *warning);
 /// @memberof xccdf_refine_rule
-const char *  xccdf_refine_rule_get_item(const struct xccdf_refine_rule* rr);
+OSCAP_API const char *  xccdf_refine_rule_get_item(const struct xccdf_refine_rule* rr);
 /// @memberof xccdf_refine_rule
-const char *  xccdf_refine_rule_get_selector(const struct xccdf_refine_rule* rr);
+OSCAP_API const char *  xccdf_refine_rule_get_selector(const struct xccdf_refine_rule* rr);
 /// @memberof xccdf_refine_rule
-xccdf_role_t  xccdf_refine_rule_get_role(const struct xccdf_refine_rule* rr);
+OSCAP_API xccdf_role_t  xccdf_refine_rule_get_role(const struct xccdf_refine_rule* rr);
 /// @memberof xccdf_refine_rule
-xccdf_level_t xccdf_refine_rule_get_severity(const struct xccdf_refine_rule* rr);
+OSCAP_API xccdf_level_t xccdf_refine_rule_get_severity(const struct xccdf_refine_rule* rr);
 /// @memberof xccdf_refine_rule
-struct oscap_text_iterator* xccdf_refine_rule_get_remarks(const struct xccdf_refine_rule *rr);
+OSCAP_API struct oscap_text_iterator* xccdf_refine_rule_get_remarks(const struct xccdf_refine_rule *rr);
 /// @memberof xccdf_refine_rule
-xccdf_numeric xccdf_refine_rule_get_weight(const struct xccdf_refine_rule *item);
+OSCAP_API xccdf_numeric xccdf_refine_rule_get_weight(const struct xccdf_refine_rule *item);
 /// @memberof xccdf_refine_rule
-bool xccdf_refine_rule_weight_defined(const struct xccdf_refine_rule *item);
+OSCAP_API bool xccdf_refine_rule_weight_defined(const struct xccdf_refine_rule *item);
 /// @memberof xccdf_refine_value
-const char *     xccdf_refine_value_get_item(const struct xccdf_refine_value* rv);
+OSCAP_API const char *     xccdf_refine_value_get_item(const struct xccdf_refine_value* rv);
 /// @memberof xccdf_refine_value
-const char *     xccdf_refine_value_get_selector(const struct xccdf_refine_value* rv);
+OSCAP_API const char *     xccdf_refine_value_get_selector(const struct xccdf_refine_value* rv);
 /// @memberof xccdf_refine_value
-xccdf_operator_t xccdf_refine_value_get_oper(const struct xccdf_refine_value* rv);
+OSCAP_API xccdf_operator_t xccdf_refine_value_get_oper(const struct xccdf_refine_value* rv);
 /// @memberof xccdf_refine_value
-struct oscap_text_iterator* xccdf_refine_value_get_remarks(const struct xccdf_refine_value *rv);
+OSCAP_API struct oscap_text_iterator* xccdf_refine_value_get_remarks(const struct xccdf_refine_value *rv);
 /// @memberof xccdf_set_value
-const char *xccdf_setvalue_get_item(const struct xccdf_setvalue* sv);
+OSCAP_API const char *xccdf_setvalue_get_item(const struct xccdf_setvalue* sv);
 /// @memberof xccdf_set_value
-const char *xccdf_setvalue_get_value(const struct xccdf_setvalue* sv);
+OSCAP_API const char *xccdf_setvalue_get_value(const struct xccdf_setvalue* sv);
 
 /// @memberof xccdf_plain_text
-const char *xccdf_plain_text_get_id(const struct xccdf_plain_text *item);
+OSCAP_API const char *xccdf_plain_text_get_id(const struct xccdf_plain_text *item);
 /// @memberof xccdf_plain_text
-const char *xccdf_plain_text_get_text(const struct xccdf_plain_text *item);
+OSCAP_API const char *xccdf_plain_text_get_text(const struct xccdf_plain_text *item);
 
 /// @memberof xccdf_result
-struct xccdf_benchmark *xccdf_result_get_benchmark(const struct xccdf_result *item);
+OSCAP_API struct xccdf_benchmark *xccdf_result_get_benchmark(const struct xccdf_result *item);
 /// @memberof xccdf_result
-const char *xccdf_result_get_id(const struct xccdf_result *item);
+OSCAP_API const char *xccdf_result_get_id(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct oscap_text_iterator *xccdf_result_get_title(const struct xccdf_result *item);
+OSCAP_API struct oscap_text_iterator *xccdf_result_get_title(const struct xccdf_result *item);
 /// @memberof xccdf_result
-const char *xccdf_result_get_version(const struct xccdf_result *item);
+OSCAP_API const char *xccdf_result_get_version(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct oscap_string_iterator *xccdf_result_get_platforms(const struct xccdf_result *item);
+OSCAP_API struct oscap_string_iterator *xccdf_result_get_platforms(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct xccdf_status_iterator *xccdf_result_get_statuses(const struct xccdf_result *item);
+OSCAP_API struct xccdf_status_iterator *xccdf_result_get_statuses(const struct xccdf_result *item);
 /// @memberof xccdf_result
-const char *xccdf_result_get_test_system(const struct xccdf_result *item);
+OSCAP_API const char *xccdf_result_get_test_system(const struct xccdf_result *item);
 /// @memberof xccdf_result
-const char *xccdf_result_get_benchmark_uri(const struct xccdf_result *item);
+OSCAP_API const char *xccdf_result_get_benchmark_uri(const struct xccdf_result *item);
 /// @memberof xccdf_result
-const char *xccdf_result_get_profile(const struct xccdf_result *item);
+OSCAP_API const char *xccdf_result_get_profile(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct xccdf_identity_iterator *xccdf_result_get_identities(const struct xccdf_result *item);
+OSCAP_API struct xccdf_identity_iterator *xccdf_result_get_identities(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct oscap_string_iterator *xccdf_result_get_targets(const struct xccdf_result *item);
+OSCAP_API struct oscap_string_iterator *xccdf_result_get_targets(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct oscap_string_iterator *xccdf_result_get_target_addresses(const struct xccdf_result *item);
+OSCAP_API struct oscap_string_iterator *xccdf_result_get_target_addresses(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct oscap_string_iterator *xccdf_result_get_applicable_platforms(const struct xccdf_result *item);
+OSCAP_API struct oscap_string_iterator *xccdf_result_get_applicable_platforms(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct oscap_string_iterator *xccdf_result_get_organizations(const struct xccdf_result *item);
+OSCAP_API struct oscap_string_iterator *xccdf_result_get_organizations(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct oscap_text_iterator *xccdf_result_get_remarks(const struct xccdf_result *item);
+OSCAP_API struct oscap_text_iterator *xccdf_result_get_remarks(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct xccdf_target_fact_iterator *xccdf_result_get_target_facts(const struct xccdf_result *item);
+OSCAP_API struct xccdf_target_fact_iterator *xccdf_result_get_target_facts(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct xccdf_target_identifier_iterator *xccdf_result_get_target_id_refs(const struct xccdf_result *item);
+OSCAP_API struct xccdf_target_identifier_iterator *xccdf_result_get_target_id_refs(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct xccdf_setvalue_iterator *xccdf_result_get_setvalues(const struct xccdf_result *item);
+OSCAP_API struct xccdf_setvalue_iterator *xccdf_result_get_setvalues(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct xccdf_rule_result_iterator *xccdf_result_get_rule_results(const struct xccdf_result *item);
+OSCAP_API struct xccdf_rule_result_iterator *xccdf_result_get_rule_results(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct xccdf_score_iterator *xccdf_result_get_scores(const struct xccdf_result *item);
+OSCAP_API struct xccdf_score_iterator *xccdf_result_get_scores(const struct xccdf_result *item);
 /// @memberof xccdf_result
-const char * xccdf_result_get_start_time(const struct xccdf_result *item);
+OSCAP_API const char * xccdf_result_get_start_time(const struct xccdf_result *item);
 /// @memberof xccdf_result
-const char * xccdf_result_get_end_time(const struct xccdf_result *item);
+OSCAP_API const char * xccdf_result_get_end_time(const struct xccdf_result *item);
 /// @memberof xccdf_result
-struct oscap_string_iterator *xccdf_result_get_metadata(const struct xccdf_result *result);
+OSCAP_API struct oscap_string_iterator *xccdf_result_get_metadata(const struct xccdf_result *result);
 
 /**
  * Override the result of rule-result.
@@ -2652,109 +2653,109 @@ struct oscap_string_iterator *xccdf_result_get_metadata(const struct xccdf_resul
  * @param remark Rationale of the override
  * @returns true on success
  */
-bool xccdf_rule_result_override(struct xccdf_rule_result *rule_result, xccdf_test_result_type_t new_result, const char *time, const char *authority, struct oscap_text *remark);
+OSCAP_API bool xccdf_rule_result_override(struct xccdf_rule_result *rule_result, xccdf_test_result_type_t new_result, const char *time, const char *authority, struct oscap_text *remark);
 
 /// @memberof xccdf_rule_result
-const char * xccdf_rule_result_get_time(const struct xccdf_rule_result *item);
+OSCAP_API const char * xccdf_rule_result_get_time(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-xccdf_role_t xccdf_rule_result_get_role(const struct xccdf_rule_result *item);
+OSCAP_API xccdf_role_t xccdf_rule_result_get_role(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-float xccdf_rule_result_get_weight(const struct xccdf_rule_result *item);
+OSCAP_API float xccdf_rule_result_get_weight(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-xccdf_level_t xccdf_rule_result_get_severity(const struct xccdf_rule_result *item);
+OSCAP_API xccdf_level_t xccdf_rule_result_get_severity(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-xccdf_test_result_type_t xccdf_rule_result_get_result(const struct xccdf_rule_result *item);
+OSCAP_API xccdf_test_result_type_t xccdf_rule_result_get_result(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-const char *xccdf_rule_result_get_version(const struct xccdf_rule_result *item);
+OSCAP_API const char *xccdf_rule_result_get_version(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-const char *xccdf_rule_result_get_idref(const struct xccdf_rule_result *item);
+OSCAP_API const char *xccdf_rule_result_get_idref(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-struct xccdf_ident_iterator *xccdf_rule_result_get_idents(const struct xccdf_rule_result *item);
+OSCAP_API struct xccdf_ident_iterator *xccdf_rule_result_get_idents(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-struct xccdf_fix_iterator *xccdf_rule_result_get_fixes(const struct xccdf_rule_result *item);
+OSCAP_API struct xccdf_fix_iterator *xccdf_rule_result_get_fixes(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-struct xccdf_check_iterator *xccdf_rule_result_get_checks(const struct xccdf_rule_result *item);
+OSCAP_API struct xccdf_check_iterator *xccdf_rule_result_get_checks(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-struct xccdf_override_iterator *xccdf_rule_result_get_overrides(const struct xccdf_rule_result *item);
+OSCAP_API struct xccdf_override_iterator *xccdf_rule_result_get_overrides(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-struct xccdf_message_iterator *xccdf_rule_result_get_messages(const struct xccdf_rule_result *item);
+OSCAP_API struct xccdf_message_iterator *xccdf_rule_result_get_messages(const struct xccdf_rule_result *item);
 /// @memberof xccdf_rule_result
-struct xccdf_instance_iterator *xccdf_rule_result_get_instances(const struct xccdf_rule_result *item);
+OSCAP_API struct xccdf_instance_iterator *xccdf_rule_result_get_instances(const struct xccdf_rule_result *item);
 /// @memberof xccdf_identity
-bool xccdf_identity_get_authenticated(const struct xccdf_identity *item);
+OSCAP_API bool xccdf_identity_get_authenticated(const struct xccdf_identity *item);
 /// @memberof xccdf_identity
-bool xccdf_identity_get_privileged(const struct xccdf_identity *item);
+OSCAP_API bool xccdf_identity_get_privileged(const struct xccdf_identity *item);
 /// @memberof xccdf_identity
-const char *xccdf_identity_get_name(const struct xccdf_identity *item);
+OSCAP_API const char *xccdf_identity_get_name(const struct xccdf_identity *item);
 /// @memberof xccdf_score
-xccdf_numeric xccdf_score_get_maximum(const struct xccdf_score *item);
+OSCAP_API xccdf_numeric xccdf_score_get_maximum(const struct xccdf_score *item);
 /// @memberof xccdf_score
-xccdf_numeric xccdf_score_get_score(const struct xccdf_score *item);
+OSCAP_API xccdf_numeric xccdf_score_get_score(const struct xccdf_score *item);
 /// @memberof xccdf_score
-const char *xccdf_score_get_system(const struct xccdf_score *item);
+OSCAP_API const char *xccdf_score_get_system(const struct xccdf_score *item);
 /// @memberof xccdf_override
-const char *xccdf_override_get_time(const struct xccdf_override *item);
+OSCAP_API const char *xccdf_override_get_time(const struct xccdf_override *item);
 /// @memberof xccdf_override
-xccdf_test_result_type_t xccdf_override_get_new_result(const struct xccdf_override *item);
+OSCAP_API xccdf_test_result_type_t xccdf_override_get_new_result(const struct xccdf_override *item);
 /// @memberof xccdf_override
-xccdf_test_result_type_t xccdf_override_get_old_result(const struct xccdf_override *item);
+OSCAP_API xccdf_test_result_type_t xccdf_override_get_old_result(const struct xccdf_override *item);
 /// @memberof xccdf_override
-const char *xccdf_override_get_authority(const struct xccdf_override *item);
+OSCAP_API const char *xccdf_override_get_authority(const struct xccdf_override *item);
 /// @memberof xccdf_override
-struct oscap_text *xccdf_override_get_remark(const struct xccdf_override *item);
+OSCAP_API struct oscap_text *xccdf_override_get_remark(const struct xccdf_override *item);
 /// @memberof xccdf_message
-xccdf_message_severity_t xccdf_message_get_severity(const struct xccdf_message *item);
+OSCAP_API xccdf_message_severity_t xccdf_message_get_severity(const struct xccdf_message *item);
 /// @memberof xccdf_message
-const char *xccdf_message_get_content(const struct xccdf_message *item);
+OSCAP_API const char *xccdf_message_get_content(const struct xccdf_message *item);
 /// @memberof xccdf_target_fact
-xccdf_value_type_t xccdf_target_fact_get_type(const struct xccdf_target_fact *item);
+OSCAP_API xccdf_value_type_t xccdf_target_fact_get_type(const struct xccdf_target_fact *item);
 /// @memberof xccdf_target_fact
-const char *xccdf_target_fact_get_value(const struct xccdf_target_fact *item);
+OSCAP_API const char *xccdf_target_fact_get_value(const struct xccdf_target_fact *item);
 /// @memberof xccdf_target_fact
-const char *xccdf_target_fact_get_name(const struct xccdf_target_fact *item);
+OSCAP_API const char *xccdf_target_fact_get_name(const struct xccdf_target_fact *item);
 /// @memberof xccdf_target_identifier
-void* xccdf_target_identifier_get_xml_node(const struct xccdf_target_identifier *item);
+OSCAP_API void* xccdf_target_identifier_get_xml_node(const struct xccdf_target_identifier *item);
 /// @memberof xccdf_target_identifier
-const char *xccdf_target_identifier_get_system(const struct xccdf_target_identifier *item);
+OSCAP_API const char *xccdf_target_identifier_get_system(const struct xccdf_target_identifier *item);
 /// @memberof xccdf_target_identifier
-const char *xccdf_target_identifier_get_href(const struct xccdf_target_identifier *item);
+OSCAP_API const char *xccdf_target_identifier_get_href(const struct xccdf_target_identifier *item);
 /// @memberof xccdf_target_identifier
-const char *xccdf_target_identifier_get_name(const struct xccdf_target_identifier *item);
+OSCAP_API const char *xccdf_target_identifier_get_name(const struct xccdf_target_identifier *item);
 /// @memberof xccdf_instance
-const char *xccdf_instance_get_context(const struct xccdf_instance *item);
+OSCAP_API const char *xccdf_instance_get_context(const struct xccdf_instance *item);
 /// @memberof xccdf_instance
-const char *xccdf_instance_get_parent_context(const struct xccdf_instance *item);
+OSCAP_API const char *xccdf_instance_get_parent_context(const struct xccdf_instance *item);
 /// @memberof xccdf_instance
-const char *xccdf_instance_get_content(const struct xccdf_instance *item);
+OSCAP_API const char *xccdf_instance_get_content(const struct xccdf_instance *item);
 /// @memberof xccdf_tailoring
-struct xccdf_tailoring *xccdf_tailoring_import_source(struct oscap_source *source, struct xccdf_benchmark *benchmark);
+OSCAP_API struct xccdf_tailoring *xccdf_tailoring_import_source(struct oscap_source *source, struct xccdf_benchmark *benchmark);
 /*
  * @memberof xccdf_tailoring
  * @deprecated This function has been deprecated by @ref xccdf_tailoring_import_source.
  * This function may be dropped from later versions of the library.
  */
-OSCAP_DEPRECATED(struct xccdf_tailoring *xccdf_tailoring_import(const char *file, struct xccdf_benchmark *benchmark));
+OSCAP_API OSCAP_DEPRECATED(struct xccdf_tailoring *xccdf_tailoring_import(const char *file, struct xccdf_benchmark *benchmark));
 
 /// @memberof xccdf_tailoring
-const char *xccdf_tailoring_get_id(const struct xccdf_tailoring *tailoring);
+OSCAP_API const char *xccdf_tailoring_get_id(const struct xccdf_tailoring *tailoring);
 /// @memberof xccdf_tailoring
-const char *xccdf_tailoring_get_version(const struct xccdf_tailoring *tailoring);
+OSCAP_API const char *xccdf_tailoring_get_version(const struct xccdf_tailoring *tailoring);
 /// @memberof xccdf_tailoring
-const char *xccdf_tailoring_get_version_update(const struct xccdf_tailoring *tailoring);
+OSCAP_API const char *xccdf_tailoring_get_version_update(const struct xccdf_tailoring *tailoring);
 /// @memberof xccdf_tailoring
-const char *xccdf_tailoring_get_version_time(const struct xccdf_tailoring *tailoring);
+OSCAP_API const char *xccdf_tailoring_get_version_time(const struct xccdf_tailoring *tailoring);
 /// @memberof xccdf_tailoring
-const char *xccdf_tailoring_get_benchmark_ref(const struct xccdf_tailoring *tailoring);
+OSCAP_API const char *xccdf_tailoring_get_benchmark_ref(const struct xccdf_tailoring *tailoring);
 /// @memberof xccdf_tailoring
-const char *xccdf_tailoring_get_benchmark_ref_version(const struct xccdf_tailoring *tailoring);
+OSCAP_API const char *xccdf_tailoring_get_benchmark_ref_version(const struct xccdf_tailoring *tailoring);
 /// @memberof xccdf_tailoring
-struct oscap_string_iterator *xccdf_tailoring_get_metadata(const struct xccdf_tailoring *tailoring);
+OSCAP_API struct oscap_string_iterator *xccdf_tailoring_get_metadata(const struct xccdf_tailoring *tailoring);
 /// @memberof xccdf_tailoring
-struct xccdf_profile_iterator *xccdf_tailoring_get_profiles(const struct xccdf_tailoring *tailoring);
+OSCAP_API struct xccdf_profile_iterator *xccdf_tailoring_get_profiles(const struct xccdf_tailoring *tailoring);
 /// @memberof xccdf_tailoring
-struct xccdf_status_iterator *xccdf_tailoring_get_statuses(const struct xccdf_tailoring *tailoring);
+OSCAP_API struct xccdf_status_iterator *xccdf_tailoring_get_statuses(const struct xccdf_tailoring *tailoring);
 /// @memberof xccdf_tailoring
-struct oscap_reference_iterator *xccdf_tailoring_get_dc_statuses(const struct xccdf_tailoring *tailoring);
+OSCAP_API struct oscap_reference_iterator *xccdf_tailoring_get_dc_statuses(const struct xccdf_tailoring *tailoring);
 /**
  * @param profile_id id of the profile that should be returned or NULL for default profile
  * @note
@@ -2762,7 +2763,7 @@ struct oscap_reference_iterator *xccdf_tailoring_get_dc_statuses(const struct xc
  * match the "selected" attribute from each individual XCCDF Item.
  * @memberof xccdf_tailoring
  */
-struct xccdf_profile *xccdf_tailoring_get_profile_by_id(const struct xccdf_tailoring *tailoring, const char *profile_id);
+OSCAP_API struct xccdf_profile *xccdf_tailoring_get_profile_by_id(const struct xccdf_tailoring *tailoring, const char *profile_id);
 
 /************************************************************
  ** @} End of Getters group */
@@ -2776,389 +2777,389 @@ struct xccdf_profile *xccdf_tailoring_get_profile_by_id(const struct xccdf_tailo
  */
 
 /// @memberof xccdf_item
-bool xccdf_item_set_weight(struct xccdf_item *item, xccdf_numeric newval);
+OSCAP_API bool xccdf_item_set_weight(struct xccdf_item *item, xccdf_numeric newval);
 /// @memberof xccdf_item
-bool xccdf_item_set_id(struct xccdf_item *item, const char *newval);
+OSCAP_API bool xccdf_item_set_id(struct xccdf_item *item, const char *newval);
 /// @memberof xccdf_item
-bool xccdf_item_set_cluster_id(struct xccdf_item *item, const char *newval);
+OSCAP_API bool xccdf_item_set_cluster_id(struct xccdf_item *item, const char *newval);
 /// @memberof xccdf_item
-bool xccdf_item_set_extends(struct xccdf_item *item, const char *newval);
+OSCAP_API bool xccdf_item_set_extends(struct xccdf_item *item, const char *newval);
 /// @memberof xccdf_item
-bool xccdf_item_set_version(struct xccdf_item *item, const char *newval);
+OSCAP_API bool xccdf_item_set_version(struct xccdf_item *item, const char *newval);
 /// @memberof xccdf_item
-bool xccdf_item_set_version_time(struct xccdf_item *item, const char *newval);
+OSCAP_API bool xccdf_item_set_version_time(struct xccdf_item *item, const char *newval);
 /// @memberof xccdf_item
-bool xccdf_item_set_version_update(struct xccdf_item *item, const char *newval);
+OSCAP_API bool xccdf_item_set_version_update(struct xccdf_item *item, const char *newval);
 /// @memberof xccdf_item
-bool xccdf_item_set_abstract(struct xccdf_item *item, bool newval);
+OSCAP_API bool xccdf_item_set_abstract(struct xccdf_item *item, bool newval);
 /// @memberof xccdf_item
-bool xccdf_item_set_hidden(struct xccdf_item *item, bool newval);
+OSCAP_API bool xccdf_item_set_hidden(struct xccdf_item *item, bool newval);
 /// @memberof xccdf_item
-bool xccdf_item_set_prohibit_changes(struct xccdf_item *item, bool newval);
+OSCAP_API bool xccdf_item_set_prohibit_changes(struct xccdf_item *item, bool newval);
 /// @memberof xccdf_item
-bool xccdf_item_set_selected(struct xccdf_item *item, bool newval);
+OSCAP_API bool xccdf_item_set_selected(struct xccdf_item *item, bool newval);
 
 /// @memberof xccdf_item
-bool xccdf_item_add_metadata(struct xccdf_item *item, const char* metadata);
+OSCAP_API bool xccdf_item_add_metadata(struct xccdf_item *item, const char* metadata);
 
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_set_resolved(struct xccdf_benchmark *item, bool newval);
+OSCAP_API bool xccdf_benchmark_set_resolved(struct xccdf_benchmark *item, bool newval);
 
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_set_style_href(struct xccdf_benchmark *item, const char *newval);
+OSCAP_API bool xccdf_benchmark_set_style_href(struct xccdf_benchmark *item, const char *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_set_style(struct xccdf_benchmark *item, const char *newval);
+OSCAP_API bool xccdf_benchmark_set_style(struct xccdf_benchmark *item, const char *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_set_id(struct xccdf_benchmark *item, const char *newval);
+OSCAP_API bool xccdf_benchmark_set_id(struct xccdf_benchmark *item, const char *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_set_version(struct xccdf_benchmark *item, const char *newval);
+OSCAP_API bool xccdf_benchmark_set_version(struct xccdf_benchmark *item, const char *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_set_version_time(struct xccdf_benchmark *item, const char *newval);
+OSCAP_API bool xccdf_benchmark_set_version_time(struct xccdf_benchmark *item, const char *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_set_version_update(struct xccdf_benchmark *item, const char *newval);
+OSCAP_API bool xccdf_benchmark_set_version_update(struct xccdf_benchmark *item, const char *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_set_schema_version(struct xccdf_benchmark* item, const struct xccdf_version_info* newval);
+OSCAP_API bool xccdf_benchmark_set_schema_version(struct xccdf_benchmark* item, const struct xccdf_version_info* newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_metadata(struct xccdf_benchmark* item, const char* metadata);
+OSCAP_API bool xccdf_benchmark_add_metadata(struct xccdf_benchmark* item, const char* metadata);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_set_cpe_list(struct xccdf_benchmark* item, struct cpe_dict_model* cpe_list);
+OSCAP_API bool xccdf_benchmark_set_cpe_list(struct xccdf_benchmark* item, struct cpe_dict_model* cpe_list);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_set_cpe_lang_model(struct xccdf_benchmark* item, struct cpe_lang_model* cpe_lang_model);
+OSCAP_API bool xccdf_benchmark_set_cpe_lang_model(struct xccdf_benchmark* item, struct cpe_lang_model* cpe_lang_model);
 /// @memberof xccdf_profile
-bool xccdf_profile_set_note_tag(struct xccdf_profile *item, const char *newval);
+OSCAP_API bool xccdf_profile_set_note_tag(struct xccdf_profile *item, const char *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_set_id(struct xccdf_profile *item, const char *newval);
+OSCAP_API bool xccdf_profile_set_id(struct xccdf_profile *item, const char *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_set_abstract(struct xccdf_profile *item, bool newval);
+OSCAP_API bool xccdf_profile_set_abstract(struct xccdf_profile *item, bool newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_set_prohibit_changes(struct xccdf_profile *item, bool newval);
+OSCAP_API bool xccdf_profile_set_prohibit_changes(struct xccdf_profile *item, bool newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_set_extends(struct xccdf_profile *item, const char *newval);
+OSCAP_API bool xccdf_profile_set_extends(struct xccdf_profile *item, const char *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_set_version(struct xccdf_profile *item, const char *newval);
+OSCAP_API bool xccdf_profile_set_version(struct xccdf_profile *item, const char *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_set_version_time(struct xccdf_profile *item, const char *newval);
+OSCAP_API bool xccdf_profile_set_version_time(struct xccdf_profile *item, const char *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_set_version_update(struct xccdf_profile *item, const char *newval);
+OSCAP_API bool xccdf_profile_set_version_update(struct xccdf_profile *item, const char *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_set_tailoring(struct xccdf_profile *item, bool tailoring);
+OSCAP_API bool xccdf_profile_set_tailoring(struct xccdf_profile *item, bool tailoring);
 /// @memberof xccdf_profile
-bool xccdf_profile_add_metadata(struct xccdf_profile* item, const char* metadata);
+OSCAP_API bool xccdf_profile_add_metadata(struct xccdf_profile* item, const char* metadata);
 
 /// @memberof xccdf_rule
-bool xccdf_rule_set_id(struct xccdf_rule *item, const char *newval);
+OSCAP_API bool xccdf_rule_set_id(struct xccdf_rule *item, const char *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_cluster_id(struct xccdf_rule *item, const char *newval);
+OSCAP_API bool xccdf_rule_set_cluster_id(struct xccdf_rule *item, const char *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_extends(struct xccdf_rule *item, const char *newval);
+OSCAP_API bool xccdf_rule_set_extends(struct xccdf_rule *item, const char *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_version(struct xccdf_rule *item, const char *newval);
+OSCAP_API bool xccdf_rule_set_version(struct xccdf_rule *item, const char *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_version_time(struct xccdf_rule *item, const char *newval);
+OSCAP_API bool xccdf_rule_set_version_time(struct xccdf_rule *item, const char *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_version_update(struct xccdf_rule *item, const char *newval);
+OSCAP_API bool xccdf_rule_set_version_update(struct xccdf_rule *item, const char *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_abstract(struct xccdf_rule *item, bool newval);
+OSCAP_API bool xccdf_rule_set_abstract(struct xccdf_rule *item, bool newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_hidden(struct xccdf_rule *item, bool newval);
+OSCAP_API bool xccdf_rule_set_hidden(struct xccdf_rule *item, bool newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_prohibit_changes(struct xccdf_rule *item, bool newval);
+OSCAP_API bool xccdf_rule_set_prohibit_changes(struct xccdf_rule *item, bool newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_selected(struct xccdf_rule *item, bool newval);
+OSCAP_API bool xccdf_rule_set_selected(struct xccdf_rule *item, bool newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_multiple(struct xccdf_rule *item, bool newval);
+OSCAP_API bool xccdf_rule_set_multiple(struct xccdf_rule *item, bool newval);
 /// @memberof xccdf_rule
 //bool xccdf_rule_set_selector(struct xccdf_rule *item, const char * selector);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_impact_metric(struct xccdf_rule *item, const char *newval);
+OSCAP_API bool xccdf_rule_set_impact_metric(struct xccdf_rule *item, const char *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_role(struct xccdf_rule *item, xccdf_role_t newval);
+OSCAP_API bool xccdf_rule_set_role(struct xccdf_rule *item, xccdf_role_t newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_set_severity(struct xccdf_rule *item, xccdf_level_t newval);
+OSCAP_API bool xccdf_rule_set_severity(struct xccdf_rule *item, xccdf_level_t newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_metadata(struct xccdf_rule* item, const char* metadata);
+OSCAP_API bool xccdf_rule_add_metadata(struct xccdf_rule* item, const char* metadata);
 
 /// @memberof xccdf_group
-bool xccdf_group_set_id(struct xccdf_group *item, const char *newval);
+OSCAP_API bool xccdf_group_set_id(struct xccdf_group *item, const char *newval);
 /// @memberof xccdf_group
-bool xccdf_group_set_cluster_id(struct xccdf_group *item, const char *newval);
+OSCAP_API bool xccdf_group_set_cluster_id(struct xccdf_group *item, const char *newval);
 /// @memberof xccdf_group
-bool xccdf_group_set_extends(struct xccdf_group *item, const char *newval);
+OSCAP_API bool xccdf_group_set_extends(struct xccdf_group *item, const char *newval);
 /// @memberof xccdf_group
-bool xccdf_group_set_version(struct xccdf_group *item, const char *newval);
+OSCAP_API bool xccdf_group_set_version(struct xccdf_group *item, const char *newval);
 /// @memberof xccdf_group
-bool xccdf_group_set_version_time(struct xccdf_group *item, const char *newval);
+OSCAP_API bool xccdf_group_set_version_time(struct xccdf_group *item, const char *newval);
 /// @memberof xccdf_group
-bool xccdf_group_set_version_update(struct xccdf_group *item, const char *newval);
+OSCAP_API bool xccdf_group_set_version_update(struct xccdf_group *item, const char *newval);
 /// @memberof xccdf_group
-bool xccdf_group_set_abstract(struct xccdf_group *item, bool newval);
+OSCAP_API bool xccdf_group_set_abstract(struct xccdf_group *item, bool newval);
 /// @memberof xccdf_group
-bool xccdf_group_set_hidden(struct xccdf_group *item, bool newval);
+OSCAP_API bool xccdf_group_set_hidden(struct xccdf_group *item, bool newval);
 /// @memberof xccdf_group
-bool xccdf_group_set_prohibit_changes(struct xccdf_group *item, bool newval);
+OSCAP_API bool xccdf_group_set_prohibit_changes(struct xccdf_group *item, bool newval);
 /// @memberof xccdf_group
-bool xccdf_group_set_selected(struct xccdf_group *item, bool newval);
+OSCAP_API bool xccdf_group_set_selected(struct xccdf_group *item, bool newval);
 /// @memberof xccdf_group
-bool xccdf_group_add_metadata(struct xccdf_group* item, const char* metadata);
+OSCAP_API bool xccdf_group_add_metadata(struct xccdf_group* item, const char* metadata);
 
 /// @memberof xccdf_value
-bool xccdf_value_set_id(struct xccdf_value *item, const char *newval);
+OSCAP_API bool xccdf_value_set_id(struct xccdf_value *item, const char *newval);
 /// @memberof xccdf_value
-bool xccdf_value_set_cluster_id(struct xccdf_value *item, const char *newval);
+OSCAP_API bool xccdf_value_set_cluster_id(struct xccdf_value *item, const char *newval);
 /// @memberof xccdf_value
-bool xccdf_value_set_extends(struct xccdf_value *item, const char *newval);
+OSCAP_API bool xccdf_value_set_extends(struct xccdf_value *item, const char *newval);
 /// @memberof xccdf_value
-bool xccdf_value_set_version(struct xccdf_value *item, const char *newval);
+OSCAP_API bool xccdf_value_set_version(struct xccdf_value *item, const char *newval);
 /// @memberof xccdf_value
-bool xccdf_value_set_version_time(struct xccdf_value *item, const char *newval);
+OSCAP_API bool xccdf_value_set_version_time(struct xccdf_value *item, const char *newval);
 /// @memberof xccdf_value
-bool xccdf_value_set_version_update(struct xccdf_value *item, const char *newval);
+OSCAP_API bool xccdf_value_set_version_update(struct xccdf_value *item, const char *newval);
 /// @memberof xccdf_value
-bool xccdf_value_set_abstract(struct xccdf_value *item, bool newval);
+OSCAP_API bool xccdf_value_set_abstract(struct xccdf_value *item, bool newval);
 /// @memberof xccdf_value
-bool xccdf_value_set_hidden(struct xccdf_value *item, bool newval);
+OSCAP_API bool xccdf_value_set_hidden(struct xccdf_value *item, bool newval);
 /// @memberof xccdf_value
-bool xccdf_value_set_multiple(struct xccdf_value *item, bool newval);
+OSCAP_API bool xccdf_value_set_multiple(struct xccdf_value *item, bool newval);
 /// @memberof xccdf_value
-bool xccdf_value_set_prohibit_changes(struct xccdf_value *item, bool newval);
+OSCAP_API bool xccdf_value_set_prohibit_changes(struct xccdf_value *item, bool newval);
 /// @memberof xccdf_value
-bool xccdf_value_set_oper(struct xccdf_value * item, xccdf_operator_t oper);
+OSCAP_API bool xccdf_value_set_oper(struct xccdf_value * item, xccdf_operator_t oper);
 /// @memberof xccdf_value
-bool xccdf_value_set_interactive(struct xccdf_value *item, bool newval);
+OSCAP_API bool xccdf_value_set_interactive(struct xccdf_value *item, bool newval);
 /// @memberof xccdf_value
-bool xccdf_value_add_metadata(struct xccdf_value* item, const char* metadata);
+OSCAP_API bool xccdf_value_add_metadata(struct xccdf_value* item, const char* metadata);
 
 /// @memberof xccdf_status
-bool xccdf_status_set_date(struct xccdf_status *obj, time_t newval);
+OSCAP_API bool xccdf_status_set_date(struct xccdf_status *obj, time_t newval);
 /// @memberof xccdf_status
-bool xccdf_status_set_status(struct xccdf_status *obj, xccdf_status_type_t newval);
+OSCAP_API bool xccdf_status_set_status(struct xccdf_status *obj, xccdf_status_type_t newval);
 
 /// @memberof xccdf_notice
-bool xccdf_notice_set_id(struct xccdf_notice *obj, const char *newval);
+OSCAP_API bool xccdf_notice_set_id(struct xccdf_notice *obj, const char *newval);
 /// @memberof xccdf_notice
-bool xccdf_notice_set_text(struct xccdf_notice *obj, struct oscap_text *newval);
+OSCAP_API bool xccdf_notice_set_text(struct xccdf_notice *obj, struct oscap_text *newval);
 
 /// @memberof xccdf_model
-bool xccdf_model_set_system(struct xccdf_model *obj, const char *newval);
+OSCAP_API bool xccdf_model_set_system(struct xccdf_model *obj, const char *newval);
 
 /// @memberof xccdf_check
-bool xccdf_check_set_id(struct xccdf_check *obj, const char *newval);
+OSCAP_API bool xccdf_check_set_id(struct xccdf_check *obj, const char *newval);
 /// @memberof xccdf_check
-bool xccdf_check_set_system(struct xccdf_check *obj, const char *newval);
+OSCAP_API bool xccdf_check_set_system(struct xccdf_check *obj, const char *newval);
 /// @memberof xccdf_check
-bool xccdf_check_set_selector(struct xccdf_check *obj, const char *newval);
+OSCAP_API bool xccdf_check_set_selector(struct xccdf_check *obj, const char *newval);
 /// @memberof xccdf_check
-bool xccdf_check_set_content(struct xccdf_check *obj, const char *newval);
+OSCAP_API bool xccdf_check_set_content(struct xccdf_check *obj, const char *newval);
 /// @memberof xccdf_check
-bool xccdf_check_set_oper(struct xccdf_check *obj, xccdf_bool_operator_t newval);
+OSCAP_API bool xccdf_check_set_oper(struct xccdf_check *obj, xccdf_bool_operator_t newval);
 /// @memberof xccdf_check
-bool xccdf_check_set_multicheck(struct xccdf_check *obj, bool newval);
+OSCAP_API bool xccdf_check_set_multicheck(struct xccdf_check *obj, bool newval);
 /// @memberof xccdf_check
-bool xccdf_check_set_negate(struct xccdf_check *obj, bool newval);
+OSCAP_API bool xccdf_check_set_negate(struct xccdf_check *obj, bool newval);
 
 /// @memberof xccdf_check_content_ref
-bool xccdf_check_content_ref_set_name(struct xccdf_check_content_ref *obj, const char *newval);
+OSCAP_API bool xccdf_check_content_ref_set_name(struct xccdf_check_content_ref *obj, const char *newval);
 /// @memberof xccdf_check_content_ref
-bool xccdf_check_content_ref_set_href(struct xccdf_check_content_ref *obj, const char *newval);
+OSCAP_API bool xccdf_check_content_ref_set_href(struct xccdf_check_content_ref *obj, const char *newval);
 
 /// @memberof xccdf_profile_note
-bool xccdf_profile_note_set_reftag(struct xccdf_profile_note *obj, const char *newval);
+OSCAP_API bool xccdf_profile_note_set_reftag(struct xccdf_profile_note *obj, const char *newval);
 /// @memberof xccdf_profile_note
-bool xccdf_profile_note_set_text(struct xccdf_profile_note *obj, struct oscap_text *newval);
+OSCAP_API bool xccdf_profile_note_set_text(struct xccdf_profile_note *obj, struct oscap_text *newval);
 
 /// @memberof xccdf_check_import
-bool xccdf_check_import_set_name(struct xccdf_check_import *obj, const char *newval);
+OSCAP_API bool xccdf_check_import_set_name(struct xccdf_check_import *obj, const char *newval);
 /// @memberof xccdf_check_import
-bool xccdf_check_import_set_xpath(struct xccdf_check_import *obj, const char *newval);
+OSCAP_API bool xccdf_check_import_set_xpath(struct xccdf_check_import *obj, const char *newval);
 /// @memberof xccdf_check_import
-bool xccdf_check_import_set_content(struct xccdf_check_import *obj, const char *newval);
+OSCAP_API bool xccdf_check_import_set_content(struct xccdf_check_import *obj, const char *newval);
 
 /// @memberof xccdf_check_export
-bool xccdf_check_export_set_name(struct xccdf_check_export *obj, const char *newval);
+OSCAP_API bool xccdf_check_export_set_name(struct xccdf_check_export *obj, const char *newval);
 /// @memberof xccdf_check_export
-bool xccdf_check_export_set_value(struct xccdf_check_export *obj, const char *newval);
+OSCAP_API bool xccdf_check_export_set_value(struct xccdf_check_export *obj, const char *newval);
 
 /// @memberof xccdf_fix
-bool xccdf_fix_set_strategy(struct xccdf_fix *obj, xccdf_strategy_t newval);
+OSCAP_API bool xccdf_fix_set_strategy(struct xccdf_fix *obj, xccdf_strategy_t newval);
 /// @memberof xccdf_fix
-bool xccdf_fix_set_disruption(struct xccdf_fix *obj, xccdf_level_t newval);
+OSCAP_API bool xccdf_fix_set_disruption(struct xccdf_fix *obj, xccdf_level_t newval);
 /// @memberof xccdf_fix
-bool xccdf_fix_set_complexity(struct xccdf_fix *obj, xccdf_level_t newval);
+OSCAP_API bool xccdf_fix_set_complexity(struct xccdf_fix *obj, xccdf_level_t newval);
 /// @memberof xccdf_fix
-bool xccdf_fix_set_reboot(struct xccdf_fix *obj, bool newval);
+OSCAP_API bool xccdf_fix_set_reboot(struct xccdf_fix *obj, bool newval);
 /// @memberof xccdf_fix
-bool xccdf_fix_set_content(struct xccdf_fix *obj, const char *newval);
+OSCAP_API bool xccdf_fix_set_content(struct xccdf_fix *obj, const char *newval);
 /// @memberof xccdf_fix
-bool xccdf_fix_set_system(struct xccdf_fix *obj, const char *newval);
+OSCAP_API bool xccdf_fix_set_system(struct xccdf_fix *obj, const char *newval);
 /// @memberof xccdf_fix
-bool xccdf_fix_set_platform(struct xccdf_fix *obj, const char *newval);
+OSCAP_API bool xccdf_fix_set_platform(struct xccdf_fix *obj, const char *newval);
 /// @memberof xccdf_fix
-bool xccdf_fix_set_id(struct xccdf_fix *obj, const char *newval);
+OSCAP_API bool xccdf_fix_set_id(struct xccdf_fix *obj, const char *newval);
 
 /// @memberof xccdf_fixtext
-bool xccdf_fixtext_set_strategy(struct xccdf_fixtext *obj, xccdf_strategy_t newval);
+OSCAP_API bool xccdf_fixtext_set_strategy(struct xccdf_fixtext *obj, xccdf_strategy_t newval);
 /// @memberof xccdf_fixtext
-bool xccdf_fixtext_set_disruption(struct xccdf_fixtext *obj, xccdf_level_t newval);
+OSCAP_API bool xccdf_fixtext_set_disruption(struct xccdf_fixtext *obj, xccdf_level_t newval);
 /// @memberof xccdf_fixtext
-bool xccdf_fixtext_set_complexity(struct xccdf_fixtext *obj, xccdf_level_t newval);
+OSCAP_API bool xccdf_fixtext_set_complexity(struct xccdf_fixtext *obj, xccdf_level_t newval);
 /// @memberof xccdf_fixtext
-bool xccdf_fixtext_set_reboot(struct xccdf_fixtext *obj, bool newval);
+OSCAP_API bool xccdf_fixtext_set_reboot(struct xccdf_fixtext *obj, bool newval);
 /// @memberof xccdf_fixtext
-bool xccdf_fixtext_set_text(struct xccdf_fixtext *obj, struct oscap_text *newval);
+OSCAP_API bool xccdf_fixtext_set_text(struct xccdf_fixtext *obj, struct oscap_text *newval);
 /// @memberof xccdf_fixtext
-bool xccdf_fixtext_set_fixref(struct xccdf_fixtext *obj, const char *newval);
+OSCAP_API bool xccdf_fixtext_set_fixref(struct xccdf_fixtext *obj, const char *newval);
 
 /// @memberof xccdf_select
-bool xccdf_select_set_item(struct xccdf_select *obj, const char *newval);
+OSCAP_API bool xccdf_select_set_item(struct xccdf_select *obj, const char *newval);
 /// @memberof xccdf_select
-bool xccdf_select_set_selected(struct xccdf_select *obj, bool newval);
+OSCAP_API bool xccdf_select_set_selected(struct xccdf_select *obj, bool newval);
 
 /// @memberof xccdf_warning
-bool xccdf_warning_set_category(struct xccdf_warning *obj, xccdf_warning_category_t newval);
+OSCAP_API bool xccdf_warning_set_category(struct xccdf_warning *obj, xccdf_warning_category_t newval);
 /// @memberof xccdf_warning
-bool xccdf_warning_set_text(struct xccdf_warning *obj, struct oscap_text *newval);
+OSCAP_API bool xccdf_warning_set_text(struct xccdf_warning *obj, struct oscap_text *newval);
 /// @memberof xccdf_refine_rule
-struct xccdf_refine_rule *xccdf_refine_rule_new(void);
+OSCAP_API struct xccdf_refine_rule *xccdf_refine_rule_new(void);
 
 /// @memberof xccdf_refine_rule
-struct xccdf_refine_rule * xccdf_refine_rule_clone(const struct xccdf_refine_rule * old_rule);
+OSCAP_API struct xccdf_refine_rule * xccdf_refine_rule_clone(const struct xccdf_refine_rule * old_rule);
 /// @memberof xccdf_refine_rule
-bool xccdf_refine_rule_set_item(struct xccdf_refine_rule *obj, const char *newval);
+OSCAP_API bool xccdf_refine_rule_set_item(struct xccdf_refine_rule *obj, const char *newval);
 /// @memberof xccdf_refine_rule
-bool xccdf_refine_rule_set_selector(struct xccdf_refine_rule *obj, const char *newval);
+OSCAP_API bool xccdf_refine_rule_set_selector(struct xccdf_refine_rule *obj, const char *newval);
 /// @memberof xccdf_refine_rule
-bool xccdf_refine_rule_set_role(struct xccdf_refine_rule *obj, xccdf_role_t newval);
+OSCAP_API bool xccdf_refine_rule_set_role(struct xccdf_refine_rule *obj, xccdf_role_t newval);
 /// @memberof xccdf_refine_rule
-bool xccdf_refine_rule_set_severity(struct xccdf_refine_rule *obj, xccdf_level_t newval);
+OSCAP_API bool xccdf_refine_rule_set_severity(struct xccdf_refine_rule *obj, xccdf_level_t newval);
 /// @memberof xccdf_refine_rule
-bool xccdf_refine_rule_set_weight(struct xccdf_refine_rule *obj, xccdf_numeric newval);
+OSCAP_API bool xccdf_refine_rule_set_weight(struct xccdf_refine_rule *obj, xccdf_numeric newval);
 
 /// @memberof xccdf_refine_value
-struct xccdf_refine_value *xccdf_refine_value_new(void);
+OSCAP_API struct xccdf_refine_value *xccdf_refine_value_new(void);
 /// @memberof xccdf_refine_value
-struct xccdf_refine_value * xccdf_refine_value_clone(const struct xccdf_refine_value * old_value);
+OSCAP_API struct xccdf_refine_value * xccdf_refine_value_clone(const struct xccdf_refine_value * old_value);
 /// @memberof xccdf_refine_value
-bool xccdf_refine_value_set_item(struct xccdf_refine_value *obj, const char *newval);
+OSCAP_API bool xccdf_refine_value_set_item(struct xccdf_refine_value *obj, const char *newval);
 /// @memberof xccdf_refine_value
-bool xccdf_refine_value_set_selector(struct xccdf_refine_value *obj, const char *newval);
+OSCAP_API bool xccdf_refine_value_set_selector(struct xccdf_refine_value *obj, const char *newval);
 /// @memberof xccdf_refine_value
-bool xccdf_refine_value_set_oper(struct xccdf_refine_value *obj, xccdf_operator_t newval);
+OSCAP_API bool xccdf_refine_value_set_oper(struct xccdf_refine_value *obj, xccdf_operator_t newval);
 
 /// @memberof xccdf_set_value
-struct xccdf_setvalue *xccdf_setvalue_new(void);
+OSCAP_API struct xccdf_setvalue *xccdf_setvalue_new(void);
 /// @memberof xccdf_set_value
-struct xccdf_setvalue * xccdf_setvalue_clone(const struct xccdf_setvalue * old_value);
+OSCAP_API struct xccdf_setvalue * xccdf_setvalue_clone(const struct xccdf_setvalue * old_value);
 /// @memberof xccdf_set_value
-bool xccdf_setvalue_set_item(struct xccdf_setvalue *obj, const char *newval);
+OSCAP_API bool xccdf_setvalue_set_item(struct xccdf_setvalue *obj, const char *newval);
 /// @memberof xccdf_set_value
-bool xccdf_setvalue_set_value(struct xccdf_setvalue *obj, const char *newval);
+OSCAP_API bool xccdf_setvalue_set_value(struct xccdf_setvalue *obj, const char *newval);
 /// @memberof xccdf_plain_text
-bool xccdf_plain_text_set_id(struct xccdf_plain_text *obj, const char *newval);
+OSCAP_API bool xccdf_plain_text_set_id(struct xccdf_plain_text *obj, const char *newval);
 /// @memberof xccdf_plain_text
-bool xccdf_plain_text_set_text(struct xccdf_plain_text *obj, const char *newval);
+OSCAP_API bool xccdf_plain_text_set_text(struct xccdf_plain_text *obj, const char *newval);
 
 /// @memberof xccdf_result
-bool xccdf_result_set_id(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_set_id(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-bool xccdf_result_set_test_system(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_set_test_system(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-bool xccdf_result_set_benchmark_uri(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_set_benchmark_uri(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-bool xccdf_result_set_profile(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_set_profile(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-bool xccdf_result_set_start_time(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_set_start_time(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-bool xccdf_result_set_end_time(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_set_end_time(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-bool xccdf_result_set_version(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_set_version(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_metadata(struct xccdf_result *item, const char *metadata);
+OSCAP_API bool xccdf_result_add_metadata(struct xccdf_result *item, const char *metadata);
 
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_set_time(struct xccdf_rule_result *obj, const char *newval);
+OSCAP_API bool xccdf_rule_result_set_time(struct xccdf_rule_result *obj, const char *newval);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_set_role(struct xccdf_rule_result *obj, xccdf_role_t newval);
+OSCAP_API bool xccdf_rule_result_set_role(struct xccdf_rule_result *obj, xccdf_role_t newval);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_set_weight(struct xccdf_rule_result *obj, float newval);
+OSCAP_API bool xccdf_rule_result_set_weight(struct xccdf_rule_result *obj, float newval);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_set_severity(struct xccdf_rule_result *obj, xccdf_level_t newval);
+OSCAP_API bool xccdf_rule_result_set_severity(struct xccdf_rule_result *obj, xccdf_level_t newval);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_set_result(struct xccdf_rule_result *obj, xccdf_test_result_type_t newval);
+OSCAP_API bool xccdf_rule_result_set_result(struct xccdf_rule_result *obj, xccdf_test_result_type_t newval);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_set_version(struct xccdf_rule_result *obj, const char *newval);
+OSCAP_API bool xccdf_rule_result_set_version(struct xccdf_rule_result *obj, const char *newval);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_set_idref(struct xccdf_rule_result *obj, const char *newval);
+OSCAP_API bool xccdf_rule_result_set_idref(struct xccdf_rule_result *obj, const char *newval);
 
 /// @memberof xccdf_identity
-bool xccdf_identity_set_authenticated(struct xccdf_identity *obj, bool newval);
+OSCAP_API bool xccdf_identity_set_authenticated(struct xccdf_identity *obj, bool newval);
 /// @memberof xccdf_identity
-bool xccdf_identity_set_privileged(struct xccdf_identity *obj, bool newval);
+OSCAP_API bool xccdf_identity_set_privileged(struct xccdf_identity *obj, bool newval);
 /// @memberof xccdf_identity
-bool xccdf_identity_set_name(struct xccdf_identity *obj, const char *newval);
+OSCAP_API bool xccdf_identity_set_name(struct xccdf_identity *obj, const char *newval);
 
 /// @memberof xccdf_score
-bool xccdf_score_set_maximum(struct xccdf_score *obj, xccdf_numeric newval);
+OSCAP_API bool xccdf_score_set_maximum(struct xccdf_score *obj, xccdf_numeric newval);
 /// @memberof xccdf_score
-bool xccdf_score_set_score(struct xccdf_score *obj, xccdf_numeric newval);
+OSCAP_API bool xccdf_score_set_score(struct xccdf_score *obj, xccdf_numeric newval);
 /// @memberof xccdf_score
-bool xccdf_score_set_system(struct xccdf_score *obj, const char *newval);
+OSCAP_API bool xccdf_score_set_system(struct xccdf_score *obj, const char *newval);
 
 /// @memberof xccdf_override
-bool xccdf_override_set_time(struct xccdf_override *obj, const char *newval);
+OSCAP_API bool xccdf_override_set_time(struct xccdf_override *obj, const char *newval);
 /// @memberof xccdf_override
-bool xccdf_override_set_new_result(struct xccdf_override *obj, xccdf_test_result_type_t newval);
+OSCAP_API bool xccdf_override_set_new_result(struct xccdf_override *obj, xccdf_test_result_type_t newval);
 /// @memberof xccdf_override
-bool xccdf_override_set_old_result(struct xccdf_override *obj, xccdf_test_result_type_t newval);
+OSCAP_API bool xccdf_override_set_old_result(struct xccdf_override *obj, xccdf_test_result_type_t newval);
 /// @memberof xccdf_override
-bool xccdf_override_set_authority(struct xccdf_override *obj, const char *newval);
+OSCAP_API bool xccdf_override_set_authority(struct xccdf_override *obj, const char *newval);
 /// @memberof xccdf_override
-bool xccdf_override_set_remark(struct xccdf_override *obj, struct oscap_text *newval);
+OSCAP_API bool xccdf_override_set_remark(struct xccdf_override *obj, struct oscap_text *newval);
 
 /// @memberof xccdf_message
-bool xccdf_message_set_severity(struct xccdf_message *obj, xccdf_message_severity_t newval);
+OSCAP_API bool xccdf_message_set_severity(struct xccdf_message *obj, xccdf_message_severity_t newval);
 /// @memberof xccdf_message
-bool xccdf_message_set_content(struct xccdf_message *obj, const char *newval);
+OSCAP_API bool xccdf_message_set_content(struct xccdf_message *obj, const char *newval);
 
 /// @memberof xccdf_target_fact
-bool xccdf_target_fact_set_string(struct xccdf_target_fact *fact, const char *str);
+OSCAP_API bool xccdf_target_fact_set_string(struct xccdf_target_fact *fact, const char *str);
 /// @memberof xccdf_target_fact
-bool xccdf_target_fact_set_number(struct xccdf_target_fact *fact, xccdf_numeric val);
+OSCAP_API bool xccdf_target_fact_set_number(struct xccdf_target_fact *fact, xccdf_numeric val);
 /// @memberof xccdf_target_fact
-bool xccdf_target_fact_set_boolean(struct xccdf_target_fact *fact, bool val);
+OSCAP_API bool xccdf_target_fact_set_boolean(struct xccdf_target_fact *fact, bool val);
 /// @memberof xccdf_target_fact
-bool xccdf_target_fact_set_name(struct xccdf_target_fact *obj, const char *newval);
+OSCAP_API bool xccdf_target_fact_set_name(struct xccdf_target_fact *obj, const char *newval);
 
 /// @memberof xccdf_target_identifier
-bool xccdf_target_identifier_set_xml_node(struct xccdf_target_identifier *ti, void* node);
+OSCAP_API bool xccdf_target_identifier_set_xml_node(struct xccdf_target_identifier *ti, void* node);
 /// @memberof xccdf_target_identifier
-bool xccdf_target_identifier_set_system(struct xccdf_target_identifier *ti, const char *newval);
+OSCAP_API bool xccdf_target_identifier_set_system(struct xccdf_target_identifier *ti, const char *newval);
 /// @memberof xccdf_target_identifier
-bool xccdf_target_identifier_set_href(struct xccdf_target_identifier *ti, const char *newval);
+OSCAP_API bool xccdf_target_identifier_set_href(struct xccdf_target_identifier *ti, const char *newval);
 /// @memberof xccdf_target_identifier
-bool xccdf_target_identifier_set_name(struct xccdf_target_identifier *ti, const char *newval);
+OSCAP_API bool xccdf_target_identifier_set_name(struct xccdf_target_identifier *ti, const char *newval);
 
 /// @memberof xccdf_instance
-bool xccdf_instance_set_context(struct xccdf_instance *obj, const char *newval);
+OSCAP_API bool xccdf_instance_set_context(struct xccdf_instance *obj, const char *newval);
 /// @memberof xccdf_instance
-bool xccdf_instance_set_parent_context(struct xccdf_instance *obj, const char *newval);
+OSCAP_API bool xccdf_instance_set_parent_context(struct xccdf_instance *obj, const char *newval);
 /// @memberof xccdf_instance
-bool xccdf_instance_set_content(struct xccdf_instance *obj, const char *newval);
+OSCAP_API bool xccdf_instance_set_content(struct xccdf_instance *obj, const char *newval);
 
 /// @memberof xccdf_tailoring
-bool xccdf_tailoring_set_id(struct xccdf_tailoring *tailoring, const char* newval);
+OSCAP_API bool xccdf_tailoring_set_id(struct xccdf_tailoring *tailoring, const char* newval);
 /// @memberof xccdf_tailoring
-bool xccdf_tailoring_set_version(struct xccdf_tailoring *tailoring, const char* newval);
+OSCAP_API bool xccdf_tailoring_set_version(struct xccdf_tailoring *tailoring, const char* newval);
 /// @memberof xccdf_tailoring
-bool xccdf_tailoring_set_version_update(struct xccdf_tailoring *tailoring, const char *newval);
+OSCAP_API bool xccdf_tailoring_set_version_update(struct xccdf_tailoring *tailoring, const char *newval);
 /// @memberof xccdf_tailoring
-bool xccdf_tailoring_set_version_time(struct xccdf_tailoring *tailoring, const char *newval);
+OSCAP_API bool xccdf_tailoring_set_version_time(struct xccdf_tailoring *tailoring, const char *newval);
 /// @memberof xccdf_tailoring
-bool xccdf_tailoring_set_benchmark_ref(struct xccdf_tailoring *tailoring, const char *newval);
+OSCAP_API bool xccdf_tailoring_set_benchmark_ref(struct xccdf_tailoring *tailoring, const char *newval);
 /// @memberof xccdf_tailoring
-bool xccdf_tailoring_set_benchmark_ref_version(struct xccdf_tailoring *tailoring, const char *newval);
+OSCAP_API bool xccdf_tailoring_set_benchmark_ref_version(struct xccdf_tailoring *tailoring, const char *newval);
 
 /// @memberof xccdf_tailoring
-bool xccdf_tailoring_add_profile(struct xccdf_tailoring *tailoring, struct xccdf_profile *profile);
+OSCAP_API bool xccdf_tailoring_add_profile(struct xccdf_tailoring *tailoring, struct xccdf_profile *profile);
 /**
  * Removes given profile from tailoring.
  *
@@ -3171,231 +3172,231 @@ bool xccdf_tailoring_add_profile(struct xccdf_tailoring *tailoring, struct xccdf
  * @note User is responsible for freeing the profile!
  * @memberof xccdf_tailoring
  */
-bool xccdf_tailoring_remove_profile(struct xccdf_tailoring *tailoring, struct xccdf_profile *profile);
+OSCAP_API bool xccdf_tailoring_remove_profile(struct xccdf_tailoring *tailoring, struct xccdf_profile *profile);
 /// @memberof xccdf_tailoring
-bool xccdf_tailoring_resolve(struct xccdf_tailoring *tailoring, struct xccdf_benchmark *benchmark);
+OSCAP_API bool xccdf_tailoring_resolve(struct xccdf_tailoring *tailoring, struct xccdf_benchmark *benchmark);
 
 // @memberof xccdf_ident
-void xccdf_ident_set_id(struct xccdf_ident * ident, const char *id);
+OSCAP_API void xccdf_ident_set_id(struct xccdf_ident * ident, const char *id);
 // @memberof xccdf_ident
-void xccdf_ident_set_system(struct xccdf_ident * ident, const char *sys);
+OSCAP_API void xccdf_ident_set_system(struct xccdf_ident * ident, const char *sys);
 
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_result(struct xccdf_benchmark *bench, struct xccdf_result *result);
+OSCAP_API bool xccdf_benchmark_add_result(struct xccdf_benchmark *bench, struct xccdf_result *result);
 
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_description(struct xccdf_benchmark *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_benchmark_add_description(struct xccdf_benchmark *item, struct oscap_text *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_platform(struct xccdf_benchmark *item, const char *newval);
+OSCAP_API bool xccdf_benchmark_add_platform(struct xccdf_benchmark *item, const char *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_reference(struct xccdf_benchmark *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_benchmark_add_reference(struct xccdf_benchmark *item, struct oscap_reference *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_status(struct xccdf_benchmark *item, struct xccdf_status *newval);
+OSCAP_API bool xccdf_benchmark_add_status(struct xccdf_benchmark *item, struct xccdf_status *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_dc_status(struct xccdf_benchmark *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_benchmark_add_dc_status(struct xccdf_benchmark *item, struct oscap_reference *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_title(struct xccdf_benchmark *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_benchmark_add_title(struct xccdf_benchmark *item, struct oscap_text *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_front_matter(struct xccdf_benchmark *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_benchmark_add_front_matter(struct xccdf_benchmark *item, struct oscap_text *newval);
 /// @memberof xccdf_benchmark
 //bool xccdf_benchmark_add_item(struct xccdf_benchmark *item, struct xccdf_item *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_model(struct xccdf_benchmark *item, struct xccdf_model *newval);
+OSCAP_API bool xccdf_benchmark_add_model(struct xccdf_benchmark *item, struct xccdf_model *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_notice(struct xccdf_benchmark *item, struct xccdf_notice *newval);
+OSCAP_API bool xccdf_benchmark_add_notice(struct xccdf_benchmark *item, struct xccdf_notice *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_plain_text(struct xccdf_benchmark *item, struct xccdf_plain_text *newval);
+OSCAP_API bool xccdf_benchmark_add_plain_text(struct xccdf_benchmark *item, struct xccdf_plain_text *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_profile(struct xccdf_benchmark *item, struct xccdf_profile *newval);
+OSCAP_API bool xccdf_benchmark_add_profile(struct xccdf_benchmark *item, struct xccdf_profile *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_rear_matter(struct xccdf_benchmark *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_benchmark_add_rear_matter(struct xccdf_benchmark *item, struct oscap_text *newval);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_rule(struct xccdf_benchmark *benchmark, struct xccdf_rule *rule);
+OSCAP_API bool xccdf_benchmark_add_rule(struct xccdf_benchmark *benchmark, struct xccdf_rule *rule);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_group(struct xccdf_benchmark *benchmark, struct xccdf_group *group);
+OSCAP_API bool xccdf_benchmark_add_group(struct xccdf_benchmark *benchmark, struct xccdf_group *group);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_value(struct xccdf_benchmark *benchmark, struct xccdf_value *value);
+OSCAP_API bool xccdf_benchmark_add_value(struct xccdf_benchmark *benchmark, struct xccdf_value *value);
 /// @memberof xccdf_benchmark
-bool xccdf_benchmark_add_content(struct xccdf_benchmark *bench, struct xccdf_item *item);
+OSCAP_API bool xccdf_benchmark_add_content(struct xccdf_benchmark *bench, struct xccdf_item *item);
 
 /// @memberof xccdf_profile
-bool xccdf_profile_add_select(struct xccdf_profile *item, struct xccdf_select *newval);
+OSCAP_API bool xccdf_profile_add_select(struct xccdf_profile *item, struct xccdf_select *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_add_setvalue(struct xccdf_profile *item, struct xccdf_setvalue *newval);
+OSCAP_API bool xccdf_profile_add_setvalue(struct xccdf_profile *item, struct xccdf_setvalue *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_add_refine_value(struct xccdf_profile *item, struct xccdf_refine_value *newval);
+OSCAP_API bool xccdf_profile_add_refine_value(struct xccdf_profile *item, struct xccdf_refine_value *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_add_refine_rule(struct xccdf_profile *item, struct xccdf_refine_rule *newval);
+OSCAP_API bool xccdf_profile_add_refine_rule(struct xccdf_profile *item, struct xccdf_refine_rule *newval);
 
 /// @memberof xccdf_profile
-bool xccdf_profile_add_description(struct xccdf_profile *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_profile_add_description(struct xccdf_profile *item, struct oscap_text *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_add_platform(struct xccdf_profile *item, const char *newval);
+OSCAP_API bool xccdf_profile_add_platform(struct xccdf_profile *item, const char *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_add_reference(struct xccdf_profile *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_profile_add_reference(struct xccdf_profile *item, struct oscap_reference *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_add_status(struct xccdf_profile *item, struct xccdf_status *newval);
+OSCAP_API bool xccdf_profile_add_status(struct xccdf_profile *item, struct xccdf_status *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_add_dc_status(struct xccdf_profile *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_profile_add_dc_status(struct xccdf_profile *item, struct oscap_reference *newval);
 /// @memberof xccdf_profile
-bool xccdf_profile_add_title(struct xccdf_profile *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_profile_add_title(struct xccdf_profile *item, struct oscap_text *newval);
 
 /// @memberof xccdf_rule
-bool xccdf_rule_add_description(struct xccdf_rule *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_rule_add_description(struct xccdf_rule *item, struct oscap_text *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_platform(struct xccdf_rule *item, const char *newval);
+OSCAP_API bool xccdf_rule_add_platform(struct xccdf_rule *item, const char *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_question(struct xccdf_rule *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_rule_add_question(struct xccdf_rule *item, struct oscap_text *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_rationale(struct xccdf_rule *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_rule_add_rationale(struct xccdf_rule *item, struct oscap_text *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_reference(struct xccdf_rule *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_rule_add_reference(struct xccdf_rule *item, struct oscap_reference *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_status(struct xccdf_rule *item, struct xccdf_status *newval);
+OSCAP_API bool xccdf_rule_add_status(struct xccdf_rule *item, struct xccdf_status *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_dc_status(struct xccdf_rule *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_rule_add_dc_status(struct xccdf_rule *item, struct oscap_reference *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_title(struct xccdf_rule *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_rule_add_title(struct xccdf_rule *item, struct oscap_text *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_warning(struct xccdf_rule *item, struct xccdf_warning *newval);
+OSCAP_API bool xccdf_rule_add_warning(struct xccdf_rule *item, struct xccdf_warning *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_ident(struct xccdf_rule *item, struct xccdf_ident *newval);
+OSCAP_API bool xccdf_rule_add_ident(struct xccdf_rule *item, struct xccdf_ident *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_check(struct xccdf_rule *item, struct xccdf_check *newval);
+OSCAP_API bool xccdf_rule_add_check(struct xccdf_rule *item, struct xccdf_check *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_profile_note(struct xccdf_rule *item, struct xccdf_profile_note *newval);
+OSCAP_API bool xccdf_rule_add_profile_note(struct xccdf_rule *item, struct xccdf_profile_note *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_fix(struct xccdf_rule *item, struct xccdf_fix *newval);
+OSCAP_API bool xccdf_rule_add_fix(struct xccdf_rule *item, struct xccdf_fix *newval);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_fixtext(struct xccdf_rule *item, struct xccdf_fixtext *newval);
+OSCAP_API bool xccdf_rule_add_fixtext(struct xccdf_rule *item, struct xccdf_fixtext *newval);
 
 /// @memberof xccdf_group
-bool xccdf_group_add_description(struct xccdf_group *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_group_add_description(struct xccdf_group *item, struct oscap_text *newval);
 /// @memberof xccdf_group
-bool xccdf_group_add_platform(struct xccdf_group *item, const char *newval);
+OSCAP_API bool xccdf_group_add_platform(struct xccdf_group *item, const char *newval);
 /// @memberof xccdf_group
-bool xccdf_group_add_question(struct xccdf_group *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_group_add_question(struct xccdf_group *item, struct oscap_text *newval);
 /// @memberof xccdf_group
-bool xccdf_group_add_rationale(struct xccdf_group *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_group_add_rationale(struct xccdf_group *item, struct oscap_text *newval);
 /// @memberof xccdf_group
-bool xccdf_group_add_reference(struct xccdf_group *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_group_add_reference(struct xccdf_group *item, struct oscap_reference *newval);
 /// @memberof xccdf_group
-bool xccdf_group_add_status(struct xccdf_group *item, struct xccdf_status *newval);
+OSCAP_API bool xccdf_group_add_status(struct xccdf_group *item, struct xccdf_status *newval);
 /// @memberof xccdf_group
-bool xccdf_group_add_dc_status(struct xccdf_group *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_group_add_dc_status(struct xccdf_group *item, struct oscap_reference *newval);
 /// @memberof xccdf_group
-bool xccdf_group_add_title(struct xccdf_group *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_group_add_title(struct xccdf_group *item, struct oscap_text *newval);
 /// @memberof xccdf_group
-bool xccdf_group_add_warning(struct xccdf_group *item, struct xccdf_warning *newval);
+OSCAP_API bool xccdf_group_add_warning(struct xccdf_group *item, struct xccdf_warning *newval);
 /// @memberof xccdf_group
-bool xccdf_group_add_rule(struct xccdf_group *group, struct xccdf_rule *item);
+OSCAP_API bool xccdf_group_add_rule(struct xccdf_group *group, struct xccdf_rule *item);
 /// @memberof xccdf_group
-bool xccdf_group_add_group(struct xccdf_group *group, struct xccdf_group *item);
+OSCAP_API bool xccdf_group_add_group(struct xccdf_group *group, struct xccdf_group *item);
 /// @memberof xccdf_group
-bool xccdf_group_add_value(struct xccdf_group *group, struct xccdf_value *item);
+OSCAP_API bool xccdf_group_add_value(struct xccdf_group *group, struct xccdf_value *item);
 /// @memberof xccdf_group
-bool xccdf_group_add_content(struct xccdf_group *rule, struct xccdf_item *item);
+OSCAP_API bool xccdf_group_add_content(struct xccdf_group *rule, struct xccdf_item *item);
 
 /// @memberof xccdf_value
-bool xccdf_value_add_description(struct xccdf_value *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_value_add_description(struct xccdf_value *item, struct oscap_text *newval);
 /// @memberof xccdf_value
-bool xccdf_value_add_question(struct xccdf_value *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_value_add_question(struct xccdf_value *item, struct oscap_text *newval);
 /// @memberof xccdf_value
-bool xccdf_value_add_reference(struct xccdf_value *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_value_add_reference(struct xccdf_value *item, struct oscap_reference *newval);
 /// @memberof xccdf_value
-bool xccdf_value_add_status(struct xccdf_value *item, struct xccdf_status *newval);
+OSCAP_API bool xccdf_value_add_status(struct xccdf_value *item, struct xccdf_status *newval);
 /// @memberof xccdf_value
-bool xccdf_value_add_dc_status(struct xccdf_value *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_value_add_dc_status(struct xccdf_value *item, struct oscap_reference *newval);
 /// @memberof xccdf_value
-bool xccdf_value_add_title(struct xccdf_value *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_value_add_title(struct xccdf_value *item, struct oscap_text *newval);
 /// @memberof xccdf_value
-bool xccdf_value_add_warning(struct xccdf_value *item, struct xccdf_warning *newval);
+OSCAP_API bool xccdf_value_add_warning(struct xccdf_value *item, struct xccdf_warning *newval);
 
 /// @memberof xccdf_check
-bool xccdf_check_add_import(struct xccdf_check *obj, struct xccdf_check_import *item);
+OSCAP_API bool xccdf_check_add_import(struct xccdf_check *obj, struct xccdf_check_import *item);
 /// @memberof xccdf_check
-bool xccdf_check_add_export(struct xccdf_check *obj, struct xccdf_check_export *item);
+OSCAP_API bool xccdf_check_add_export(struct xccdf_check *obj, struct xccdf_check_export *item);
 /// @memberof xccdf_check
-bool xccdf_check_add_content_ref(struct xccdf_check *obj, struct xccdf_check_content_ref *item);
+OSCAP_API bool xccdf_check_add_content_ref(struct xccdf_check *obj, struct xccdf_check_content_ref *item);
 /// @memberof xccdf_check
-bool xccdf_check_add_child(struct xccdf_check *obj, struct xccdf_check *item);
+OSCAP_API bool xccdf_check_add_child(struct xccdf_check *obj, struct xccdf_check *item);
 /// @memberof xccdf_select
-bool xccdf_select_add_remark(struct xccdf_select *obj, struct oscap_text *item);
+OSCAP_API bool xccdf_select_add_remark(struct xccdf_select *obj, struct oscap_text *item);
 /// @memberof xccdf_refine_value
-bool xccdf_refine_value_add_remark(struct xccdf_refine_value *obj, struct oscap_text *item);
+OSCAP_API bool xccdf_refine_value_add_remark(struct xccdf_refine_value *obj, struct oscap_text *item);
 /// @memberof xccdf_result
-bool xccdf_result_add_rule_result(struct xccdf_result *item, struct xccdf_rule_result *newval);
+OSCAP_API bool xccdf_result_add_rule_result(struct xccdf_result *item, struct xccdf_rule_result *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_setvalue(struct xccdf_result *item, struct xccdf_setvalue *newval);
+OSCAP_API bool xccdf_result_add_setvalue(struct xccdf_result *item, struct xccdf_setvalue *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_target_fact(struct xccdf_result *item, struct xccdf_target_fact *newval);
+OSCAP_API bool xccdf_result_add_target_fact(struct xccdf_result *item, struct xccdf_target_fact *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_target_identifier(struct xccdf_result *item, struct xccdf_target_identifier *newval);
+OSCAP_API bool xccdf_result_add_target_identifier(struct xccdf_result *item, struct xccdf_target_identifier *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_applicable_platform(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_add_applicable_platform(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_remark(struct xccdf_result *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_result_add_remark(struct xccdf_result *item, struct oscap_text *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_organization(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_add_organization(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_target(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_add_target(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_identity(struct xccdf_result *item, struct xccdf_identity *newval);
+OSCAP_API bool xccdf_result_add_identity(struct xccdf_result *item, struct xccdf_identity *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_score(struct xccdf_result *item, struct xccdf_score *newval);
+OSCAP_API bool xccdf_result_add_score(struct xccdf_result *item, struct xccdf_score *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_title(struct xccdf_result *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_result_add_title(struct xccdf_result *item, struct oscap_text *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_target_address(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_add_target_address(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-bool xccdf_result_add_applicable_platform(struct xccdf_result *item, const char *newval);
+OSCAP_API bool xccdf_result_add_applicable_platform(struct xccdf_result *item, const char *newval);
 /// @memberof xccdf_result
-int xccdf_result_recalculate_scores(struct xccdf_result *result, struct xccdf_item *benchmark);
+OSCAP_API int xccdf_result_recalculate_scores(struct xccdf_result *result, struct xccdf_item *benchmark);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_add_ident(struct xccdf_rule_result *obj, struct xccdf_ident *item);
+OSCAP_API bool xccdf_rule_result_add_ident(struct xccdf_rule_result *obj, struct xccdf_ident *item);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_add_fix(struct xccdf_rule_result *obj, struct xccdf_fix *item);
+OSCAP_API bool xccdf_rule_result_add_fix(struct xccdf_rule_result *obj, struct xccdf_fix *item);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_add_check(struct xccdf_rule_result *obj, struct xccdf_check *item);
+OSCAP_API bool xccdf_rule_result_add_check(struct xccdf_rule_result *obj, struct xccdf_check *item);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_add_override(struct xccdf_rule_result *obj, struct xccdf_override *item);
+OSCAP_API bool xccdf_rule_result_add_override(struct xccdf_rule_result *obj, struct xccdf_override *item);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_add_message(struct xccdf_rule_result *obj, struct xccdf_message *item);
+OSCAP_API bool xccdf_rule_result_add_message(struct xccdf_rule_result *obj, struct xccdf_message *item);
 /// @memberof xccdf_rule_result
-bool xccdf_rule_result_add_instance(struct xccdf_rule_result *obj, struct xccdf_instance *item);
+OSCAP_API bool xccdf_rule_result_add_instance(struct xccdf_rule_result *obj, struct xccdf_instance *item);
 /// @memberof xccdf_item
-bool xccdf_item_add_description(struct xccdf_item *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_item_add_description(struct xccdf_item *item, struct oscap_text *newval);
 /// @memberof xccdf_item
-bool xccdf_item_add_platform(struct xccdf_item *item, const char *newval);
+OSCAP_API bool xccdf_item_add_platform(struct xccdf_item *item, const char *newval);
 /// @memberof xccdf_item
-bool xccdf_item_add_question(struct xccdf_item *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_item_add_question(struct xccdf_item *item, struct oscap_text *newval);
 /// @memberof xccdf_item
-bool xccdf_item_add_rationale(struct xccdf_item *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_item_add_rationale(struct xccdf_item *item, struct oscap_text *newval);
 /// @memberof xccdf_item
-bool xccdf_item_add_reference(struct xccdf_item *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_item_add_reference(struct xccdf_item *item, struct oscap_reference *newval);
 /// @memberof xccdf_item
-bool xccdf_item_add_dc_status(struct xccdf_item *item, struct oscap_reference *newval);
+OSCAP_API bool xccdf_item_add_dc_status(struct xccdf_item *item, struct oscap_reference *newval);
 /// @memberof xccdf_item
-bool xccdf_item_add_status(struct xccdf_item *item, struct xccdf_status *newval);
+OSCAP_API bool xccdf_item_add_status(struct xccdf_item *item, struct xccdf_status *newval);
 /// @memberof xccdf_item
-bool xccdf_item_add_title(struct xccdf_item *item, struct oscap_text *newval);
+OSCAP_API bool xccdf_item_add_title(struct xccdf_item *item, struct oscap_text *newval);
 /// @memberof xccdf_item
-bool xccdf_item_add_warning(struct xccdf_item *item, struct xccdf_warning *newval);
+OSCAP_API bool xccdf_item_add_warning(struct xccdf_item *item, struct xccdf_warning *newval);
 /// @memberof xccdf_refine_rule
-bool xccdf_refine_rule_add_remark(struct xccdf_refine_rule *obj, struct oscap_text *item);
+OSCAP_API bool xccdf_refine_rule_add_remark(struct xccdf_refine_rule *obj, struct oscap_text *item);
 
 /// @memberof xccdf_rule
-bool xccdf_rule_add_requires(struct xccdf_rule *rule, struct oscap_stringlist *requires);
+OSCAP_API bool xccdf_rule_add_requires(struct xccdf_rule *rule, struct oscap_stringlist *requires);
 /// @memberof xccdf_group
-bool xccdf_group_add_requires(struct xccdf_group *group, struct oscap_stringlist *requires);
+OSCAP_API bool xccdf_group_add_requires(struct xccdf_group *group, struct oscap_stringlist *requires);
 /// @memberof xccdf_item
-bool xccdf_item_add_requires(struct xccdf_item *item, struct oscap_stringlist *requires);
+OSCAP_API bool xccdf_item_add_requires(struct xccdf_item *item, struct oscap_stringlist *requires);
 /// @memberof xccdf_rule
-bool xccdf_rule_add_conflicts(struct xccdf_rule *rule, const char *conflicts);
+OSCAP_API bool xccdf_rule_add_conflicts(struct xccdf_rule *rule, const char *conflicts);
 /// @memberof xccdf_group
-bool xccdf_group_add_conflicts(struct xccdf_group *group, const char *conflicts);
+OSCAP_API bool xccdf_group_add_conflicts(struct xccdf_group *group, const char *conflicts);
 /// @memberof xccdf_item
-bool xccdf_item_add_conflicts(struct xccdf_item *item, const char *conflicts);
+OSCAP_API bool xccdf_item_add_conflicts(struct xccdf_item *item, const char *conflicts);
 
 /************************************************************
  ** @} End of Setters group */
@@ -3403,65 +3404,65 @@ bool xccdf_item_add_conflicts(struct xccdf_item *item, const char *conflicts);
 // remove operations
 
 /// @memberof xccdf_notice_iterator
-void xccdf_notice_iterator_remove(struct xccdf_notice_iterator *it);
+OSCAP_API void xccdf_notice_iterator_remove(struct xccdf_notice_iterator *it);
 /// @memberof xccdf_model_iterator
-void xccdf_model_iterator_remove(struct xccdf_model_iterator *it);
+OSCAP_API void xccdf_model_iterator_remove(struct xccdf_model_iterator *it);
 /// @memberof xccdf_profile_iterator
-void xccdf_profile_iterator_remove(struct xccdf_profile_iterator *it);
+OSCAP_API void xccdf_profile_iterator_remove(struct xccdf_profile_iterator *it);
 /// @memberof xccdf_item_iterator
-void xccdf_item_iterator_remove(struct xccdf_item_iterator *it);
+OSCAP_API void xccdf_item_iterator_remove(struct xccdf_item_iterator *it);
 /// @memberof xccdf_status_iterator
-void xccdf_status_iterator_remove(struct xccdf_status_iterator *it);
+OSCAP_API void xccdf_status_iterator_remove(struct xccdf_status_iterator *it);
 /// @memberof xccdf_profile_note_iterator
-void xccdf_profile_note_iterator_remove(struct xccdf_profile_note_iterator *it);
+OSCAP_API void xccdf_profile_note_iterator_remove(struct xccdf_profile_note_iterator *it);
 /// @memberof xccdf_refine_value_iterator
-void xccdf_refine_value_iterator_remove(struct xccdf_refine_value_iterator *it);
+OSCAP_API void xccdf_refine_value_iterator_remove(struct xccdf_refine_value_iterator *it);
 /// @memberof xccdf_refine_rule_iterator
-void xccdf_refine_rule_iterator_remove(struct xccdf_refine_rule_iterator *it);
+OSCAP_API void xccdf_refine_rule_iterator_remove(struct xccdf_refine_rule_iterator *it);
 /// @memberof xccdf_setvalue_iterator
-void xccdf_setvalue_iterator_remove(struct xccdf_setvalue_iterator *it);
+OSCAP_API void xccdf_setvalue_iterator_remove(struct xccdf_setvalue_iterator *it);
 /// @memberof xccdf_select_iterator
-void xccdf_select_iterator_remove(struct xccdf_select_iterator *it);
+OSCAP_API void xccdf_select_iterator_remove(struct xccdf_select_iterator *it);
 /// @memberof xccdf_ident_iterator
-void xccdf_ident_iterator_remove(struct xccdf_ident_iterator *it);
+OSCAP_API void xccdf_ident_iterator_remove(struct xccdf_ident_iterator *it);
 /// @memberof xccdf_check_content_ref_iterator
-void xccdf_check_content_ref_iterator_remove(struct xccdf_check_content_ref_iterator *it);
+OSCAP_API void xccdf_check_content_ref_iterator_remove(struct xccdf_check_content_ref_iterator *it);
 /// @memberof xccdf_check_export_iterator
-void xccdf_check_export_iterator_remove(struct xccdf_check_export_iterator *it);
+OSCAP_API void xccdf_check_export_iterator_remove(struct xccdf_check_export_iterator *it);
 /// @memberof xccdf_check_import_iterator
-void xccdf_check_import_iterator_remove(struct xccdf_check_import_iterator *it);
+OSCAP_API void xccdf_check_import_iterator_remove(struct xccdf_check_import_iterator *it);
 /// @memberof xccdf_check_iterator
-void xccdf_check_iterator_remove(struct xccdf_check_iterator *it);
+OSCAP_API void xccdf_check_iterator_remove(struct xccdf_check_iterator *it);
 /// @memberof xccdf_fixtext_iterator
-void xccdf_fixtext_iterator_remove(struct xccdf_fixtext_iterator *it);
+OSCAP_API void xccdf_fixtext_iterator_remove(struct xccdf_fixtext_iterator *it);
 /// @memberof xccdf_fix_iterator
-void xccdf_fix_iterator_remove(struct xccdf_fix_iterator *it);
+OSCAP_API void xccdf_fix_iterator_remove(struct xccdf_fix_iterator *it);
 /// @memberof xccdf_value_iterator
-void xccdf_value_iterator_remove(struct xccdf_value_iterator *it);
+OSCAP_API void xccdf_value_iterator_remove(struct xccdf_value_iterator *it);
 /// @memberof xccdf_plain_text_iterator
-void xccdf_plain_text_iterator_remove(struct xccdf_plain_text_iterator *it);
+OSCAP_API void xccdf_plain_text_iterator_remove(struct xccdf_plain_text_iterator *it);
 /// @memberof xccdf_warning_iterator
-void xccdf_warning_iterator_remove(struct xccdf_warning_iterator *it);
+OSCAP_API void xccdf_warning_iterator_remove(struct xccdf_warning_iterator *it);
 /// @memberof xccdf_result_iterator
-void xccdf_result_iterator_remove(struct xccdf_result_iterator *it);
+OSCAP_API void xccdf_result_iterator_remove(struct xccdf_result_iterator *it);
 /// @memberof xccdf_override_iterator
-void xccdf_override_iterator_remove(struct xccdf_override_iterator *it);
+OSCAP_API void xccdf_override_iterator_remove(struct xccdf_override_iterator *it);
 /// @memberof xccdf_message_iterator
-void xccdf_message_iterator_remove(struct xccdf_message_iterator *it);
+OSCAP_API void xccdf_message_iterator_remove(struct xccdf_message_iterator *it);
 /// @memberof xccdf_instance_iterator
-void xccdf_instance_iterator_remove(struct xccdf_instance_iterator *it);
+OSCAP_API void xccdf_instance_iterator_remove(struct xccdf_instance_iterator *it);
 /// @memberof xccdf_rule_result_iterator
-void xccdf_rule_result_iterator_remove(struct xccdf_rule_result_iterator *it);
+OSCAP_API void xccdf_rule_result_iterator_remove(struct xccdf_rule_result_iterator *it);
 /// @memberof xccdf_identity_iterator
-void xccdf_identity_iterator_remove(struct xccdf_identity_iterator *it);
+OSCAP_API void xccdf_identity_iterator_remove(struct xccdf_identity_iterator *it);
 /// @memberof xccdf_score_iterator
-void xccdf_score_iterator_remove(struct xccdf_score_iterator *it);
+OSCAP_API void xccdf_score_iterator_remove(struct xccdf_score_iterator *it);
 /// @memberof xccdf_target_fact_iterator
-void xccdf_target_fact_iterator_remove(struct xccdf_target_fact_iterator *it);
+OSCAP_API void xccdf_target_fact_iterator_remove(struct xccdf_target_fact_iterator *it);
 /// @memberof xccdf_target_identifier_iterator
-void xccdf_target_identifier_iterator_remove(struct xccdf_target_identifier_iterator *it);
+OSCAP_API void xccdf_target_identifier_iterator_remove(struct xccdf_target_identifier_iterator *it);
 /// @memberof xccdf_value_instance_iterator
-void xccdf_value_instance_iterator_remove(struct xccdf_value_instance_iterator *it);
+OSCAP_API void xccdf_value_instance_iterator_remove(struct xccdf_value_instance_iterator *it);
 
 
 // textual substitution interface
@@ -3488,7 +3489,7 @@ typedef enum xccdf_subst_type {
  * @deprecated This callback has been deprecated. It cannot be applied on XCCDF 1.2+ documents
  * given the xccdf:sub/@use parameter.
  */
-typedef char*(*xccdf_substitution_func)(xccdf_subst_type_t type, const char *id, void *arg);
+OSCAP_API typedef char*(*xccdf_substitution_func)(xccdf_subst_type_t type, const char *id, void *arg);
 
 
 /**
@@ -3501,7 +3502,7 @@ typedef char*(*xccdf_substitution_func)(xccdf_subst_type_t type, const char *id,
  * @deprecated This function has been deprecated. It cannot be applied on XCCDF 1.2+ documents
  * given the xccdf:sub/@use parameter.
  */
-OSCAP_DEPRECATED(char* oscap_text_xccdf_substitute(const char *text, xccdf_substitution_func cb, void *arg));
+OSCAP_API OSCAP_DEPRECATED(char* oscap_text_xccdf_substitute(const char *text, xccdf_substitution_func cb, void *arg));
 
 /************************************************************/
 /** @} End of XCCDF group */

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -34,6 +34,7 @@
 
 #include "xccdf_policy.h"
 #include "oscap_download_cb.h"
+#include "oscap_export.h"
 
 /**
  * @struct xccdf_session
@@ -62,7 +63,7 @@ typedef enum {
  * @returns newly created \ref xccdf_session.
  * @retval NULL is returned in case of error. Details might be found through \ref oscap_err_desc()
  */
-struct xccdf_session *xccdf_session_new(const char *filename);
+OSCAP_API struct xccdf_session *xccdf_session_new(const char *filename);
 
 /**
  * Costructor of xccdf_session. It creates a new xccdf_session from an oscap_source structure.
@@ -71,20 +72,20 @@ struct xccdf_session *xccdf_session_new(const char *filename);
  * @returns newly created \ref xccdf_session.
  * @retval NULL is returned in case of error. Details might be found through \ref oscap_err_desc()
  */
-struct xccdf_session *xccdf_session_new_from_source(struct oscap_source *source);
+OSCAP_API struct xccdf_session *xccdf_session_new_from_source(struct oscap_source *source);
 
 /**
  * Destructor of xccdf_session.
  * @memberof xccdf_session
  * @param session to destroy.
  */
-void xccdf_session_free(struct xccdf_session *session);
+OSCAP_API void xccdf_session_free(struct xccdf_session *session);
 
 /**
  * Retrieves the filename the session was created with
  * @memberof xccdf_session
  */
-const char *xccdf_session_get_filename(const struct xccdf_session *session);
+OSCAP_API const char *xccdf_session_get_filename(const struct xccdf_session *session);
 
 /**
  * Query if the session is based on Source DataStream.
@@ -92,7 +93,7 @@ const char *xccdf_session_get_filename(const struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns true if the session is based on Source Datastream
  */
-bool xccdf_session_is_sds(const struct xccdf_session *session);
+OSCAP_API bool xccdf_session_is_sds(const struct xccdf_session *session);
 
 /**
  * Set rule for session - if rule is not NULL, session will use only this
@@ -101,7 +102,7 @@ bool xccdf_session_is_sds(const struct xccdf_session *session);
  * @param session XCCDF Session
  * @param rule If not NULL, session will use only this rule
  */
-void xccdf_session_set_rule(struct xccdf_session *session, const char *rule);
+OSCAP_API void xccdf_session_set_rule(struct xccdf_session *session, const char *rule);
 
 /**
  * Set XSD validation level to one of three possibilities:
@@ -113,7 +114,7 @@ void xccdf_session_set_rule(struct xccdf_session *session, const char *rule);
  * @param validate False value indicates to skip any XSD validation.
  * @param full_validation True value indicates that every possible step will be validated by XSD.
  */
-void xccdf_session_set_validation(struct xccdf_session *session, bool validate, bool full_validation);
+OSCAP_API void xccdf_session_set_validation(struct xccdf_session *session, bool validate, bool full_validation);
 
 /**
  * Set whether the thin results override is enabled.
@@ -123,7 +124,7 @@ void xccdf_session_set_validation(struct xccdf_session *session, bool validate, 
  * @memberof xccdf_session
  * @param thin_results true to enable thin_results, default is false
  */
-void xccdf_session_set_thin_results(struct xccdf_session *session, bool thin_result);
+OSCAP_API void xccdf_session_set_thin_results(struct xccdf_session *session, bool thin_result);
 
 /**
  * Set requested datastream_id for this session. This datastream_id is later
@@ -133,14 +134,14 @@ void xccdf_session_set_thin_results(struct xccdf_session *session, bool thin_res
  * @param session XCCDF Session
  * @param datastream_id requested datastream_id for this session.
  */
-void xccdf_session_set_datastream_id(struct xccdf_session *session, const char *datastream_id);
+OSCAP_API void xccdf_session_set_datastream_id(struct xccdf_session *session, const char *datastream_id);
 
 /**
  * Retrieves the datastream id
  * @see xccdf_session_set_datastream_id
  * @memberof xccdf_session
  */
-const char *xccdf_session_get_datastream_id(struct xccdf_session *session);
+OSCAP_API const char *xccdf_session_get_datastream_id(struct xccdf_session *session);
 
 /**
  * Set requested component_id for this session. This component_id is later
@@ -150,14 +151,14 @@ const char *xccdf_session_get_datastream_id(struct xccdf_session *session);
  * @param session XCCDF Session
  * @param component_id requested component_id for this session.
  */
-void xccdf_session_set_component_id(struct xccdf_session *session, const char *component_id);
+OSCAP_API void xccdf_session_set_component_id(struct xccdf_session *session, const char *component_id);
 
 /**
  * Retrieves the component id
  * @see xccdf_session_set_component_id
  * @memberof xccdf_session
  */
-const char *xccdf_session_get_component_id(struct xccdf_session *session);
+OSCAP_API const char *xccdf_session_get_component_id(struct xccdf_session *session);
 
 /**
  * Sets requested benchmark_id for this session. It is only used when no component_id
@@ -165,20 +166,20 @@ const char *xccdf_session_get_component_id(struct xccdf_session *session);
  * element inside a component that is referenced with a checklist component-ref.
  * @memberof xccdf_session
  */
-void xccdf_session_set_benchmark_id(struct xccdf_session *session, const char *benchmark_id);
+OSCAP_API void xccdf_session_set_benchmark_id(struct xccdf_session *session, const char *benchmark_id);
 
 /**
  * Retrieves the benchmark_id
  * @see xccdf_session_set_benchmark_id
  * @memberof xccdf_session
  */
-const char *xccdf_session_get_benchmark_id(struct xccdf_session *session);
+OSCAP_API const char *xccdf_session_get_benchmark_id(struct xccdf_session *session);
 
 /**
  * Retrieves the result id
  * @memberof xccdf_session
  */
-const char *xccdf_session_get_result_id(struct xccdf_session *session);
+OSCAP_API const char *xccdf_session_get_result_id(struct xccdf_session *session);
 
 /**
  * Set path to custom CPE dictionary for the session. This function is applicable
@@ -187,7 +188,7 @@ const char *xccdf_session_get_result_id(struct xccdf_session *session);
  * @param session XCCDF Session
  * @param user_cpe File path to user defined cpe dictionary.
  */
-void xccdf_session_set_user_cpe(struct xccdf_session *session, const char *user_cpe);
+OSCAP_API void xccdf_session_set_user_cpe(struct xccdf_session *session, const char *user_cpe);
 
 /**
  * Set path to custom Tailoring file for the session. This function is applicable
@@ -196,7 +197,7 @@ void xccdf_session_set_user_cpe(struct xccdf_session *session, const char *user_
  * @param session XCCDF Session
  * @param user_tailoring_file File path to user defined tailoring file.
  */
-void xccdf_session_set_user_tailoring_file(struct xccdf_session *session, const char *user_tailoring_file);
+OSCAP_API void xccdf_session_set_user_tailoring_file(struct xccdf_session *session, const char *user_tailoring_file);
 
 /**
  * Set ID of Tailoring component for the session. This function is applicable
@@ -205,7 +206,7 @@ void xccdf_session_set_user_tailoring_file(struct xccdf_session *session, const 
  * @param session XCCDF Session
  * @param user_tailoring_cid ID of component with a tailoring file.
  */
-void xccdf_session_set_user_tailoring_cid(struct xccdf_session *session, const char *user_tailoring_cid);
+OSCAP_API void xccdf_session_set_user_tailoring_cid(struct xccdf_session *session, const char *user_tailoring_cid);
 
 /**
  * Set properties of remote content.
@@ -215,7 +216,7 @@ void xccdf_session_set_user_tailoring_cid(struct xccdf_session *session, const c
  * @param callback used to notify user about download proceeds. This might be safely set
  * to NULL -- ignoring user notification.
  */
-void xccdf_session_set_remote_resources(struct xccdf_session *session, bool allowed, download_progress_calllback_t callback);
+OSCAP_API void xccdf_session_set_remote_resources(struct xccdf_session *session, bool allowed, download_progress_calllback_t callback);
 
 /**
  * Disable or allow loading of depending content (OVAL, SCE, CPE)
@@ -223,7 +224,7 @@ void xccdf_session_set_remote_resources(struct xccdf_session *session, bool allo
  * @param session XCCDF Session
  * @param flags Bit mask that sets loading of other content in the session.
  */
-void xccdf_session_set_loading_flags(struct xccdf_session *session, xccdf_session_loading_flags_t flags);
+OSCAP_API void xccdf_session_set_loading_flags(struct xccdf_session *session, xccdf_session_loading_flags_t flags);
 
 /**
  * Set custom oval files for this session
@@ -233,7 +234,7 @@ void xccdf_session_set_loading_flags(struct xccdf_session *session, xccdf_sessio
  * no OVAL file will be used for the session. If this parameter is NULL then OVAL
  * files will be find automatically, as defined in XCCDF (which is default).
  */
-void xccdf_session_set_custom_oval_files(struct xccdf_session *session, char **oval_filenames);
+OSCAP_API void xccdf_session_set_custom_oval_files(struct xccdf_session *session, char **oval_filenames);
 
 /**
  * Set custom OVAL eval function to register with each OVAL session. This function shall
@@ -242,7 +243,7 @@ void xccdf_session_set_custom_oval_files(struct xccdf_session *session, char **o
  * @param session XCCDF Session.
  * @param eval_fn Callback - pointer to function called by XCCDF Policy for each evaluated rule.
  */
-void xccdf_session_set_custom_oval_eval_fn(struct xccdf_session *session, xccdf_policy_engine_eval_fn eval_fn);
+OSCAP_API void xccdf_session_set_custom_oval_eval_fn(struct xccdf_session *session, xccdf_policy_engine_eval_fn eval_fn);
 
 /**
  * Set custom product CPE name.
@@ -251,7 +252,7 @@ void xccdf_session_set_custom_oval_eval_fn(struct xccdf_session *session, xccdf_
  * @param product_cpe Name of the scanner product.
  * @returns true on success
  */
-bool xccdf_session_set_product_cpe(struct xccdf_session *session, const char *product_cpe);
+OSCAP_API bool xccdf_session_set_product_cpe(struct xccdf_session *session, const char *product_cpe);
 
 /**
  * Set whether the System Characteristics shall be exported in result files.
@@ -259,7 +260,7 @@ bool xccdf_session_set_product_cpe(struct xccdf_session *session, const char *pr
  * @param session XCCDF Session
  * @param without_sys_chars whether to export System Characteristics or not.
  */
-void xccdf_session_set_without_sys_chars_export(struct xccdf_session *session, bool without_sys_chars);
+OSCAP_API void xccdf_session_set_without_sys_chars_export(struct xccdf_session *session, bool without_sys_chars);
 
 /**
  * Set whether the OVAL result files shall be exported.
@@ -267,7 +268,7 @@ void xccdf_session_set_without_sys_chars_export(struct xccdf_session *session, b
  * @param session XCCDF Session
  * @param to_export_oval_results whether to export results or not.
  */
-void xccdf_session_set_oval_results_export(struct xccdf_session *session, bool to_export_oval_results);
+OSCAP_API void xccdf_session_set_oval_results_export(struct xccdf_session *session, bool to_export_oval_results);
 
 /**
  * Set that check engine plugin's result files shall be exported.
@@ -275,7 +276,7 @@ void xccdf_session_set_oval_results_export(struct xccdf_session *session, bool t
  * @param session XCCDF Session
  * @param to_export_results whether to export results from check engine plugins or not.
  */
-void xccdf_session_set_check_engine_plugins_results_export(struct xccdf_session *session, bool to_export_results);
+OSCAP_API void xccdf_session_set_check_engine_plugins_results_export(struct xccdf_session *session, bool to_export_results);
 
 /**
  * Set that SCE reult files shall be exported.
@@ -283,7 +284,7 @@ void xccdf_session_set_check_engine_plugins_results_export(struct xccdf_session 
  * @param session XCCDF Session
  * @param to_export_sce_results whether to export SCE results or not.
  */
-OSCAP_DEPRECATED(void xccdf_session_set_sce_results_export(struct xccdf_session *session, bool to_export_sce_results));
+OSCAP_API OSCAP_DEPRECATED(void xccdf_session_set_sce_results_export(struct xccdf_session *session, bool to_export_sce_results));
 
 /**
  * Set whether the OVAL variables files shall be exported.
@@ -291,7 +292,7 @@ OSCAP_DEPRECATED(void xccdf_session_set_sce_results_export(struct xccdf_session 
  * @param session XCCDF Session
  * @param to_export_oval_variables whether to export results or not.
  */
-void xccdf_session_set_oval_variables_export(struct xccdf_session *session, bool to_export_oval_variables);
+OSCAP_API void xccdf_session_set_oval_variables_export(struct xccdf_session *session, bool to_export_oval_variables);
 
 /**
  * Set where to export XCCDF file. NULL value means to not export at all.
@@ -300,7 +301,7 @@ void xccdf_session_set_oval_variables_export(struct xccdf_session *session, bool
  * @param xccdf_file path to XCCDF file
  * @returns true on success
  */
-bool xccdf_session_set_xccdf_export(struct xccdf_session *session, const char *xccdf_file);
+OSCAP_API bool xccdf_session_set_xccdf_export(struct xccdf_session *session, const char *xccdf_file);
 
 /**
  * Set where to export STIG Viewer XCCDF file. NULL value means to not export at all.
@@ -309,7 +310,7 @@ bool xccdf_session_set_xccdf_export(struct xccdf_session *session, const char *x
  * @param xccdf_file path to STIG Viewer file
  * @returns true on success
  */
-bool xccdf_session_set_xccdf_stig_viewer_export(struct xccdf_session *session, const char *xccdf_stig_viewer_file);
+OSCAP_API bool xccdf_session_set_xccdf_stig_viewer_export(struct xccdf_session *session, const char *xccdf_stig_viewer_file);
 
 /**
  * Set where to export ARF file. NULL value means to not export at all.
@@ -318,7 +319,7 @@ bool xccdf_session_set_xccdf_stig_viewer_export(struct xccdf_session *session, c
  * @param arf_file path to ARF file
  * @returns true on success
  */
-bool xccdf_session_set_arf_export(struct xccdf_session *session, const char *arf_file);
+OSCAP_API bool xccdf_session_set_arf_export(struct xccdf_session *session, const char *arf_file);
 
 /**
  * Set where to export HTML Report file. NULL value means to not export at all.
@@ -327,7 +328,7 @@ bool xccdf_session_set_arf_export(struct xccdf_session *session, const char *arf
  * @param report_file
  * @returns true on success
  */
-bool xccdf_session_set_report_export(struct xccdf_session *session, const char *report_file);
+OSCAP_API bool xccdf_session_set_report_export(struct xccdf_session *session, const char *report_file);
 
 /**
  * Select XCCDF Profile for evaluation.
@@ -336,7 +337,7 @@ bool xccdf_session_set_report_export(struct xccdf_session *session, const char *
  * @param profile_id ID of profile to set
  * @returns true on success
  */
-bool xccdf_session_set_profile_id(struct xccdf_session *session, const char *profile_id);
+OSCAP_API bool xccdf_session_set_profile_id(struct xccdf_session *session, const char *profile_id);
 
 /**
  *Select XCCDF Profile for evaluation with only profile suffix as input. Reports error
@@ -346,14 +347,14 @@ bool xccdf_session_set_profile_id(struct xccdf_session *session, const char *pro
  *@param profile_suffix unique profile ID or suffix of the ID of the profile to set
  *@returns 0 on success, 1 if profile is not found, and 2 if multiple matches are found.
  */
-int xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const char *profile_suffix);
+OSCAP_API int xccdf_session_set_profile_id_by_suffix(struct xccdf_session *session, const char *profile_suffix);
 
 /**
  * Retrieves ID of the profile that we will evaluate with, or NULL.
  * @memberof xccdf_session
  * @param session XCCDF Session
  */
-const char *xccdf_session_get_profile_id(struct xccdf_session *session);
+OSCAP_API const char *xccdf_session_get_profile_id(struct xccdf_session *session);
 
 /**
  * Get Source DataStream index of the session.
@@ -362,7 +363,7 @@ const char *xccdf_session_get_profile_id(struct xccdf_session *session);
  * otherwise.
  * @return sds index
  */
-struct ds_sds_index *xccdf_session_get_sds_idx(struct xccdf_session *session);
+OSCAP_API struct ds_sds_index *xccdf_session_get_sds_idx(struct xccdf_session *session);
 
 /**
  * Load and parse all XCCDF structures needed to evaluate this session. This is
@@ -371,7 +372,7 @@ struct ds_sds_index *xccdf_session_get_sds_idx(struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_load(struct xccdf_session *session);
+OSCAP_API int xccdf_session_load(struct xccdf_session *session);
 
 /**
  * Load and parse XCCDF file. If the file upon which is based this session is
@@ -385,7 +386,7 @@ int xccdf_session_load(struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_load_xccdf(struct xccdf_session *session);
+OSCAP_API int xccdf_session_load_xccdf(struct xccdf_session *session);
 
 /**
  * Load and parse CPE dictionaries. Function xccdf_session_set_user_cpe
@@ -394,7 +395,7 @@ int xccdf_session_load_xccdf(struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_load_cpe(struct xccdf_session *session);
+OSCAP_API int xccdf_session_load_cpe(struct xccdf_session *session);
 
 /**
  * Load and parse OVAL definitions files for the XCCDF session.
@@ -402,7 +403,7 @@ int xccdf_session_load_cpe(struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_load_oval(struct xccdf_session *session);
+OSCAP_API int xccdf_session_load_oval(struct xccdf_session *session);
 
 /**
  * Load extra check engine from a plugin of given name to the XCCDF session.
@@ -418,8 +419,8 @@ int xccdf_session_load_oval(struct xccdf_session *session);
  * @param quiet If true we will not output errors if loading fails
  * @returns zero on success
  */
-int xccdf_session_load_check_engine_plugin2(struct xccdf_session *session, const char* plugin_name, bool quiet);
-int xccdf_session_load_check_engine_plugin(struct xccdf_session *session, const char* plugin_name);
+OSCAP_API int xccdf_session_load_check_engine_plugin2(struct xccdf_session *session, const char* plugin_name, bool quiet);
+OSCAP_API int xccdf_session_load_check_engine_plugin(struct xccdf_session *session, const char* plugin_name);
 
 /**
  * Load extra check engines (if any are available) to the XCCDF session.
@@ -431,14 +432,14 @@ int xccdf_session_load_check_engine_plugin(struct xccdf_session *session, const 
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_load_check_engine_plugins(struct xccdf_session *session);
+OSCAP_API int xccdf_session_load_check_engine_plugins(struct xccdf_session *session);
 
 /**
  * @deprecated
  * SCE is no longer part of the main openscap library,
  * use xccdf_session_load_check_engine_plugins instead.
  */
-OSCAP_DEPRECATED(int xccdf_session_load_sce(struct xccdf_session *session));
+OSCAP_API OSCAP_DEPRECATED(int xccdf_session_load_sce(struct xccdf_session *session));
 
 /**
  * Load Tailoring file (if applicable) to the XCCDF session.
@@ -446,7 +447,7 @@ OSCAP_DEPRECATED(int xccdf_session_load_sce(struct xccdf_session *session));
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_load_tailoring(struct xccdf_session *session);
+OSCAP_API int xccdf_session_load_tailoring(struct xccdf_session *session);
 
 /**
  * Evaluate XCCDF Policy.
@@ -454,7 +455,7 @@ int xccdf_session_load_tailoring(struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_evaluate(struct xccdf_session *session);
+OSCAP_API int xccdf_session_evaluate(struct xccdf_session *session);
 
 /**
  * Export XCCDF file.
@@ -462,7 +463,7 @@ int xccdf_session_evaluate(struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_export_xccdf(struct xccdf_session *session);
+OSCAP_API int xccdf_session_export_xccdf(struct xccdf_session *session);
 
 /**
  * Export OVAL (result and variables) files.
@@ -470,7 +471,7 @@ int xccdf_session_export_xccdf(struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_export_oval(struct xccdf_session *session);
+OSCAP_API int xccdf_session_export_oval(struct xccdf_session *session);
 
 /**
  * Export results (if any) from any check engine plugins that are loaded
@@ -480,7 +481,7 @@ int xccdf_session_export_oval(struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_export_check_engine_plugins(struct xccdf_session *session);
+OSCAP_API int xccdf_session_export_check_engine_plugins(struct xccdf_session *session);
 
 /**
  * Export SCE files (if enabled by @ref xccdf_session_set_sce_results_export).
@@ -490,7 +491,7 @@ int xccdf_session_export_check_engine_plugins(struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns zero on success
  */
-OSCAP_DEPRECATED(int xccdf_session_export_sce(struct xccdf_session *session));
+OSCAP_API OSCAP_DEPRECATED(int xccdf_session_export_sce(struct xccdf_session *session));
 
 /**
  * Export ARF (if enabled by @ref xccdf_session_set_arf_export).
@@ -498,7 +499,7 @@ OSCAP_DEPRECATED(int xccdf_session_export_sce(struct xccdf_session *session));
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_export_arf(struct xccdf_session *session);
+OSCAP_API int xccdf_session_export_arf(struct xccdf_session *session);
 
 /**
  * Get policy_model of the session. The @ref xccdf_session_load_xccdf shall be run
@@ -507,7 +508,7 @@ int xccdf_session_export_arf(struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns XCCDF Policy Model or NULL in case of failure.
  */
-struct xccdf_policy_model *xccdf_session_get_policy_model(const struct xccdf_session *session);
+OSCAP_API struct xccdf_policy_model *xccdf_session_get_policy_model(const struct xccdf_session *session);
 
 /**
  * Get xccdf_policy of the session.
@@ -515,7 +516,7 @@ struct xccdf_policy_model *xccdf_session_get_policy_model(const struct xccdf_ses
  * @param session XCCDF Session
  * @returns XCCDF Policy or NULL in case of failure.
  */
-struct xccdf_policy *xccdf_session_get_xccdf_policy(const struct xccdf_session *session);
+OSCAP_API struct xccdf_policy *xccdf_session_get_xccdf_policy(const struct xccdf_session *session);
 
 /**
  * Get the base score of the latest XCCDF evaluation in the session.
@@ -523,7 +524,7 @@ struct xccdf_policy *xccdf_session_get_xccdf_policy(const struct xccdf_session *
  * @param session XCCDF Session
  * @returns the score
  */
-float xccdf_session_get_base_score(const struct xccdf_session *session);
+OSCAP_API float xccdf_session_get_base_score(const struct xccdf_session *session);
 
 /**
  * Get count of OVAL agent sessions not used for CPE in the xccdf_session.
@@ -531,7 +532,7 @@ float xccdf_session_get_base_score(const struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns number of OVAL agents.
  */
-unsigned int xccdf_session_get_oval_agents_count(const struct xccdf_session *session);
+OSCAP_API unsigned int xccdf_session_get_oval_agents_count(const struct xccdf_session *session);
 
 /**
  * Get count of OVAL agent sessions for CPE in the xccdf_session.
@@ -541,7 +542,7 @@ unsigned int xccdf_session_get_oval_agents_count(const struct xccdf_session *ses
  * @param session XCCDF Session
  * @returns number of OVAL agents for CPE.
  */
-unsigned int xccdf_session_get_cpe_oval_agents_count(const struct xccdf_session *session);
+OSCAP_API unsigned int xccdf_session_get_cpe_oval_agents_count(const struct xccdf_session *session);
 
 /**
  * Query if the result of evaluation contains FAIL, ERROR, or UNKNOWN rule-result elements.
@@ -549,7 +550,7 @@ unsigned int xccdf_session_get_cpe_oval_agents_count(const struct xccdf_session 
  * @param session XCCDF Session
  * @returns Exists such rule-result r . r = FAIL | r = UNKNOWN | r = ERROR
  */
-bool xccdf_session_contains_fail_result(const struct xccdf_session *session);
+OSCAP_API bool xccdf_session_contains_fail_result(const struct xccdf_session *session);
 
 /**
  * Run XCCDF Remediation. It uses XCCDF Policy and XCCDF TestResult from the session
@@ -559,7 +560,7 @@ bool xccdf_session_contains_fail_result(const struct xccdf_session *session);
  * @param session XCCDF Session
  * @returns zero on success
  */
-int xccdf_session_remediate(struct xccdf_session *session);
+OSCAP_API int xccdf_session_remediate(struct xccdf_session *session);
 
 /**
  * Load xccdf:TestResult to the session from file and prepare session for remediation.
@@ -571,7 +572,7 @@ int xccdf_session_remediate(struct xccdf_session *session);
  * for the last TestResult). Suffix match is attempted if exact match is not found.
  * @returns zero on success.
  */
-int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, const char *testresult_id);
+OSCAP_API int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, const char *testresult_id);
 
 /**
  * Load xccdf:TestResult to the session from oscap_source
@@ -580,7 +581,7 @@ int xccdf_session_build_policy_from_testresult(struct xccdf_session *session, co
  * @param report_source Structure conataining oscap_source of the test results
  * @returns zero on success.
  */
-int xccdf_session_add_report_from_source(struct xccdf_session *session, struct oscap_source *report_source);
+OSCAP_API int xccdf_session_add_report_from_source(struct xccdf_session *session, struct oscap_source *report_source);
 
 /// @}
 /// @}

--- a/src/XCCDF_POLICY/public/check_engine_plugin.h
+++ b/src/XCCDF_POLICY/public/check_engine_plugin.h
@@ -32,6 +32,7 @@
 #define OPENSCAP_CHECK_ENGINE_PLUGIN_H_
 
 #include "xccdf_policy.h"
+#include "oscap_export.h"
 
 struct check_engine_plugin_def
 {
@@ -43,28 +44,28 @@ struct check_engine_plugin_def
 	// NB: path hint is the input file path, can be used for relative path resolution
 
 	// first arg: policy model to register with, second arg: path hint, third arg: user data
-	int (*register_fn)(struct xccdf_policy_model *, const char*, void**);
+int (*register_fn)(struct xccdf_policy_model *, const char*, void**);
 	// first arg: policy model, second arg: user data
-	int (*cleanup_fn)(struct xccdf_policy_model *, void**);
+int (*cleanup_fn)(struct xccdf_policy_model *, void**);
 	// first arg: policy model, second arg: validate, third arg: path hint, fourth arg: user data
-	int (*export_results_fn)(struct xccdf_policy_model *, bool, const char*, void**);
+int (*export_results_fn)(struct xccdf_policy_model *, bool, const char*, void**);
 	// first arg: user data
-	const char *(*get_capabilities_fn)(void**);
+const char *(*get_capabilities_fn)(void**);
 };
 
-struct check_engine_plugin_def *check_engine_plugin_load2(const char* path, bool quiet);
-struct check_engine_plugin_def *check_engine_plugin_load(const char* path);
-void check_engine_plugin_unload(struct check_engine_plugin_def *plugin);
+OSCAP_API struct check_engine_plugin_def *check_engine_plugin_load2(const char* path, bool quiet);
+OSCAP_API struct check_engine_plugin_def *check_engine_plugin_load(const char* path);
+OSCAP_API void check_engine_plugin_unload(struct check_engine_plugin_def *plugin);
 
-int check_engine_plugin_register(struct check_engine_plugin_def *plugin, struct xccdf_policy_model *model, const char *path_hint);
-int check_engine_plugin_cleanup(struct check_engine_plugin_def *plugin, struct xccdf_policy_model *model);
-int check_engine_plugin_export_results(struct check_engine_plugin_def *plugin, struct xccdf_policy_model *model, bool validate, const char *path_hint);
-const char *check_engine_plugin_get_capabilities(struct check_engine_plugin_def *plugin);
+OSCAP_API int check_engine_plugin_register(struct check_engine_plugin_def *plugin, struct xccdf_policy_model *model, const char *path_hint);
+OSCAP_API int check_engine_plugin_cleanup(struct check_engine_plugin_def *plugin, struct xccdf_policy_model *model);
+OSCAP_API int check_engine_plugin_export_results(struct check_engine_plugin_def *plugin, struct xccdf_policy_model *model, bool validate, const char *path_hint);
+OSCAP_API const char *check_engine_plugin_get_capabilities(struct check_engine_plugin_def *plugin);
 
 /**
  * This is the entry point of shared objects implementing extra check engines
  */
-typedef int (*check_engine_plugin_entry_fn) (struct check_engine_plugin_def*);
+OSCAP_API typedef int (*check_engine_plugin_entry_fn) (struct check_engine_plugin_def*);
 
 #define OPENSCAP_CHECK_ENGINE_PLUGIN_ENTRY OPENSCAP_CHECK_ENGINE_PLUGIN_ENTRY
 
@@ -73,7 +74,7 @@ typedef int (*check_engine_plugin_entry_fn) (struct check_engine_plugin_def*);
  *
  * Loading of these will be attempted automatically
  */
-const char * const *check_engine_plugin_get_known_plugins(void);
+OSCAP_API const char * const *check_engine_plugin_get_known_plugins(void);
 
 /// @}
 /// @}

--- a/src/XCCDF_POLICY/public/xccdf_policy.h
+++ b/src/XCCDF_POLICY/public/xccdf_policy.h
@@ -35,6 +35,7 @@
 #include <stdbool.h>
 #include <time.h>
 #include <oscap.h>
+#include "oscap_export.h"
 
 /**
  * @struct xccdf_policy_model
@@ -85,7 +86,7 @@ typedef enum {
  *  - (struct oscap_stringlists *) -- for POLICY_ENGINE_QUERY_NAMES_FOR_HREF
  *  - NULL shall be returned if the function doesn't understand the query.
  */
-typedef void *(*xccdf_policy_engine_query_fn) (void *, xccdf_policy_engine_query_t, void *);
+OSCAP_API typedef void *(*xccdf_policy_engine_query_fn) (void *, xccdf_policy_engine_query_t, void *);
 
 /**
  * Type of function which implements OpenSCAP checking engine.
@@ -95,7 +96,7 @@ typedef void *(*xccdf_policy_engine_query_fn) (void *, xccdf_policy_engine_query
  * function registerd. The registered function is then used by xccdf_policy module to
  * perform evaluation on the machine.
  */
-typedef xccdf_test_result_type_t (*xccdf_policy_engine_eval_fn) (struct xccdf_policy *policy, const char *rule_id, const char *definition_id, const char *href_if, struct xccdf_value_binding_iterator *value_binding_it, struct xccdf_check_import_iterator *check_imports_it, void *user_data);
+OSCAP_API typedef xccdf_test_result_type_t (*xccdf_policy_engine_eval_fn) (struct xccdf_policy *policy, const char *rule_id, const char *definition_id, const char *href_if, struct xccdf_value_binding_iterator *value_binding_it, struct xccdf_check_import_iterator *check_imports_it, void *user_data);
 
 /************************************************************/
 
@@ -108,7 +109,7 @@ typedef xccdf_test_result_type_t (*xccdf_policy_engine_eval_fn) (struct xccdf_po
  * when it's being destructed!
  * @memberof xccdf_policy_model
  */
-struct xccdf_policy_model *xccdf_policy_model_new(struct xccdf_benchmark *benchmark);
+OSCAP_API struct xccdf_policy_model *xccdf_policy_model_new(struct xccdf_benchmark *benchmark);
 
 /**
  * Constructor of Policy structure
@@ -116,32 +117,32 @@ struct xccdf_policy_model *xccdf_policy_model_new(struct xccdf_benchmark *benchm
  * @param profile Profile from XCCDF Benchmark
  * @memberof xccdf_policy
  */
-struct xccdf_policy * xccdf_policy_new(struct xccdf_policy_model * model, struct xccdf_profile * profile);
+OSCAP_API struct xccdf_policy * xccdf_policy_new(struct xccdf_policy_model * model, struct xccdf_profile * profile);
 
 /**
  * Constructor of structure with profile bindings - refine_rules, refine_values and set_values
  * @memberof xccdf_value_binding
  * @return new structure of xccdf_value_binding
  */
-struct xccdf_value_binding * xccdf_value_binding_new(void);
+OSCAP_API struct xccdf_value_binding * xccdf_value_binding_new(void);
 
 /** 
  * Destructor of Policy Model structure
  * @memberof xccdf_policy_model
  */
-void xccdf_policy_model_free(struct xccdf_policy_model *);
+OSCAP_API void xccdf_policy_model_free(struct xccdf_policy_model *);
 
 /** 
  * Destructor of Policy structure
  * @memberof xccdf_policy
  */
-void xccdf_policy_free(struct xccdf_policy *);
+OSCAP_API void xccdf_policy_free(struct xccdf_policy *);
 
 /** 
  * Destructor of Value binding structure
  * @memberof xccdf_value_binding
  */
-void xccdf_value_binding_free(struct xccdf_value_binding *);
+OSCAP_API void xccdf_value_binding_free(struct xccdf_value_binding *);
 
 /**
  * Sets the Tailoring element to use in the policy.
@@ -158,13 +159,13 @@ void xccdf_value_binding_free(struct xccdf_value_binding *);
  * The policy model will take ownership of given tailoring and free it
  * when it's being destructed or when new tailoring is being set.
  */
-bool xccdf_policy_model_set_tailoring(struct xccdf_policy_model *model, struct xccdf_tailoring *tailoring);
+OSCAP_API bool xccdf_policy_model_set_tailoring(struct xccdf_policy_model *model, struct xccdf_tailoring *tailoring);
 
 /**
  * Retrieves the Tailoring element used in this policy.
  * @memberof xccdf_policy_model
  */
-struct xccdf_tailoring *xccdf_policy_model_get_tailoring(struct xccdf_policy_model *model);
+OSCAP_API struct xccdf_tailoring *xccdf_policy_model_get_tailoring(struct xccdf_policy_model *model);
 
 /**
  * Get human readable title of given XCCDF Item. This finds title with best matching language
@@ -175,7 +176,7 @@ struct xccdf_tailoring *xccdf_policy_model_get_tailoring(struct xccdf_policy_mod
  * @param preferred_lang Language of your choice, Null value for the default.
  * @returns plaintext C string which must be freed by caller
  */
-char *xccdf_policy_get_readable_item_title(struct xccdf_policy *policy, struct xccdf_item *item, const char *preferred_lang);
+OSCAP_API char *xccdf_policy_get_readable_item_title(struct xccdf_policy *policy, struct xccdf_item *item, const char *preferred_lang);
 
 /**
  * Get human readable description of given XCCDF Item. This function searches for description
@@ -187,13 +188,13 @@ char *xccdf_policy_get_readable_item_title(struct xccdf_policy *policy, struct x
  * @param preferred_lang Language of your choice, Null value for the default.
  * @returns plaintext C string which must be freed by caller
  */
-char *xccdf_policy_get_readable_item_description(struct xccdf_policy *policy, struct xccdf_item *item, const char *preferred_lang);
+OSCAP_API char *xccdf_policy_get_readable_item_description(struct xccdf_policy *policy, struct xccdf_item *item, const char *preferred_lang);
 
 /**
  * Registers an additional CPE dictionary for applicability testing
  * The one embedded in the evaluated XCCDF take precedence!
  */
-bool xccdf_policy_model_add_cpe_dict_source(struct xccdf_policy_model * model, struct oscap_source *source);
+OSCAP_API bool xccdf_policy_model_add_cpe_dict_source(struct xccdf_policy_model * model, struct oscap_source *source);
 
 /**
  * Registers an additional CPE dictionary for applicability testing
@@ -201,13 +202,13 @@ bool xccdf_policy_model_add_cpe_dict_source(struct xccdf_policy_model * model, s
  *
  * @deprecated Deprecated in favor of @ref xccdf_policy_model_add_cpe_dict_source
  */
-bool xccdf_policy_model_add_cpe_dict(struct xccdf_policy_model * model, const char * cpe_dict);
+OSCAP_API bool xccdf_policy_model_add_cpe_dict(struct xccdf_policy_model * model, const char * cpe_dict);
 
 /**
  * Registers an additional CPE lang model for applicability testing
  * The one embedded in the evaluated XCCDF take precedence!
  */
-bool xccdf_policy_model_add_cpe_lang_model_source(struct xccdf_policy_model * model, struct oscap_source *source);
+OSCAP_API bool xccdf_policy_model_add_cpe_lang_model_source(struct xccdf_policy_model * model, struct oscap_source *source);
 
 /**
  * Registers an additional CPE lang model for applicability testing
@@ -215,14 +216,14 @@ bool xccdf_policy_model_add_cpe_lang_model_source(struct xccdf_policy_model * mo
  *
  * @deprecated Deprecated in favor of @ref xccdf_policy_model_add_cpe_lang_model_source
  */
-OSCAP_DEPRECATED(bool xccdf_policy_model_add_cpe_lang_model(struct xccdf_policy_model * model, const char *cpe_lang));
+OSCAP_API OSCAP_DEPRECATED(bool xccdf_policy_model_add_cpe_lang_model(struct xccdf_policy_model * model, const char *cpe_lang));
 
 /**
  * Registers an additional CPE resource (either dictionary or language)
  * Autodetects given file and acts accordingly.
  * The one embedded in the evaluated XCCDF take precedence!
  */
-bool xccdf_policy_model_add_cpe_autodetect_source(struct xccdf_policy_model *model, struct oscap_source *source);
+OSCAP_API bool xccdf_policy_model_add_cpe_autodetect_source(struct xccdf_policy_model *model, struct oscap_source *source);
 
 /**
  * Registers an additional CPE resource (either dictionary or language)
@@ -231,13 +232,13 @@ bool xccdf_policy_model_add_cpe_autodetect_source(struct xccdf_policy_model *mod
  *
  * @deprecated Deprecated in favor of @ref xccdf_policy_model_add_cpe_autodetect_source
  */
-OSCAP_DEPRECATED(bool xccdf_policy_model_add_cpe_autodetect(struct xccdf_policy_model *model, const char *filepath));
+OSCAP_API OSCAP_DEPRECATED(bool xccdf_policy_model_add_cpe_autodetect(struct xccdf_policy_model *model, const char *filepath));
 
 /**
  * Retrieves an iterator of all OVAL sessions created for CPE applicability evaluation
  * key is the OVAL href, value is the OVAL session itself (type oval_agent_session*)
  */
-struct oscap_htable_iterator *xccdf_policy_model_get_cpe_oval_sessions(struct xccdf_policy_model *model);
+OSCAP_API struct oscap_htable_iterator *xccdf_policy_model_get_cpe_oval_sessions(struct xccdf_policy_model *model);
 
 /**
  * Function to register callback for checking system
@@ -251,7 +252,7 @@ struct oscap_htable_iterator *xccdf_policy_model_get_cpe_oval_sessions(struct xc
  * @deprecated This function is deprecated by @ref xccdf_policy_model_register_engine_and_query_callback
  * and might be dropped from future releases.
  */
-OSCAP_DEPRECATED(bool xccdf_policy_model_register_engine_callback(struct xccdf_policy_model * model, char * sys, void * func, void * usr));
+OSCAP_API OSCAP_DEPRECATED(bool xccdf_policy_model_register_engine_callback(struct xccdf_policy_model * model, char * sys, void * func, void * usr));
 
 /**
  * Function to register callback for checking system
@@ -263,9 +264,9 @@ OSCAP_DEPRECATED(bool xccdf_policy_model_register_engine_callback(struct xccdf_p
  * @memberof xccdf_policy_model
  * @return true if callback registered succesfully, false otherwise
  */
-bool xccdf_policy_model_register_engine_and_query_callback(struct xccdf_policy_model *model, char *sys, xccdf_policy_engine_eval_fn eval_fn, void *usr, xccdf_policy_engine_query_fn query_fn);
+OSCAP_API bool xccdf_policy_model_register_engine_and_query_callback(struct xccdf_policy_model *model, char *sys, xccdf_policy_engine_eval_fn eval_fn, void *usr, xccdf_policy_engine_query_fn query_fn);
 
-typedef int (*policy_reporter_output)(struct xccdf_rule_result *, void *);
+OSCAP_API typedef int (*policy_reporter_output)(struct xccdf_rule_result *, void *);
 
 /**
  * Function to register output callback for checking system that will be called AFTER each rule evaluation.
@@ -275,9 +276,9 @@ typedef int (*policy_reporter_output)(struct xccdf_rule_result *, void *);
  * @memberof xccdf_policy_model
  * @return true if callback registered succesfully, false otherwise
  */
-bool xccdf_policy_model_register_output_callback(struct xccdf_policy_model * model, policy_reporter_output func, void * usr);
+OSCAP_API bool xccdf_policy_model_register_output_callback(struct xccdf_policy_model * model, policy_reporter_output func, void * usr);
 
-typedef int (*policy_reporter_start)(struct xccdf_rule *, void *);
+OSCAP_API typedef int (*policy_reporter_start)(struct xccdf_rule *, void *);
 
 /**
  * Function to register start callback for checking system that will be called BEFORE each rule evaluation.
@@ -287,7 +288,7 @@ typedef int (*policy_reporter_start)(struct xccdf_rule *, void *);
  * @memberof xccdf_policy_model
  * @return true if callback registered succesfully, false otherwise
  */
-bool xccdf_policy_model_register_start_callback(struct xccdf_policy_model * model, policy_reporter_start func, void * usr);
+OSCAP_API bool xccdf_policy_model_register_start_callback(struct xccdf_policy_model * model, policy_reporter_start func, void * usr);
 
 /************************************************************/
 /**
@@ -303,7 +304,7 @@ bool xccdf_policy_model_register_start_callback(struct xccdf_policy_model * mode
  * @return Policy model
  * @memberof xccdf_policy
  */
-struct xccdf_policy_model * xccdf_policy_get_model(const struct xccdf_policy * policy);
+OSCAP_API struct xccdf_policy_model * xccdf_policy_get_model(const struct xccdf_policy * policy);
 
 /**
  * Get Benchmark from Policy Model
@@ -311,13 +312,13 @@ struct xccdf_policy_model * xccdf_policy_get_model(const struct xccdf_policy * p
  * @return XCCDF Benchmark for given policy model
  * @memberof xccdf_policy_model
  */
-struct xccdf_benchmark * xccdf_policy_model_get_benchmark(const struct xccdf_policy_model * item);
+OSCAP_API struct xccdf_benchmark * xccdf_policy_model_get_benchmark(const struct xccdf_policy_model * item);
 
 /**
  * Get Value Bindings from XCCDF Policy
  * @memberof xccdf_policy
  */
-struct xccdf_value_binding_iterator  * xccdf_policy_get_values(const struct xccdf_policy * item);
+OSCAP_API struct xccdf_value_binding_iterator  * xccdf_policy_get_values(const struct xccdf_policy * item);
 
 /**
  * Get policies from Policy Model. Be aware, this function returns only a list of previously
@@ -326,7 +327,7 @@ struct xccdf_value_binding_iterator  * xccdf_policy_get_values(const struct xccd
  * @return Iterator for list of policies
  * @memberof xccdf_policy_model
  */
-struct xccdf_policy_iterator * xccdf_policy_model_get_policies(const struct xccdf_policy_model *model);
+OSCAP_API struct xccdf_policy_iterator * xccdf_policy_model_get_policies(const struct xccdf_policy_model *model);
 
 /**
  * Build all policies that can be useful for user. The useful policy is any
@@ -336,7 +337,7 @@ struct xccdf_policy_iterator * xccdf_policy_model_get_policies(const struct xccd
  * @param policy_model - XCCDF Policy Model
  * @return 0 on success
  */
-int xccdf_policy_model_build_all_useful_policies(struct xccdf_policy_model *policy_model);
+OSCAP_API int xccdf_policy_model_build_all_useful_policies(struct xccdf_policy_model *policy_model);
 
 /**
  * Get selected rules from policy
@@ -344,69 +345,69 @@ int xccdf_policy_model_build_all_useful_policies(struct xccdf_policy_model *poli
  * @return Pointer to select iterator.
  * @retval NULL on faliure
  */
-struct xccdf_select_iterator * xccdf_policy_get_selected_rules(struct xccdf_policy *);
+OSCAP_API struct xccdf_select_iterator * xccdf_policy_get_selected_rules(struct xccdf_policy *);
 
 /**
  * Get XCCDF Profile from Policy
  * @memberof xccdf_policy
  * @return XCCDF Profile
  */
-struct xccdf_profile * xccdf_policy_get_profile(const struct xccdf_policy *);
+OSCAP_API struct xccdf_profile * xccdf_policy_get_profile(const struct xccdf_policy *);
 
 /**
  * Get rules from Policy
  * @memberof xccdf_policy
  * @return xccdf_select_iterator
  */
-struct xccdf_select_iterator * xccdf_policy_get_selects(const struct xccdf_policy *);
+OSCAP_API struct xccdf_select_iterator * xccdf_policy_get_selects(const struct xccdf_policy *);
 
 /**
  * Get variable name from value bindings
  * @memberof xccdf_value_binding
  * @return String
  */
-char * xccdf_value_binding_get_name(const struct xccdf_value_binding *);
+OSCAP_API char * xccdf_value_binding_get_name(const struct xccdf_value_binding *);
 
 /**
  * Get value from value bindings
  * @memberof xccdf_value_binding
  * @return String
  */
-char * xccdf_value_binding_get_value(const struct xccdf_value_binding *);
+OSCAP_API char * xccdf_value_binding_get_value(const struct xccdf_value_binding *);
 
 /**
  * get variable type from value bindings
  * @memberof xccdf_value_binding
  * @return xccdf_value_type_t
  */
-xccdf_value_type_t xccdf_value_binding_get_type(const struct xccdf_value_binding *);
+OSCAP_API xccdf_value_type_t xccdf_value_binding_get_type(const struct xccdf_value_binding *);
 
 /**
  * get Value operator from value bindings
  * @memberof xccdf_value_binding
  * @return xccdf_operator_t
  */
-xccdf_operator_t xccdf_value_binding_get_operator(const struct xccdf_value_binding *);
+OSCAP_API xccdf_operator_t xccdf_value_binding_get_operator(const struct xccdf_value_binding *);
 
 /**
  * get Set Value from value bindings
  * @memberof xccdf_value_binding
  * @return String
  */
-char * xccdf_value_binding_get_setvalue(const struct xccdf_value_binding *);
+OSCAP_API char * xccdf_value_binding_get_setvalue(const struct xccdf_value_binding *);
 
 /**
  * Get results of all XCCDF Policy results
  * @memberof xccdf_policy_model
  */
-struct xccdf_result_iterator * xccdf_policy_get_results(const struct xccdf_policy * policy);
+OSCAP_API struct xccdf_result_iterator * xccdf_policy_get_results(const struct xccdf_policy * policy);
 
 /**
  * Get XCCDF Result structure by it's idetificator if there is one
  * @memberof xccdf_policy_model
  * @return structure xccdf_result if found, NULL otherwise
  */
-struct xccdf_result * xccdf_policy_get_result_by_id(struct xccdf_policy * policy, const char * id);
+OSCAP_API struct xccdf_result * xccdf_policy_get_result_by_id(struct xccdf_policy * policy, const char * id);
 
 /**
  * Get ID of XCCDF Profile that is implemented by XCCDF Policy
@@ -414,7 +415,7 @@ struct xccdf_result * xccdf_policy_get_result_by_id(struct xccdf_policy * policy
  * @memberof xccdf_policy
  * @return ID of Policy's Profile
  */
-const char * xccdf_policy_get_id(struct xccdf_policy * policy);
+OSCAP_API const char * xccdf_policy_get_id(struct xccdf_policy * policy);
 
 /**
  * Get XCCDF Policy from Policy model by speciefied ID of Profile
@@ -423,7 +424,7 @@ const char * xccdf_policy_get_id(struct xccdf_policy * policy);
  * @memberof xccdf_policy_model
  * @return XCCDF Policy
  */
-struct xccdf_policy * xccdf_policy_model_get_policy_by_id(struct xccdf_policy_model * policy_model, const char * id);
+OSCAP_API struct xccdf_policy * xccdf_policy_model_get_policy_by_id(struct xccdf_policy_model * policy_model, const char * id);
 
 /************************************************************/
 /** @} End of Getters group */
@@ -441,14 +442,14 @@ struct xccdf_policy * xccdf_policy_model_get_policy_by_id(struct xccdf_policy_mo
  * @memberof xccdf_policy_model
  * @return true if policy has been added succesfully
  */
-bool xccdf_policy_model_add_policy(struct xccdf_policy_model *, struct xccdf_policy *);
+OSCAP_API bool xccdf_policy_model_add_policy(struct xccdf_policy_model *, struct xccdf_policy *);
 
 /**
  * Add rule to Policy
  * @memberof xccdf_policy
  * @return true if rule has been added succesfully
  */
-bool xccdf_policy_add_select(struct xccdf_policy *, struct xccdf_select *);
+OSCAP_API bool xccdf_policy_add_select(struct xccdf_policy *, struct xccdf_select *);
 
 /**
  * Set a new selector to the Policy structure
@@ -465,34 +466,34 @@ bool xccdf_policy_set_selected(struct xccdf_policy * policy, char * idref)
  * Add result to XCCDF Policy Model
  * @memberof xccdf_policy_model
  */
-bool xccdf_policy_add_result(struct xccdf_policy * policy, struct xccdf_result * item);
+OSCAP_API bool xccdf_policy_add_result(struct xccdf_policy * policy, struct xccdf_result * item);
 
 /**
  * Add value binding to the Policy structure
  * @memberof xccdf_policy
  * @return true if rule has been added succesfully
  */
-bool xccdf_policy_add_value(struct xccdf_policy *, struct xccdf_value_binding *);
+OSCAP_API bool xccdf_policy_add_value(struct xccdf_policy *, struct xccdf_value_binding *);
 
 /**
  * Get the selection settings of the item.
  * @memberof xccdf_policy
  * @return true if the item is selected
  */
-bool xccdf_policy_is_item_selected(struct xccdf_policy *policy, const char *id);
+OSCAP_API bool xccdf_policy_is_item_selected(struct xccdf_policy *policy, const char *id);
 
 /**
  * Retrieves number of selected items in the policy
  * @note This is meant to be used to estimate scanning progress for example.
  */
-int xccdf_policy_get_selected_rules_count(struct xccdf_policy *policy);
+OSCAP_API int xccdf_policy_get_selected_rules_count(struct xccdf_policy *policy);
 
 /**
  * Get select from policy by specified ID of XCCDF Item
  * @memberof xccdf_policy
  * @return XCCDF Select
  */
-struct xccdf_select * xccdf_policy_get_select_by_id(struct xccdf_policy * policy, const char *item_id);
+OSCAP_API struct xccdf_select * xccdf_policy_get_select_by_id(struct xccdf_policy * policy, const char *item_id);
 
 /************************************************************/
 /** @} End of Setters group */
@@ -518,10 +519,10 @@ struct xccdf_select * xccdf_policy_get_select_by_id(struct xccdf_policy * policy
  * \par
  * If you use this predefined OVAL callback, user data structure (last parameter of register function) \b MUST be of type \ref\a oval_agent_session_t:
  * \code
- * struct oval_agent_session * sess = oval_agent_new_session((struct oval_definition_model *) model, "name-of-file");
+OSCAP_API  * struct oval_agent_session * sess = oval_agent_new_session((struct oval_definition_model *) model, "name-of-file");
  * \endcode
  * */
-struct xccdf_result *  xccdf_policy_evaluate(struct xccdf_policy * policy);
+OSCAP_API struct xccdf_result *  xccdf_policy_evaluate(struct xccdf_policy * policy);
 
 /**
  * Resolve benchmark by applying all refine_rules and refine_values to rules / values
@@ -531,7 +532,7 @@ struct xccdf_result *  xccdf_policy_evaluate(struct xccdf_policy * policy);
  * @return true if process ends succesfuly or false in case of error
  * @memberof xccdf_policy
  */
-bool xccdf_policy_resolve(struct xccdf_policy * policy);
+OSCAP_API bool xccdf_policy_resolve(struct xccdf_policy * policy);
 
 /**
  * Generate remediation prescription (presumably a remediation script).
@@ -543,7 +544,7 @@ bool xccdf_policy_resolve(struct xccdf_policy * policy);
  * @param output_fd write prescription to this file descriptor
  * @returns zero on success, non-zero indicate partial (incomplete) output.
  */
-int xccdf_policy_generate_fix(struct xccdf_policy *policy, struct xccdf_result *result, const char *sys, int output_fd);
+OSCAP_API int xccdf_policy_generate_fix(struct xccdf_policy *policy, struct xccdf_result *result, const char *sys, int output_fd);
 
 /**
  * Clone the item and tailor it against given policy (profile)
@@ -552,7 +553,7 @@ int xccdf_policy_generate_fix(struct xccdf_policy *policy, struct xccdf_result *
  * @return new item that has to be freed by user
  * @deprecated This function is deprecated and might be dropped from future releases.
  */
-OSCAP_DEPRECATED(struct xccdf_item * xccdf_policy_tailor_item(struct xccdf_policy * policy, struct xccdf_item * item));
+OSCAP_API OSCAP_DEPRECATED(struct xccdf_item * xccdf_policy_tailor_item(struct xccdf_policy * policy, struct xccdf_item * item));
 
 /**
  * xccdf_policy_model_get_files and xccdf_item_get_files each return oscap_file_entries instead of raw strings
@@ -560,15 +561,15 @@ OSCAP_DEPRECATED(struct xccdf_item * xccdf_policy_tailor_item(struct xccdf_polic
 struct oscap_file_entry;
 
 /// @memberof oscap_file_entry
-struct oscap_file_entry *oscap_file_entry_new(void);
+OSCAP_API struct oscap_file_entry *oscap_file_entry_new(void);
 /// @memberof oscap_file_entry
-struct oscap_file_entry *oscap_file_entry_dup(struct oscap_file_entry* file_entry);
+OSCAP_API struct oscap_file_entry *oscap_file_entry_dup(struct oscap_file_entry* file_entry);
 /// @memberof oscap_file_entry
-void oscap_file_entry_free(struct oscap_file_entry* entry);
+OSCAP_API void oscap_file_entry_free(struct oscap_file_entry* entry);
 /// @memberof oscap_file_entry
-const char* oscap_file_entry_get_system(struct oscap_file_entry* entry);
+OSCAP_API const char* oscap_file_entry_get_system(struct oscap_file_entry* entry);
 /// @memberof oscap_file_entry
-const char* oscap_file_entry_get_file(struct oscap_file_entry* entry);
+OSCAP_API const char* oscap_file_entry_get_file(struct oscap_file_entry* entry);
 
 /** @struct oscap_file_entry_iterator
  * @see oscap_iterator
@@ -576,13 +577,13 @@ const char* oscap_file_entry_get_file(struct oscap_file_entry* entry);
 struct oscap_file_entry_iterator;
 
 /// @memberof oscap_file_entry_iterator
-const struct oscap_file_entry *oscap_file_entry_iterator_next(struct oscap_file_entry_iterator *it);
+OSCAP_API const struct oscap_file_entry *oscap_file_entry_iterator_next(struct oscap_file_entry_iterator *it);
 /// @memberof oscap_file_entry_iterator
-bool oscap_file_entry_iterator_has_more(struct oscap_file_entry_iterator *it);
+OSCAP_API bool oscap_file_entry_iterator_has_more(struct oscap_file_entry_iterator *it);
 /// @memberof oscap_file_entry_iterator
-void oscap_file_entry_iterator_free(struct oscap_file_entry_iterator *it);
+OSCAP_API void oscap_file_entry_iterator_free(struct oscap_file_entry_iterator *it);
 /// @memberof oscap_file_entry_iterator
-void oscap_file_entry_iterator_reset(struct oscap_file_entry_iterator *it);
+OSCAP_API void oscap_file_entry_iterator_reset(struct oscap_file_entry_iterator *it);
 
 /** @struct oscap_file_entry_list
  * @see oscap_list
@@ -590,11 +591,11 @@ void oscap_file_entry_iterator_reset(struct oscap_file_entry_iterator *it);
 struct oscap_file_entry_list;
 
 /// @memberof oscap_file_entry_list
-struct oscap_file_entry_list* oscap_file_entry_list_new(void);
+OSCAP_API struct oscap_file_entry_list* oscap_file_entry_list_new(void);
 /// @memberof oscap_file_entry_list
-void oscap_file_entry_list_free(struct oscap_file_entry_list* list);
+OSCAP_API void oscap_file_entry_list_free(struct oscap_file_entry_list* list);
 /// @memberof oscap_file_entry_list
-struct oscap_file_entry_iterator* oscap_file_entry_list_get_files(struct oscap_file_entry_list* list);
+OSCAP_API struct oscap_file_entry_iterator* oscap_file_entry_list_get_files(struct oscap_file_entry_list* list);
 
 /**
  * Return names of files that are used in checks of particular rules. Every check needs this file to be
@@ -604,7 +605,7 @@ struct oscap_file_entry_iterator* oscap_file_entry_list_get_files(struct oscap_f
  *
  * The resulting list should be freed with oscap_filelist_free.
  */
-struct oscap_file_entry_list * xccdf_policy_model_get_systems_and_files(struct xccdf_policy_model * policy_model);
+OSCAP_API struct oscap_file_entry_list * xccdf_policy_model_get_systems_and_files(struct xccdf_policy_model * policy_model);
 
 /**
  * Return names of files that are used in checks of particular rules. Every check needs this file to be
@@ -613,28 +614,28 @@ struct oscap_file_entry_list * xccdf_policy_model_get_systems_and_files(struct x
  *
  * The resulting list should be freed with oscap_filelist_free.
  */
-struct oscap_file_entry_list * xccdf_item_get_systems_and_files(struct xccdf_item * item);
+OSCAP_API struct oscap_file_entry_list * xccdf_item_get_systems_and_files(struct xccdf_item * item);
 
 /**
  * Return names of files that are used in checks of particular rules. Every check needs this file to be
  * evaluated properly. If this file will not be imported and bind to the XCCDF Policy system the result
  * of rule after evaluation will be "Not checked"
  */
-struct oscap_stringlist * xccdf_policy_model_get_files(struct xccdf_policy_model * policy_model);
+OSCAP_API struct oscap_stringlist * xccdf_policy_model_get_files(struct xccdf_policy_model * policy_model);
 
 /**
  * Return names of files that are used in checks of particular rules. Every check needs this file to be
  * evaluated properly. If this file will not be imported and bind to the XCCDF Policy system the result
  * of rule after evaluation will be "Not checked"
  */
-struct oscap_stringlist * xccdf_item_get_files(struct xccdf_item * item);
+OSCAP_API struct oscap_stringlist * xccdf_item_get_files(struct xccdf_item * item);
 
 /**
  * Return result of the AND operation for two given attributes.
  * For more details about the attributes A and B please consult 'Table 26: Possible Results for a Single Test' from NISTIR-7275r4.
  * For more details about the AND operation please consult 'Table 12: Truth Table for AND' in the very same document.
  */
-xccdf_test_result_type_t xccdf_test_result_resolve_and_operation(xccdf_test_result_type_t A, xccdf_test_result_type_t B);
+OSCAP_API xccdf_test_result_type_t xccdf_test_result_resolve_and_operation(xccdf_test_result_type_t A, xccdf_test_result_type_t B);
 
 /************************************************************/
 /** @} End of Evaluators group */
@@ -649,49 +650,49 @@ xccdf_test_result_type_t xccdf_test_result_resolve_and_operation(xccdf_test_resu
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_policy_iterator
  */
-bool xccdf_policy_iterator_has_more(struct xccdf_policy_iterator *it);
+OSCAP_API bool xccdf_policy_iterator_has_more(struct xccdf_policy_iterator *it);
 
 /**
  * Return the next xccdf_policy structure from the list and increment the iterator
  * @memberof xccdf_policy_iterator
  */
-struct xccdf_policy * xccdf_policy_iterator_next(struct xccdf_policy_iterator *it);
+OSCAP_API struct xccdf_policy * xccdf_policy_iterator_next(struct xccdf_policy_iterator *it);
 
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_policy_iterator
  */
-void xccdf_policy_iterator_free(struct xccdf_policy_iterator *it);
+OSCAP_API void xccdf_policy_iterator_free(struct xccdf_policy_iterator *it);
 
 /**
  * Reset the iterator structure (it will point to the first item in the list)
  * @memberof xccdf_policy_iterator
  */
-void xccdf_policy_iterator_reset(struct xccdf_policy_iterator *it);
+OSCAP_API void xccdf_policy_iterator_reset(struct xccdf_policy_iterator *it);
 
 /**
  * Return true if the list is not empty, false otherwise
  * @memberof xccdf_value_binding_iterator
  */
-bool xccdf_value_binding_iterator_has_more(struct xccdf_value_binding_iterator *it);
+OSCAP_API bool xccdf_value_binding_iterator_has_more(struct xccdf_value_binding_iterator *it);
 
 /**
  * Return the next xccdf_value_binding structure from the list and increment the iterator
  * @memberof xccdf_value_binding_iterator
  */
-struct xccdf_value_binding * xccdf_value_binding_iterator_next(struct xccdf_value_binding_iterator *it);
+OSCAP_API struct xccdf_value_binding * xccdf_value_binding_iterator_next(struct xccdf_value_binding_iterator *it);
 
 /**
  * Free the iterator structure (it makes no changes to the list structure)
  * @memberof xccdf_value_binding_iterator
  */
-void xccdf_value_binding_iterator_free(struct xccdf_value_binding_iterator *it);
+OSCAP_API void xccdf_value_binding_iterator_free(struct xccdf_value_binding_iterator *it);
 
 /**
  * Reset the iterator structure (it will point to the first item in the list)
  * @memberof xccdf_value_binding_iterator
  */
-void xccdf_value_binding_iterator_reset(struct xccdf_value_binding_iterator *it);
+OSCAP_API void xccdf_value_binding_iterator_reset(struct xccdf_value_binding_iterator *it);
 
 /**
  * Get score of the XCCDF Benchmark
@@ -700,7 +701,7 @@ void xccdf_value_binding_iterator_reset(struct xccdf_value_binding_iterator *it)
  * @param system Score system
  * @return XCCDF Score
  */
-struct xccdf_score * xccdf_policy_get_score(struct xccdf_policy * policy, struct xccdf_result * test_result, const char * system);
+OSCAP_API struct xccdf_score * xccdf_policy_get_score(struct xccdf_policy * policy, struct xccdf_result * test_result, const char * system);
 
 /**
  * Recalculate score of the XCCDF Benchmark
@@ -708,7 +709,7 @@ struct xccdf_score * xccdf_policy_get_score(struct xccdf_policy * policy, struct
  * @param test_result Test Result model
  * @returns zero on success
  */
-int xccdf_policy_recalculate_score(struct xccdf_policy * policy, struct xccdf_result * test_result);
+OSCAP_API int xccdf_policy_recalculate_score(struct xccdf_policy * policy, struct xccdf_result * test_result);
 
 /**
  * Get value of given value item in context of given policy
@@ -718,14 +719,14 @@ int xccdf_policy_recalculate_score(struct xccdf_policy * policy, struct xccdf_re
  * @returns string representation of resolved value_instance.
  * @retval NULL indicates failure
  */
-const char *xccdf_policy_get_value_of_item(struct xccdf_policy * policy, struct xccdf_item * item);
+OSCAP_API const char *xccdf_policy_get_value_of_item(struct xccdf_policy * policy, struct xccdf_item * item);
 
 /**
  * Perform textual substitution of cdf:sub elements with respect to given XCCDF policy.
  * @param text text to be substituted
  * @param policy policy to be used
  */
-char* xccdf_policy_substitute(const char *text, struct xccdf_policy *policy);
+OSCAP_API char* xccdf_policy_substitute(const char *text, struct xccdf_policy *policy);
 
 /************************************************************/
 /** @} End of Iterators group */

--- a/src/common/public/oscap.h
+++ b/src/common/public/oscap.h
@@ -36,6 +36,7 @@
 
 #include "oscap_text.h"
 #include "oscap_reference.h"
+#include "oscap_export.h"
 
 /**
  * This macro will warn, when a deprecated function is used.
@@ -58,7 +59,7 @@
  * However, it is a good practice to call this function
  * always at the beginning of the program execution.
  */
-void oscap_init(void);
+OSCAP_API void oscap_init(void);
 
 /**
  * Release library internal caches.
@@ -67,10 +68,10 @@ void oscap_init(void);
  * any of the libraries included in OpenScap framework.
  * It frees internally allocated memory, e.g. cache of the XML parser.
  */
-void oscap_cleanup(void);
+OSCAP_API void oscap_cleanup(void);
 
 /// Get version of the OpenSCAP library
-const char *oscap_get_version(void);
+OSCAP_API const char *oscap_get_version(void);
 
 
 /**
@@ -109,9 +110,9 @@ typedef enum oscap_document_type {
  * @retval Returned value might be pointer to static memory and must not be modified.
  * @retval NULL in case of unrecognized document type
  */
-const char *oscap_document_type_to_string(oscap_document_type_t type);
+OSCAP_API const char *oscap_document_type_to_string(oscap_document_type_t type);
 
-typedef int (*xml_reporter)(const char *file, int line, const char *msg, void *arg);
+OSCAP_API typedef int (*xml_reporter)(const char *file, int line, const char *msg, void *arg);
 
 /**
  * Validate a SCAP document file against a XML schema.
@@ -131,7 +132,7 @@ typedef int (*xml_reporter)(const char *file, int line, const char *msg, void *a
  * @deprecated This function has been deprecated and it may be dropped from later
  * OpenSCAP releases. Please use oscap_source_validate instead.
  */
-OSCAP_DEPRECATED(int oscap_validate_document(const char *xmlfile, oscap_document_type_t doctype, const char *version, xml_reporter reporter, void *arg));
+OSCAP_API OSCAP_DEPRECATED(int oscap_validate_document(const char *xmlfile, oscap_document_type_t doctype, const char *version, xml_reporter reporter, void *arg));
 
 /**
  * Validate a SCAP document file against schematron rules.
@@ -147,7 +148,7 @@ OSCAP_DEPRECATED(int oscap_validate_document(const char *xmlfile, oscap_document
  * @deprecated This function has been deprecated and it may be dropped from later
  * OpenSCAP releases. Please use oscap_source_validate_schematron instead.
  */
-OSCAP_DEPRECATED(int oscap_schematron_validate_document(const char *xmlfile, oscap_document_type_t doctype, const char *version, const char *outfile));
+OSCAP_API OSCAP_DEPRECATED(int oscap_schematron_validate_document(const char *xmlfile, oscap_document_type_t doctype, const char *version, const char *outfile));
 
 /**
  * Apply a XSLT stylesheet to a XML file.
@@ -161,12 +162,12 @@ OSCAP_DEPRECATED(int oscap_schematron_validate_document(const char *xmlfile, osc
  * @param params list of key-value pairs to pass to the stylesheet.
  * @return the number of bytes written or -1 in case of failure
  */
-int oscap_apply_xslt(const char *xmlfile, const char *xsltfile, const char *outfile, const char **params);
+OSCAP_API int oscap_apply_xslt(const char *xmlfile, const char *xsltfile, const char *outfile, const char **params);
 
 /**
  * Function returns path used to locate OpenSCAP XML schemas
  */
-const char * oscap_path_to_schemas(void);
+OSCAP_API const char * oscap_path_to_schemas(void);
 
 /**
  * Function returns path used to locate OpenSCAP Schematron files
@@ -174,19 +175,19 @@ const char * oscap_path_to_schemas(void);
  * correct path to schematron files. This function may be dropped from
  * the next version of the library.
  */
-OSCAP_DEPRECATED(const char * oscap_path_to_schematron(void));
+OSCAP_API OSCAP_DEPRECATED(const char * oscap_path_to_schematron(void));
 
 /**
  * Function returns path used to locate OpenSCAP Default CPE files
  */
-const char * oscap_path_to_cpe(void);
+OSCAP_API const char * oscap_path_to_cpe(void);
 
 /**
  * Determine document type
  * @deprecated This function has been deprecated and it may be dropped from later
  * OpenSCAP releases. Please use oscap_source_get_scap_type instead.
  */
-OSCAP_DEPRECATED(int oscap_determine_document_type(const char *document, oscap_document_type_t *doc_type));
+OSCAP_API OSCAP_DEPRECATED(int oscap_determine_document_type(const char *document, oscap_document_type_t *doc_type));
 
 /************************************************************/
 /** @} validation group end */

--- a/src/common/public/oscap_debug.h
+++ b/src/common/public/oscap_debug.h
@@ -23,6 +23,8 @@
 #ifndef OSCAP_DEBUG_H_
 #define OSCAP_DEBUG_H_
 
+#include "oscap_export.h"
+
 typedef enum {
 	DBG_E = 1,
 	DBG_W,
@@ -42,7 +44,7 @@ typedef enum {
  * @param fmt   printf-line format string
  * @param ...   __oscap_dlprintf parameters
  */
-void __oscap_dlprintf(int level, const char *file, const char *fn, size_t line, int delta_indent, const char *fmt, ...);
+OSCAP_API void __oscap_dlprintf(int level, const char *file, const char *fn, size_t line, int delta_indent, const char *fmt, ...);
 
 /**
  * Turn on debugging information
@@ -53,14 +55,14 @@ void __oscap_dlprintf(int level, const char *file, const char *fn, size_t line, 
  *                 from a probe (true) or from the base library (false).
  * @return When an error occured, returns false, otherwise true.
  */
-bool oscap_set_verbose(const char *verbosity_level, const char *filename, bool is_probe);
+OSCAP_API bool oscap_set_verbose(const char *verbosity_level, const char *filename, bool is_probe);
 
 /**
  * Parse verbosity level from a string.
  * @param level_name Verbosity level as a C string.
  * @return Verbosity level number (or -1 on error).
  */
-oscap_verbosity_levels oscap_verbosity_level_from_cstr(const char *level_name);
+OSCAP_API oscap_verbosity_levels oscap_verbosity_level_from_cstr(const char *level_name);
 
 #if defined(_WIN32)
 errno_t getenv_s(size_t *pReturnValue, char* buffer, size_t numberOfElements, const char * varname);

--- a/src/common/public/oscap_download_cb.h
+++ b/src/common/public/oscap_download_cb.h
@@ -22,11 +22,13 @@
 #ifndef OSCAP_DOWNLOAD_CB_H_
 #define OSCAP_DOWNLOAD_CB_H_
 
+#include "oscap_export.h"
+
 /**
  * Type of the function used to report progress of download.
  * @param warning indicates whether the message is rather warning or notice
  * @param format printf-like format string
  */
-typedef void (*download_progress_calllback_t) (bool warning, const char * format, ...);
+OSCAP_API typedef void (*download_progress_calllback_t) (bool warning, const char * format, ...);
 
 #endif

--- a/src/common/public/oscap_error.h
+++ b/src/common/public/oscap_error.h
@@ -30,9 +30,9 @@
  * and textual description. Example of usage:
  *
  * @code
- * syschar = oval_probe_object_eval (pctx, object);
+OSCAP_API  * syschar = oval_probe_object_eval (pctx, object);
  * if (syschar == NULL && oscap_err()) {
- *     printf("Error: (%d) %s\n", oscap_err_family(), oscap_err_desc());
+OSCAP_API  *     printf("Error: (%d) %s\n", oscap_err_family(), oscap_err_desc());
  * }
  * oscap_clearerr()
  * @endcode
@@ -44,6 +44,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+
+#include "oscap_export.h"
 
 /// Error family type
 typedef uint16_t oscap_errfamily_t;
@@ -66,22 +68,22 @@ typedef uint16_t oscap_errfamily_t;
 /**
  * Clear an error.
  */
-void oscap_clearerr(void);
+OSCAP_API void oscap_clearerr(void);
 
 /**
  * Check for an error.
  */
-bool oscap_err(void);
+OSCAP_API bool oscap_err(void);
 
 /**
  * Get last error family.
  */
-oscap_errfamily_t oscap_err_family(void);
+OSCAP_API oscap_errfamily_t oscap_err_family(void);
 
 /**
  * Get last error description.
  */
-const char *oscap_err_desc(void);
+OSCAP_API const char *oscap_err_desc(void);
 
 /**
  * Get the full description for all the errors which has occured in this
@@ -91,7 +93,7 @@ const char *oscap_err_desc(void);
  * be disposed by caller.
  * @retval NULL if there are no errors.
  */
-char *oscap_err_get_full_error(void);
+OSCAP_API char *oscap_err_get_full_error(void);
 
 /// @}
 /// @}

--- a/src/common/public/oscap_export.h
+++ b/src/common/public/oscap_export.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 Red Hat Inc., Durham, North Carolina.
+ * Copyright 2017 Red Hat Inc., Durham, North Carolina.
  * All Rights Reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -17,35 +17,29 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  * Authors:
- *      "Daniel Kopecek" <dkopecek@redhat.com>
+ *    Jan Černý <jcerny@redhat.com>
  */
 
-#pragma once
-#ifndef SEAP_ERROR_H
-#define SEAP_ERROR_H
+#ifndef OSCAP_API_H
+#define OSCAP_API_H
 
-#include <stdint.h>
-#include "oscap_export.h"
-
-#ifdef __cplusplus
-extern "C" {
+/**
+ * OSCAP_API macro
+ *
+ * OSCAP_API is a macro that marks every public function in OpenSCAP API.
+ * Functions marked with OSCAP_API will be exported to the shared library
+ * interface.
+ */
+#ifndef OSCAP_API
+#  if defined(_WIN32) && defined(_MSC_VER)
+#    ifdef OSCAP_BUILD_SHARED /* build DLL */
+#      define OSCAP_API __declspec(dllexport)
+#    else /* use DLL */
+#      define OSCAP_API __declspec(dllimport)
+#    endif
+#  else
+#    define OSCAP_API
+#  endif
 #endif
 
-struct SEAP_err {
-        SEAP_msgid_t id;
-        uint32_t     code;
-        uint8_t      type;
-        SEXP_t      *data;
-};
-
-typedef struct SEAP_err SEAP_err_t;
-
-OSCAP_API SEAP_err_t *SEAP_error_new(void);
-OSCAP_API SEAP_err_t *SEAP_error_clone(SEAP_err_t *e);
-OSCAP_API void SEAP_error_free(SEAP_err_t *e);
-
-#ifdef __cplusplus
-}
 #endif
-
-#endif /* SEAP_ERROR_H */

--- a/src/common/public/oscap_reference.h
+++ b/src/common/public/oscap_reference.h
@@ -25,6 +25,8 @@
 #ifndef OSCAP_REFERENCE_H_
 #define OSCAP_REFERENCE_H_
 
+#include "oscap_export.h"
+
 /**
  * Dublin Core reference
  */
@@ -33,89 +35,89 @@ struct oscap_reference;
 /// @see oscap_reference
 struct oscap_reference_iterator;
 /// @memberof oscap_reference_iterator
-bool oscap_reference_iterator_has_more(struct oscap_reference_iterator *it);
+OSCAP_API bool oscap_reference_iterator_has_more(struct oscap_reference_iterator *it);
 /// @memberof oscap_reference_iterator
-struct oscap_reference *oscap_reference_iterator_next(struct oscap_reference_iterator *it);
+OSCAP_API struct oscap_reference *oscap_reference_iterator_next(struct oscap_reference_iterator *it);
 /// @memberof oscap_reference_iterator
-void oscap_reference_iterator_free(struct oscap_reference_iterator *it);
+OSCAP_API void oscap_reference_iterator_free(struct oscap_reference_iterator *it);
 /// @memberof oscap_reference_iterator
-void oscap_reference_iterator_reset(struct oscap_reference_iterator *it);
+OSCAP_API void oscap_reference_iterator_reset(struct oscap_reference_iterator *it);
 
 /// @memberof oscap_reference
-struct oscap_reference *oscap_reference_new(void);
+OSCAP_API struct oscap_reference *oscap_reference_new(void);
 /// @memberof oscap_reference
-void oscap_reference_free(struct oscap_reference *ref);
+OSCAP_API void oscap_reference_free(struct oscap_reference *ref);
 /// @memberof oscap_reference
-struct oscap_reference *oscap_reference_clone(const struct oscap_reference *ref);
+OSCAP_API struct oscap_reference *oscap_reference_clone(const struct oscap_reference *ref);
 
 /// @memberof oscap_reference
-bool oscap_reference_get_is_dublincore(const struct oscap_reference *item);
+OSCAP_API bool oscap_reference_get_is_dublincore(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_is_dublincore(struct oscap_reference *obj, bool newval);
+OSCAP_API bool oscap_reference_set_is_dublincore(struct oscap_reference *obj, bool newval);
 
 /// @memberof oscap_reference
-const char *oscap_reference_get_href(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_href(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_href(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_href(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_title(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_title(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_title(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_title(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_creator(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_creator(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_creator(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_creator(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_subject(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_subject(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_subject(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_subject(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_description(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_description(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_description(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_description(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_publisher(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_publisher(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_publisher(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_publisher(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_contributor(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_contributor(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_contributor(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_contributor(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_date(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_date(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_date(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_date(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_type(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_type(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_type(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_type(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_format(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_format(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_format(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_format(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_identifier(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_identifier(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_identifier(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_identifier(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_source(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_source(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_source(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_source(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_language(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_language(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_language(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_language(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_relation(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_relation(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_relation(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_relation(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_coverage(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_coverage(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_coverage(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_coverage(struct oscap_reference *obj, const char *newval);
 /// @memberof oscap_reference
-const char *oscap_reference_get_rights(const struct oscap_reference *item);
+OSCAP_API const char *oscap_reference_get_rights(const struct oscap_reference *item);
 /// @memberof oscap_reference
-bool oscap_reference_set_rights(struct oscap_reference *obj, const char *newval);
+OSCAP_API bool oscap_reference_set_rights(struct oscap_reference *obj, const char *newval);
 
 #endif

--- a/src/common/public/oscap_text.h
+++ b/src/common/public/oscap_text.h
@@ -39,6 +39,7 @@
 #define OSCAP_TEXT_H_
 
 #include <stdbool.h>
+#include "oscap_export.h"
 
 /**
  * @name Common language codes
@@ -70,14 +71,14 @@ struct oscap_stringlist;
  * @param encoding - language encoding (@see oscap_text_encoding)
  * @memberof oscap_text
  */
-struct oscap_text *oscap_text_new(void);
+OSCAP_API struct oscap_text *oscap_text_new(void);
 
 /**
  * Clone an internationalized text field.
  * @param text oscap_text structure to clone
  * @memberof oscap_text
  */
-struct oscap_text *oscap_text_clone(const struct oscap_text * text);
+OSCAP_API struct oscap_text *oscap_text_clone(const struct oscap_text * text);
 
 /**
  * Create an internationalized text field with HTML content.
@@ -85,13 +86,13 @@ struct oscap_text *oscap_text_clone(const struct oscap_text * text);
  * @param encoding - language encoding (@see oscap_text_encoding)
  * @memberof oscap_text
  */
-struct oscap_text *oscap_text_new_html(void);
+OSCAP_API struct oscap_text *oscap_text_new_html(void);
 
 /**
  * Release an internationalized text field.
  * @memberof oscap_text
  */
-void oscap_text_free(struct oscap_text *);
+OSCAP_API void oscap_text_free(struct oscap_text *);
 
 /************************************************************/
 /**
@@ -102,41 +103,41 @@ void oscap_text_free(struct oscap_text *);
  * */
 
 /// @memberof oscap_stringlist
-struct oscap_string_iterator *oscap_stringlist_get_strings(const struct oscap_stringlist* list);
+OSCAP_API struct oscap_string_iterator *oscap_stringlist_get_strings(const struct oscap_stringlist* list);
 /// @memberof oscap_stringlist
-struct oscap_stringlist *oscap_stringlist_clone(struct oscap_stringlist *list);
+OSCAP_API struct oscap_stringlist *oscap_stringlist_clone(struct oscap_stringlist *list);
 
 /// @memberof oscap_text
-const char *oscap_text_get_text(const struct oscap_text *text);
+OSCAP_API const char *oscap_text_get_text(const struct oscap_text *text);
 /// @memberof oscap_text
-const char *oscap_text_get_lang(const struct oscap_text *text);
+OSCAP_API const char *oscap_text_get_lang(const struct oscap_text *text);
 /**
  * Get plaintext representation of the text.
  * Caller is responsible for freeing returned string.
  * @memberof oscap_text
  */
-char *oscap_text_get_plaintext(const struct oscap_text *text);
+OSCAP_API char *oscap_text_get_plaintext(const struct oscap_text *text);
 
 /**
  * Does this text posses a HTML content?
  * @memberof oscap_text
  */
-bool oscap_text_get_is_html(const struct oscap_text *text);
+OSCAP_API bool oscap_text_get_is_html(const struct oscap_text *text);
 /**
  * Can this text contain substitutions?
  * @memberof oscap_text
  */
-bool oscap_text_get_can_substitute(const struct oscap_text *text);
+OSCAP_API bool oscap_text_get_can_substitute(const struct oscap_text *text);
 /**
  * Can this text override parent content?
  * @memberof oscap_text
  */
-bool oscap_text_get_can_override(const struct oscap_text *text);
+OSCAP_API bool oscap_text_get_can_override(const struct oscap_text *text);
 /**
  * Does this text override parent content?
  * @memberof oscap_text
  */
-bool oscap_text_get_overrides(const struct oscap_text *text);
+OSCAP_API bool oscap_text_get_overrides(const struct oscap_text *text);
 
 /************************************************************/
 /** @} End of Getters group */
@@ -153,19 +154,19 @@ bool oscap_text_get_overrides(const struct oscap_text *text);
  * Set whether this text overrides parent content.
  * @memberof oscap_text
  */
-bool oscap_text_set_overrides(struct oscap_text *text, bool overrides);
+OSCAP_API bool oscap_text_set_overrides(struct oscap_text *text, bool overrides);
 
 /// @memberof oscap_text
-bool oscap_text_set_text(struct oscap_text *text, const char * string);
+OSCAP_API bool oscap_text_set_text(struct oscap_text *text, const char * string);
 /// @memberof oscap_text
-bool oscap_text_set_lang(struct oscap_text *text, const char *string);
+OSCAP_API bool oscap_text_set_lang(struct oscap_text *text, const char *string);
 
 /// @memberof oscap_stringlist
-bool oscap_stringlist_add_string(struct oscap_stringlist* list, const char *str);
+OSCAP_API bool oscap_stringlist_add_string(struct oscap_stringlist* list, const char *str);
 /// @memberof oscap_stringlist
-struct oscap_stringlist * oscap_stringlist_new(void);
+OSCAP_API struct oscap_stringlist * oscap_stringlist_new(void);
 /// @memberof oscap_stringlist
-void oscap_stringlist_free(struct oscap_stringlist *list);
+OSCAP_API void oscap_stringlist_free(struct oscap_stringlist *list);
 
 
 /************************************************************/
@@ -183,15 +184,15 @@ void oscap_stringlist_free(struct oscap_stringlist *list);
  */
 struct oscap_text_iterator;
 /// @memberof oscap_text_iterator
-struct oscap_text *oscap_text_iterator_next(struct oscap_text_iterator *it);
+OSCAP_API struct oscap_text *oscap_text_iterator_next(struct oscap_text_iterator *it);
 /// @memberof oscap_text_iterator
-bool oscap_text_iterator_has_more(struct oscap_text_iterator *it);
+OSCAP_API bool oscap_text_iterator_has_more(struct oscap_text_iterator *it);
 /// @memberof oscap_text_iterator
-void oscap_text_iterator_free(struct oscap_text_iterator *it);
+OSCAP_API void oscap_text_iterator_free(struct oscap_text_iterator *it);
 /// @memberof oscap_text_iterator
-void oscap_text_iterator_remove(struct oscap_text_iterator *it);
+OSCAP_API void oscap_text_iterator_remove(struct oscap_text_iterator *it);
 /// @memberof oscap_text_iterator
-void oscap_text_iterator_reset(struct oscap_text_iterator *it);
+OSCAP_API void oscap_text_iterator_reset(struct oscap_text_iterator *it);
 
 /**
  * @struct oscap_string_iterator
@@ -202,15 +203,15 @@ void oscap_text_iterator_reset(struct oscap_text_iterator *it);
  */
 struct oscap_string_iterator;
 /// @memberof oscap_string_iterator
-const char *oscap_string_iterator_next(struct oscap_string_iterator *it);
+OSCAP_API const char *oscap_string_iterator_next(struct oscap_string_iterator *it);
 /// @memberof oscap_string_iterator
-bool oscap_string_iterator_has_more(struct oscap_string_iterator *it);
+OSCAP_API bool oscap_string_iterator_has_more(struct oscap_string_iterator *it);
 /// @memberof oscap_string_iterator
-void oscap_string_iterator_free(struct oscap_string_iterator *it);
+OSCAP_API void oscap_string_iterator_free(struct oscap_string_iterator *it);
 /// @memberof oscap_string_iterator
-void oscap_string_iterator_remove(struct oscap_string_iterator *it);
+OSCAP_API void oscap_string_iterator_remove(struct oscap_string_iterator *it);
 /// @memberof oscap_string_iterator
-void oscap_string_iterator_reset(struct oscap_string_iterator *it);
+OSCAP_API void oscap_string_iterator_reset(struct oscap_string_iterator *it);
 
 /**
  * @struct oscap_stringlist_iterator
@@ -219,15 +220,15 @@ void oscap_string_iterator_reset(struct oscap_string_iterator *it);
  */
 struct oscap_stringlist_iterator;
 /// @memberof oscap_stringlist_iterator
-struct oscap_stringlist *oscap_stringlist_iterator_next(struct oscap_stringlist_iterator *it);
+OSCAP_API struct oscap_stringlist *oscap_stringlist_iterator_next(struct oscap_stringlist_iterator *it);
 /// @memberof oscap_stringlist_iterator
-bool oscap_stringlist_iterator_has_more(struct oscap_stringlist_iterator *it);
+OSCAP_API bool oscap_stringlist_iterator_has_more(struct oscap_stringlist_iterator *it);
 /// @memberof oscap_stringlist_iterator
-void oscap_stringlist_iterator_free(struct oscap_stringlist_iterator *it);
+OSCAP_API void oscap_stringlist_iterator_free(struct oscap_stringlist_iterator *it);
 /// @memberof oscap_stringlist_iterator
-void oscap_stringlist_iterator_remove(struct oscap_stringlist_iterator *it);
+OSCAP_API void oscap_stringlist_iterator_remove(struct oscap_stringlist_iterator *it);
 /// @memberof oscap_stringlist_iterator
-void oscap_stringlist_iterator_reset(struct oscap_stringlist_iterator *it);
+OSCAP_API void oscap_stringlist_iterator_reset(struct oscap_stringlist_iterator *it);
 
 /************************************************************/
 /** @} End of Iterators group */
@@ -244,7 +245,7 @@ void oscap_stringlist_iterator_reset(struct oscap_stringlist_iterator *it);
  * returned. If nothing is found, plaintext representation of the first text in
  * the list is returned. If the textlist is empty, NULL is returned.
  */
-char* oscap_textlist_get_preferred_plaintext(struct oscap_text_iterator* texts, const char* preferred_lang);
+OSCAP_API char* oscap_textlist_get_preferred_plaintext(struct oscap_text_iterator* texts, const char* preferred_lang);
 
 /**
  * @brief gets oscap_text representing given textlist
@@ -252,7 +253,7 @@ char* oscap_textlist_get_preferred_plaintext(struct oscap_text_iterator* texts, 
  * Similar to @ref oscap_textlist_get_preferred_plaintext but returns oscap_text
  * instead of just the plaintext.
  */
-struct oscap_text *oscap_textlist_get_preferred_text(struct oscap_text_iterator *texts, const char *preferred_lang);
+OSCAP_API struct oscap_text *oscap_textlist_get_preferred_text(struct oscap_text_iterator *texts, const char *preferred_lang);
 
 
 /** @} */

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -30,6 +30,7 @@
 #include "alloc.h"
 #include <stdarg.h>
 #include <string.h>
+#include "oscap_export.h"
 
 #ifndef __attribute__nonnull__
 #define __attribute__nonnull__(x) assert((x) != NULL)
@@ -361,7 +362,7 @@ char *oscap_vsprintf(const char *fmt, va_list ap);
 OSCAP_HIDDEN_END;
 
 /// Print to a newly allocated string using varialbe arguments.
-char *oscap_sprintf(const char *fmt, ...);
+OSCAP_API char *oscap_sprintf(const char *fmt, ...);
 
 OSCAP_HIDDEN_START;
 
@@ -408,7 +409,7 @@ OSCAP_HIDDEN_END;
  * @param str string to be converted
  * @memberof oscap_string_map
  */
-int oscap_string_to_enum(const struct oscap_string_map *map, const char *str);
+OSCAP_API int oscap_string_to_enum(const struct oscap_string_map *map, const char *str);
 
 /**
  * Convert an enumeration constant to its corresponding string representation.
@@ -416,7 +417,7 @@ int oscap_string_to_enum(const struct oscap_string_map *map, const char *str);
  * @param val value to be converted
  * @memberof oscap_string_map
  */
-const char *oscap_enum_to_string(const struct oscap_string_map *map, int val);
+OSCAP_API const char *oscap_enum_to_string(const struct oscap_string_map *map, int val);
 
 /**
  * Split a string.
@@ -426,7 +427,7 @@ const char *oscap_enum_to_string(const struct oscap_string_map *map, int val);
  * @param str String we want to split
  * @param delim Delimiter of string parts
  */
-char **oscap_split(char *str, const char *delim);
+OSCAP_API char **oscap_split(char *str, const char *delim);
 
 /**
  * Return the canonicalized absolute pathname.
@@ -434,13 +435,13 @@ char **oscap_split(char *str, const char *delim);
  * @param resolved_path pointer to a buffer
  * @return resolved_path or NULL in case of error
  */
-char *oscap_realpath(const char *path, char *resolved_path);
+OSCAP_API char *oscap_realpath(const char *path, char *resolved_path);
 
 /**
  * Return filename component of a path
  * @param path path
  * @return filename component of path
  */
-char *oscap_basename(char *path);
+OSCAP_API char *oscap_basename(char *path);
 
 #endif				/* OSCAP_UTIL_H_ */

--- a/src/source/public/oscap_source.h
+++ b/src/source/public/oscap_source.h
@@ -29,6 +29,7 @@
 #include <stddef.h>
 
 #include "oscap.h"
+#include "oscap_export.h"
 
 /**
  * The oscap_source is low-level structure. The oscap_source shall hold
@@ -64,7 +65,7 @@ struct oscap_source;
  * @param filepath Path to the file on a disk
  * @returns newly created oscap_source structure
  */
-struct oscap_source *oscap_source_new_from_file(const char *filepath);
+OSCAP_API struct oscap_source *oscap_source_new_from_file(const char *filepath);
 
 /**
  * Create new oscap_source from raw memory. The memory can contain \0 bytes
@@ -79,20 +80,20 @@ struct oscap_source *oscap_source_new_from_file(const char *filepath);
  * @param filepath Suggested filename for the file or NULL
  * @returns newly created oscap_source_structure
  */
-struct oscap_source *oscap_source_new_from_memory(const char *buffer, size_t size, const char *filepath);
+OSCAP_API struct oscap_source *oscap_source_new_from_memory(const char *buffer, size_t size, const char *filepath);
 
 /**
  * Clone oscap_source structure.
  * @param old Resource to clone
  * @returns A clone of the given oscap_source.
  */
-struct oscap_source *oscap_source_clone(struct oscap_source *old);
+OSCAP_API struct oscap_source *oscap_source_clone(struct oscap_source *old);
 
 /**
  * Dispose oscap_source structure.
  * @param source Resource to dispose
  */
-void oscap_source_free(struct oscap_source *source);
+OSCAP_API void oscap_source_free(struct oscap_source *source);
 
 /**
  * Get filepath of the given resource
@@ -100,7 +101,7 @@ void oscap_source_free(struct oscap_source *source);
  * @param source
  * @returns filepath of the original source or NULL
  */
-const char *oscap_source_get_filepath(struct oscap_source *source);
+OSCAP_API const char *oscap_source_get_filepath(struct oscap_source *source);
 
 /**
  * Get SCAP document type of the given resource
@@ -112,7 +113,7 @@ const char *oscap_source_get_filepath(struct oscap_source *source);
  * This function returns OSCAP_DOCUMENT_UNKNOWN to signal an error. Not being
  * able to determine a valid documnent type is treated as an error.
  */
-oscap_document_type_t oscap_source_get_scap_type(struct oscap_source *source);
+OSCAP_API oscap_document_type_t oscap_source_get_scap_type(struct oscap_source *source);
 
 /**
  * Get the version of the schema for the particular document type
@@ -120,7 +121,7 @@ oscap_document_type_t oscap_source_get_scap_type(struct oscap_source *source);
  * @param source The oscap_source to get the schema version from.
  * @returns the schema version
  */
-const char *oscap_source_get_schema_version(struct oscap_source *source);
+OSCAP_API const char *oscap_source_get_schema_version(struct oscap_source *source);
 
 /**
  * Validate the SCAP document against particular XML schema definition.
@@ -129,7 +130,7 @@ const char *oscap_source_get_schema_version(struct oscap_source *source);
  * @note The held resource has to be XML for this function to work.
  * @returns 0 on pass; 1 on fail, and -1 on internal error
  */
-int oscap_source_validate(struct oscap_source *source, xml_reporter reporter, void *user);
+OSCAP_API int oscap_source_validate(struct oscap_source *source, xml_reporter reporter, void *user);
 
 /**
  * Validate the SCAP document against schematron assertions
@@ -139,7 +140,7 @@ int oscap_source_validate(struct oscap_source *source, xml_reporter reporter, vo
  * @note The held resource has to be XML for this function to work.
  * @returns 0 on pass; 1 on fail, and -1 on internal error
  */
-int oscap_source_validate_schematron(struct oscap_source *source, const char *outfile);
+OSCAP_API int oscap_source_validate_schematron(struct oscap_source *source, const char *outfile);
 
 /**
  * Returns human readable description of oscap_source origin
@@ -147,7 +148,7 @@ int oscap_source_validate_schematron(struct oscap_source *source, const char *ou
  * @param source The oscap_source to get readable source from.
  * @returns human readable description
  */
-const char *oscap_source_readable_origin(const struct oscap_source *source);
+OSCAP_API const char *oscap_source_readable_origin(const struct oscap_source *source);
 
 /**
  * Store the resource represented by oscap_source to the file.
@@ -157,7 +158,7 @@ const char *oscap_source_readable_origin(const struct oscap_source *source);
  * be used if filename is NULL.
  * @returns 0 on success, 1 or -1 to indicate error
  */
-int oscap_source_save_as(struct oscap_source *source, const char *filename);
+OSCAP_API int oscap_source_save_as(struct oscap_source *source, const char *filename);
 
 /**
  * Retrieve contents refered to by oscap_source as raw memory.
@@ -171,6 +172,6 @@ int oscap_source_save_as(struct oscap_source *source, const char *filename);
  * @param size Will be filled with size of the buffer
  * @returns 0 on success, 1 otherwise
  */
-int oscap_source_get_raw_memory(struct oscap_source *source, char **buffer, size_t *size);
+OSCAP_API int oscap_source_get_raw_memory(struct oscap_source *source, char **buffer, size_t *size);
 
 #endif

--- a/swig/openscap.i
+++ b/swig/openscap.i
@@ -26,6 +26,9 @@
  *
  */
 
+/* Define OSCAP_API as an empty string */
+/* Prevents 'Syntax error in input(1).' message */
+#define OSCAP_API
 
 /* Convert a tuple element to a C array */
 /* SWIG can't understand __attribute__(x), so we make it go away */


### PR DESCRIPTION
OSCAP_API is a macro that marks every public function in OpenSCAP API.
Functions marked with OSCAP_API will be exported to the shared library
interface.