### PR TITLE
Use chroot offline mode for rpm probes

### DIFF
--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -269,7 +269,7 @@ void probe_preload ()
 
 int probe_offline_mode_supported()
 {
-	return PROBE_OFFLINE_OWN|PROBE_OFFLINE_RPMDB;
+	return PROBE_OFFLINE_CHROOT | PROBE_OFFLINE_RPMDB;
 }
 
 void *probe_init (void)

--- a/src/OVAL/probes/unix/linux/rpmverify.c
+++ b/src/OVAL/probes/unix/linux/rpmverify.c
@@ -226,7 +226,8 @@ void probe_preload ()
 
 int probe_offline_mode_supported()
 {
-	return PROBE_OFFLINE_OWN;
+	// TODO: Switch this to OFFLINE_MODE_OWN once rpmtsSetRootDir is fully supported by librpm
+	return PROBE_OFFLINE_CHROOT;
 }
 
 void *probe_init (void)

--- a/src/OVAL/probes/unix/linux/rpmverifyfile.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile.c
@@ -311,7 +311,8 @@ void probe_preload ()
 
 int probe_offline_mode_supported()
 {
-	return PROBE_OFFLINE_OWN;
+	// TODO: Switch this to OFFLINE_MODE_OWN once rpmtsSetRootDir is fully supported by librpm
+	return PROBE_OFFLINE_CHROOT;
 }
 
 void *probe_init (void)

--- a/src/OVAL/probes/unix/linux/rpmverifypackage.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage.c
@@ -312,7 +312,8 @@ ret:
 
 int probe_offline_mode_supported()
 {
-	return PROBE_OFFLINE_OWN;
+	// TODO: Switch this to OFFLINE_MODE_OWN once rpmtsSetRootDir is fully supported by librpm
+	return PROBE_OFFLINE_CHROOT;
 }
 
 void *probe_init (void)


### PR DESCRIPTION
We thought the OWN mode would work because rpmtsSetRootDir seems well
suited for it. However rpmtsSetRootDir is not 100% supported by librpm
so it causes false-positives and false-negatives. Let's switch back to
chroot mode until this is fixed in librpm.