### PR TITLE
Fixed string length bug related to ansible remediations.

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -643,9 +643,12 @@ static inline int _xccdf_policy_rule_generate_fix_ansible(const char *template, 
 			}
 		}
 		else {
-			char *remediation_part = malloc((ovector[0] + 1) * sizeof(char));
-			memcpy(remediation_part, &fix_text[start_offset], ovector[0]);
-			remediation_part[ovector[0]] = '\0';
+			// Remarks: ovector doesn't contain values relative to start_offset, it contains
+			// absolute indices of fix_text.
+			const int length_between_matches = ovector[0] - start_offset;
+			char *remediation_part = malloc((length_between_matches + 1) * sizeof(char));
+			memcpy(remediation_part, &fix_text[start_offset], length_between_matches);
+			remediation_part[length_between_matches] = '\0';
 			if (_write_remediation_to_fd_and_free(output_fd, template, remediation_part) != 0) {
 				pcre_free(re);
 				return 1;

--- a/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_ds.xml
+++ b/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_ds.xml
@@ -99,6 +99,12 @@
   tags:
     - foo
     - bar
+
+- name: XCCDF Value www_value_val3 # promote to variable
+  set_fact:
+    www_value_val3: "dummy value"
+  tags:
+    - always
     </fix>
     <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
       <check-export export-name="oval:ssg:var:1" value-id="xccdf_com.example.www_value_val1"/>

--- a/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden.yml
+++ b/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden.yml
@@ -2,6 +2,7 @@
  - hosts: all
    vars:
       www_value_val1: 100
+      www_value_val3: "dummy value"
       www_value_val2: 50
    tasks:
     - name: default1

--- a/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden_altered.yml
+++ b/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden_altered.yml
@@ -2,6 +2,7 @@
  - hosts: all
    vars:
       www_value_val1: 0
+      www_value_val3: "dummy value"
       www_value_val2: 50
    tasks:
     - name: default1

--- a/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden_tailoring.yml
+++ b/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars_golden_tailoring.yml
@@ -2,6 +2,7 @@
  - hosts: all
    vars:
       www_value_val1: 200
+      www_value_val3: "dummy value"
    tasks:
     - name: default1
       lineinfile:


### PR DESCRIPTION
The previous code allocated wrong amount of memory for the remediation fix body.
If the second remediation body was longer than body of the first one, there was not enough of memory allocated. The first remediation was always handled correctly, and third, fourth etc. remediations usually got much more memory than they needed.
Fixes https://github.com/OpenSCAP/scap-security-guide/issues/2593

Update: The issue was caused by assuming that the "return value" of `pcre_exec` `ovector` is relative to `start_offset`. However, we have verified that it contains (absolute) indices of the `fix_text` string.