### PR TITLE
Adding with-sce-script-dir flag to configure.ac. Fixes #1016

### DIFF
--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -434,15 +434,15 @@ AC_ARG_ENABLE([sce],
        *) AC_MSG_ERROR([bad value ${enableval} for --enable-sce]) ;;
      esac],[sce=no])
 
-AC_ARG_WITH([sce-script-dir],
-     [AS_HELP_STRING([--with-sce-script-dir],
+AC_ARG_WITH([oscap-temp-dir],
+     [AS_HELP_STRING([--with-oscap-temp-dir],
      [use different temporary directory to execute sce scripts [default=/tmp]])],
      [],
-     [with_sce_script_dir="/tmp"])
+     [with_oscap_temp_dir="/tmp"])
 
 if test "x${sce}" = xyes; then
   AC_DEFINE([ENABLE_SCE], [1], [compilation of script check engine enabled])
-  CFLAGS="$CFLAGS -DSCE_SCRIPT_DIR=\\\"${with_sce_script_dir}\\\"" # double escape needed for compilation on some systems
+  CFLAGS="$CFLAGS -DOSCAP_TEMP_DIR=\\\"${with_oscap_temp_dir}\\\"" # double escape needed for compilation on some systems
 fi
 
 AC_ARG_ENABLE([util-oscap],

--- a/ac_probes/configure.ac.tpl
+++ b/ac_probes/configure.ac.tpl
@@ -434,8 +434,15 @@ AC_ARG_ENABLE([sce],
        *) AC_MSG_ERROR([bad value ${enableval} for --enable-sce]) ;;
      esac],[sce=no])
 
+AC_ARG_WITH([sce-script-dir],
+     [AS_HELP_STRING([--with-sce-script-dir],
+     [use different temporary directory to execute sce scripts [default=/tmp]])],
+     [],
+     [with_sce_script_dir="/tmp"])
+
 if test "x${sce}" = xyes; then
   AC_DEFINE([ENABLE_SCE], [1], [compilation of script check engine enabled])
+  CFLAGS="$CFLAGS -DSCE_SCRIPT_DIR=\\\"${with_sce_script_dir}\\\"" # double escape needed for compilation on some systems
 fi
 
 AC_ARG_ENABLE([util-oscap],

--- a/configure.ac
+++ b/configure.ac
@@ -1152,15 +1152,15 @@ AC_ARG_ENABLE([sce],
      esac],[sce=no])
 
 
-AC_ARG_WITH([sce-script-dir],
-     [AS_HELP_STRING([--with-sce-script-dir],
+AC_ARG_WITH([oscap-temp-dir],
+     [AS_HELP_STRING([--with-oscap-temp-dir],
      [use different temporary directory to execute sce scripts [default=/tmp]])],
      [],
-     [with_sce_script_dir="/tmp"])
+     [with_oscap_temp_dir="/tmp"])
 
 if test "x${sce}" = xyes; then
   AC_DEFINE([ENABLE_SCE], [1], [compilation of script check engine enabled])
-  CFLAGS="$CFLAGS -DSCE_SCRIPT_DIR=\\\"${with_sce_script_dir}\\\"" # double escape needed for compilation on some systems
+  CFLAGS="$CFLAGS -DOSCAP_TEMP_DIR=\\\"${with_oscap_temp_dir}\\\"" # double escape needed for compilation on some systems
 fi
 
 AC_ARG_ENABLE([util-oscap],

--- a/configure.ac
+++ b/configure.ac
@@ -1160,7 +1160,7 @@ AC_ARG_WITH([sce-script-dir],
 
 if test "x${sce}" = xyes; then
   AC_DEFINE([ENABLE_SCE], [1], [compilation of script check engine enabled])
-  CFLAGS="$CFLAGS -DSCE_SCRIPT_DIR=\\\"${with_sce_script_dir}\\\""
+  CFLAGS="$CFLAGS -DSCE_SCRIPT_DIR=\\\"${with_sce_script_dir}\\\"" # double escape needed for compilation on some systems
 fi
 
 AC_ARG_ENABLE([util-oscap],

--- a/configure.ac
+++ b/configure.ac
@@ -1160,7 +1160,7 @@ AC_ARG_WITH([sce-script-dir],
 
 if test "x${sce}" = xyes; then
   AC_DEFINE([ENABLE_SCE], [1], [compilation of script check engine enabled])
-  CFLAGS="$CFLAGS -DSCE_SCRIPT_DIR=\"${with_sce_script_dir}\""
+  CFLAGS="$CFLAGS -DSCE_SCRIPT_DIR=\\\"${with_sce_script_dir}\\\""
 fi
 
 AC_ARG_ENABLE([util-oscap],

--- a/configure.ac
+++ b/configure.ac
@@ -1151,8 +1151,16 @@ AC_ARG_ENABLE([sce],
        *) AC_MSG_ERROR([bad value ${enableval} for --enable-sce]) ;;
      esac],[sce=no])
 
+
+AC_ARG_WITH([sce-script-dir],
+     [AS_HELP_STRING([--with-sce-script-dir],
+     [use different temporary directory to execute sce scripts [default=/tmp]])],
+     [],
+     [with_sce_script_dir="/tmp"])
+
 if test "x${sce}" = xyes; then
   AC_DEFINE([ENABLE_SCE], [1], [compilation of script check engine enabled])
+  CFLAGS="$CFLAGS -DSCE_SCRIPT_DIR=\"${with_sce_script_dir}\""
 fi
 
 AC_ARG_ENABLE([util-oscap],

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -22,7 +22,6 @@
 #include <config.h>
 #endif
 
-#include <stdio.h> // for P_tmpdir macro
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -41,11 +40,11 @@
 #include "common/_error.h"
 #include "oscap_string.h"
 
-#ifndef P_tmpdir
-#define P_tmpdir "/tmp"
+#ifndef SCE_SCRIPT_DIR
+#define SCE_SCRIPT_DIR "/tmp"
 #endif
 
-#define TEMP_DIR_TEMPLATE P_tmpdir "/oscap.XXXXXX"
+#define TEMP_DIR_TEMPLATE SCE_SCRIPT_DIR "/oscap.XXXXXX"
 #define TEMP_URL_TEMPLATE "downloaded.XXXXXX"
 
 char *

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -40,11 +40,11 @@
 #include "common/_error.h"
 #include "oscap_string.h"
 
-#ifndef SCE_SCRIPT_DIR
-#define SCE_SCRIPT_DIR "/tmp"
+#ifndef OSCAP_TEMP_DIR
+#define OSCAP_TEMP_DIR "/tmp"
 #endif
 
-#define TEMP_DIR_TEMPLATE SCE_SCRIPT_DIR "/oscap.XXXXXX"
+#define TEMP_DIR_TEMPLATE OSCAP_TEMP_DIR "/oscap.XXXXXX"
 #define TEMP_URL_TEMPLATE "downloaded.XXXXXX"
 
 char *


### PR DESCRIPTION
When configure is run with --enable-sce, add a new parameter --with-sce-script-dir to set the directory path for SCE to store and execute script files (default /tmp). Configure will append -DSCE_SCRIPT_DIR to CFLAGS (P_tmpdir is always defined by stdio.h, which is included by curl.h. Therefore we added SCE_SCRIPT_DIR to prevent the provided cflag from being overwritten.) 