### PR TITLE
tests/API/XCCDF/unittests: added test for Ansible variables

### DIFF
--- a/tests/API/XCCDF/unittests/Makefile.am
+++ b/tests/API/XCCDF/unittests/Makefile.am
@@ -75,6 +75,12 @@ EXTRA_DIST += \
 	test_fix_resultid_by_suffix.xml \
 	test_fix_script_header.sh \
 	test_fix_script_header.xccdf.xml \
+	test_generate_fix_ansible_vars.sh \
+	test_generate_fix_ansible_vars_ds.xml \
+	test_generate_fix_ansible_vars_ds-tailoring.xml \
+	test_generate_fix_ansible_vars_golden.yml \
+	test_generate_fix_ansible_vars_golden_altered.yml \
+	test_generate_fix_ansible_vars_golden_tailoring.yml \
 	test_inherit_selector.oval.xml \
 	test_inherit_selector.sh \
 	test_inherit_selector.tailoring.xml \

--- a/tests/API/XCCDF/unittests/all.sh
+++ b/tests/API/XCCDF/unittests/all.sh
@@ -111,5 +111,6 @@ test_run "generate fix: generate header for bash script" $srcdir/test_fix_script
 test_run "generate fix: from result DataStream" $srcdir/test_fix_arf.sh
 test_run "generate fix: result id selection by suffix" $srcdir/test_fix_resultid_by_suffix.sh
 test_run "generate fix: from result DataStream" $srcdir/test_fix_arf.sh
+test_run "generate fix: Ansible variables sanity" $srcdir/test_generate_fix_ansible_vars.sh
 
 test_exit

--- a/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars.sh
+++ b/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+profile="xccdf_com.example.www_profile_test_ansible_vars"
+profile_tailored="xccdf_com.example.www_profile_test_ansible_vars_tailored"
+ansible_template="urn:xccdf:fix:script:ansible"
+ds="test_generate_fix_ansible_vars_ds.xml"
+tailoring_file="test_generate_fix_ansible_vars_ds-tailoring.xml"
+golden="test_generate_fix_ansible_vars_golden.yml"
+golden_altered="test_generate_fix_ansible_vars_golden_altered.yml"
+golden_tailored="test_generate_fix_ansible_vars_golden_tailoring.yml"
+var="www_value_val1"
+
+name=$(basename $0 .sh)
+playbook=$(mktemp -t ${name}.XXXXXX.yml)
+out=$(mktemp -t ${name}.out.XXXXXX)
+
+
+$OSCAP xccdf generate fix --profile $profile --template $ansible_template \
+	$srcdir/$ds >$playbook 2>$out
+[ -f $out ]; [ ! -s $out ]; :> $out
+[ -f $playbook ]; [ -s $playbook ]
+# Removes comment and blank lines from the generated playbook.
+sed -i '/#.*/d' $playbook
+sed -i '/^[ \t]*$/d' $playbook
+
+# Compares golden playbook with generated playbook to ensure that Ansible
+# variables were generated correctly. Both playbooks must be the same.
+diff -u $srcdir/$golden $playbook >$out
+[ -f $out ]; [ ! -s $out ]; :> $out
+
+# Compares value of Ansible variable $var from the golden altered playbook with
+# the $var from the generated playbook. Values of the Ansible variables $var
+# must differ (altered golden playbook has different value set).
+generated_var=$(grep "$var:" $playbook | sed "s|.*$var:[^0-9]*||")
+golden_altered_var=$(grep "$var:" $srcdir/$golden_altered \
+	| sed "s|.*$var:[^0-9]*||")
+[ "$generated_var" != "$golden_altered_var" ]
+
+
+# Generates Ansible playbook using tailoring file.
+$OSCAP xccdf generate fix --template $ansible_template \
+	--profile $profile_tailored --tailoring-file $srcdir/$tailoring_file \
+	$srcdir/$ds >$playbook 2>$out
+[ -f $out ]; [ ! -s $out ]; :> $out
+[ -f $playbook ]; [ -s $playbook ]
+# Removes comment and blank lines from the generated playbook.
+sed -i '/#.*/d' $playbook
+sed -i '/^[ \t]*$/d' $playbook
+
+# Compares golden tailored playbook with generated playbook to ensure that only
+# tailored Ansible variables are generated in the playbook. Both playbooks must
+# be the same.
+diff -u $srcdir/$golden_tailored $playbook >$out
+[ -f $out ]; [ ! -s $out ]; :> $out
+
+
+rm $playbook $out

--- a/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_ds-tailoring.xml
+++ b/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_ds-tailoring.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xccdf:Tailoring xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
+  <xccdf:benchmark href="/home/matus/test_generate_fix_ansible_vars_ds.xml"/>
+  <xccdf:version time="2018-01-11T10:42:04">1</xccdf:version>
+  <xccdf:Profile id="xccdf_com.example.www_profile_test_ansible_vars_tailored" extends="xccdf_com.example.www_profile_test_ansible_vars">
+    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">xccdf_test_profile [CUSTOMIZED]</xccdf:title>
+    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This profile is for testing.</xccdf:description>
+    <xccdf:select idref="xccdf_com.example.www_rule_default2" selected="false"/>
+    <xccdf:set-value idref="xccdf_com.example.www_value_val1">200</xccdf:set-value>
+  </xccdf:Profile>
+</xccdf:Tailoring>

--- a/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_ds.xml
+++ b/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_ds.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ds:data-stream-collection xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" id="scap_org.open-scap_collection_from_xccdf_test_ansible_vars.xccdf.xml" schematron-version="1.2"><ds:data-stream id="scap_org.open-scap_datastream_from_xccdf_test_ansible_vars.xccdf.xml" scap-version="1.2" use-case="OTHER"><ds:checklists><ds:component-ref id="scap_org.open-scap_cref_test_ansible_vars.xccdf.xml" xlink:href="#scap_org.open-scap_comp_test_ansible_vars.xccdf.xml"><cat:catalog><cat:uri name="test_ansible_vars.oval.xml" uri="#scap_org.open-scap_cref_test_ansible_vars.oval.xml"/></cat:catalog></ds:component-ref></ds:checklists><ds:checks><ds:component-ref id="scap_org.open-scap_cref_test_ansible_vars.oval.xml" xlink:href="#scap_org.open-scap_comp_test_ansible_vars.oval.xml"/></ds:checks></ds:data-stream><ds:component id="scap_org.open-scap_comp_test_ansible_vars.oval.xml" timestamp="2017-06-09T07:07:38"><oval_definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:win-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd    http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#windows windows-definitions-schema.xsd">
+  <generator>
+    <oval:schema_version>5.11</oval:schema_version>
+    <oval:timestamp>2009-01-12T10:41:00-05:00</oval:timestamp>
+  </generator>
+
+  <definitions>
+    <definition class="compliance" id="oval:default1:def:1" version="1">
+      <metadata>
+        <title>PASS</title>
+	<description>pass</description>
+      </metadata>
+      <criteria>
+        <criterion comment="PASS test" test_ref="oval:x:tst:1"/>
+      </criteria>
+    </definition>
+    <definition class="compliance" id="oval:test-fail:def:2" version="1">
+      <metadata>
+        <title>FAIL</title>
+	<description>conditional fail</description>
+      </metadata>
+      <criteria>
+        <criterion comment="FAIL test" test_ref="oval:x:tst:2"/>
+      </criteria>
+    </definition>
+  </definitions>
+
+    <tests>
+    <variable_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:tst:1" check="all" comment="always pass" version="1">
+      <object object_ref="oval:x:obj:1"/>
+    </variable_test>
+
+    <variable_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:tst:2" check="all" comment="always fail" version="1">
+      <object object_ref="oval:x:obj:1"/>
+      <state state_ref="oval:x:ste:1"/>
+    </variable_test>
+    </tests>
+
+    <objects>
+    <variable_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:obj:1" version="1" comment="x">
+      <var_ref>oval:x:var:1</var_ref>
+    </variable_object>
+    </objects>
+
+    <states>
+        <variable_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:ste:1" version="1">
+            <value datatype="int" operation="equals" var_ref="oval:ssg:var:1"/>
+        </variable_state>
+    </states>
+
+    <variables>
+      <constant_variable id="oval:x:var:1" version="1" comment="x" datatype="int">
+        <value>100</value>
+      </constant_variable>
+      <external_variable comment="default1" datatype="int" id="oval:ssg:var:1" version="1"/>
+    </variables>
+
+</oval_definitions></ds:component><ds:component id="scap_org.open-scap_comp_test_ansible_vars.xccdf.xml" timestamp="2017-06-09T09:15:45"><Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_com.example.www_benchmark_dummy" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="false" xml:lang="en-US">
+  <status>accepted</status>
+  <version>1.0</version>
+
+  <Profile id="xccdf_com.example.www_profile_test_ansible_vars">
+    <title>xccdf_test_profile</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_default1" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_default2" selected="true"/>
+    <refine-value idref="xccdf_com.example.www_value_val1" selector="bar_2"/>
+    <refine-value idref="xccdf_com.example.www_value_val2" selector="bar_1"/>
+  </Profile>
+
+  <Value id="xccdf_com.example.www_value_val1" type="number" interactive="0">
+    <title>test value</title>
+    <description>foo</description>
+    <value selector="bar_1">50</value>
+    <value selector="bar_2">100</value>
+  </Value>
+  <Value id="xccdf_com.example.www_value_val2" type="number" interactive="0">
+    <title>test value</title>
+    <description>foo</description>
+    <value selector="bar_1">50</value>
+    <value selector="bar_2">100</value>
+  </Value>
+
+  <Rule selected="true" id="xccdf_com.example.www_rule_default1">
+    <title>Rule default1 to test ansible variable www_value_val1</title>
+    <fix id="www_rule_default1" system="urn:xccdf:fix:script:ansible" complexity="low" disruption="low" strategy="restrict">- name: XCCDF Value www_value_val1 # promote to variable
+  set_fact:
+    www_value_val1: <sub idref="xccdf_com.example.www_value_val1" use="legacy"/>
+  tags:
+    - always
+
+- name: default1
+  lineinfile:
+    dest: /foo/bar
+    regexp: "^bar *[0-9]*"
+    state: present
+    line: "bar {{ www_value_val1 }}"
+  tags:
+    - foo
+    - bar
+    </fix>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-export export-name="oval:ssg:var:1" value-id="xccdf_com.example.www_value_val1"/>
+      <check-content-ref href="test_ansible_vars.oval.xml" name="oval:default1:def:1"/>
+    </check>
+  </Rule>
+
+  <Rule selected="true" id="xccdf_com.example.www_rule_default2">
+    <title>Rule default2 to test ansible variable www_value_val2</title>
+    <fix id="www_rule_default2" system="urn:xccdf:fix:script:ansible" complexity="low" disruption="low" strategy="restrict">- name: XCCDF Value www_value_val2 # promote to variable
+  set_fact:
+    www_value_val2: <sub idref="xccdf_com.example.www_value_val2" use="legacy"/>
+  tags:
+    - always
+
+- name: default2
+  lineinfile:
+    dest: /foo/baz
+    regexp: "^baz *[0-9]*"
+    state: present
+    line: "baz {{ www_value_val2 }}"
+  tags:
+    - foo
+    - baz
+    </fix>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-export export-name="oval:ssg:var:1" value-id="xccdf_com.example.www_value_val2"/>
+      <check-content-ref href="test_ansible_vars.oval.xml" name="oval:default1:def:1"/>
+    </check>
+  </Rule>
+
+</Benchmark></ds:component></ds:data-stream-collection>

--- a/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden.yml
+++ b/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden.yml
@@ -1,0 +1,24 @@
+---
+ - hosts: all
+   vars:
+      www_value_val1: 100
+      www_value_val2: 50
+   tasks:
+    - name: default1
+      lineinfile:
+        dest: /foo/bar
+        regexp: "^bar *[0-9]*"
+        state: present
+        line: "bar {{ www_value_val1 }}"
+      tags:
+        - foo
+        - bar
+    - name: default2
+      lineinfile:
+        dest: /foo/baz
+        regexp: "^baz *[0-9]*"
+        state: present
+        line: "baz {{ www_value_val2 }}"
+      tags:
+        - foo
+        - baz

--- a/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden_altered.yml
+++ b/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden_altered.yml
@@ -1,0 +1,24 @@
+---
+ - hosts: all
+   vars:
+      www_value_val1: 0
+      www_value_val2: 50
+   tasks:
+    - name: default1
+      lineinfile:
+        dest: /foo/bar
+        regexp: "^bar *[0-9]*"
+        state: present
+        line: "bar {{ www_value_val1 }}"
+      tags:
+        - foo
+        - bar
+    - name: default2
+      lineinfile:
+        dest: /foo/baz
+        regexp: "^baz *[0-9]*"
+        state: present
+        line: "baz {{ www_value_val2 }}"
+      tags:
+        - foo
+        - baz

--- a/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden_tailoring.yml
+++ b/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden_tailoring.yml
@@ -1,0 +1,14 @@
+---
+ - hosts: all
+   vars:
+      www_value_val1: 200
+   tasks:
+    - name: default1
+      lineinfile:
+        dest: /foo/bar
+        regexp: "^bar *[0-9]*"
+        state: present
+        line: "bar {{ www_value_val1 }}"
+      tags:
+        - foo
+        - bar


### PR DESCRIPTION
* Test checks that generate fix produces Ansible variables correctly,
  defined inline in a playbook in "vars" section.