### PR TITLE
CVE: IDs are now 4-7 digits long

### DIFF
--- a/schemas/cve/cve_0.1.xsd
+++ b/schemas/cve/cve_0.1.xsd
@@ -21,7 +21,7 @@
       <xsd:documentation>Format for CVE Names is CVE-YYYY-NNNN, where YYYY is the year of publication and NNNN is a sequence number.</xsd:documentation>
     </xsd:annotation>
     <xsd:restriction base="xsd:token">
-      <xsd:pattern value="CVE-([1,2])\d{3}-\d{4}"/>
+      <xsd:pattern value="CVE-([1,2])\d{3}-\d{4,7}"/>
     </xsd:restriction>
   </xsd:simpleType>
   <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->


### PR DESCRIPTION
Reviewing the NVD feeds from
https://nvd.nist.gov/vuln/data-feeds#CVE_FEED reflects like
`CVE-2016-1000031`, `CVE-2017-18016` and `CVE-2017-1000439`.

I'm sure this xsd needs to be vetted in other places, but currently
`oscap cve validate ./nvdcve-2.0-modified.xml` fails with

```shell
File './nvdcve-2.0-modified.xml' line 65535: Element '{http://scap.nist.gov/schema/vulnerability/0.4}cve-id': [facet 'pattern'] The value 'CVE-2017-1000367' is not accepted by the pattern 'CVE-([1,2])\d{3}-\d{4}'.
File './nvdcve-2.0-modified.xml' line 65535: Element '{http://scap.nist.gov/schema/vulnerability/0.4}cve-id': 'CVE-2017-1000367' is not a valid value of the atomic type '{http://scap.nist.gov/schema/cve/0.1}cveNamePatternType'.
```

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>