### PR TITLE
Remove OSCAP_GSYM macro

### DIFF
--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -50,7 +50,7 @@
 #include "oval_probe_ext.h"
 #include "collectVarRefs_impl.h"
 
-oval_probe_meta_t OSCAP_GSYM(__probe_meta)[] = {
+oval_probe_meta_t __probe_meta[] = {
         { OVAL_SUBTYPE_SYSINFO, "system_info", &oval_probe_sys_handler, OVAL_PROBEMETA_EXTERNAL, "probe_system_info" },
         OVAL_PROBE_EXTERNAL(OVAL_INDEPENDENT_FAMILY, "family"),
         OVAL_PROBE_EXTERNAL(OVAL_INDEPENDENT_FILE_MD5, "filemd5"),
@@ -94,14 +94,14 @@ oval_probe_meta_t OSCAP_GSYM(__probe_meta)[] = {
         OVAL_PROBE_EXTERNAL(OVAL_UNIX_SYMLINK, "symlink")
 };
 
-#define __PROBE_META_COUNT (sizeof OSCAP_GSYM(__probe_meta)/sizeof OSCAP_GSYM(__probe_meta)[0])
+#define __PROBE_META_COUNT (sizeof __probe_meta/sizeof __probe_meta[0])
 
-size_t OSCAP_GSYM(__probe_meta_count) = __PROBE_META_COUNT;
-oval_subtypedsc_t OSCAP_GSYM(__s2n_tbl)[__PROBE_META_COUNT];
-oval_subtypedsc_t OSCAP_GSYM(__n2s_tbl)[__PROBE_META_COUNT];
+size_t __probe_meta_count = __PROBE_META_COUNT;
+oval_subtypedsc_t __s2n_tbl[__PROBE_META_COUNT];
+oval_subtypedsc_t __n2s_tbl[__PROBE_META_COUNT];
 
-#define __s2n_tbl_count OSCAP_GSYM(__probe_meta_count)
-#define __n2s_tbl_count OSCAP_GSYM(__probe_meta_count)
+#define __s2n_tbl_count __probe_meta_count
+#define __n2s_tbl_count __probe_meta_count
 
 static int __s2n_tbl_cmp(oval_subtype_t *type, oval_subtypedsc_t *dsc)
 {
@@ -119,8 +119,8 @@ static int __n2s_tbl_cmp(const char *name, oval_subtypedsc_t *dsc)
  * of memory used by this cache is done at exit using a hook
  * registered with atexit().
  */
-probe_ncache_t  *OSCAP_GSYM(ncache) = NULL;
-struct id_desc_t OSCAP_GSYM(id_desc);
+probe_ncache_t  *ncache = NULL;
+struct id_desc_t id_desc;
 
 #if defined(OSCAP_THREAD_SAFE)
 # include <pthread.h>
@@ -145,17 +145,17 @@ void oval_probe_tblinit(void)
 {
         register size_t i;
 
-        for(i = 0; i < OSCAP_GSYM(__probe_meta_count); ++i) {
-                OSCAP_GSYM(__s2n_tbl)[i].type = OSCAP_GSYM(__probe_meta)[i].otype;
-                OSCAP_GSYM(__n2s_tbl)[i].type = OSCAP_GSYM(__probe_meta)[i].otype;
-                OSCAP_GSYM(__s2n_tbl)[i].name = OSCAP_GSYM(__probe_meta)[i].stype;
-                OSCAP_GSYM(__n2s_tbl)[i].name = OSCAP_GSYM(__probe_meta)[i].stype;
+        for(i = 0; i < __probe_meta_count; ++i) {
+                __s2n_tbl[i].type = __probe_meta[i].otype;
+                __n2s_tbl[i].type = __probe_meta[i].otype;
+                __s2n_tbl[i].name = __probe_meta[i].stype;
+                __n2s_tbl[i].name = __probe_meta[i].stype;
         }
 
-        qsort(OSCAP_GSYM(__s2n_tbl), OSCAP_GSYM(__probe_meta_count), sizeof (oval_subtypedsc_t),
+        qsort(__s2n_tbl, __probe_meta_count, sizeof (oval_subtypedsc_t),
               (int(*)(const void *, const void *))__s2n_tbl_sortcmp);
 
-        qsort(OSCAP_GSYM(__n2s_tbl), OSCAP_GSYM(__probe_meta_count), sizeof (oval_subtypedsc_t),
+        qsort(__n2s_tbl, __probe_meta_count, sizeof (oval_subtypedsc_t),
               (int(*)(const void *, const void *))__n2s_tbl_sortcmp);
 }
 
@@ -179,7 +179,7 @@ oval_subtype_t oval_str_to_subtype(const char *str)
 
         __init_once();
 
-        d = oscap_bfind(OSCAP_GSYM(__n2s_tbl), __n2s_tbl_count, sizeof(oval_subtypedsc_t), (void *)str,
+        d = oscap_bfind(__n2s_tbl, __n2s_tbl_count, sizeof(oval_subtypedsc_t), (void *)str,
                         (int(*)(void *, void *))__n2s_tbl_cmp);
 
         return (d == NULL ? OVAL_SUBTYPE_UNKNOWN : d->type);
@@ -482,7 +482,7 @@ static int oval_probe_query_criteria(oval_probe_session_t *sess, struct oval_cri
 #if 0
 const oval_probe_meta_t * const oval_probe_meta_get(void)
 {
-    return (const oval_probe_meta_t * const)OSCAP_GSYM(__probe_meta);
+    return (const oval_probe_meta_t * const)__probe_meta;
 }
 #endif
 
@@ -490,7 +490,7 @@ void oval_probe_meta_list(FILE *output, int flags)
 {
 	register size_t i;
 	const char *probe_dir;
-	oval_probe_meta_t *meta = OSCAP_GSYM(__probe_meta);
+	oval_probe_meta_t *meta = __probe_meta;
 	size_t probe_dirlen;
 	char probe_path[PATH_MAX+1];
 
@@ -502,7 +502,7 @@ void oval_probe_meta_list(FILE *output, int flags)
 	probe_dirlen = strlen(probe_dir);
 	assume_r(probe_dirlen + 1 <= PATH_MAX, /* void */);
 
-	for (i = 0; i < OSCAP_GSYM(__probe_meta_count); ++i) {
+	for (i = 0; i < __probe_meta_count; ++i) {
 		if (meta[i].flags & OVAL_PROBEMETA_EXTERNAL) {
 			strncpy(probe_path, probe_dir, PATH_MAX);
 			probe_path[probe_dirlen] = '/';

--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -992,34 +992,34 @@ int oval_probe_ext_init(oval_pext_t *pext)
                         goto _ret;
 		}
 
-		pext->pdsc = malloc(sizeof(oval_pdsc_t) * OSCAP_GSYM(__probe_meta_count));
+		pext->pdsc = malloc(sizeof(oval_pdsc_t) * __probe_meta_count);
 
-                dD("__probe_meta_count = %zu", OSCAP_GSYM(__probe_meta_count));
+                dD("__probe_meta_count = %zu", __probe_meta_count);
 
-		for (r = 0, i = 0; i < OSCAP_GSYM(__probe_meta_count); ++i) {
-                        if (!(OSCAP_GSYM(__probe_meta)[i].flags & OVAL_PROBEMETA_EXTERNAL)) {
-                                dD("skipped: %s (not an external probe)", OSCAP_GSYM(__probe_meta)[i].stype);
+		for (r = 0, i = 0; i < __probe_meta_count; ++i) {
+                        if (!(__probe_meta[i].flags & OVAL_PROBEMETA_EXTERNAL)) {
+                                dD("skipped: %s (not an external probe)", __probe_meta[i].stype);
                                 continue;
                         }
 
-			if (stat(OSCAP_GSYM(__probe_meta)[i].pname, &st) != 0) {
-				dD("skipped: %s (stat failed, errno=%d)", OSCAP_GSYM(__probe_meta)[i].stype, errno);
+			if (stat(__probe_meta[i].pname, &st) != 0) {
+				dD("skipped: %s (stat failed, errno=%d)", __probe_meta[i].stype, errno);
 				continue;
 			}
 
 			if (!S_ISREG(st.st_mode)) {
-				dD("skipped: %s (not a regular file)", OSCAP_GSYM(__probe_meta)[i].stype);
+				dD("skipped: %s (not a regular file)", __probe_meta[i].stype);
 				continue;
 			}
 
-                        pext->pdsc[r].type = OSCAP_GSYM(__probe_meta)[i].otype;
-                        pext->pdsc[r].name = OSCAP_GSYM(__probe_meta)[i].stype;
-                        pext->pdsc[r].file = OSCAP_GSYM(__probe_meta)[i].pname;
+                        pext->pdsc[r].type = __probe_meta[i].otype;
+                        pext->pdsc[r].name = __probe_meta[i].stype;
+                        pext->pdsc[r].file = __probe_meta[i].pname;
 
 			++r;
 		}
 
-		if (r < OSCAP_GSYM(__probe_meta_count))
+		if (r < __probe_meta_count)
 			pext->pdsc = realloc(pext->pdsc, sizeof(oval_pdsc_t) * r);
 
 		pext->pdsc_cnt = r;

--- a/src/OVAL/oval_probe_ext.h
+++ b/src/OVAL/oval_probe_ext.h
@@ -75,6 +75,6 @@ int oval_probe_ext_abort(SEAP_CTX_t *ctx, oval_pd_t *pd, oval_pext_t *pext);
 int oval_probe_ext_handler(oval_subtype_t type, void *ptr, int act, ...);
 int oval_probe_sys_handler(oval_subtype_t type, void *ptr, int act, ...);
 
-extern const oval_pdsc_t OSCAP_GSYM(default_pdsc)[];
+extern const oval_pdsc_t default_pdsc[];
 
 #endif /* OVAL_PROBE_EXT_H */

--- a/src/OVAL/oval_probe_impl.h
+++ b/src/OVAL/oval_probe_impl.h
@@ -59,7 +59,7 @@ int oval_probe_query_test(oval_probe_session_t *sess, struct oval_test *test);
 
 OSCAP_HIDDEN_END;
 
-extern probe_ncache_t *OSCAP_GSYM(ncache);
+extern probe_ncache_t *ncache;
 
 typedef struct {
         oval_subtype_t type;

--- a/src/OVAL/oval_probe_meta.h
+++ b/src/OVAL/oval_probe_meta.h
@@ -34,10 +34,10 @@ typedef struct {
         const char    *pname;
 } oval_probe_meta_t;
 
-extern oval_probe_meta_t OSCAP_GSYM(__probe_meta)[];
-extern size_t OSCAP_GSYM(__probe_meta_count);
-extern oval_subtypedsc_t OSCAP_GSYM(__s2n_tbl)[];
-extern oval_subtypedsc_t OSCAP_GSYM(__n2s_tbl)[];
+extern oval_probe_meta_t __probe_meta[];
+extern size_t __probe_meta_count;
+extern oval_subtypedsc_t __s2n_tbl[];
+extern oval_subtypedsc_t __n2s_tbl[];
 
 #define OVAL_PROBEMETA_EXTERNAL 0x00000001 /**< pass the `pext' structure to the handler oval_probe_session_new */
 

--- a/src/OVAL/oval_probe_session.c
+++ b/src/OVAL/oval_probe_session.c
@@ -63,7 +63,7 @@ static volatile int __oval_probe_session_init_once = 0;
  */
 static void ncache_libfree(void)
 {
-        probe_ncache_free(OSCAP_GSYM(ncache));
+        probe_ncache_free(ncache);
 }
 
 /**
@@ -71,8 +71,8 @@ static void ncache_libfree(void)
  */
 static void ncache_libinit(void)
 {
-        if (OSCAP_GSYM(ncache) == NULL) {
-                OSCAP_GSYM(ncache) = probe_ncache_new();
+        if (ncache == NULL) {
+                ncache = probe_ncache_new();
                 atexit(ncache_libfree);
         }
 }
@@ -132,17 +132,17 @@ static void oval_probe_session_init(oval_probe_session_t *sess, struct oval_sysc
 
         __init_once();
 
-        dD("__probe_meta_count = %zu", OSCAP_GSYM(__probe_meta_count));
+        dD("__probe_meta_count = %zu", __probe_meta_count);
 
-        for (i = 0; i < OSCAP_GSYM(__probe_meta_count); ++i) {
+        for (i = 0; i < __probe_meta_count; ++i) {
                 handler_arg = NULL;
 
-                if (OSCAP_GSYM(__probe_meta)[i].flags & OVAL_PROBEMETA_EXTERNAL)
+                if (__probe_meta[i].flags & OVAL_PROBEMETA_EXTERNAL)
                         handler_arg = sess->pext;
 
                 oval_probe_handler_set(sess->ph,
-				       OSCAP_GSYM(__probe_meta)[i].otype,
-				       OSCAP_GSYM(__probe_meta)[i].handler, handler_arg);
+				       __probe_meta[i].otype,
+				       __probe_meta[i].handler, handler_arg);
         }
 
         oval_probe_handler_set(sess->ph, OVAL_SUBTYPE_ALL, oval_probe_ext_handler, sess->pext); /* special case for reset */

--- a/src/OVAL/probes/independent/textfilecontent.c
+++ b/src/OVAL/probes/independent/textfilecontent.c
@@ -331,7 +331,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 	pfd.ctx = ctx;
 
 	path_with_root[PATH_MAX] = '\0';
-	if (OSCAP_GSYM(offline_mode) & PROBE_OFFLINE_OWN) {
+	if (offline_mode & PROBE_OFFLINE_OWN) {
 		strncpy(path_with_root, getenv("OSCAP_PROBE_ROOT"), PATH_MAX);
 		root_len = strlen(path_with_root);
 

--- a/src/OVAL/probes/independent/textfilecontent54.c
+++ b/src/OVAL/probes/independent/textfilecontent54.c
@@ -429,7 +429,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 	}
 
 	path_with_root[PATH_MAX] = '\0';
-	if (OSCAP_GSYM(offline_mode) & PROBE_OFFLINE_OWN) {
+	if (offline_mode & PROBE_OFFLINE_OWN) {
 		strncpy(path_with_root, getenv("OSCAP_PROBE_ROOT"), PATH_MAX);
 		root_len = strlen(path_with_root);
 

--- a/src/OVAL/probes/probe-api.c
+++ b/src/OVAL/probes/probe-api.c
@@ -48,11 +48,11 @@
 #include "probe/probe.h"
 #include "SEAP/generic/strto.h"
 
-extern probe_rcache_t  *OSCAP_GSYM(pcache);
-extern probe_ncache_t  *OSCAP_GSYM(ncache);
-extern struct id_desc_t OSCAP_GSYM(id_desc);
-extern probe_option_t *OSCAP_GSYM(probe_optdef);
-extern size_t OSCAP_GSYM(probe_optdef_count);
+extern probe_rcache_t  *pcache;
+extern probe_ncache_t  *ncache;
+extern struct id_desc_t id_desc;
+extern probe_option_t *probe_optdef;
+extern size_t probe_optdef_count;
 
 /*
  * items
@@ -71,7 +71,7 @@ SEXP_t *probe_item_creat(const char *name, SEXP_t * attrs, ...)
 		attrs = va_arg(ap, SEXP_t *);
 		val = va_arg(ap, SEXP_t *);
 
-                ns  = probe_ncache_ref (OSCAP_GSYM(ncache), name);
+                ns  = probe_ncache_ref (ncache, name);
 		ent = SEXP_list_new(NULL);
 
 		if (attrs != NULL) {
@@ -349,7 +349,7 @@ SEXP_t *probe_obj_creat(const char *name, SEXP_t * attrs, ...)
 		attrs = va_arg(ap, SEXP_t *);
 		val = va_arg(ap, SEXP_t *);
 
-                ns  = probe_ncache_ref (OSCAP_GSYM(ncache), name);
+                ns  = probe_ncache_ref (ncache, name);
 		ent = SEXP_list_new(NULL);
 
 		if (attrs != NULL) {
@@ -383,7 +383,7 @@ SEXP_t *probe_obj_new(const char *name, SEXP_t * attrs)
 	SEXP_t *obj, *ns;
 
 	obj = SEXP_list_new(NULL);
-	ns  = probe_ncache_ref (OSCAP_GSYM(ncache), name);
+	ns  = probe_ncache_ref (ncache, name);
 
 	if (attrs != NULL) {
 		SEXP_t *nl, *nj;
@@ -986,7 +986,7 @@ SEXP_t *probe_ent_creat1(const char *name, SEXP_t * attrs, SEXP_t * val)
 	SEXP_t *ent, *ns;
 
 	ent = SEXP_list_new(NULL);
-	ns  = probe_ncache_ref (OSCAP_GSYM(ncache), name);
+	ns  = probe_ncache_ref (ncache, name);
 
 	if (attrs != NULL) {
 		SEXP_t *nl, *nj;
@@ -1511,7 +1511,7 @@ SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attr
                         return (NULL);
                 }
 
-                name_sexp = probe_ncache_ref(OSCAP_GSYM(ncache), value_name);
+                name_sexp = probe_ncache_ref(ncache, value_name);
 
                 while(value_i < multiply) {
                         entity = SEXP_list_new_r(&entity_mem, name_sexp, value_sexp + value_i, NULL);

--- a/src/OVAL/probes/probe/icache.c
+++ b/src/OVAL/probes/probe/icache.c
@@ -184,7 +184,7 @@ static void *probe_icache_worker(void *arg)
 	pair = &pair_mem;
         dD("icache worker ready");
 
-        switch (errno = pthread_barrier_wait(&OSCAP_GSYM(th_barrier)))
+        switch (errno = pthread_barrier_wait(&th_barrier))
         {
         case 0:
         case PTHREAD_BARRIER_SERIAL_THREAD:

--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -76,7 +76,7 @@ void *probe_input_handler(void *arg)
 
         pthread_cleanup_push((void(*)(void *))pthread_attr_destroy, (void *)&pth_attr);
         
-        switch (errno = pthread_barrier_wait(&OSCAP_GSYM(th_barrier)))
+        switch (errno = pthread_barrier_wait(&th_barrier))
         {
         case 0:
         case PTHREAD_BARRIER_SERIAL_THREAD:
@@ -118,14 +118,14 @@ void *probe_input_handler(void *arg)
 		if (oid != NULL) {
 			SEXP_VALIDATE(oid);
 
-			dD("offline_mode=%08x", OSCAP_GSYM(offline_mode));
-			dD("offline_mode_supported=%08x", OSCAP_GSYM(offline_mode_supported));
+			dD("offline_mode=%08x", offline_mode);
+			dD("offline_mode_supported=%08x", offline_mode_supported);
 
-			if ((OSCAP_GSYM(offline_mode) != PROBE_OFFLINE_NONE) &&
-			    !(OSCAP_GSYM(offline_mode) & OSCAP_GSYM(offline_mode_supported))) {
+			if ((offline_mode != PROBE_OFFLINE_NONE) &&
+			    !(offline_mode & offline_mode_supported)) {
 				dW("Requested offline mode is not supported by %s.", probe->name);
 				/* Return a dummy. */
-				probe_out = probe_cobj_new(OSCAP_GSYM(offline_mode_cobjflag), NULL, NULL, NULL);
+				probe_out = probe_cobj_new(offline_mode_cobjflag, NULL, NULL, NULL);
 				probe_ret = 0;
 				SEXP_free(oid);
 				SEXP_free(probe_in);

--- a/src/OVAL/probes/probe/option.c
+++ b/src/OVAL/probes/probe/option.c
@@ -5,13 +5,13 @@
 #include <stdarg.h>
 #include "option.h"
 
-size_t OSCAP_GSYM(probe_optdef_count) = 0;
-probe_option_t *OSCAP_GSYM(probe_optdef) = NULL;
+size_t probe_optdef_count = 0;
+probe_option_t *probe_optdef = NULL;
 
 static int __probe_option_op(int option, int op, va_list ap)
 {
-  probe_option_t* optdef = OSCAP_GSYM(probe_optdef);
-  size_t i, optdef_count = OSCAP_GSYM(probe_optdef_count);
+  probe_option_t* optdef = probe_optdef;
+  size_t i, optdef_count = probe_optdef_count;
   int ret = -1;
 
   for (i = 0; i < optdef_count; ++i) {

--- a/src/OVAL/probes/probe/option.h
+++ b/src/OVAL/probes/probe/option.h
@@ -17,8 +17,8 @@ typedef struct {
   int (*handler)(int, int, va_list);
 } probe_option_t;
 
-extern size_t OSCAP_GSYM(probe_optdef_count);
-extern probe_option_t *OSCAP_GSYM(probe_optdef);
+extern size_t probe_optdef_count;
+extern probe_option_t *probe_optdef;
 
 int probe_setoption(int option, ...);
 int probe_getoption(int option, ...);

--- a/src/OVAL/probes/probe/probe.h
+++ b/src/OVAL/probes/probe/probe.h
@@ -80,9 +80,9 @@ typedef enum {
 	PROBE_OFFLINE_ALL = 0x0f
 } probe_offline_flags;
 
-extern pthread_barrier_t OSCAP_GSYM(th_barrier);
-extern probe_offline_flags OSCAP_GSYM(offline_mode);
-extern probe_offline_flags OSCAP_GSYM(offline_mode_supported);
-extern int OSCAP_GSYM(offline_mode_cobjflag);
+extern pthread_barrier_t th_barrier;
+extern probe_offline_flags offline_mode;
+extern probe_offline_flags offline_mode_supported;
+extern int offline_mode_cobjflag;
 
 #endif /* PROBE_H */

--- a/src/OVAL/probes/probe/signal_handler.c
+++ b/src/OVAL/probes/probe/signal_handler.c
@@ -88,7 +88,7 @@ void *probe_signal_handler(void *arg)
 #endif
        
 	dD("Signal handler ready");
-	switch (errno = pthread_barrier_wait(&OSCAP_GSYM(th_barrier)))
+	switch (errno = pthread_barrier_wait(&th_barrier))
 	{
 	case 0:
 	case PTHREAD_BARRIER_SERIAL_THREAD:

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -37,8 +37,8 @@
 
 #include "worker.h"
 
-extern bool  OSCAP_GSYM(varref_handling);
-extern void *OSCAP_GSYM(probe_arg);
+extern bool  varref_handling;
+extern void *probe_arg;
 
 void *probe_worker_runfn(void *arg)
 {
@@ -931,12 +931,12 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 		pctx.filters = probe_prepare_filters(probe, probe_in);
                 mask = probe_obj_getmask(probe_in);
 
-		if (OSCAP_GSYM(varref_handling))
+		if (varref_handling)
 			varrefs = probe_obj_getent(probe_in, "varrefs", 1);
                 else
                         varrefs = NULL;
 
-		if (varrefs == NULL || !OSCAP_GSYM(varref_handling)) {
+		if (varrefs == NULL || !varref_handling) {
                         /*
                          * Prepare the collected object
                          */

--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -296,7 +296,7 @@ void *probe_init (void)
 		addMacro(NULL, "_dbpath", NULL, dbpath, 0);
 	}
 
-	if (OSCAP_GSYM(offline_mode) & PROBE_OFFLINE_OWN) {
+	if (offline_mode & PROBE_OFFLINE_OWN) {
 		const char* root = getenv("OSCAP_PROBE_ROOT");
 		rpmtsSetRootDir(g_rpm.rpmts, root);
 	}

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -243,7 +243,7 @@ void *probe_init (void)
 
         pthread_mutex_init(&(g_rpm.mutex), NULL);
 
-	if (OSCAP_GSYM(offline_mode) & PROBE_OFFLINE_OWN) {
+	if (offline_mode & PROBE_OFFLINE_OWN) {
 		const char* root = getenv("OSCAP_PROBE_ROOT");
 		rpmtsSetRootDir(g_rpm.rpmts, root);
 	}

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -328,7 +328,7 @@ void *probe_init (void)
 
 	pthread_mutex_init(&(g_rpm.mutex), NULL);
 
-	if (OSCAP_GSYM(offline_mode) & PROBE_OFFLINE_OWN) {
+	if (offline_mode & PROBE_OFFLINE_OWN) {
 		const char* root = getenv("OSCAP_PROBE_ROOT");
 		rpmtsSetRootDir(g_rpm.rpmts, root);
 	}

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -393,8 +393,6 @@ char *oscap_expand_ipv6(const char *input);
 # define OSCAP_CONCAT(a,b) OSCAP_CONCAT1(a,b)
 #endif
 
-#define OSCAP_GSYM(s) OSCAP_CONCAT(___G_, s)
-
 #define protect_errno                                                   \
         for (int OSCAP_CONCAT(__e,__LINE__)=errno, OSCAP_CONCAT(__s,__LINE__)=1; OSCAP_CONCAT(__s,__LINE__)--; errno=OSCAP_CONCAT(__e,__LINE__))
 


### PR DESCRIPTION
OSCAP_GSYM is a macro that adds prefix `___G_` to its argument. It's used for marking some global variables. I haven't found any reason for using it. In my opinion this macro makes code less readable and complicates debugging.