### PR TITLE
Fix offline scan in probes

### DIFF
--- a/src/OVAL/probes/independent/filehash.c
+++ b/src/OVAL/probes/independent/filehash.c
@@ -265,7 +265,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
 		return (PROBE_EFATAL);
         }
 
-	if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open_prefixed(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			filehash_cb(ofts_ent->path, ofts_ent->file, ctx, over);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/independent/filehash.c
+++ b/src/OVAL/probes/independent/filehash.c
@@ -265,7 +265,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
 		return (PROBE_EFATAL);
         }
 
-	if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			filehash_cb(ofts_ent->path, ofts_ent->file, ctx, over);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/independent/filehash.c
+++ b/src/OVAL/probes/independent/filehash.c
@@ -112,7 +112,7 @@ static int filehash_cb (const char *prefix, const char *p, const char *f, probe_
 	if (prefix == NULL) {
 		fd = open(pbuf, O_RDONLY);
 	} else {
-		char *path_with_prefix = oscap_sprintf("%s%s", prefix, pbuf);
+		char *path_with_prefix = oscap_path_join(prefix, pbuf);
 		fd = open(path_with_prefix, O_RDONLY);
 		free(path_with_prefix);
 	}

--- a/src/OVAL/probes/independent/filehash58.c
+++ b/src/OVAL/probes/independent/filehash58.c
@@ -140,7 +140,7 @@ static int filehash58_cb(const char *prefix, const char *p, const char *f, const
 	if (prefix == NULL) {
 		fd = open(pbuf, O_RDONLY);
 	} else {
-		char *path_with_prefix = oscap_sprintf("%s%s", prefix, pbuf);
+		char *path_with_prefix = oscap_path_join(prefix, pbuf);
 		fd = open(path_with_prefix, O_RDONLY);
 		free(path_with_prefix);
 	}

--- a/src/OVAL/probes/independent/filehash58.c
+++ b/src/OVAL/probes/independent/filehash58.c
@@ -284,7 +284,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
 		goto cleanup;
 	}
 
-	if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open_prefixed(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			/* find hash types to compare with entity, think "not satisfy" */
 			const struct oscap_string_map *p = CRAPI_ALG_MAP;

--- a/src/OVAL/probes/independent/filehash58.c
+++ b/src/OVAL/probes/independent/filehash58.c
@@ -284,7 +284,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
 		goto cleanup;
 	}
 
-	if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			/* find hash types to compare with entity, think "not satisfy" */
 			const struct oscap_string_map *p = CRAPI_ALG_MAP;

--- a/src/OVAL/probes/independent/filemd5.c
+++ b/src/OVAL/probes/independent/filemd5.c
@@ -243,7 +243,7 @@ int probe_main (SEXP_t *probe_in, SEXP_t *probe_out, void *mutex, SEXP_t *filter
 		return (PROBE_EFATAL);
         }
 
-	if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			filehash_cb(ofts_ent->path, ofts_ent->file, probe_out, filters);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/independent/filemd5.c
+++ b/src/OVAL/probes/independent/filemd5.c
@@ -243,7 +243,7 @@ int probe_main (SEXP_t *probe_in, SEXP_t *probe_out, void *mutex, SEXP_t *filter
 		return (PROBE_EFATAL);
         }
 
-	if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open_prefixed(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			filehash_cb(ofts_ent->path, ofts_ent->file, probe_out, filters);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/independent/textfilecontent.c
+++ b/src/OVAL/probes/independent/textfilecontent.c
@@ -392,7 +392,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 
 	const char *prefix = getenv("OSCAP_PROBE_ROOT");
 
-	if ((ofts = oval_fts_open(prefix, path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open_prefixed(prefix, path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			if (ofts_ent->fts_info == FTS_F
 			    || ofts_ent->fts_info == FTS_SL) {

--- a/src/OVAL/probes/independent/textfilecontent.c
+++ b/src/OVAL/probes/independent/textfilecontent.c
@@ -283,7 +283,7 @@ static int process_file(const char *prefix, const char *path, const char *filena
 	 * to return 'FTS_SL' and the presence of a valid target has to
 	 * be determined with stat().
 	 */
-	whole_path_with_prefix = oscap_sprintf("%s%s", prefix ? prefix : "", whole_path);
+	whole_path_with_prefix = oscap_path_join(prefix, whole_path);
 	if (stat(whole_path_with_prefix, &st) == -1)
 		goto cleanup;
 	if (!S_ISREG(st.st_mode))

--- a/src/OVAL/probes/independent/textfilecontent.c
+++ b/src/OVAL/probes/independent/textfilecontent.c
@@ -334,6 +334,7 @@ int probe_offline_mode_supported()
 
 void *probe_init(void)
 {
+	probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
 	return NULL;
 }
 
@@ -341,8 +342,6 @@ int probe_main(probe_ctx *ctx, void *arg)
 {
 	SEXP_t *path_ent, *filename_ent, *line_ent, *behaviors_ent, *filepath_ent, *probe_in;
 	char *pattern;
-	char path_with_root[PATH_MAX + 1];
-	unsigned int root_len = 0;
 
 	OVAL_FTS    *ofts;
 	OVAL_FTSENT *ofts_ent;
@@ -389,22 +388,12 @@ int probe_main(probe_ctx *ctx, void *arg)
 	pfd.filename_ent = filename_ent;
 	pfd.ctx = ctx;
 
-	path_with_root[PATH_MAX] = '\0';
-	if (ctx->offline_mode & PROBE_OFFLINE_OWN) {
-		strncpy(path_with_root, getenv("OSCAP_PROBE_ROOT"), PATH_MAX);
-		root_len = strlen(path_with_root);
-
-		if (path_with_root[root_len - 1] == FILE_SEPARATOR)
-			--root_len;
-	}		
-
 	if ((ofts = oval_fts_open(path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			if (ofts_ent->fts_info == FTS_F
 			    || ofts_ent->fts_info == FTS_SL) {
-				strncpy(path_with_root + root_len, ofts_ent->path, PATH_MAX - root_len);
 				// todo: handle return code
-				process_file(path_with_root, ofts_ent->file, &pfd);
+				process_file(ofts_ent->path, ofts_ent->file, &pfd);
 			}
 			oval_ftsent_free(ofts_ent);
 		}

--- a/src/OVAL/probes/independent/textfilecontent.c
+++ b/src/OVAL/probes/independent/textfilecontent.c
@@ -388,7 +388,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 	pfd.filename_ent = filename_ent;
 	pfd.ctx = ctx;
 
-	if ((ofts = oval_fts_open(path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open(NULL, path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			if (ofts_ent->fts_info == FTS_F
 			    || ofts_ent->fts_info == FTS_SL) {

--- a/src/OVAL/probes/independent/textfilecontent54.c
+++ b/src/OVAL/probes/independent/textfilecontent54.c
@@ -260,7 +260,7 @@ static int process_file(const char *prefix, const char *path, const char *file, 
 	 * to return 'FTS_SL' and the presence of a valid target has to
 	 * be determined with stat().
 	 */
-	whole_path_with_prefix = oscap_sprintf("%s%s", prefix ? prefix : "", whole_path);
+	whole_path_with_prefix = oscap_path_join(prefix, whole_path);
 	if (stat(whole_path_with_prefix, &st) == -1)
 		goto cleanup;
 	if (!S_ISREG(st.st_mode))

--- a/src/OVAL/probes/independent/textfilecontent54.c
+++ b/src/OVAL/probes/independent/textfilecontent54.c
@@ -354,6 +354,7 @@ int probe_offline_mode_supported()
 
 void *probe_init(void)
 {
+  probe_setoption(PROBEOPT_OFFLINE_MODE_SUPPORTED, PROBE_OFFLINE_CHROOT);
   return NULL;
 }
 
@@ -375,8 +376,6 @@ int probe_main(probe_ctx *ctx, void *arg)
 #endif
 	OVAL_FTS    *ofts;
 	OVAL_FTSENT *ofts_ent;
-	char path_with_root[PATH_MAX + 1];
-	unsigned int root_len = 0;
 
         (void)arg;
 
@@ -505,22 +504,12 @@ int probe_main(probe_ctx *ctx, void *arg)
 	}
 #endif
 
-	path_with_root[PATH_MAX] = '\0';
-	if (ctx->offline_mode & PROBE_OFFLINE_OWN) {
-		strncpy(path_with_root, getenv("OSCAP_PROBE_ROOT"), PATH_MAX);
-		root_len = strlen(path_with_root);
-
-		if (path_with_root[root_len - 1] == FILE_SEPARATOR)
-			--root_len;
-	}
-
 	if ((ofts = oval_fts_open(path_ent, file_ent, filepath_ent, bh_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			if (ofts_ent->fts_info == FTS_F
 			    || ofts_ent->fts_info == FTS_SL) {
-				strncpy(path_with_root + root_len, ofts_ent->path, PATH_MAX - root_len);
 				// todo: handle return code
-				process_file(path_with_root, ofts_ent->file, &pfd);
+				process_file(ofts_ent->path, ofts_ent->file, &pfd);
 			}
 			oval_ftsent_free(ofts_ent);
 		}

--- a/src/OVAL/probes/independent/textfilecontent54.c
+++ b/src/OVAL/probes/independent/textfilecontent54.c
@@ -503,8 +503,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 		goto cleanup;
 	}
 #endif
-
-	if ((ofts = oval_fts_open(path_ent, file_ent, filepath_ent, bh_ent, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open(NULL, path_ent, file_ent, filepath_ent, bh_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			if (ofts_ent->fts_info == FTS_F
 			    || ofts_ent->fts_info == FTS_SL) {

--- a/src/OVAL/probes/independent/textfilecontent54.c
+++ b/src/OVAL/probes/independent/textfilecontent54.c
@@ -507,7 +507,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 #endif
 	const char *prefix = getenv("OSCAP_PROBE_ROOT");
 
-	if ((ofts = oval_fts_open(prefix, path_ent, file_ent, filepath_ent, bh_ent, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open_prefixed(prefix, path_ent, file_ent, filepath_ent, bh_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			if (ofts_ent->fts_info == FTS_F
 			    || ofts_ent->fts_info == FTS_SL) {

--- a/src/OVAL/probes/independent/xmlfilecontent.c
+++ b/src/OVAL/probes/independent/xmlfilecontent.c
@@ -320,7 +320,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 	pfd.filename_ent = filename_ent;
         pfd.ctx = ctx;
 
-	if ((ofts = oval_fts_open(NULL, path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open_prefixed(NULL, path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			process_file(ofts_ent->path, ofts_ent->file, &pfd);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/independent/xmlfilecontent.c
+++ b/src/OVAL/probes/independent/xmlfilecontent.c
@@ -320,7 +320,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 	pfd.filename_ent = filename_ent;
         pfd.ctx = ctx;
 
-	if ((ofts = oval_fts_open(path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open(NULL, path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			process_file(ofts_ent->path, ofts_ent->file, &pfd);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/independent/xmlfilecontent.c
+++ b/src/OVAL/probes/independent/xmlfilecontent.c
@@ -128,7 +128,6 @@ static int process_file(const char *prefix, const char *path, const char *filena
 		whole_path[path_len] = FILE_SEPARATOR;
 		++path_len;
 	}
-	dI("%s", path);
 
 	memcpy(whole_path + path_len, filename, filename_len + 1);
 

--- a/src/OVAL/probes/independent/xmlfilecontent.c
+++ b/src/OVAL/probes/independent/xmlfilecontent.c
@@ -134,7 +134,7 @@ static int process_file(const char *prefix, const char *path, const char *filena
 	if (prefix == NULL) {
 		doc = xmlParseFile(whole_path);
 	} else {
-		char *path_with_prefix = oscap_sprintf("%s%s", prefix, whole_path);
+		char *path_with_prefix = oscap_path_join(prefix, whole_path);
 		doc = xmlParseFile(path_with_prefix);
 		free(path_with_prefix);
 	}

--- a/src/OVAL/probes/independent/xmlfilecontent.c
+++ b/src/OVAL/probes/independent/xmlfilecontent.c
@@ -83,7 +83,7 @@ static void dummy_err_func(void * ctx, const char * msg, ...)
 
 int probe_offline_mode_supported()
 {
-	return PROBE_OFFLINE_CHROOT;
+	return PROBE_OFFLINE_OWN;
 }
 
 void *probe_init(void)
@@ -103,7 +103,7 @@ void probe_fini(void *arg)
 	xmlCleanupParser();
 }
 
-static int process_file(const char *path, const char *filename, void *arg)
+static int process_file(const char *prefix, const char *path, const char *filename, void *arg)
 {
 	struct pfdata *pfd = (struct pfdata *) arg;
 	int ret = 0, path_len, filename_len;
@@ -128,12 +128,18 @@ static int process_file(const char *path, const char *filename, void *arg)
 		whole_path[path_len] = FILE_SEPARATOR;
 		++path_len;
 	}
+	dI("%s", path);
 
 	memcpy(whole_path + path_len, filename, filename_len + 1);
 
-	/* evaluate xpath */
+	if (prefix == NULL) {
+		doc = xmlParseFile(whole_path);
+	} else {
+		char *path_with_prefix = oscap_sprintf("%s%s", prefix, whole_path);
+		doc = xmlParseFile(path_with_prefix);
+		free(path_with_prefix);
+	}
 
-	doc = xmlParseFile(whole_path);
 	if (doc == NULL) {
                 SEXP_t *msg;
                 msg = probe_msg_creatf(OVAL_MESSAGE_LEVEL_ERROR, "Can't parse '%s'.", whole_path);
@@ -145,6 +151,7 @@ static int process_file(const char *path, const char *filename, void *arg)
 		goto cleanup;
 	}
 
+	/* evaluate xpath */
 	xpath_ctx = xmlXPathNewContext(doc);
 	if (xpath_ctx == NULL) {
                 SEXP_t *msg;
@@ -169,7 +176,12 @@ static int process_file(const char *path, const char *filename, void *arg)
 		goto cleanup;
 	}
 
-        snprintf(filepath, PATH_MAX, "%s%c%s", path, FILE_SEPARATOR, filename);
+	/* Avoid 2 slashes */
+	if (path_len >= 1 && path[path_len - 1] == FILE_SEPARATOR) {
+		snprintf(filepath, PATH_MAX, "%s%s", path, filename);
+	} else {
+		snprintf(filepath, PATH_MAX, "%s%c%s", path, FILE_SEPARATOR, filename);
+	}
 
         item = probe_item_create(OVAL_INDEPENDENT_XML_FILE_CONTENT, NULL,
                                  "filepath", OVAL_DATATYPE_STRING, filepath,
@@ -320,9 +332,11 @@ int probe_main(probe_ctx *ctx, void *arg)
 	pfd.filename_ent = filename_ent;
         pfd.ctx = ctx;
 
-	if ((ofts = oval_fts_open_prefixed(NULL, path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
+	const char *prefix = getenv("OSCAP_PROBE_ROOT");
+
+	if ((ofts = oval_fts_open_prefixed(prefix, path_ent, filename_ent, filepath_ent, behaviors_ent, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
-			process_file(ofts_ent->path, ofts_ent->file, &pfd);
+			process_file(prefix, ofts_ent->path, ofts_ent->file, &pfd);
 			oval_ftsent_free(ofts_ent);
 		}
 

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -661,7 +661,12 @@ static int process_pattern_match(const char *path, pcre **regex_out)
 #undef TEST_PATH1
 #undef TEST_PATH2
 
-OVAL_FTS *oval_fts_open(const char *prefix, SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result)
+OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result)
+{
+	return oval_fts_open_prefixed(NULL, path, filename, filepath, behaviors, result);
+}
+
+OVAL_FTS *oval_fts_open_prefixed(const char *prefix, SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result)
 {
 	OVAL_FTS *ofts;
 
@@ -1237,7 +1242,7 @@ static FTSENT *oval_fts_read_recurse_path(OVAL_FTS *ofts)
 				   it would be more accurate to obtain the device
 				   id here, but for the sake of supporting the
 				   comparison also in oval_fts_read_match_path(),
-				   the device id is obtained in oval_fts_open()
+				   the device id is obtained in oval_fts_open_prefixed()
 
 				if (ofts->ofts_recurse_path_curdepth == 0)
 					ofts->ofts_recurse_path_devid = fts_ent->fts_statp->st_dev;

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -102,6 +102,12 @@ static OVAL_FTSENT *OVAL_FTSENT_new(OVAL_FTS *ofts, FTSENT *fts_ent)
 	ofts_ent = oscap_talloc(OVAL_FTSENT);
 
 	ofts_ent->fts_info = fts_ent->fts_info;
+	/* The 'shift' variable stores length of the prefix if the prefix
+	 * is defined, otherwise it is set to 0. The value of 'shift' gives
+	 * us information how many characters of the path string are part of
+	 * the prefix and also where the actual path begins.
+	 * We use it to remove the prefix from the path.
+	 */
 	const size_t shift = ofts->prefix ? strlen(ofts->prefix) : 0;
 	if (ofts->ofts_sfilename || ofts->ofts_sfilepath) {
 		ofts_ent->path_len = pathlen_from_ftse(fts_ent->fts_pathlen, fts_ent->fts_namelen) - shift;

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -844,8 +844,6 @@ OVAL_FTS *oval_fts_open_prefixed(const char *prefix, SEXP_t *path, SEXP_t *filen
 		return NULL;
 	}
 
-	dI("Opening file '%s'.", paths[0]);
-
 	ofts = OVAL_FTS_new();
 	ofts->prefix = prefix;
 

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -834,7 +834,7 @@ OVAL_FTS *oval_fts_open_prefixed(const char *prefix, SEXP_t *path, SEXP_t *filen
 	}
 
 	if (prefix != NULL) {
-		char *path_with_prefix = oscap_sprintf("%s%s", prefix, paths[0]);
+		char *path_with_prefix = oscap_path_join(prefix, paths[0]);
 		free((void *) paths[0]);
 		paths[0] = path_with_prefix;
 	}

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -107,7 +107,7 @@ static OVAL_FTSENT *OVAL_FTSENT_new(OVAL_FTS *ofts, FTSENT *fts_ent)
 		ofts_ent->path_len = pathlen_from_ftse(fts_ent->fts_pathlen, fts_ent->fts_namelen) - shift;
 		if (ofts_ent->path_len > 0) {
 			ofts_ent->path = malloc(ofts_ent->path_len + 1);
-			strncpy(ofts_ent->path + shift, fts_ent->fts_path, ofts_ent->path_len);
+			strncpy(ofts_ent->path, fts_ent->fts_path + shift, ofts_ent->path_len);
 			ofts_ent->path[ofts_ent->path_len] = '\0';
 		} else {
 			ofts_ent->path_len = 1;

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -650,7 +650,7 @@ static int process_pattern_match(const char *path, pcre **regex_out)
 #undef TEST_PATH1
 #undef TEST_PATH2
 
-OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result)
+OVAL_FTS *oval_fts_open(const char *prefix, SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result)
 {
 	OVAL_FTS *ofts;
 

--- a/src/OVAL/probes/oval_fts.h
+++ b/src/OVAL/probes/oval_fts.h
@@ -91,6 +91,7 @@ typedef struct {
 	int filesystem;
 
 	fsdev_t *localdevs;
+	const char *prefix;
 } OVAL_FTS;
 
 #define OVAL_RECURSE_DIRECTION_NONE 0 /* default */

--- a/src/OVAL/probes/oval_fts.h
+++ b/src/OVAL/probes/oval_fts.h
@@ -119,7 +119,7 @@ typedef struct {
 /*
  * OVAL FTS public API
  */
-OVAL_FTS    *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result);
+OVAL_FTS *oval_fts_open(const char *prefix, SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result);
 OVAL_FTSENT *oval_fts_read(OVAL_FTS *ofts);
 int          oval_fts_close(OVAL_FTS *ofts);
 

--- a/src/OVAL/probes/oval_fts.h
+++ b/src/OVAL/probes/oval_fts.h
@@ -120,7 +120,8 @@ typedef struct {
 /*
  * OVAL FTS public API
  */
-OVAL_FTS *oval_fts_open(const char *prefix, SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result);
+OVAL_FTS *oval_fts_open_prefixed(const char *prefix, SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result);
+OVAL_FTS *oval_fts_open(SEXP_t *path, SEXP_t *filename, SEXP_t *filepath, SEXP_t *behaviors, SEXP_t* result);
 OVAL_FTSENT *oval_fts_read(OVAL_FTS *ofts);
 int          oval_fts_close(OVAL_FTS *ofts);
 

--- a/src/OVAL/probes/unix/file.c
+++ b/src/OVAL/probes/unix/file.c
@@ -284,7 +284,7 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr)
 		st_path = path_buffer;
 	}
 
-	char *st_path_with_prefix = oscap_sprintf("%s%s", prefix ? prefix : "", st_path);
+	char *st_path_with_prefix = oscap_path_join(prefix, st_path);
 	if (lstat(st_path_with_prefix, &st) == -1) {
                 dI("lstat failed when processing %s: errno=%u, %s.", st_path, errno, strerror (errno));
 		/*

--- a/src/OVAL/probes/unix/file.c
+++ b/src/OVAL/probes/unix/file.c
@@ -507,7 +507,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
         cbargs.ctx     = ctx;
 	cbargs.error   = 0;
 
-	if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open_prefixed(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			if (file_cb(ofts_ent->path, ofts_ent->file, &cbargs) != 0) {
 				oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/unix/file.c
+++ b/src/OVAL/probes/unix/file.c
@@ -279,7 +279,7 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr)
 		if (p_len >= 1 && p[p_len - 1] == FILE_SEPARATOR) {
 			snprintf(path_buffer, sizeof path_buffer, "%s%s", p, f);
 		} else {
-			snprintf(path_buffer, sizeof path_buffer, "%s/%s", p, f);
+			snprintf(path_buffer, sizeof path_buffer, "%s%c%s", p, FILE_SEPARATOR, f);
 		}
 		st_path = path_buffer;
 	}

--- a/src/OVAL/probes/unix/file.c
+++ b/src/OVAL/probes/unix/file.c
@@ -507,7 +507,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
         cbargs.ctx     = ctx;
 	cbargs.error   = 0;
 
-	if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			if (file_cb(ofts_ent->path, ofts_ent->file, &cbargs) != 0) {
 				oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/unix/fileextendedattribute.c
+++ b/src/OVAL/probes/unix/fileextendedattribute.c
@@ -111,7 +111,7 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr)
 
         SEXP_init(&xattr_name);
 
-	char *st_path_with_prefix = oscap_sprintf("%s%s", prefix ? prefix : "", st_path);
+	char *st_path_with_prefix = oscap_path_join(prefix, st_path);
 	do {
 		/* estimate the size of the buffer */
 

--- a/src/OVAL/probes/unix/fileextendedattribute.c
+++ b/src/OVAL/probes/unix/fileextendedattribute.c
@@ -302,7 +302,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
 	cbargs.error    = 0;
         cbargs.attr_ent = attribute_;
 
-	if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open_prefixed(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			file_cb(ofts_ent->path, ofts_ent->file, &cbargs);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/unix/fileextendedattribute.c
+++ b/src/OVAL/probes/unix/fileextendedattribute.c
@@ -53,6 +53,8 @@
 #define PATH_MAX 4096
 #endif
 
+#define FILE_SEPARATOR '/'
+
 #undef OS_FREEBSD
 #undef OS_LINUX
 #undef OS_SOLARIS
@@ -83,7 +85,7 @@ struct cbargs {
         SEXP_t    *attr_ent;
 };
 
-static int file_cb (const char *p, const char *f, void *ptr)
+static int file_cb(const char *prefix, const char *p, const char *f, void *ptr)
 {
         char path_buffer[PATH_MAX];
         SEXP_t *item, xattr_name;
@@ -97,20 +99,31 @@ static int file_cb (const char *p, const char *f, void *ptr)
 	if (f == NULL) {
 		st_path = p;
 	} else {
-		snprintf (path_buffer, sizeof path_buffer, "%s/%s", p, f);
+		const size_t p_len = strlen(p);
+		/* Avoid 2 slashes */
+		if (p_len >= 1 && p[p_len - 1] == FILE_SEPARATOR) {
+			snprintf(path_buffer, sizeof path_buffer, "%s%s", p, f);
+		} else {
+			snprintf(path_buffer, sizeof path_buffer, "%s/%s", p, f);
+		}
 		st_path = path_buffer;
 	}
 
         SEXP_init(&xattr_name);
 
+	char *st_path_with_prefix = oscap_sprintf("%s%s", prefix ? prefix : "", st_path);
 	do {
 		/* estimate the size of the buffer */
-		xattr_count = llistxattr(st_path, NULL, 0);
 
-		if (xattr_count == 0)
-				return (0);
+		xattr_count = llistxattr(st_path_with_prefix, NULL, 0);
+
+		if (xattr_count == 0) {
+			free(st_path_with_prefix);
+			return (0);
+		}
 
 		if (xattr_count < 0) {
+			free(st_path_with_prefix);
 				dI("FAIL: llistxattr(%s, %p, %zu): errno=%u, %s.", errno, strerror(errno));
 				return 0;
 		}
@@ -120,7 +133,7 @@ static int file_cb (const char *p, const char *f, void *ptr)
 		xattr_buf    = realloc(xattr_buf, sizeof(char) * xattr_buflen);
 
 		/* fill the buffer */
-		xattr_count = llistxattr(st_path, xattr_buf, xattr_buflen);
+		xattr_count = llistxattr(st_path_with_prefix, xattr_buf, xattr_buflen);
 
 		/* check & retry if needed */
 	} while (errno == ERANGE);
@@ -148,7 +161,7 @@ static int file_cb (const char *p, const char *f, void *ptr)
                         ssize_t xattr_vallen = -1;
                         char   *xattr_val = NULL;
 
-                        xattr_vallen = lgetxattr(st_path, xattr_buf + i, NULL, 0);
+                        xattr_vallen = lgetxattr(st_path_with_prefix, xattr_buf + i, NULL, 0);
                 retry_value:
                         if (xattr_vallen >= 0) {
 				// Check possible buffer overflow
@@ -162,7 +175,7 @@ static int file_cb (const char *p, const char *f, void *ptr)
 
 				// we don't want to override space for '\0' by call of 'lgetxattr'
 				// we pass only 'xattr_vallen' instead of 'xattr_vallen + 1'
-                                xattr_vallen = lgetxattr(st_path, xattr_buf + i, xattr_val, xattr_vallen);
+                                xattr_vallen = lgetxattr(st_path_with_prefix, xattr_buf + i, xattr_val, xattr_vallen);
 
                                 if (xattr_vallen < 0 || errno == ERANGE)
                                         goto retry_value;
@@ -200,7 +213,7 @@ static int file_cb (const char *p, const char *f, void *ptr)
         } while (xattr_buf + i < xattr_buf + xattr_buflen - 1);
 
         free(xattr_buf);
-
+	free(st_path_with_prefix);
         return (0);
 }
 
@@ -208,7 +221,7 @@ static pthread_mutex_t __file_probe_mutex;
 
 int probe_offline_mode_supported()
 {
-	return PROBE_OFFLINE_CHROOT;
+	return PROBE_OFFLINE_OWN;
 }
 
 void *probe_init (void)
@@ -302,9 +315,11 @@ int probe_main (probe_ctx *ctx, void *mutex)
 	cbargs.error    = 0;
         cbargs.attr_ent = attribute_;
 
-	if ((ofts = oval_fts_open_prefixed(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+	const char *prefix = getenv("OSCAP_PROBE_ROOT");
+
+	if ((ofts = oval_fts_open_prefixed(prefix, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
-			file_cb(ofts_ent->path, ofts_ent->file, &cbargs);
+			file_cb(prefix, ofts_ent->path, ofts_ent->file, &cbargs);
 			oval_ftsent_free(ofts_ent);
 		}
 		oval_fts_close(ofts);

--- a/src/OVAL/probes/unix/fileextendedattribute.c
+++ b/src/OVAL/probes/unix/fileextendedattribute.c
@@ -104,7 +104,7 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr)
 		if (p_len >= 1 && p[p_len - 1] == FILE_SEPARATOR) {
 			snprintf(path_buffer, sizeof path_buffer, "%s%s", p, f);
 		} else {
-			snprintf(path_buffer, sizeof path_buffer, "%s/%s", p, f);
+			snprintf(path_buffer, sizeof path_buffer, "%s%c%s", p, FILE_SEPARATOR, f);
 		}
 		st_path = path_buffer;
 	}

--- a/src/OVAL/probes/unix/fileextendedattribute.c
+++ b/src/OVAL/probes/unix/fileextendedattribute.c
@@ -302,7 +302,7 @@ int probe_main (probe_ctx *ctx, void *mutex)
 	cbargs.error    = 0;
         cbargs.attr_ent = attribute_;
 
-	if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+	if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 			file_cb(ofts_ent->path, ofts_ent->file, &cbargs);
 			oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/unix/gconf.c
+++ b/src/OVAL/probes/unix/gconf.c
@@ -201,7 +201,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 
 		probe_filebehaviors_canonicalize(&behaviors);
 
-                if ((ofts = oval_fts_open(NULL, NULL, NULL, gconf_src, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+                if ((ofts = oval_fts_open_prefixed(NULL, NULL, NULL, gconf_src, behaviors, probe_ctx_getresult(ctx))) != NULL) {
                         while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
                                 assume_r(ofts_ent->path_len
                                          + ofts_ent->file_len + 2 <= PATH_MAX, PROBE_EFATAL);

--- a/src/OVAL/probes/unix/gconf.c
+++ b/src/OVAL/probes/unix/gconf.c
@@ -201,7 +201,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
 
 		probe_filebehaviors_canonicalize(&behaviors);
 
-                if ((ofts = oval_fts_open(NULL, NULL, gconf_src, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+                if ((ofts = oval_fts_open(NULL, NULL, NULL, gconf_src, behaviors, probe_ctx_getresult(ctx))) != NULL) {
                         while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
                                 assume_r(ofts_ent->path_len
                                          + ofts_ent->file_len + 2 <= PATH_MAX, PROBE_EFATAL);

--- a/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
+++ b/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
@@ -310,7 +310,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 	if (filepath || (path && filename)) {
 		probe_filebehaviors_canonicalize(&behaviors);
 
-		if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+		if ((ofts = oval_fts_open_prefixed(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 			while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 				selinuxsecuritycontext_file_cb(ofts_ent->path, ofts_ent->file, ctx);
 				oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
+++ b/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
@@ -217,7 +217,7 @@ static int selinuxsecuritycontext_file_cb(const char *prefix, const char *p, con
 
 	pbuf[plen+flen] = '\0';
 
-	char *path_with_prefix = oscap_sprintf("%s%s", prefix ? prefix : "", pbuf);
+	char *path_with_prefix = oscap_path_join(prefix, pbuf);
 	file_context_size = getfilecon(path_with_prefix, &file_context);
 	free(path_with_prefix);
 	if (file_context_size == -1) {

--- a/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
+++ b/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
@@ -310,7 +310,7 @@ int probe_main(probe_ctx *ctx, void *arg)
 	if (filepath || (path && filename)) {
 		probe_filebehaviors_canonicalize(&behaviors);
 
-		if ((ofts = oval_fts_open(path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
+		if ((ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, probe_ctx_getresult(ctx))) != NULL) {
 			while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
 				selinuxsecuritycontext_file_cb(ofts_ent->path, ofts_ent->file, ctx);
 				oval_ftsent_free(ofts_ent);

--- a/src/OVAL/probes/unix/sysctl.c
+++ b/src/OVAL/probes/unix/sysctl.c
@@ -99,10 +99,10 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
          * collect sysctls
          *  XXX: use direct access for the "equals" op
          */
-        ofts = oval_fts_open(NULL, path_entity, filename_entity, NULL, bh_entity, probe_ctx_getresult(ctx));
+        ofts = oval_fts_open_prefixed(NULL, path_entity, filename_entity, NULL, bh_entity, probe_ctx_getresult(ctx));
 
         if (ofts == NULL) {
-                dE("oval_fts_open(%s, %s) failed", PROC_SYS_DIR, ".\\+");
+                dE("oval_fts_open_prefixed(%s, %s) failed", PROC_SYS_DIR, ".\\+");
                 SEXP_vfree(path_entity, filename_entity, bh_entity, name_entity, NULL);
 
                 return (PROBE_EFATAL);

--- a/src/OVAL/probes/unix/sysctl.c
+++ b/src/OVAL/probes/unix/sysctl.c
@@ -99,7 +99,7 @@ int probe_main(probe_ctx *ctx, void *probe_arg)
          * collect sysctls
          *  XXX: use direct access for the "equals" op
          */
-        ofts = oval_fts_open(path_entity, filename_entity, NULL, bh_entity, probe_ctx_getresult(ctx));
+        ofts = oval_fts_open(NULL, path_entity, filename_entity, NULL, bh_entity, probe_ctx_getresult(ctx));
 
         if (ofts == NULL) {
                 dE("oval_fts_open(%s, %s) failed", PROC_SYS_DIR, ".\\+");

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -35,6 +35,7 @@
 #include "_error.h"
 #include "oscap.h"
 
+#define PATH_SEPARATOR '/'
 
 int oscap_string_to_enum(const struct oscap_string_map *map, const char *str)
 {
@@ -228,4 +229,31 @@ char *oscap_expand_ipv6(const char *input)
 	*output_it = '\0';
 
 	return ret;
+}
+
+char *oscap_path_join(const char *path1, const char *path2)
+{
+	if (path1 == NULL) {
+		return oscap_strdup(path2);
+	}
+	if (path2 == NULL) {
+		return oscap_strdup(path1);
+	}
+	size_t path1_len = strlen(path1);
+	size_t path2_len = strlen(path2);
+	size_t path2_shift = 0;
+	while (path1_len >= 1 && path1[path1_len - 1] == PATH_SEPARATOR) {
+		path1_len--;
+	}
+	while (path2_shift < path2_len && path2[path2_shift] == PATH_SEPARATOR) {
+		path2_shift++;
+	}
+	path2_len -= path2_shift;
+	const size_t joined_path_len = path1_len + 1 + path2_len;
+	char *joined_path = malloc(joined_path_len + 1);
+	strncpy(joined_path, path1, path1_len);
+	joined_path[path1_len++] = PATH_SEPARATOR;
+	strncpy(joined_path + path1_len, path2 + path2_shift, path2_len);
+	joined_path[joined_path_len] = '\0';
+	return joined_path;
 }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -391,11 +391,13 @@ OSCAP_HIDDEN_END;
 char *oscap_sprintf(const char *fmt, ...);
 
 /**
- * Join 2 paths intelligently
- * Caller is responsible to free the returned pointer.
+ * Join 2 paths in an intelligent way.
+ * Both paths are allowed to be NULL.
+ * Caller is responsible for freeing the returned pointer.
  * @param path1 first path
  * @param path2 second path
- * @return Join of path1 and path2.
+ * @return Join of path1 and path2. The first path is separated by the second
+ * path by exactly 1 slash separator.
  */
 char *oscap_path_join(const char *path1, const char *path2);
 

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -390,6 +390,15 @@ OSCAP_HIDDEN_END;
 /// Print to a newly allocated string using varialbe arguments.
 char *oscap_sprintf(const char *fmt, ...);
 
+/**
+ * Join 2 paths intelligently
+ * Caller is responsible to free the returned pointer.
+ * @param path1 first path
+ * @param path2 second path
+ * @return Join of path1 and path2.
+ */
+char *oscap_path_join(const char *path1, const char *path2);
+
 OSCAP_HIDDEN_START;
 
 /// In a list of key-value pairs (odd indicies are keys, even values), find a value for given key

--- a/tests/API/probes/oval_fts_list.c
+++ b/tests/API/probes/oval_fts_list.c
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
 		"filepath=%p\n"
 		"behaviors=%p\n", path, filename, filepath, behaviors);
 
-	ofts = oval_fts_open(path, filename, filepath, behaviors, result);
+	ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, result);
 
 	if (ofts != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {

--- a/tests/API/probes/oval_fts_list.c
+++ b/tests/API/probes/oval_fts_list.c
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
 		"filepath=%p\n"
 		"behaviors=%p\n", path, filename, filepath, behaviors);
 
-	ofts = oval_fts_open(NULL, path, filename, filepath, behaviors, result);
+	ofts = oval_fts_open_prefixed(NULL, path, filename, filepath, behaviors, result);
 
 	if (ofts != NULL) {
 		while ((ofts_ent = oval_fts_read(ofts)) != NULL) {

--- a/tests/offline_mode/Makefile.am
+++ b/tests/offline_mode/Makefile.am
@@ -8,10 +8,10 @@ TESTS_ENVIRONMENT= \
 		OSCAP_FULL_VALIDATION=1 \
 		$(top_builddir)/run
 
-TESTS = test_system_info.sh \
-		test_textfilecontent54.sh
+TESTS = test_offline_mode_system_info.sh \
+		test_offline_mode_textfilecontent54.sh
 
-EXTRA_DIST += test_system_info.sh \
-		test_textfilecontent54.sh \
+EXTRA_DIST += test_offline_mode_system_info.sh \
+		test_offline_mode_textfilecontent54.sh \
 		grubenv \
 		textfilecontent54.oval.xml

--- a/tests/offline_mode/Makefile.am
+++ b/tests/offline_mode/Makefile.am
@@ -8,8 +8,10 @@ TESTS_ENVIRONMENT= \
 		OSCAP_FULL_VALIDATION=1 \
 		$(top_builddir)/run
 
-TESTS = test_system_info.sh
+TESTS = test_system_info.sh \
+		test_textfilecontent54.sh
 
 EXTRA_DIST += test_system_info.sh \
+		test_textfilecontent54.sh \
 		grubenv \
 		textfilecontent54.oval.xml

--- a/tests/offline_mode/test_offline_mode_system_info.sh
+++ b/tests/offline_mode/test_offline_mode_system_info.sh
@@ -12,7 +12,7 @@
 
 set -e -o pipefail
 
-function test_system_info {
+function test_offline_mode_system_info {
     temp_dir="$(mktemp -d)"
 
     # create a mock host name
@@ -48,8 +48,8 @@ function test_system_info {
 
 # Testing.
 
-test_init "test_system_info.log"
+test_init "test_offline_mode_system_info.log"
 
-test_run "test_system_info" test_system_info
+test_run "test_offline_mode_system_info" test_offline_mode_system_info
 
 test_exit

--- a/tests/offline_mode/test_offline_mode_textfilecontent54.sh
+++ b/tests/offline_mode/test_offline_mode_textfilecontent54.sh
@@ -12,7 +12,7 @@
 
 set -e -o pipefail
 
-function test_textfilecontent54 {
+function test_offline_mode_textfilecontent54 {
     temp_dir="$(mktemp -d)"
 
     # prepare /bar.txt
@@ -51,8 +51,8 @@ function test_textfilecontent54 {
 
 # Testing.
 
-test_init "test_textfilecontent54.log"
+test_init "test_offline_mode_textfilecontent54.log"
 
-test_run "test_textfilecontent54" test_textfilecontent54
+test_run "test_offline_mode_textfilecontent54" test_offline_mode_textfilecontent54
 
 test_exit

--- a/tests/offline_mode/test_textfilecontent54.sh
+++ b/tests/offline_mode/test_textfilecontent54.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright 2018 Red Hat Inc., Durham, North Carolina.
+# All Rights Reserved.
+#
+# OpenSCAP Test Suite
+#
+# Authors:
+#      Jan Černý <jcerny@redhat.com>
+
+. ${srcdir}/../test_common.sh
+
+set -e -o pipefail
+
+function test_textfilecontent54 {
+    temp_dir="$(mktemp -d)"
+
+    # prepare /bar.txt
+    echo "Hello" > "$temp_dir/bar.txt"
+
+    # prepare /zzz/foo.txt
+    mkdir -p "$temp_dir/zzz"
+    echo "Bye" > "$temp_dir/zzz/foo.txt"
+
+    result="$(mktemp)"
+
+    export OSCAP_PROBE_ROOT
+    OSCAP_PROBE_ROOT="$temp_dir"
+    $OSCAP oval eval --results $result $srcdir/textfilecontent54.oval.xml
+
+    [ -s "$result" ]
+
+    assert_exists 1 '/oval_results/results/system/oval_system_characteristics/system_data'
+
+    tfc_item='/oval_results/results/system/oval_system_characteristics/system_data/ind-sys:textfilecontent_item'
+    assert_exists 2 $tfc_item
+
+    assert_exists 1 $tfc_item'/ind-sys:filepath[text()="/bar.txt"]'
+    assert_exists 1 $tfc_item'/ind-sys:path[text()="/"]'
+    assert_exists 1 $tfc_item'/ind-sys:filename[text()="bar.txt"]'
+    assert_exists 1 $tfc_item'/ind-sys:text[text()="Hello"]'
+
+    assert_exists 1 $tfc_item'/ind-sys:filepath[text()="/zzz/foo.txt"]'
+    assert_exists 1 $tfc_item'/ind-sys:path[text()="/zzz"]'
+    assert_exists 1 $tfc_item'/ind-sys:filename[text()="foo.txt"]'
+    assert_exists 1 $tfc_item'/ind-sys:text[text()="Bye"]'
+
+    rm -rf "$temp_dir"
+    rm -f "$result"
+}
+
+# Testing.
+
+test_init "test_textfilecontent54.log"
+
+test_run "test_textfilecontent54" test_textfilecontent54
+
+test_exit

--- a/tests/offline_mode/textfilecontent54.oval.xml
+++ b/tests/offline_mode/textfilecontent54.oval.xml
@@ -18,17 +18,38 @@
         <criterion test_ref="oval:x:tst:1" comment="textfilecontent54_test"/>
       </criteria>
     </definition>
+    <definition class="compliance" version="1" id="oval:x:def:2">
+      <metadata>
+        <title>A second simple test OVAL for textfilecontent54 test.</title>
+        <description>x</description>
+        <affected family="unix">
+          <platform>x</platform>
+        </affected>
+      </metadata>
+      <criteria>
+        <criterion test_ref="oval:x:tst:2" comment="textfilecontent54_test"/>
+      </criteria>
+    </definition>
   </definitions>
 
   <tests>
     <ind:textfilecontent54_test id="oval:x:tst:1" version="1" comment="File /bar.txt must contain something"  check="all">
       <ind:object object_ref="oval:x:obj:1"/>
     </ind:textfilecontent54_test>
+    <ind:textfilecontent54_test id="oval:x:tst:2" version="1" comment="File /zzz/foo.txt must contain something"  check="all">
+      <ind:object object_ref="oval:x:obj:2"/>
+    </ind:textfilecontent54_test>
   </tests>
 
   <objects>
     <ind:textfilecontent54_object id="oval:x:obj:1" version="1" comment="Object representing file">
       <ind:filepath>/bar.txt</ind:filepath>
+      <ind:pattern operation="pattern match">^.*$</ind:pattern>
+      <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+    <ind:textfilecontent54_object id="oval:x:obj:2" version="1" comment="Object representing file">
+      <ind:path>/zzz</ind:path>
+      <ind:filename>foo.txt</ind:filename>
       <ind:pattern operation="pattern match">^.*$</ind:pattern>
       <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
     </ind:textfilecontent54_object>


### PR DESCRIPTION
The textfilecontent(54) probes were not able to read from file in the guest filesystem if a file with the same name doesn't exist on host filesystem.

Fixes #1001.

This PR first reverts commit 908d002c68e43a3d3c3bede128c535fbee815a10 and then it adds new commits that change the offline mode in the probes, namely: 
* textfilecontent
* textfilecontent54
* filehash
* filehash58
* xmlfilecontent
* file
* fileexetendedattribute
* selinuxsecuritycontext

The problem with the commit  908d002c68e43a3d3c3bede128c535fbee815a10 is that it ignores how oval_fts functions work. They traverse the host filesystem, handle OVAL file behaviors, check if the filesystem is remote, check recurse directions, ... 

The revert commit will revert us back to use `chroot()`.

I tried to find some way how to enable offline mode in textfilecontent(54) probes without doing `chroot()`.

The basic idea is very simple: You just add a prefix to the filepath that you want to check, eg. if your container is mounted in `/tmp/abcdef` and you want to check `/etc/passwd` there, you just check `/tmp/abcdef/etc/passwd`.

However, it is not so easy as it seems, for multiple reasons:
* The filepath in OVAL can be specified by a regular expression. The regular expressions can be very complex. You have to understand them and modify the regular expression by the prefix correctly.
* The filepath in OVAL can be specified in a variable, which is handled by SEXPs, so we have to modify how OVAL variables are handled, too.
* The paths can be obtained by some functions, eg. glob_to_regex. We have to make sure glob_to_regex returns a prefixed path.
* The paths could be read from another files, returned by other definitions, etc etc. and we would have to make sure they are prefixed, but not multiple times. 
* The OVAL_fts compares the path it checks with oval_probe_ent using generic functions. They can handle various cases, like OVAL sets, OVAL variables, regexes, OVAL filters, and so on. We would have to modify all this comparisons to be able to handle the filepath prefix - either always add it or always strip it. That's a  change of whole SEXP module.
* We would also have to make sure the prefix doesn't appear in the collected OVAL item. Otherwise OVAL states don't work (which btw doesn't work now in 1.2.16).
* Moreover we would have to make sure the filepath prefix doesn't appear the OVAL results documents and HTML reports. It would be terribly confusing for users if they see some `/tmp/abcdef` prefixes there, because they expect the container scan is completely isolated from the host.

I think it is possible to do that properly, but I expect that to be a very big task due to aforementioned reasons.

For more details, please see #1001 .