### PR TITLE
Enable Ninja Build

### DIFF
--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -1,4 +1,5 @@
-file(GLOB_RECURSE COMPAT_SOURCES "*.h")
+file(GLOB_RECURSE COMPAT_HEADERS "*.h")
+list(APPEND COMPAT_SOURCES "")
 
 if(NOT HAVE_FLOCK)
 	list(APPEND COMPAT_SOURCES "flock.c")
@@ -16,4 +17,6 @@ if(NOT HAVE_GETOPT_H)
 	list(APPEND COMPAT_SOURCES "getopt.c")
 endif()
 
-add_library(compat_object OBJECT ${COMPAT_SOURCES})
+if(COMPAT_SOURCES)
+	add_library(compat_object OBJECT ${COMPAT_HEADERS} ${COMPAT_SOURCES})
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,6 @@ add_subdirectory("XCCDF")
 add_subdirectory("XCCDF_POLICY")
 
 set(OBJECTS_TO_LINK_AGAINST
-	$<TARGET_OBJECTS:compat_object>
 	$<TARGET_OBJECTS:common_object>
 	$<TARGET_OBJECTS:cpe_object>
 	$<TARGET_OBJECTS:cve_object>
@@ -58,6 +57,9 @@ set(OBJECTS_TO_LINK_AGAINST
 	$<TARGET_OBJECTS:xccdf_object>
 	$<TARGET_OBJECTS:xccdfPolicy_object>
 )
+if (TARGET "compat_object")
+	list(APPEND OBJECTS_TO_LINK_AGAINST $<TARGET_OBJECTS:compat_object>)
+endif()
 if (ENABLE_CCE)
 	list(APPEND OBJECTS_TO_LINK_AGAINST $<TARGET_OBJECTS:cce_object>)
 endif()


### PR DESCRIPTION
Ninja Build didn't work when 'compat' object was empty.
We should build and link 'compat' object only if it contains
at least 1 function.
Addressing:
`CMake Error: CMake can not determine linker language for target: compat_object`