### PR TITLE
Comment OSCAP_GSYM macro

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -420,6 +420,12 @@ char *oscap_expand_ipv6(const char *input);
 # define OSCAP_CONCAT(a,b) OSCAP_CONCAT1(a,b)
 #endif
 
+/**
+ * Mark global symbols.
+ * This macro can be used to wrap global variables and helps distinguish
+ * global variables and local varibles.
+ * It adds '___G_' prefix to variable name.
+ */
 #define OSCAP_GSYM(s) OSCAP_CONCAT(___G_, s)
 
 #define protect_errno                                                   \


### PR DESCRIPTION
We will not remove this macro, because it can stay and we should keep
the prefixes. Instead, we can write docs.

This is a follow up of https://github.com/OpenSCAP/openscap/pull/940.