### PR TITLE
Use ctest logs instead of separate log files for testing

### DIFF
--- a/tests/API/CCE/test_api_cce.sh
+++ b/tests/API/CCE/test_api_cce.sh
@@ -46,7 +46,7 @@ function test_api_cce_search_non_existing {
 }
 
 # Testing.
-test_init "test_api_cce.log" 
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_api_cce_smoke" test_api_cce_smoke

--- a/tests/API/CPE/dict/test_api_cpe_dict.sh
+++ b/tests/API/CPE/dict/test_api_cpe_dict.sh
@@ -115,7 +115,7 @@ function test_api_cpe_dict_import_official_v23(){
 
 # Testing.
 
-test_init "test_api_cpe_dict.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_api_cpe_dict_smoke" test_api_cpe_dict_smoke

--- a/tests/API/CPE/lang/test_api_cpe_lang.sh
+++ b/tests/API/CPE/lang/test_api_cpe_lang.sh
@@ -147,7 +147,7 @@ function test_api_cpe_lang_match {
 
 # Testing.
 
-test_init "test_api_cpe_lang.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_api_cpe_lang_smoke" test_api_cpe_lang_smoke

--- a/tests/API/CPE/name/test_api_cpe_uri.sh
+++ b/tests/API/CPE/name/test_api_cpe_uri.sh
@@ -125,7 +125,7 @@ function test_api_cpe_uri_match {
 
 # Testing.
 
-test_init "test_api_cpe_uri.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_api_cpe_uri_smoke"  test_api_cpe_uri_smoke

--- a/tests/API/CVE/test_api_cve.sh
+++ b/tests/API/CVE/test_api_cve.sh
@@ -31,7 +31,7 @@ function test_api_cve_export {
     return $ret_val
 }
 
-test_init "test_api_cve.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_api_cve_cvss" test_api_cve_cvss

--- a/tests/API/CVRF/test_api_cvrf.sh
+++ b/tests/API/CVRF/test_api_cvrf.sh
@@ -65,7 +65,7 @@ function test_api_cvrf_validate {
 	return $ret_val
 }
 
-test_init "test_api_cvrf.log"
+test_init
 test_run "test_api_cvrf_export" test_api_cvrf_export
 test_run "test_api_cvrf_eval" test_api_cvrf_eval
 test_run "test_api_cvrf_validate" test_api_cvrf_validate

--- a/tests/API/CVSS/test_api_cvss.sh
+++ b/tests/API/CVSS/test_api_cvss.sh
@@ -33,7 +33,7 @@ function test_api_cvss_vector {
 
 # Testing.
 
-test_init "test_api_cvss.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_api_cvss_vector" test_api_cvss_vector

--- a/tests/API/OVAL/glob_to_regex/test_glob_to_regex.sh
+++ b/tests/API/OVAL/glob_to_regex/test_glob_to_regex.sh
@@ -18,7 +18,7 @@ function test_glob_to_regex {
 
 # Testing.
 
-test_init "test_glob_to_regex.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_glob_to_regex" test_glob_to_regex

--- a/tests/API/OVAL/schema_version/test_schema_version.sh
+++ b/tests/API/OVAL/schema_version/test_schema_version.sh
@@ -41,7 +41,7 @@ function test_comparing_schema_versions {
 
 # Testing.
 
-test_init "test_schema_version.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_comparing_schema_versions" test_comparing_schema_versions

--- a/tests/API/OVAL/test_api_oval.sh
+++ b/tests/API/OVAL/test_api_oval.sh
@@ -37,7 +37,7 @@ function test_api_oval_directives {
 
 # Testing.
 
-test_init "test_api_oval.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_api_oval_definition" test_api_oval_definition

--- a/tests/API/SEAP/test_api_seap.sh
+++ b/tests/API/SEAP/test_api_seap.sh
@@ -482,7 +482,7 @@ function test_api_strto {
 
 # Testing.
 
-test_init "test_api_seap.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_api_seap_incorrect_expression"   test_api_seap_incorrect_expression

--- a/tests/API/XCCDF/parser/test_api_xccdf.sh
+++ b/tests/API/XCCDF/parser/test_api_xccdf.sh
@@ -47,7 +47,7 @@ function test_api_xccdf_validate {
 
 # Testing.
 
-test_init "test_api_xccdf.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "export xccdf 1.1" test_api_xccdf_export xccdf11.xml

--- a/tests/API/crypt/test_api_crypt.sh
+++ b/tests/API/crypt/test_api_crypt.sh
@@ -82,7 +82,7 @@ function test_crapi_mdigest {
 
 # Testing.
 
-test_init "test_api_crypt.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_crapi_digest" test_crapi_digest

--- a/tests/DS/test_ds_misc.sh
+++ b/tests/DS/test_ds_misc.sh
@@ -219,7 +219,7 @@ function test_sds_tailoring {
 }
 
 # Testing.
-test_init "test_ds.log"
+test_init
 
 test_run "sds_external_xccdf" test_sds_external_xccdf sds_external_xccdf sds_external_xccdf/sds.ds.xml scap_org.open-scap_cref_xccdf.xml xccdf_external_profile_datastream_1
 test_run "sds_external_xccdf" test_sds_external_xccdf sds_external_xccdf sds_external_xccdf/sds.ds.xml scap_org.open-scap_cref_xccdf-file.xml xccdf_external_profile_file_1

--- a/tests/DS/test_rds.sh
+++ b/tests/DS/test_rds.sh
@@ -109,7 +109,7 @@ function test_rds_split {
 }
 
 # Testing.
-test_init "test_rds.log"
+test_init
 
 test_run "rds_simple" test_rds rds_simple/sds.xml rds_simple/results-xccdf.xml rds_simple/results-oval.xml
 test_run "rds_testresult" test_rds rds_testresult/sds.xml rds_testresult/results-xccdf.xml rds_testresult/results-oval.xml

--- a/tests/DS/test_sds_compose_split.sh
+++ b/tests/DS/test_sds_compose_split.sh
@@ -52,7 +52,7 @@ function test_sds {
 }
 
 # Testing.
-test_init "test_sds_compose_split.log"
+test_init
 
 test_run "sds_simple" test_sds sds_simple scap-fedora14-xccdf.xml 0
 test_run "sds_simple OVAL 5.11.1" test_sds sds_simple_5_11_1 simple_xccdf.xml 0

--- a/tests/DS/test_sds_eval.sh
+++ b/tests/DS/test_sds_eval.sh
@@ -154,7 +154,7 @@ function test_sds_tailoring {
 }
 
 # Testing.
-test_init "test_sds_eval.log"
+test_init
 
 test_run "sds_external_xccdf" test_sds_external_xccdf sds_external_xccdf sds_external_xccdf/sds.ds.xml scap_org.open-scap_cref_xccdf.xml xccdf_external_profile_datastream_1
 test_run "sds_external_xccdf" test_sds_external_xccdf sds_external_xccdf sds_external_xccdf/sds.ds.xml scap_org.open-scap_cref_xccdf-file.xml xccdf_external_profile_file_1

--- a/tests/DS/test_sds_fix_from_results.sh
+++ b/tests/DS/test_sds_fix_from_results.sh
@@ -30,7 +30,7 @@ function test_generate_fix_results {
 }
 
 # Testing.
-test_init "test_sds_fix_from_results.log"
+test_init
 
 test_run "generate_fix_cpe_results" test_generate_fix_results eval_cpe/sds.xml
 

--- a/tests/DS/test_sds_fix_from_source.sh
+++ b/tests/DS/test_sds_fix_from_source.sh
@@ -28,7 +28,7 @@ function test_generate_fix_source {
 }
 
 # Testing.
-test_init "test_ds.log"
+test_init
 
 test_run "generate_fix_cpe_source" test_generate_fix_source eval_cpe/sds.xml
 

--- a/tests/bindings/test_perl.sh
+++ b/tests/bindings/test_perl.sh
@@ -17,7 +17,7 @@ function test_perl_import {
 }
 
 # Testing.
-test_init "test_perl.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "perl_import" test_perl_import

--- a/tests/bindings/test_python.sh
+++ b/tests/bindings/test_python.sh
@@ -12,7 +12,7 @@ function test_python_import {
 }
 
 # Testing.
-test_init "test_python.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "python_import" test_python_import

--- a/tests/mitre/test_mitre_ind_probes.sh
+++ b/tests/mitre/test_mitre_ind_probes.sh
@@ -9,7 +9,7 @@
 . $srcdir/test_mitre_common.sh
 
 # Test Cases.
-test_init "test_mitre_ind_probes.log"
+test_init
 
 test_run "ind-def_unknown_test.xml" test_mitre ind-def_unknown_test.xml "unknown"
 test_run "ind-def_variable_test.xml" test_mitre ind-def_variable_test.xml "true"

--- a/tests/mitre/test_mitre_linux_probes.sh
+++ b/tests/mitre/test_mitre_linux_probes.sh
@@ -9,7 +9,7 @@
 . $srcdir/test_mitre_common.sh
 
 # Test Cases.
-test_init "test_mitre_linux_probes.log"
+test_init
 
 test_run "linux-def_partition_test.xml" test_mitre linux-def_partition_test.xml "true"
 test_run "linux-def_rpminfo_test.xml" test_mitre linux-def_rpminfo_test.xml "true"

--- a/tests/mitre/test_mitre_oval.sh
+++ b/tests/mitre/test_mitre_oval.sh
@@ -9,7 +9,7 @@
 . $srcdir/test_mitre_common.sh
 
 # Test Cases.
-test_init "test_mitre_oval.log"
+test_init
 
 test_run "oval_binary_datatype.xml" test_mitre oval_binary_datatype.xml "true"
 test_run "oval_boolean_datatype.xml" test_mitre oval_boolean_datatype.xml "true"

--- a/tests/mitre/test_mitre_unix_probes.sh
+++ b/tests/mitre/test_mitre_unix_probes.sh
@@ -9,7 +9,7 @@
 . $srcdir/test_mitre_common.sh
 
 # Test Cases.
-test_init "test_mitre_unix_probes.log"
+test_init
 
 # does not work because of symplink `/etc/rc' -> `/etc/rc.d/rc' (oval:org.mitre.oval.test:tst:102)
 #test_run "unix-def_file_test.xml" test_mitre unix-def_file_test.xml "true"

--- a/tests/oscap_string/test_oscap_string.sh
+++ b/tests/oscap_string/test_oscap_string.sh
@@ -18,7 +18,7 @@ function test_oscap_string {
 
 # Testing.
 
-test_init "test_oscap_string.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_oscap_string" test_oscap_string

--- a/tests/oval_details/test_oval_details.sh
+++ b/tests/oval_details/test_oval_details.sh
@@ -21,7 +21,7 @@ function test_oval_details {
 
 # Testing.
 
-test_init "test_oval_details.log"
+test_init
 if ! [ -f countries.xml ] ; then
   cp $srcdir/countries.src.xml ./countries.xml
 fi

--- a/tests/probes/environmentvariable/test_probes_environmentvariable.sh
+++ b/tests/probes/environmentvariable/test_probes_environmentvariable.sh
@@ -43,7 +43,7 @@ function test_probes_environmentvariable {
 
 # Testing.
 
-test_init "test_probes_environmentvariable.log"
+test_init
 
 test_run "test_probes_environmentvariable" test_probes_environmentvariable \
     test_probes_environmentvariable

--- a/tests/probes/environmentvariable58/test_probes_environmentvariable58.sh
+++ b/tests/probes/environmentvariable58/test_probes_environmentvariable58.sh
@@ -44,7 +44,7 @@ function test_probes_environmentvariable58 {
 
 # Testing.
 
-test_init "test_probes_environmentvariable58.log"
+test_init
 
 test_run "test_probes_environmentvariable58" test_probes_environmentvariable58 \
     test_probes_environmentvariable58

--- a/tests/probes/family/test_probes_family.sh
+++ b/tests/probes/family/test_probes_family.sh
@@ -40,7 +40,7 @@ function test_probes_family {
 
 # Testing.
 
-test_init "test_probes_family.log"
+test_init
 
 test_run "test_probes_family" test_probes_family
 

--- a/tests/probes/file/test_probes_file.sh
+++ b/tests/probes/file/test_probes_file.sh
@@ -122,7 +122,7 @@ function test_probes_file_invalid_utf8 {
 
 # Testing.
 
-test_init "test_probes_file.log"
+test_init
 
 test_run "test_probes_file with verbose mode" test_probes_file verbose
 test_run "test_probes_file" test_probes_file

--- a/tests/probes/fileextendedattribute/test_probes_fileextendedattribute.sh
+++ b/tests/probes/fileextendedattribute/test_probes_fileextendedattribute.sh
@@ -44,6 +44,6 @@ function test_probes_fileextendedattribute {
 }
 
 # Testing.
-test_init "test_probes_fileattribute.log"
+test_init
 test_run "test_probes_fileattribute" test_probes_fileextendedattribute
 test_exit

--- a/tests/probes/filehash/test_probes_filehash.sh
+++ b/tests/probes/filehash/test_probes_filehash.sh
@@ -45,7 +45,7 @@ function test_probes_filehash {
 
 # Testing.
 
-test_init "test_probes_filehash.log"
+test_init
 
 test_run "test_probes_filehash" test_probes_filehash
 

--- a/tests/probes/filehash58/test_probes_filehash58.sh
+++ b/tests/probes/filehash58/test_probes_filehash58.sh
@@ -45,7 +45,7 @@ function test_probes_filehash58 {
 
 # Testing.
 
-test_init "test_probes_filehash58.log"
+test_init
 
 test_run "test_probes_filehash58" test_probes_filehash58
 

--- a/tests/probes/filemd5/test_probes_filemd5.sh
+++ b/tests/probes/filemd5/test_probes_filemd5.sh
@@ -42,7 +42,7 @@ function test_probes_filemd5 {
 
 # Testing.
 
-test_init "test_probes_filemd5.log"
+test_init
 
 test_run "test_probes_filemd5" test_probes_filemd5
 

--- a/tests/probes/iflisteners/test_probes_iflisteners.sh
+++ b/tests/probes/iflisteners/test_probes_iflisteners.sh
@@ -47,7 +47,7 @@ function test_probes_iflisteners {
 }
 
 # Testing.
-test_init "test_probes_iflisteners.log"
+test_init
 
 tcpdump -i lo -p tcp port 12345 > /dev/null 2> /dev/null &
 sleep 3

--- a/tests/probes/interface/test_probes_interface.sh
+++ b/tests/probes/interface/test_probes_interface.sh
@@ -48,7 +48,7 @@ function test_probes_interface {
 
 # Testing.
 
-test_init "test_probes_interface.log"
+test_init
 
 test_run "test_probes_interface" test_probes_interface
 

--- a/tests/probes/isainfo/test_probes_isainfo.sh
+++ b/tests/probes/isainfo/test_probes_isainfo.sh
@@ -40,7 +40,7 @@ function test_probes_isainfo {
 
 # Testing.
 
-test_init "test_probes_isainfo.log"
+test_init
 
 test_run "test_probes_isainfo" test_probes_isainfo
 

--- a/tests/probes/password/test_probes_password.sh
+++ b/tests/probes/password/test_probes_password.sh
@@ -49,7 +49,7 @@ function test_probes_password {
 
 # Testing.
 
-test_init "test_probes_password.log"
+test_init
 
 test_run "test_probes_password" test_probes_password
 

--- a/tests/probes/rpminfo/test_probes_rpminfo.sh
+++ b/tests/probes/rpminfo/test_probes_rpminfo.sh
@@ -45,7 +45,7 @@ function test_probes_rpminfo {
 
 # Testing.
 
-test_init "test_probes_rpminfo.log"
+test_init
 
 test_run "test_probes_rpminfo" test_probes_rpminfo
 

--- a/tests/probes/rpmverifypackage/test_probes_rpmverifypackage.sh
+++ b/tests/probes/rpmverifypackage/test_probes_rpmverifypackage.sh
@@ -77,7 +77,7 @@ function test_probes_rpmverifypackage_noepoch {
 
 # Testing.
 
-test_init "test_probes_rpmverifypackage.log"
+test_init
 
 test_run "test_probes_rpmverifypackage_epoch" test_probes_rpmverifypackage_epoch
 test_run "test_probes_rpmverifypackage_noepoch" test_probes_rpmverifypackage_noepoch

--- a/tests/probes/runlevel/test_probes_runlevel.sh
+++ b/tests/probes/runlevel/test_probes_runlevel.sh
@@ -129,7 +129,7 @@ function test_probes_runlevel_C {
 
 # Testing.
 
-test_init "test_probes_runlevel.log"
+test_init
 
 test_run "test_probes_runlevel_A" test_probes_runlevel_A
 test_run "test_probes_runlevel_B" test_probes_runlevel_B

--- a/tests/probes/selinuxboolean/test_probes_selinuxboolean.sh
+++ b/tests/probes/selinuxboolean/test_probes_selinuxboolean.sh
@@ -46,7 +46,7 @@ function test_probes_selinuxboolean {
 
 # Testing.
 
-test_init "test_probes_selinuxboolean.log"
+test_init
 
 test_run "test_probes_selinuxboolean" test_probes_selinuxboolean \
     test_probes_selinuxboolean

--- a/tests/probes/shadow/test_probes_shadow.sh
+++ b/tests/probes/shadow/test_probes_shadow.sh
@@ -49,7 +49,7 @@ function test_probes_shadow {
 
 # Testing.
 
-test_init "test_probes_shadow.log"
+test_init
 
 test_run "test_probes_shadow" test_probes_shadow
 

--- a/tests/probes/sysinfo/test_probes_sysinfo.sh
+++ b/tests/probes/sysinfo/test_probes_sysinfo.sh
@@ -70,7 +70,7 @@ function test_probes_sysinfo {
 
 # Testing.
 
-test_init "test_probes_sysinfo.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_probes_sysinfo" test_probes_sysinfo

--- a/tests/probes/textfilecontent54/test_filecontent_non_utf.sh
+++ b/tests/probes/textfilecontent54/test_filecontent_non_utf.sh
@@ -26,7 +26,7 @@ function test_filecontent_non_utf {
     return ${exit_code}
 }
 
-test_init test_api_oval_unittests_filecontent_non_utf.log
+test_init
 
 test_run "filecontent regex of utf8 file" test_filecontent_non_utf "false" "utf8"
 test_run "filecontent regex of iso8859 file" test_filecontent_non_utf "error" "iso8859"

--- a/tests/probes/uname/test_probes_uname.sh
+++ b/tests/probes/uname/test_probes_uname.sh
@@ -42,7 +42,7 @@ function test_probes_uname {
 
 # Testing.
 
-test_init "test_probes_uname.log"
+test_init
 
 test_run "test_probes_uname" test_probes_uname
 

--- a/tests/probes/xinetd/test_xinetd_probe.sh
+++ b/tests/probes/xinetd/test_xinetd_probe.sh
@@ -82,7 +82,7 @@ function test_probe_xinetd_duplicates {
 
 # Testing.
 
-test_init "test_probe_xinetd.log"
+test_init
 
 if [ -z ${CUSTOM_OSCAP+x} ] ; then
     test_run "test_probe_xinetd_parser" test_probe_xinetd_parser

--- a/tests/sce/test_check_engine_results.sh
+++ b/tests/sce/test_check_engine_results.sh
@@ -28,7 +28,7 @@ function test_check_engine_results {
 }
 
 # Testing.
-test_init "test_check_engine_results.log"
+test_init
 
 test_run "check_engine_results" test_check_engine_results test_check_engine_results.xccdf.xml
 

--- a/tests/sce/test_passing_vars.sh
+++ b/tests/sce/test_passing_vars.sh
@@ -28,7 +28,7 @@ function test_passing_values {
 }
 
 # Testing.
-test_init "test_passing_values.log"
+test_init
 
 test_run "sce" test_passing_values test_passing_vars_xccdf.xml
 

--- a/tests/sce/test_sce.sh
+++ b/tests/sce/test_sce.sh
@@ -24,6 +24,6 @@ function test_sce {
     [ $ret_val -eq 1 ]
 }
 
-test_init "test_sce.log"
+test_init
 test_run "sce" test_sce sce_xccdf.xml
 test_exit

--- a/tests/sce/test_sce_in_ds.sh
+++ b/tests/sce/test_sce_in_ds.sh
@@ -24,7 +24,7 @@ function test_sce_in_ds {
 }
 
 # Testing.
-test_init "test_sce_in_ds.log"
+test_init
 
 test_run "SCE in DS" test_sce_in_ds test_sce_in_ds.xml
 

--- a/tests/sce/test_sce_in_report.sh
+++ b/tests/sce/test_sce_in_report.sh
@@ -23,6 +23,6 @@ function test_sce_in_report {
 
 }
 
-test_init "test_sce_in_ds.log"
+test_init
 test_run "sce results in HTML report" test_sce_in_report test_sce_in_report.xml
 test_exit

--- a/tests/sce/test_sce_parse_errors.sh
+++ b/tests/sce/test_sce_parse_errors.sh
@@ -39,7 +39,7 @@ function test_load_without_error {
 }
 
 # Testing.
-test_init "test_sce_parse_errors.log"
+test_init
 
 test_run "Load script WITHOUT error on stderr"	test_load_without_error	./test_sce_parse_errors_load_script.xccdf.xml
 test_run "Load script WITH error on stderr"		test_load_with_error	./test_sce_parse_errors_load_corrupted_xml.xccdf.xml

--- a/tests/sce/test_sce_stdout_stderr.sh
+++ b/tests/sce/test_sce_stdout_stderr.sh
@@ -24,7 +24,7 @@ function test_sce_stdout_stderr {
 }
 
 # Testing.
-test_init "test_sce_stdout_stderr.log"
+test_init
 
 test_run "SCE stdout and stderr" test_sce_stdout_stderr test_sce_stdout_stderr.xccdf.xml
 

--- a/tests/sce/test_sce_streams_fill.sh
+++ b/tests/sce/test_sce_streams_fill.sh
@@ -25,7 +25,7 @@ function test_sce_streams_fill {
 }
 
 # Testing.
-test_init "test_sce_streams_fill.log"
+test_init
 
 test_run "SCE stream filling up" test_sce_streams_fill test_sce_streams_fill.xccdf.xml
 

--- a/tests/test_common.sh.in
+++ b/tests/test_common.sh.in
@@ -66,15 +66,9 @@ fi
 # Overall test result.
 result=0
 
-# Logging file (stderr is redirected here).
-log=test.log
-
 # Set-up testing environment.
 function test_init {
-    [ $# -eq 1 ] && log="$1"
-    exec 2>$log
-    echo ""
-    echo "----------------------------------------------------------------------"
+    :
 }
 
 # Execute test and report its results.
@@ -107,9 +101,6 @@ function test_run {
 
 # Clean-up testing environment.
 function test_exit {
-    echo "--------------------------------------------------"
-    echo -e "See `pwd | sed 's|.*/\(tests/.*\)|\1|'`/${log}.\n"
-
     if [ $# -eq 1 ]
     then
         ( exec 1>&2 ; eval "$@" )


### PR DESCRIPTION
This is mostly for discussion at this point. Our test "framework" pipes stderr output from tests into log files. The user is expected to look into that log file to figure out why a test failed. ctest is setup to gather output from all tests and it can be set to output the entire test output when an error is encountered via env var CTEST_OUTPUT_ON_FAILURE. I think that may be more usable for developers than having to go on jenkins and look for log files.

If we get consensus we need to get rid of the test_init calls completely or at least remove the log file name argument before merging.