### PR TITLE
OVAL record fixes

### DIFF
--- a/src/OVAL/oval_sexp.c
+++ b/src/OVAL/oval_sexp.c
@@ -654,7 +654,13 @@ static struct oval_record_field *oval_record_field_ITEM_from_sexp(SEXP_t *sexp)
 		return NULL;
 
 	rf = oval_record_field_new(OVAL_RECORD_FIELD_ITEM);
-	oval_record_field_set_name(rf, oval_sysent_get_name(sysent));
+
+	SEXP_t *name_sexp = probe_ent_getattrval(sexp, "name");
+	char *name_str = SEXP_string_cstr(name_sexp);
+	oval_record_field_set_name(rf, name_str);
+	free(name_str);
+	SEXP_free(name_sexp);
+
 	oval_record_field_set_value(rf, oval_sysent_get_value(sysent));
 	oval_record_field_set_datatype(rf, oval_sysent_get_datatype(sysent));
 	oval_record_field_set_mask(rf, oval_sysent_get_mask(sysent));

--- a/src/OVAL/oval_sysEnt.c
+++ b/src/OVAL/oval_sysEnt.c
@@ -309,7 +309,7 @@ void oval_sysent_to_dom(struct oval_sysent *sysent, xmlDoc * doc, xmlNode * pare
 
 	rf_itr = oval_sysent_get_record_fields(sysent);
 	if (oval_record_field_iterator_has_more(rf_itr)) {
-		xmlNsPtr field_ns = xmlSearchNsByHref(doc, xmlDocGetRootElement(doc), OVAL_SYSCHAR_NAMESPACE);
+		xmlNsPtr field_ns = xmlSearchNsByHref(doc, sysent_tag, OVAL_SYSCHAR_NAMESPACE);
 		if (field_ns == NULL) {
 			field_ns = xmlNewNs(xmlDocGetRootElement(doc), OVAL_SYSCHAR_NAMESPACE, NULL);
 		}


### PR DESCRIPTION
This PR provides 2 fixes in the `record` element in OVAL System Characteristics Schema.

When we will add WMI57 Windows probe in future, these fixes will enable us to produce valid XML OVAL results.

Also, it should fix ldap57, sql57 and sql probes, but I haven't tested ldap57, sql57 and sql probes.

**1) Fix namespace of OVAL record field element**

The field element should not have same namespace as its parent element. It should have oval-system-characteristics namespace instead. This bug is caused by wrong usage of xmlSearchNsByHref function, which should have the current mode, not the root node, as argument.
Addressing:
```
File 'results.xml' line 113: Element
'{http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows}field':
This element is not expected. Expected is (
{http://oval.mitre.org/XMLSchema/oval-system-characteristics-5}field ).
OpenSCAP Error: Invalid OVAL Results (5.11.1) content in results.xml.
[oscap_source.c:342]
```

**2) Fix coversion of SEXP to struct oval_record_field**

The member name of struct oval_record_field should contain the value of 'name' attribute of the OVAL 'field' element. However, it was populated by name of the element, which is always 'field'. The values were present in SEXP, but due to this bug, the value of name attribute got lost at this place.
Before:
```
<field name="field">Brno</field>
```
After:
```
<field name="city">Brno</field>
```