### PR TITLE
[WIP] OVAL details in HTML report fixes

### DIFF
--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -674,11 +674,7 @@ Authors:
             </xsl:choose>
         </xsl:variable>
         <span class="label label-default"><abbr title="OVAL details taken from {$details_origin}">OVAL details</abbr></span>
-        <div class="panel panel-default">
-            <div class="panel-body">
-                <xsl:copy-of select="$details"/>
-            </div>
-        </div>
+        <xsl:copy-of select="$details"/>
     </xsl:if>
 </xsl:template>
 

--- a/xsl/xccdf-report-oval-details.xsl
+++ b/xsl/xccdf-report-oval-details.xsl
@@ -44,34 +44,25 @@ Authors:
 
 <xsl:template mode='brief' match='ovalres:oval_results'>
     <xsl:param name='definition-id' />
-    <xsl:param name='result'/>
     <ul>
-        <xsl:apply-templates select='key("oval-definition", $definition-id)' mode='brief'>
-            <xsl:with-param name='result' select='$result'/>
-        </xsl:apply-templates>
+        <xsl:apply-templates select='key("oval-definition", $definition-id)' mode='brief'/>
     </ul>
 </xsl:template>
 
 <xsl:template mode='brief' match='ovalres:extend_definition'>
-    <xsl:param name='result'/>
-    <xsl:apply-templates select='key("oval-definition", @definition_ref)' mode='brief'>
-        <xsl:with-param name='result' select='$result'/>
-    </xsl:apply-templates>
+    <xsl:apply-templates select='key("oval-definition", @definition_ref)' mode='brief'/>
 </xsl:template>
 
 
 <xsl:template mode='brief' match='ovalres:criterion'>
-    <xsl:param name='result'/>
     <li>
         <xsl:apply-templates select='key("oval-test", @test_ref)' mode='brief'>
             <xsl:with-param name='title' select='key("oval-testdef", @test_ref)/@comment'/>
-            <xsl:with-param name='result' select='$result'/>
         </xsl:apply-templates>
     </li>
 </xsl:template>
 
 <xsl:template mode='brief' match='ovalres:criteria'>
-    <xsl:param name='result'/>
     <li>
         <p>
             <span class="label label-info">
@@ -85,24 +76,18 @@ Authors:
         </p>
         <ul>
             <!-- descend deeper into the logic formula -->
-            <xsl:apply-templates mode='brief'>
-                <xsl:with-param name='result' select='$result'/>
-            </xsl:apply-templates>
+            <xsl:apply-templates mode='brief' />
         </ul>
     </li>
 </xsl:template>
 
 <xsl:template mode='brief' match='ovalres:definition'>
-    <xsl:param name='result'/>
-    <xsl:apply-templates select="ovalres:criteria" mode='brief'>
-        <xsl:with-param name='result' select='$result'/>
-    </xsl:apply-templates>
+    <xsl:apply-templates select="ovalres:criteria" mode='brief'/>
 </xsl:template>
 
 <!-- OVAL items dump -->
 <xsl:template mode='brief' match='ovalres:test'>
     <xsl:param name='title'/>
-    <xsl:param name='result'/>
     <xsl:variable name='items' select='ovalres:tested_item'/>
     <xsl:choose>
         <!-- if there are items to display, go ahead -->

--- a/xsl/xccdf-report-oval-details.xsl
+++ b/xsl/xccdf-report-oval-details.xsl
@@ -50,7 +50,14 @@ Authors:
     </xsl:apply-templates>
 </xsl:template>
 
-<xsl:template mode='brief' match='ovalres:definition|ovalres:criteria|ovalres:criterion|ovalres:extend_definition'>
+<xsl:template mode='brief' match='ovalres:extend_definition'>
+    <xsl:param name='result'/>
+    <xsl:apply-templates select='key("oval-definition", @definition_ref)' mode='brief'>
+        <xsl:with-param name='result' select='$result'/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<xsl:template mode='brief' match='ovalres:definition|ovalres:criteria|ovalres:criterion'>
     <xsl:param name='result'/>
     <xsl:apply-templates select='key("oval-test", @test_ref)' mode='brief'>
         <xsl:with-param name='title' select='key("oval-testdef", @test_ref)/@comment'/>

--- a/xsl/xccdf-report-oval-details.xsl
+++ b/xsl/xccdf-report-oval-details.xsl
@@ -57,14 +57,33 @@ Authors:
     </xsl:apply-templates>
 </xsl:template>
 
-<xsl:template mode='brief' match='ovalres:definition|ovalres:criteria|ovalres:criterion'>
+
+<xsl:template mode='brief' match='ovalres:criterion'>
     <xsl:param name='result'/>
-    <xsl:apply-templates select='key("oval-test", @test_ref)' mode='brief'>
-        <xsl:with-param name='title' select='key("oval-testdef", @test_ref)/@comment'/>
-        <xsl:with-param name='result' select='$result'/>
-    </xsl:apply-templates>
-    <!-- descend deeper into the logic formula -->
-    <xsl:apply-templates mode='brief'>
+    <div class="logical_tree_leaf">
+        <xsl:apply-templates select='key("oval-test", @test_ref)' mode='brief'>
+            <xsl:with-param name='title' select='key("oval-testdef", @test_ref)/@comment'/>
+            <xsl:with-param name='result' select='$result'/>
+	    </xsl:apply-templates>
+    </div>
+</xsl:template>
+
+<xsl:template mode='brief' match='ovalres:criteria'>
+    <xsl:param name='result'/>
+	<span class="label label-default">
+        <xsl:value-of select='@operator'/>
+    </span>
+    <div class="logical_tree_node" style="padding:10px;border:1px solid silver;">
+        <!-- descend deeper into the logic formula -->
+        <xsl:apply-templates mode='brief'>
+            <xsl:with-param name='result' select='$result'/>
+	    </xsl:apply-templates>
+    </div>
+</xsl:template>
+
+<xsl:template mode='brief' match='ovalres:definition'>
+    <xsl:param name='result'/>
+	<xsl:apply-templates select="ovalres:criteria" mode='brief'>
         <xsl:with-param name='result' select='$result'/>
     </xsl:apply-templates>
 </xsl:template>
@@ -85,7 +104,7 @@ Authors:
                     </xsl:choose>
                 </span><!-- #160 is nbsp -->&#160;
                 <xsl:choose>
-                    <xsl:when test='$result="pass"'><span class="label label-success">passed</span> because of these items:</xsl:when>
+                    <xsl:when test='@result'><span class="label label-success">passed</span> because of these items:</xsl:when>
                     <xsl:otherwise><span class="label label-danger">failed</span> because of these items:</xsl:otherwise>
                 </xsl:choose>
             </h4>


### PR DESCRIPTION
* If an OVAL definition was extended using 'extend_definition', there were
no details shown in the HTML report for the refereced definition(s).
This commit adds OVAL details for the extended definition to HTML report.
Fixes #916, #954.

* This pull request also adds basic AND/OR logic - Fixes #953, but only partially, because it ignores negations.

I need to solve negations before it will be finished.

I also would like to improve it graphically. It is terribly ugly. Do you have any suggestions how to improve it, please?

- [ ] Extended definitions are shown in the report.
- [ ] AND/OR logic:.

Before:

![screenshot-2018-1-19 xccdf_org open-scap_testresult_default-profile openscap evaluation report](https://user-images.githubusercontent.com/9050916/35155619-80d5f6ac-fd2e-11e7-895a-37d6c9d8e135.png)

After:

![screenshot-2018-1-19 xccdf_org open-scap_testresult_default-profile openscap evaluation report 1](https://user-images.githubusercontent.com/9050916/35155636-8ec83df6-fd2e-11e7-8b6a-a893db3ed0a8.png)
