### PR TITLE
Add missing group-by-rule texts for new reference uris from SSG

### DIFF
--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -497,7 +497,7 @@ Authors:
         <xsl:when test="starts-with($href, 'https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1')">
             <xsl:text>HIPAA</xsl:text>
         </xsl:when>
-        <xsl:when test="starts-with($href, 'https://www.iso.org/standard')">
+        <xsl:when test="starts-with($href, 'https://www.iso.org/standard/54534.html')">
             <xsl:text>ISO 27001-2013</xsl:text>
         </xsl:when>
         <xsl:when test="starts-with($href, 'https://iase.disa.mil/stigs/pages/stig-viewing-guidance')">

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -491,6 +491,18 @@ Authors:
         <xsl:when test="starts-with($href, 'https://www.fbi.gov/file-repository/cjis-security-policy')">
             <xsl:text>FBI CJIS</xsl:text>
         </xsl:when>
+        <xsl:when test="starts-with($href, 'http://www.ssi.gouv.fr/administration/bonnes-pratiques')">
+            <xsl:text>ANSSI</xsl:text>
+        </xsl:when>
+        <xsl:when test="starts-with($href, 'https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1')">
+            <xsl:text>HIPAA</xsl:text>
+        </xsl:when>
+        <xsl:when test="starts-with($href, 'https://www.iso.org/standard')">
+            <xsl:text>ISO 27001-2013</xsl:text>
+        </xsl:when>
+        <xsl:when test="starts-with($href, 'https://iase.disa.mil/stigs/pages/stig-viewing-guidance')">
+            <xsl:text>STIG Viewer</xsl:text>
+        </xsl:when>
         <xsl:otherwise>
             <xsl:value-of select="$href"/>
         </xsl:otherwise>


### PR DESCRIPTION
HTML report was missing human readable text for the new reference uris in SSG.