### PR TITLE
Split test_mitre.sh

### DIFF
--- a/tests/mitre/CMakeLists.txt
+++ b/tests/mitre/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_oscap_test("test_mitre.sh")
 add_oscap_test("test_mitre_ind_probes.sh")
+add_oscap_test("test_mitre_linux_probes.sh")

--- a/tests/mitre/CMakeLists.txt
+++ b/tests/mitre/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_oscap_test("test_mitre.sh")
 add_oscap_test("test_mitre_ind_probes.sh")
 add_oscap_test("test_mitre_linux_probes.sh")
+add_oscap_test("test_mitre_oval.sh")
 add_oscap_test("test_mitre_unix_probes.sh")

--- a/tests/mitre/CMakeLists.txt
+++ b/tests/mitre/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_oscap_test("test_mitre.sh")
+add_oscap_test("test_mitre_ind_probes.sh")

--- a/tests/mitre/CMakeLists.txt
+++ b/tests/mitre/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_oscap_test("test_mitre.sh")
 add_oscap_test("test_mitre_ind_probes.sh")
 add_oscap_test("test_mitre_linux_probes.sh")
+add_oscap_test("test_mitre_unix_probes.sh")

--- a/tests/mitre/test_mitre.sh
+++ b/tests/mitre/test_mitre.sh
@@ -6,82 +6,9 @@
 
 
 . $builddir/tests/test_common.sh
+. $srcdir/test_mitre_common.sh
 
 # Test Cases.
-
-MITRE_FILES="/tmp/support"
-EXTVARFILE="${MITRE_FILES}/var/linux-external-variables.xml"
-
-DISTRO="$(cat /etc/*-release | head -n1)"
-DISTRO_NAME="$(cat /etc/*-release | awk '{print $1}' | head -n1)"
-DISTRO_RELEASE="$(cat /etc/*-release | sed -n 's|^[^0-9]*\([0-9]*\).*$|\1|p' | head -n1)"
-SELINUX_ENABLED=$(grep -iqE "(SELINUX=enforcing|SELINUX=permissive)" \
-	/etc/selinux/config 2>/dev/null; echo $?)
-
-function test_mitre {
-
-    require "egrep" || return 255
-    require "awk" || return 255
-
-    if [ ! -d "$MITRE_FILES" ]; then
-    	tar zxf ${srcdir}/support.tgz -C /tmp
-        # workaround file access time issue
-        find "$MITRE_FILES"
-	# workaround old schema version in linux-external-variables.xml
-	sed -i 's/5.0/5.5/' "$EXTVARFILE"
-    fi
-
-    local ret_val=0;
-    local DEFFILE=${srcdir}/$1
-    local RESFILE=$1.results
-
-    [ -f $RESFILE ] && rm -f $RESFILE
-    $OSCAP oval eval --results "$RESFILE" --variables "$EXTVARFILE"  "$DEFFILE"
-    # catch error from oscap tool
-    ret_val=$?
-    if [ $ret_val -eq 1 ]; then
-	return 1
-    fi
-
-    if [ -n "$3" ]; then
-        # only check the individual results specified in the arg list
-        shift 1
-        while [ -n "$1" -a -n "$2" ]; do
-            def_id="$1"
-            def_res="$2"
-            grep -q "definition_id=\"$def_id\".*result=\"$def_res\"" "$RESFILE" || return 1
-            shift 2
-        done
-        return 0
-    fi
-
-    # assume all definitions should have the same result
-
-    LINES=`grep definition_id "$RESFILE"`
-    # catch error from grep
-    ret_val=$?
-    if [ $ret_val -eq 2 ]; then
-	return 1
-    fi
-
-    # calculate return code
-    echo "$LINES" | grep -q -v "result=\"$2\""
-    ret_val=$?
-    if [ $ret_val -eq 1 ]; then
-        return 0;
-    elif [ $ret_val -eq 0 ]; then
-	return 1;
-    else
-	return "$ret_val"
-    fi
-}
-
-function cleanup {
-    rm -rf "$MITRE_FILES"
-}
-
-
-# Testing.
 test_init "test_mitre.log"
 
 test_run "ind-def_unknown_test.xml" test_mitre ind-def_unknown_test.xml "unknown"
@@ -188,4 +115,4 @@ if [[ $DISTRO_NAME == "Debian" ]]; then
 	test_run "linux-def_dpkginfo_test.xml" test_mitre linux-def_dpkginfo_test.xml "true"
 fi
 
-test_exit cleanup
+test_exit cleanup_mitre

--- a/tests/mitre/test_mitre.sh
+++ b/tests/mitre/test_mitre.sh
@@ -11,18 +11,7 @@
 # Test Cases.
 test_init "test_mitre.log"
 
-test_run "ind-def_unknown_test.xml" test_mitre ind-def_unknown_test.xml "unknown"
-test_run "ind-def_variable_test.xml" test_mitre ind-def_variable_test.xml "true"
-test_run "ind-def_environmentvariable_test.xml" test_mitre ind-def_environmentvariable_test.xml "true"
-test_run "ind-def_environmentvariable58_test.xml" test_mitre ind-def_environmentvariable_test.xml "true"
-test_run "ind-def_family_test.xml" test_mitre ind-def_family_test.xml "true"
-test_run "ind-def_textfilecontent54_test.xml" test_mitre ind-def_textfilecontent54_test.xml "true"
-test_run "ind-def_textfilecontent_test.xml" test_mitre ind-def_textfilecontent_test.xml "true"
-test_run "ind-def_xmlfilecontent_test.xml" test_mitre ind-def_xmlfilecontent_test.xml "true"
-test_run "ind-def_filehash58_test.xml" test_mitre ind-def_filehash58_test.xml "true"
-
 # does not work because of symplink `/etc/rc' -> `/etc/rc.d/rc' (oval:org.mitre.oval.test:tst:102)
-#test_run "ind-def_filehash_test.xml" test_mitre ind-def_filehash_test.xml "true"
 #test_run "unix-def_file_test.xml" test_mitre unix-def_file_test.xml "true"
 
 test_run "linux-def_partition_test.xml" test_mitre linux-def_partition_test.xml "true"
@@ -106,8 +95,6 @@ if [[ -f "/etc/xinetd.conf" && -f "/etc/xinetd.d/tftp" && -f "/etc/xinetd.d/teln
 fi
 
 # Unsupported objects on Fedora
-#test_run "ind-def_ldap_test.xml" test_mitre ind-def_ldap_test.xml "unknown"
-#test_run "ind-def_sql_test.xml" test_mitre ind-def_sql_test.xml "unknown"
 #test_run "linux-def_slackwarepkginfo_test.xml" test_mitre linux-def_slackwarepkginfo_test.xml "unknown"
 #test_run "unix-def_inetd_test.xml" test_mitre unix-def_inetd_test.xml "unknown"
 

--- a/tests/mitre/test_mitre.sh
+++ b/tests/mitre/test_mitre.sh
@@ -11,9 +11,6 @@
 # Test Cases.
 test_init "test_mitre.log"
 
-# does not work because of symplink `/etc/rc' -> `/etc/rc.d/rc' (oval:org.mitre.oval.test:tst:102)
-#test_run "unix-def_file_test.xml" test_mitre unix-def_file_test.xml "true"
-
 test_run "oval_binary_datatype.xml" test_mitre oval_binary_datatype.xml "true"
 test_run "oval_boolean_datatype.xml" test_mitre oval_boolean_datatype.xml "true"
 test_run "oval_check_enumeration_entity.xml" test_mitre oval_check_enumeration_entity.xml "true"
@@ -51,35 +48,5 @@ test_run "oval_float_datatype.xml" test_mitre oval_float_datatype.xml "true"
 test_run "oval_int_datatype.xml" test_mitre oval_int_datatype.xml "true"
 test_run "oval_string_datatype.xml" test_mitre oval_string_datatype.xml "true"
 test_run "oval_version_datatype.xml" test_mitre oval_version_datatype.xml "true"
-
-test_run "unix-def_password_test.xml" test_mitre unix-def_password_test.xml "true"
-
-# these are outdated
-#test_run "unix-def_process58_test.xml" test_mitre unix-def_process58_test.xml "true"
-#test_run "unix-def_process_test.xml" test_mitre unix-def_process_test.xml "true"
-
-# Fedora 16 and RHEL-7 - no runlevel
-if [[ ( ${DISTRO#Fedora} != "$DISTRO" && $DISTRO_RELEASE -lt 16 ) || \
-	( ${DISTRO#Red Hat} != "$DISTRO" && $DISTRO_RELEASE -lt 7 ) ]]; then
-	test_run "unix-def_runlevel_test.xml" test_mitre unix-def_runlevel_test.xml "true"
-fi
-
-test_run "unix-def_uname_test.xml" test_mitre unix-def_uname_test.xml "true"
-
-# needs only two interfaces - lo, eth0 - without ipv6 addresses
-#test_run "unix-def_interface_test.xml" test_mitre unix-def_interface_test.xml "true"
-
-# root needed
-if [[ $(id -u) == 0 ]]; then
-	test_run "unix-def_shadow_test.xml" test_mitre unix-def_shadow_test.xml "true"
-fi
-
-# install xinetd, telnet-server and tftp-server in order to test xinetd probe
-if [[ -f "/etc/xinetd.conf" && -f "/etc/xinetd.d/tftp" && -f "/etc/xinetd.d/telnet" ]]; then
-	test_run "unix-def_xinetd_test.xml" test_mitre unix-def_xinetd_test.xml "true"
-fi
-
-# Unsupported objects on Fedora
-#test_run "unix-def_inetd_test.xml" test_mitre unix-def_inetd_test.xml "unknown"
 
 test_exit cleanup_mitre

--- a/tests/mitre/test_mitre.sh
+++ b/tests/mitre/test_mitre.sh
@@ -14,21 +14,6 @@ test_init "test_mitre.log"
 # does not work because of symplink `/etc/rc' -> `/etc/rc.d/rc' (oval:org.mitre.oval.test:tst:102)
 #test_run "unix-def_file_test.xml" test_mitre unix-def_file_test.xml "true"
 
-test_run "linux-def_partition_test.xml" test_mitre linux-def_partition_test.xml "true"
-test_run "linux-def_rpminfo_test.xml" test_mitre linux-def_rpminfo_test.xml "true"
-test_run "linux-def_rpmverify_test.xml" test_mitre linux-def_rpmverify_test.xml "true"
-# Fedora 18 and RHEL-7 - no allow_console_login
-if [[ ( ${DISTRO#Fedora} != "$DISTRO" && $DISTRO_RELEASE -lt 18 ) || \
-	( ${DISTRO#Red Hat} != "$DISTRO" && $DISTRO_RELEASE -lt 7 ) ]]; then
-	test_run "linux-def_selinuxboolean_test.xml" test_mitre linux-def_selinuxboolean_test.xml "true"
-fi
-
-if [ $SELINUX_ENABLED -eq 0 ]; then
-	test_run "linux-def_selinuxsecuritycontext_test.xml" test_mitre linux-def_selinuxsecuritycontext_test.xml "true"
-fi
-
-test_run "linux-def_inetlisteningservers_test.xml" test_mitre linux-def_inetlisteningservers_test.xml "true"
-
 test_run "oval_binary_datatype.xml" test_mitre oval_binary_datatype.xml "true"
 test_run "oval_boolean_datatype.xml" test_mitre oval_boolean_datatype.xml "true"
 test_run "oval_check_enumeration_entity.xml" test_mitre oval_check_enumeration_entity.xml "true"
@@ -95,11 +80,6 @@ if [[ -f "/etc/xinetd.conf" && -f "/etc/xinetd.d/tftp" && -f "/etc/xinetd.d/teln
 fi
 
 # Unsupported objects on Fedora
-#test_run "linux-def_slackwarepkginfo_test.xml" test_mitre linux-def_slackwarepkginfo_test.xml "unknown"
 #test_run "unix-def_inetd_test.xml" test_mitre unix-def_inetd_test.xml "unknown"
-
-if [[ $DISTRO_NAME == "Debian" ]]; then
-	test_run "linux-def_dpkginfo_test.xml" test_mitre linux-def_dpkginfo_test.xml "true"
-fi
 
 test_exit cleanup_mitre

--- a/tests/mitre/test_mitre_common.sh
+++ b/tests/mitre/test_mitre_common.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Author:
+#      Peter Vrabec, <pvrabec@redhat.com>
+#	   Daniel Kopecek <dkopecek@redhat.com>
+
+
+MITRE_FILES="/tmp/support"
+EXTVARFILE="${MITRE_FILES}/var/linux-external-variables.xml"
+
+DISTRO="$(cat /etc/*-release | head -n1)"
+DISTRO_NAME="$(cat /etc/*-release | awk '{print $1}' | head -n1)"
+DISTRO_RELEASE="$(cat /etc/*-release | sed -n 's|^[^0-9]*\([0-9]*\).*$|\1|p' | head -n1)"
+SELINUX_ENABLED=$(grep -iqE "(SELINUX=enforcing|SELINUX=permissive)" \
+	/etc/selinux/config 2>/dev/null; echo $?)
+
+function test_mitre {
+
+    require "egrep" || return 255
+    require "awk" || return 255
+
+    if [ ! -d "$MITRE_FILES" ]; then
+    	tar zxf ${srcdir}/support.tgz -C /tmp
+        # workaround file access time issue
+        find "$MITRE_FILES"
+	# workaround old schema version in linux-external-variables.xml
+	sed -i 's/5.0/5.5/' "$EXTVARFILE"
+    fi
+
+    local ret_val=0;
+    local DEFFILE=${srcdir}/$1
+    local RESFILE=$1.results
+
+    [ -f $RESFILE ] && rm -f $RESFILE
+    $OSCAP oval eval --results "$RESFILE" --variables "$EXTVARFILE"  "$DEFFILE"
+    # catch error from oscap tool
+    ret_val=$?
+    if [ $ret_val -eq 1 ]; then
+	return 1
+    fi
+
+    if [ -n "$3" ]; then
+        # only check the individual results specified in the arg list
+        shift 1
+        while [ -n "$1" -a -n "$2" ]; do
+            def_id="$1"
+            def_res="$2"
+            grep -q "definition_id=\"$def_id\".*result=\"$def_res\"" "$RESFILE" || return 1
+            shift 2
+        done
+        return 0
+    fi
+
+    # assume all definitions should have the same result
+
+    LINES=`grep definition_id "$RESFILE"`
+    # catch error from grep
+    ret_val=$?
+    if [ $ret_val -eq 2 ]; then
+	return 1
+    fi
+
+    # calculate return code
+    echo "$LINES" | grep -q -v "result=\"$2\""
+    ret_val=$?
+    if [ $ret_val -eq 1 ]; then
+        return 0;
+    elif [ $ret_val -eq 0 ]; then
+	return 1;
+    else
+	return "$ret_val"
+    fi
+}
+
+function cleanup_mitre {
+    rm -rf "$MITRE_FILES"
+}

--- a/tests/mitre/test_mitre_ind_probes.sh
+++ b/tests/mitre/test_mitre_ind_probes.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Author:
+#      Peter Vrabec, <pvrabec@redhat.com>
+#	   Daniel Kopecek <dkopecek@redhat.com>
+
+
+. $builddir/tests/test_common.sh
+. $srcdir/test_mitre_common.sh
+
+# Test Cases.
+test_init "test_mitre_ind_probes.log"
+
+test_run "ind-def_unknown_test.xml" test_mitre ind-def_unknown_test.xml "unknown"
+test_run "ind-def_variable_test.xml" test_mitre ind-def_variable_test.xml "true"
+test_run "ind-def_environmentvariable_test.xml" test_mitre ind-def_environmentvariable_test.xml "true"
+test_run "ind-def_environmentvariable58_test.xml" test_mitre ind-def_environmentvariable_test.xml "true"
+test_run "ind-def_family_test.xml" test_mitre ind-def_family_test.xml "true"
+test_run "ind-def_textfilecontent54_test.xml" test_mitre ind-def_textfilecontent54_test.xml "true"
+test_run "ind-def_textfilecontent_test.xml" test_mitre ind-def_textfilecontent_test.xml "true"
+test_run "ind-def_xmlfilecontent_test.xml" test_mitre ind-def_xmlfilecontent_test.xml "true"
+test_run "ind-def_filehash58_test.xml" test_mitre ind-def_filehash58_test.xml "true"
+
+# does not work because of symplink `/etc/rc' -> `/etc/rc.d/rc' (oval:org.mitre.oval.test:tst:102)
+#test_run "ind-def_filehash_test.xml" test_mitre ind-def_filehash_test.xml "true"
+
+# Unsupported objects on Fedora
+#test_run "ind-def_ldap_test.xml" test_mitre ind-def_ldap_test.xml "unknown"
+#test_run "ind-def_sql_test.xml" test_mitre ind-def_sql_test.xml "unknown"
+
+test_exit cleanup_mitre

--- a/tests/mitre/test_mitre_linux_probes.sh
+++ b/tests/mitre/test_mitre_linux_probes.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Author:
+#      Peter Vrabec, <pvrabec@redhat.com>
+#	   Daniel Kopecek <dkopecek@redhat.com>
+
+
+. $builddir/tests/test_common.sh
+. $srcdir/test_mitre_common.sh
+
+# Test Cases.
+test_init "test_mitre_linux_probes.log"
+
+test_run "linux-def_partition_test.xml" test_mitre linux-def_partition_test.xml "true"
+test_run "linux-def_rpminfo_test.xml" test_mitre linux-def_rpminfo_test.xml "true"
+test_run "linux-def_rpmverify_test.xml" test_mitre linux-def_rpmverify_test.xml "true"
+# Fedora 18 and RHEL-7 - no allow_console_login
+if [[ ( ${DISTRO#Fedora} != "$DISTRO" && $DISTRO_RELEASE -lt 18 ) || \
+	( ${DISTRO#Red Hat} != "$DISTRO" && $DISTRO_RELEASE -lt 7 ) ]]; then
+	test_run "linux-def_selinuxboolean_test.xml" test_mitre linux-def_selinuxboolean_test.xml "true"
+fi
+
+if [ $SELINUX_ENABLED -eq 0 ]; then
+	test_run "linux-def_selinuxsecuritycontext_test.xml" test_mitre linux-def_selinuxsecuritycontext_test.xml "true"
+fi
+
+test_run "linux-def_inetlisteningservers_test.xml" test_mitre linux-def_inetlisteningservers_test.xml "true"
+# Unsupported objects on Fedora
+#test_run "linux-def_slackwarepkginfo_test.xml" test_mitre linux-def_slackwarepkginfo_test.xml "unknown"
+
+if [[ $DISTRO_NAME == "Debian" ]]; then
+	test_run "linux-def_dpkginfo_test.xml" test_mitre linux-def_dpkginfo_test.xml "true"
+fi
+
+test_exit cleanup_mitre

--- a/tests/mitre/test_mitre_oval.sh
+++ b/tests/mitre/test_mitre_oval.sh
@@ -9,7 +9,7 @@
 . $srcdir/test_mitre_common.sh
 
 # Test Cases.
-test_init "test_mitre.log"
+test_init "test_mitre_oval.log"
 
 test_run "oval_binary_datatype.xml" test_mitre oval_binary_datatype.xml "true"
 test_run "oval_boolean_datatype.xml" test_mitre oval_boolean_datatype.xml "true"

--- a/tests/mitre/test_mitre_unix_probes.sh
+++ b/tests/mitre/test_mitre_unix_probes.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Author:
+#      Peter Vrabec, <pvrabec@redhat.com>
+#	   Daniel Kopecek <dkopecek@redhat.com>
+
+
+. $builddir/tests/test_common.sh
+. $srcdir/test_mitre_common.sh
+
+# Test Cases.
+test_init "test_mitre_unix_probes.log"
+
+# does not work because of symplink `/etc/rc' -> `/etc/rc.d/rc' (oval:org.mitre.oval.test:tst:102)
+#test_run "unix-def_file_test.xml" test_mitre unix-def_file_test.xml "true"
+
+test_run "unix-def_password_test.xml" test_mitre unix-def_password_test.xml "true"
+
+# these are outdated
+#test_run "unix-def_process58_test.xml" test_mitre unix-def_process58_test.xml "true"
+#test_run "unix-def_process_test.xml" test_mitre unix-def_process_test.xml "true"
+
+# Fedora 16 and RHEL-7 - no runlevel
+if [[ ( ${DISTRO#Fedora} != "$DISTRO" && $DISTRO_RELEASE -lt 16 ) || \
+	( ${DISTRO#Red Hat} != "$DISTRO" && $DISTRO_RELEASE -lt 7 ) ]]; then
+	test_run "unix-def_runlevel_test.xml" test_mitre unix-def_runlevel_test.xml "true"
+fi
+
+test_run "unix-def_uname_test.xml" test_mitre unix-def_uname_test.xml "true"
+
+# needs only two interfaces - lo, eth0 - without ipv6 addresses
+#test_run "unix-def_interface_test.xml" test_mitre unix-def_interface_test.xml "true"
+
+# root needed
+if [[ $(id -u) == 0 ]]; then
+	test_run "unix-def_shadow_test.xml" test_mitre unix-def_shadow_test.xml "true"
+fi
+
+# install xinetd, telnet-server and tftp-server in order to test xinetd probe
+if [[ -f "/etc/xinetd.conf" && -f "/etc/xinetd.d/tftp" && -f "/etc/xinetd.d/telnet" ]]; then
+	test_run "unix-def_xinetd_test.xml" test_mitre unix-def_xinetd_test.xml "true"
+fi
+
+# Unsupported objects on Fedora
+#test_run "unix-def_inetd_test.xml" test_mitre unix-def_inetd_test.xml "unknown"
+
+test_exit cleanup_mitre


### PR DESCRIPTION
Split the one test into 4:
- test linux probes
- test ind probes
- test unix probes
- test OVAL features

Unfortunately the linux probes test takes by far the most time on most machines because of rpmverifyfile. Still, I think this is a step in the right direction.