### PR TITLE
Fix oscap_dirname on Windows

### DIFF
--- a/src/common/util.c
+++ b/src/common/util.c
@@ -268,6 +268,9 @@ char *oscap_basename(char *path)
 char *oscap_dirname(char *path)
 {
 #ifdef _WIN32
+	if (path == NULL || *path == '\0' || strchr(path, '/') == NULL) {
+		return strdup(".");
+	}
 	char dirpath[_MAX_DIR];
 	_splitpath_s(path, NULL, 0, dirpath, _MAX_DIR, NULL, 0, NULL, 0);
 #else

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -268,7 +268,7 @@ char *oscap_basename(char *path)
 char *oscap_dirname(char *path)
 {
 #ifdef _WIN32
-	if (path == NULL || *path == '\0' || strchr(path, '/') == NULL) {
+	if (path == NULL || *path == '\0' || strchr(path, '/') == NULL || strchr(path, '\\') == NULL) {
 		return strdup(".");
 	}
 	char dirpath[_MAX_DIR];


### PR DESCRIPTION
oscap_dirname must work same as dirname(). However on Windows
it works different. We need to fix it according to 'man 3 dirname':
If path is a null pointer or points to an empty string, then both
dirname() and basename() return the string ".".
If path does not contain a slash, dirname() returns the string ".".