### PR TITLE
Fix oscap-docker to clean up temp image.

### DIFF
--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -154,10 +154,6 @@ class OscapHelpers(object):
             sys.stderr.write("Command returned exit code {0}.\n".format(oscap_process.returncode))
             sys.stderr.write(oscap_stderr.decode("utf-8") + "\n")
 
-            # Clean up
-            DM = DockerMount("/tmp")
-            self._cleanup_by_path(chroot_path, DM)
-
             sys.exit(1)
 
         sys.stderr.write(oscap_stderr.decode("utf-8") + "\n")
@@ -207,7 +203,7 @@ class OscapHelpers(object):
 
 
 def mount_image_filesystem():
-            _tmp_mnt_dir = DM.mount(image)
+    _tmp_mnt_dir = DM.mount(image)
 
 
 class OscapScan(object):
@@ -261,9 +257,9 @@ class OscapScan(object):
             sys.stderr.write(str(e) + "\n")
             return None
 
-        chroot = self._find_chroot_path(_tmp_mnt_dir)
-
         try:
+            chroot = self._find_chroot_path(_tmp_mnt_dir)
+
             # Figure out which RHEL dist is in the chroot
             dist = self.helper._get_dist(chroot, image)
 
@@ -299,11 +295,13 @@ class OscapScan(object):
             sys.stderr.write(str(e) + "\n")
             return None
 
-        chroot = self._find_chroot_path(_tmp_mnt_dir)
+        try:
+            chroot = self._find_chroot_path(_tmp_mnt_dir)
 
-        # Scan the chroot
-        sys.stdout.write(self.helper._scan(chroot, image, scan_args))
+            # Scan the chroot
+            sys.stdout.write(self.helper._scan(chroot, image, scan_args))
 
-        # Clean up
-        self.helper._cleanup_by_path(_tmp_mnt_dir, DM)
-        self._remove_mnt_dir(mnt_dir)
+        finally:
+            # Clean up
+            self.helper._cleanup_by_path(_tmp_mnt_dir, DM)
+            self._remove_mnt_dir(mnt_dir)


### PR DESCRIPTION
This fixes a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=1454637

The code contained calls to cleanup functions, but they were not effective, because the entity that kept track of temp images was left out of the process. Specifically, the `DockerMount` instance was not passed to the `_cleanup_by_path` and a new one was constructed there instead.
I have modified the code so that the cleanup code path is preserved for the `oscap_chroot` method. The code path for `scan_cve` and `scan` has changed - creation of the new `DockerMount` was avoided by passing the existing instance. I have tested the `scan` path and it performs according to expectations.