### PR TITLE
Remove '\r' characters from help output

### DIFF
--- a/utils/oscap-cvrf.c
+++ b/utils/oscap-cvrf.c
@@ -58,8 +58,8 @@ static struct oscap_module CVRF_EVALUATE_MODULE = {
 	.opt_parser = getopt_cvrf,
 	.func = app_cvrf_evaluate,
 	.help = "Options:\n"
-		"   --index\r\t\t\t\t - Use index file to evaluate a directory of CVRF files.\n"
-		"   --results\r\t\t\t\t - Filename to which evaluation results will be saved.\n",
+		"   --index                       - Use index file to evaluate a directory of CVRF files.\n"
+		"   --results                     - Filename to which evaluation results will be saved.\n",
 };
 
 static struct oscap_module CVRF_EXPORT_MODULE = {
@@ -70,8 +70,8 @@ static struct oscap_module CVRF_EXPORT_MODULE = {
 	.opt_parser = getopt_cvrf,
 	.func = app_cvrf_export,
 	.help = "Options:\n"
-		"   --index\r\t\t\t\t - Use index file to export a directory of CVRF files \n"
-		"   --output\r\t\t\t\t - Filename to which exported CVRF document will be saved.\n",
+		"   --index                       - Use index file to export a directory of CVRF files \n"
+		"   --output                      - Filename to which exported CVRF document will be saved.\n",
 };
 
 static struct oscap_module CVRF_VALIDATE_MODULE = {
@@ -82,7 +82,7 @@ static struct oscap_module CVRF_VALIDATE_MODULE = {
 	.opt_parser = getopt_cvrf,
 	.func = app_cvrf_validate,
 	.help = "Options:\n"
-		"   --index\r\t\t\t\t - Use index file to validate a directory of CVRF files \n",
+		"   --index                       - Use index file to validate a directory of CVRF files \n",
 };
 
 static struct oscap_module* CVRF_SUBMODULES[] = {

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -70,10 +70,10 @@ static struct oscap_module DS_SDS_SPLIT_MODULE = {
 		"TARGET_DIRECTORY - Directory of the resulting files.\n"
 		"\n"
 		"Options:\n"
-		"   --datastream-id <id> \r\t\t\t\t - ID of the datastream in the collection to use.\n"
-		"   --xccdf-id <id> \r\t\t\t\t - ID of XCCDF in the datastream that should be evaluated.\n"
-		"   --skip-valid \r\t\t\t\t - Skips validating of given XCCDF.\n"
-		"   --fetch-remote-resources \r\t\t\t\t - Download remote content referenced by DataStream.\n",
+		"   --datastream-id <id>          - ID of the datastream in the collection to use.\n"
+		"   --xccdf-id <id>               - ID of XCCDF in the datastream that should be evaluated.\n"
+		"   --skip-valid                  - Skips validating of given XCCDF.\n"
+		"   --fetch-remote-resources      - Download remote content referenced by DataStream.\n",
 	.opt_parser = getopt_ds,
 	.func = app_ds_sds_split
 };
@@ -84,7 +84,7 @@ static struct oscap_module DS_SDS_COMPOSE_MODULE = {
 	.summary = "Compose SourceDataStream from given XCCDF",
 	.usage = "[options] xccdf-file.xml target_datastream.xml",
 	.help = "Options:\n"
-		"   --skip-valid \r\t\t\t\t - Skips validating of given XCCDF.\n",
+		"   --skip-valid                  - Skips validating of given XCCDF.\n",
 	.opt_parser = getopt_ds,
 	.func = app_ds_sds_compose
 };
@@ -95,8 +95,8 @@ static struct oscap_module DS_SDS_ADD_MODULE = {
 	.summary = "Add a component to the existing SourceDataStream",
 	.usage = "[options] new-component.xml existing_datastream.xml",
 	.help =	"Options:\n"
-		"   --datastream-id <id> \r\t\t\t\t - ID of the datastream in the collection for adding to.\n"
-		"   --skip-valid \r\t\t\t\t - Skips validating of given XCCDF.\n",
+		"   --datastream-id <id>          - ID of the datastream in the collection for adding to.\n"
+		"   --skip-valid                  - Skips validating of given XCCDF.\n",
 	.opt_parser = getopt_ds,
 	.func = app_ds_sds_add
 };
@@ -117,8 +117,8 @@ static struct oscap_module DS_RDS_SPLIT_MODULE = {
 	.summary = "Splits a ResultDataStream. Creating source datastream (from report-request) and report in target directory.",
 	.usage = "[OPTIONS] rds.xml TARGET_DIRECTORY",
 	.help =	"Options:\n"
-		"   --report-id <id> \r\t\t\t\t - ID of report inside ARF that should be split.\n"
-		"   --skip-valid \r\t\t\t\t - Skips validating of given XCCDF.\n",
+		"   --report-id <id>              - ID of report inside ARF that should be split.\n"
+		"   --skip-valid                  - Skips validating of given XCCDF.\n",
 	.opt_parser = getopt_ds,
 	.func = app_ds_rds_split
 };
@@ -129,7 +129,7 @@ static struct oscap_module DS_RDS_CREATE_MODULE = {
 	.summary = "Create a ResultDataStream from given SourceDataStream, XCCDF results and one or more OVAL results",
 	.usage = "[options] sds.xml target-arf.xml results-xccdf.xml [results-oval1.xml [results-oval2.xml]]",
 	.help =	"Options:\n"
-		"   --skip-valid \r\t\t\t\t - Skips validating of given XCCDF.\n",
+		"   --skip-valid                  - Skips validating of given XCCDF.\n",
 	.opt_parser = getopt_ds,
 	.func = app_ds_rds_create
 };
@@ -140,8 +140,8 @@ static struct oscap_module DS_RDS_VALIDATE_MODULE = {
 	.summary = "Validate given ResultDataStream",
 	.usage = "[options] result_datastream.xml",
 	.help = "Options:\n"
-		"   --verbose <verbosity_level>\r\t\t\t\t - Turn on verbose mode at specified verbosity level.\n"
-		"   --verbose-log-file <file>\r\t\t\t\t - Write verbose informations into file.\n",
+		"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
+		"   --verbose-log-file <file>     - Write verbose informations into file.\n",
 	.opt_parser = getopt_ds,
 	.func = app_ds_rds_validate
 };

--- a/utils/oscap-info.c
+++ b/utils/oscap-info.c
@@ -62,9 +62,9 @@ struct oscap_module OSCAP_INFO_MODULE = {
     .help = "Print information about a file\n"
     "\n"
     "Options:\n"
-    "   --fetch-remote-resources \r\t\t\t\t - Download remote content referenced by DataStream.\n"
-    "   --profile <id>\r\t\t\t\t - Show info of the profile with the given ID..\n"
-    "   --profiles\r\t\t\t\t - Show profiles from the input file in the <id>:<title> format, one line per profile.\n",
+		"   --fetch-remote-resources      - Download remote content referenced by DataStream.\n"
+		"   --profile <id>                - Show info of the profile with the given ID..\n"
+		"   --profiles                    - Show profiles from the input file in the <id>:<title> format, one line per profile.\n",
     .opt_parser = getopt_info,
     .func = app_info
 };

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -76,12 +76,12 @@ static struct oscap_module OVAL_VALIDATE_XML = {
     .summary = "Validate OVAL XML content",
     .usage = "[options] oval-file.xml",
     .help =
-        "Options:\n"
-        "   --definitions\r\t\t\t\t - Validate OVAL Definitions\n"
-        "   --variables\r\t\t\t\t - Validate external OVAL Variables\n"
-        "   --syschar\r\t\t\t\t - Validate OVAL System Characteristics\n"
-        "   --results\r\t\t\t\t - Validate OVAL Results\n"
-        "   --schematron\r\t\t\t\t - Use schematron-based validation in addition to XML Schema\n",
+	"Options:\n"
+	"   --definitions                 - Validate OVAL Definitions\n"
+	"   --variables                   - Validate external OVAL Variables\n"
+	"   --syschar                     - Validate OVAL System Characteristics\n"
+	"   --results                     - Validate OVAL Results\n"
+	"   --schematron                  - Use schematron-based validation in addition to XML Schema\n",
     .opt_parser = getopt_oval_validate,
     .func = app_oval_validate
 };
@@ -92,12 +92,12 @@ static struct oscap_module OVAL_VALIDATE = {
     .summary = "Validate OVAL XML content",
     .usage = "[options] oval-file.xml",
     .help =
-        "Options:\n"
-        "   --definitions\r\t\t\t\t - Validate OVAL Definitions\n"
-        "   --variables\r\t\t\t\t - Validate external OVAL Variables\n"
-        "   --syschar\r\t\t\t\t - Validate OVAL System Characteristics\n"
-        "   --results\r\t\t\t\t - Validate OVAL Results\n"
-        "   --schematron\r\t\t\t\t - Use schematron-based validation in addition to XML Schema\n",
+	"Options:\n"
+	"   --definitions                 - Validate OVAL Definitions\n"
+	"   --variables                   - Validate external OVAL Variables\n"
+	"   --syschar                     - Validate OVAL System Characteristics\n"
+	"   --results                     - Validate OVAL Results\n"
+	"   --schematron                  - Use schematron-based validation in addition to XML Schema\n",
     .opt_parser = getopt_oval_validate,
     .func = app_oval_validate
 };
@@ -108,21 +108,21 @@ static struct oscap_module OVAL_EVAL = {
     .summary = "Probe the system and evaluate definitions from OVAL Definition file",
     .usage = "[options] oval-definitions.xml",
     .help =
-        "Options:\n"
-	"   --id <definition-id>\r\t\t\t\t - ID of the definition we want to evaluate.\n"
-	"   --variables <file>\r\t\t\t\t - Provide external variables expected by OVAL Definitions.\n"
-        "   --directives <file>\r\t\t\t\t - Use OVAL Directives content to specify desired results content.\n"
-        "   --without-syschar \r\t\t\t\t - Don't provide system characteristic in result file.\n"
-        "   --results <file>\r\t\t\t\t - Write OVAL Results into file.\n"
-        "   --report <file>\r\t\t\t\t - Create human readable (HTML) report from OVAL Results.\n"
-        "   --skip-valid\r\t\t\t\t - Skip validation.\n"
-        "   --datastream-id <id> \r\t\t\t\t - ID of the datastream in the collection to use.\n"
-        "                        \r\t\t\t\t   (only applicable for source datastreams)\n"
-        "   --oval-id <id> \r\t\t\t\t - ID of the OVAL component ref in the datastream to use.\n"
-        "                  \r\t\t\t\t   (only applicable for source datastreams)\n"
-	"   --probe-root <dir>\r\t\t\t\t - Change the root directory before scanning the system.\n"
-	"   --verbose <verbosity_level>\r\t\t\t\t - Turn on verbose mode at specified verbosity level.\n"
-	"   --verbose-log-file <file>\r\t\t\t\t - Write verbose information into file.\n",
+	"Options:\n"
+	"   --id <definition-id>          - ID of the definition we want to evaluate.\n"
+	"   --variables <file>            - Provide external variables expected by OVAL Definitions.\n"
+	"   --directives <file>           - Use OVAL Directives content to specify desired results content.\n"
+	"   --without-syschar             - Don't provide system characteristic in result file.\n"
+	"   --results <file>              - Write OVAL Results into file.\n"
+	"   --report <file>               - Create human readable (HTML) report from OVAL Results.\n"
+	"   --skip-valid                  - Skip validation.\n"
+	"   --datastream-id <id>          - ID of the datastream in the collection to use.\n"
+	"                                   (only applicable for source datastreams)\n"
+	"   --oval-id <id>                - ID of the OVAL component ref in the datastream to use.\n"
+	"                                   (only applicable for source datastreams)\n"
+	"   --probe-root <dir>            - Change the root directory before scanning the system.\n"
+	"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
+	"   --verbose-log-file <file>     - Write verbose information into file.\n",
     .opt_parser = getopt_oval_eval,
     .func = app_evaluate_oval
 };
@@ -134,12 +134,12 @@ static struct oscap_module OVAL_COLLECT = {
     .usage = "[options] oval-definitions.xml",
     .help =
 	"Options:\n"
-	"   --id <object>\r\t\t\t\t - Collect system characteristics ONLY for specified OVAL Object.\n"
-        "   --syschar <file>\r\t\t\t\t - Write OVAL System Characteristic into file.\n"
-	"   --variables <file>\r\t\t\t\t - Provide external variables expected by OVAL Definitions.\n"
-        "   --skip-valid\r\t\t\t\t - Skip validation.\n"
-	"   --verbose <verbosity_level>\r\t\t\t\t - Turn on verbose mode at specified verbosity level.\n"
-	"   --verbose-log-file <file>\r\t\t\t\t - Write verbose information into file.\n",
+	"   --id <object>                 - Collect system characteristics ONLY for specified OVAL Object.\n"
+	"   --syschar <file>              - Write OVAL System Characteristic into file.\n"
+	"   --variables <file>            - Provide external variables expected by OVAL Definitions.\n"
+	"   --skip-valid                  - Skip validation.\n"
+	"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
+	"   --verbose-log-file <file>     - Write verbose information into file.\n",
     .opt_parser = getopt_oval_collect,
     .func = app_collect_oval
 };
@@ -151,11 +151,11 @@ static struct oscap_module OVAL_ANALYSE = {
     .usage = "[options] --results FILE oval-definitions.xml system-characteristics.xml" ,
     .help =
 	"Options:\n"
-	"   --variables <file>\r\t\t\t\t - Provide external variables expected by OVAL Definitions.\n"
-        "   --directives <file>\r\t\t\t\t - Use OVAL Directives content to specify desired results content.\n"
-        "   --skip-valid\r\t\t\t\t - Skip validation.\n"
-	"   --verbose <verbosity_level>\r\t\t\t\t - Turn on verbose mode at specified verbosity level.\n"
-	"   --verbose-log-file <file>\r\t\t\t\t - Write verbose information into file.\n",
+	"   --variables <file>            - Provide external variables expected by OVAL Definitions.\n"
+	"   --directives <file>           - Use OVAL Directives content to specify desired results content.\n"
+	"   --skip-valid                  - Skip validation.\n"
+	"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
+	"   --verbose-log-file <file>     - Write verbose information into file.\n",
     .opt_parser = getopt_oval_analyse,
     .func = app_analyse_oval
 };
@@ -174,8 +174,8 @@ static struct oscap_module OVAL_REPORT = {
     .summary = "Generate a HTML report from OVAL results file",
     .usage = "[options] oval-file.xml",
     .help =
-        "Options:\n"
-        "   --output <file>\r\t\t\t\t - Write the HTML into file.",
+	"Options:\n"
+	"   --output <file>               - Write the HTML into file.",
     .opt_parser = getopt_oval_report,
     .user = "oval-results-report.xsl",
     .func = app_oval_xslt
@@ -187,9 +187,9 @@ static struct oscap_module OVAL_LIST_PROBES = {
     .summary = "List supported object types (i.e. probes)",
     .usage = "[options]",
     .help = "Options:\n"
-            "   --static\r\t\t\t\t - List all probes defined in the internal tables.\n"
-            "   --dynamic\r\t\t\t\t - List all probes supported on the current system (this is default behavior).\n"
-            "   --verbose\r\t\t\t\t - Be verbose.",
+	"   --static                      - List all probes defined in the internal tables.\n"
+	"   --dynamic                     - List all probes supported on the current system (this is default behavior).\n"
+	"   --verbose                     - Be verbose.",
     .opt_parser = getopt_oval_list_probes,
     .func = app_oval_list_probes
 };

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -141,7 +141,7 @@ static inline void oscap_module_print_summary(struct oscap_module *module, FILE 
     assert(module != NULL);
     if (!module->hidden) {
         fprintf(out, "    %s", module->name);
-        if (module->summary) fprintf(out, "\r\t\t\t\t - %s", module->summary);
+        if (module->summary) fprintf(out, " - %s", module->summary);
         fprintf(out, "\n");
     }
 }

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -84,8 +84,8 @@ static struct oscap_module XCCDF_RESOLVE = {
     .summary = "Resolve an XCCDF document",
     .usage = "[options] -o output-xccdf.xml input-xccdf.xml",
     .help =
-        "Options:\n"
-        "   --force\r\t\t\t\t - Force resolving XCCDF document even if it is aleready marked as resolved.",
+		"Options:\n"
+		"   --force                       - Force resolving XCCDF document even if it is aleready marked as resolved.",
     .opt_parser = getopt_xccdf,
     .func = app_xccdf_resolve
 };
@@ -98,7 +98,7 @@ static struct oscap_module XCCDF_VALIDATE_XML = {
     .opt_parser = getopt_xccdf,
 	.func = app_xccdf_validate,
 	.help = "Options:\n"
-		"   --schematron\r\t\t\t\t - Use schematron-based validation in addition to XML Schema\n"
+		"   --schematron                  - Use schematron-based validation in addition to XML Schema\n"
 	,
 };
 
@@ -110,7 +110,7 @@ static struct oscap_module XCCDF_VALIDATE = {
     .opt_parser = getopt_xccdf,
 	.func = app_xccdf_validate,
 	.help = "Options:\n"
-		"   --schematron\r\t\t\t\t - Use schematron-based validation in addition to XML Schema\n"
+		"   --schematron                  - Use schematron-based validation in addition to XML Schema\n"
 	,
 };
 
@@ -122,18 +122,18 @@ static struct oscap_module XCCDF_EXPORT_OVAL_VARIABLES = {
     .opt_parser = getopt_xccdf,
     .func = app_xccdf_export_oval_variables,
 	.help =	"Options:\n"
-		"   --profile <name>\r\t\t\t\t - The name of Profile to be evaluated.\n"
-		"   --skip-valid \r\t\t\t\t - Skip validation.\n"
-		"   --fetch-remote-resources \r\t\t\t\t - Download remote content referenced by XCCDF.\n"
-		"   --datastream-id <id> \r\t\t\t\t - ID of the datastream in the collection to use.\n"
-		"                        \r\t\t\t\t   (only applicable for source datastreams)\n"
-		"   --xccdf-id <id> \r\t\t\t\t - ID of component-ref with XCCDF in the datastream that should be evaluated.\n"
-		"                   \r\t\t\t\t   (only applicable for source datastreams)\n"
-		"   --benchmark-id <id> \r\t\t\t\t - ID of XCCDF Benchmark in some component in the datastream that should be evaluated.\n"
-		"                   \r\t\t\t\t   (only applicable for source datastreams)\n"
-		"                   \r\t\t\t\t   (only applicable when datastream-id AND xccdf-id are not specified)\n"
-		"   --cpe <name>\r\t\t\t\t - Use given CPE dictionary or language (autodetected)\n"
-		"               \r\t\t\t\t   for applicability checks.\n"
+		"   --profile <name>              - The name of Profile to be evaluated.\n"
+		"   --skip-valid                  - Skip validation.\n"
+		"   --fetch-remote-resources      - Download remote content referenced by XCCDF.\n"
+		"   --datastream-id <id>          - ID of the datastream in the collection to use.\n"
+		"                                   (only applicable for source datastreams)\n"
+		"   --xccdf-id <id>               - ID of component-ref with XCCDF in the datastream that should be evaluated.\n"
+		"                                   (only applicable for source datastreams)\n"
+		"   --benchmark-id <id>           - ID of XCCDF Benchmark in some component in the datastream that should be evaluated.\n"
+		"                                   (only applicable for source datastreams)\n"
+		"                                   (only applicable when datastream-id AND xccdf-id are not specified)\n"
+		"   --cpe <name>                  - Use given CPE dictionary or language (autodetected)\n"
+		"                                   for applicability checks.\n"
 	,
 };
 
@@ -144,39 +144,39 @@ static struct oscap_module XCCDF_EVAL = {
     .usage = "[options] INPUT_FILE [oval-definitions-files]",
     .help =
 		"INPUT_FILE - XCCDF file or a source data stream file\n\n"
-        "Options:\n"
-        "   --profile <name>\r\t\t\t\t - The name of Profile to be evaluated.\n"
-	"   --rule <name>\r\t\t\t\t - The name of a single rule to be evaluated.\n"
-        "   --tailoring-file <file>\r\t\t\t\t - Use given XCCDF Tailoring file.\n"
-        "   --tailoring-id <component-id>\r\t\t\t\t - Use given DS component as XCCDF Tailoring file.\n"
-        "   --cpe <name>\r\t\t\t\t - Use given CPE dictionary or language (autodetected)\n"
-        "               \r\t\t\t\t   for applicability checks.\n"
-        "   --oval-results\r\t\t\t\t - Save OVAL results as well.\n"
-        "   --sce-results\r\t\t\t\t - Save SCE results as well. (DEPRECATED! use --check-engine-results)\n"
-        "   --check-engine-results\r\t\t\t\t - Save results from check engines loaded from plugins as well.\n"
-        "   --export-variables\r\t\t\t\t - Export OVAL external variables provided by XCCDF.\n"
-        "   --results <file>\r\t\t\t\t - Write XCCDF Results into file.\n"
-        "   --results-arf <file>\r\t\t\t\t - Write ARF (result data stream) into file.\n"
-        "   --stig-viewer <file>\r\t\t\t\t - Writes XCCDF results into FILE in a format readable by DISA STIG Viewer\n"
-        "   --thin-results\r\t\t\t\t - Thin Results provides only minimal amount of information in OVAL/ARF results.\n"
-        "                 \r\t\t\t\t   The option --without-syschar is automatically enabled when you use Thin Results.\n"
-        "   --without-syschar \r\t\t\t\t - Don't provide system characteristic in OVAL/ARF result files.\n"
-        "   --report <file>\r\t\t\t\t - Write HTML report into file.\n"
-        "   --skip-valid \r\t\t\t\t - Skip validation.\n"
-	"   --fetch-remote-resources \r\t\t\t\t - Download remote content referenced by XCCDF.\n"
-	"   --progress \r\t\t\t\t - Switch to sparse output suitable for progress reporting.\n"
-	"              \r\t\t\t\t   Format is \"$rule_id:$result\\n\".\n"
-	"   --datastream-id <id> \r\t\t\t\t - ID of the datastream in the collection to use.\n"
-	"                        \r\t\t\t\t   (only applicable for source datastreams)\n"
-	"   --xccdf-id <id> \r\t\t\t\t - ID of component-ref with XCCDF in the datastream that should be evaluated.\n"
-	"                   \r\t\t\t\t   (only applicable for source datastreams)\n"
-	"   --benchmark-id <id> \r\t\t\t\t - ID of XCCDF Benchmark in some component in the datastream that should be evaluated.\n"
-	"                   \r\t\t\t\t   (only applicable for source datastreams)\n"
-	"                   \r\t\t\t\t   (only applicable when datastream-id AND xccdf-id are not specified)\n"
-	"   --remediate \r\t\t\t\t - Automatically execute XCCDF fix elements for failed rules.\n"
-	"               \r\t\t\t\t   Use of this option is always at your own risk.\n"
-	"   --verbose <verbosity_level>\r\t\t\t\t - Turn on verbose mode at specified verbosity level.\n"
-	"   --verbose-log-file <file>\r\t\t\t\t - Write verbose informations into file.\n",
+		"Options:\n"
+		"   --profile <name>              - The name of Profile to be evaluated.\n"
+		"   --rule <name>                 - The name of a single rule to be evaluated.\n"
+		"   --tailoring-file <file>       - Use given XCCDF Tailoring file.\n"
+		"   --tailoring-id <component-id> - Use given DS component as XCCDF Tailoring file.\n"
+		"   --cpe <name>                  - Use given CPE dictionary or language (autodetected)\n"
+		"                                   for applicability checks.\n"
+		"   --oval-results                - Save OVAL results as well.\n"
+		"   --sce-results                 - Save SCE results as well. (DEPRECATED! use --check-engine-results)\n"
+		"   --check-engine-results        - Save results from check engines loaded from plugins as well.\n"
+		"   --export-variables            - Export OVAL external variables provided by XCCDF.\n"
+		"   --results <file>              - Write XCCDF Results into file.\n"
+		"   --results-arf <file>          - Write ARF (result data stream) into file.\n"
+		"   --stig-viewer <file>          - Writes XCCDF results into FILE in a format readable by DISA STIG Viewer\n"
+		"   --thin-results                - Thin Results provides only minimal amount of information in OVAL/ARF results.\n"
+		"                                   The option --without-syschar is automatically enabled when you use Thin Results.\n"
+		"   --without-syschar             - Don't provide system characteristic in OVAL/ARF result files.\n"
+		"   --report <file>               - Write HTML report into file.\n"
+		"   --skip-valid                  - Skip validation.\n"
+		"   --fetch-remote-resources      - Download remote content referenced by XCCDF.\n"
+		"   --progress                    - Switch to sparse output suitable for progress reporting.\n"
+		"                                   Format is \"$rule_id:$result\\n\".\n"
+		"   --datastream-id <id>          - ID of the datastream in the collection to use.\n"
+		"                                   (only applicable for source datastreams)\n"
+		"   --xccdf-id <id>               - ID of component-ref with XCCDF in the datastream that should be evaluated.\n"
+		"                                   (only applicable for source datastreams)\n"
+		"   --benchmark-id <id>           - ID of XCCDF Benchmark in some component in the datastream that should be evaluated.\n"
+		"                                   (only applicable for source datastreams)\n"
+		"                                   (only applicable when datastream-id AND xccdf-id are not specified)\n"
+		"   --remediate                   - Automatically execute XCCDF fix elements for failed rules.\n"
+		"                                   Use of this option is always at your own risk.\n"
+		"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
+		"   --verbose-log-file <file>     - Write verbose informations into file.\n",
     .opt_parser = getopt_xccdf,
     .func = app_evaluate_xccdf
 };
@@ -187,24 +187,24 @@ static struct oscap_module XCCDF_REMEDIATE = {
 	.summary =	"Perform remediation driven by XCCDF TestResult file or ARF.",
 	.usage =	"[options] INPUT_FILE [oval-definitions-files]",
 	.help =		"INPUT_FILE - XCCDF TestResult file or ARF\n\n"
-			"Options:\n"
-			"  --result-id\r\t\t\t\t - TestResult ID to be processed. Default is the most recent one.\n"
-			"  --skip-valid\r\t\t\t\t - Skip validation.\n"
-			"  --cpe <name>\r\t\t\t\t - Use given CPE dictionary or language (autodetected)\n"
-			"              \r\t\t\t\t   for applicability checks.\n"
-			"  --fetch-remote-resources\r\t\t\t\t - Download remote content referenced by XCCDF.\n"
-			"  --results <file>\r\t\t\t\t - Write XCCDF Results into file.\n"
-			"  --results-arf <file>\r\t\t\t\t - Write ARF (result data stream) into file.\n"
-			"  --stig-viewer <file>\r\t\t\t\t - Writes XCCDF results into FILE in a format readable by DISA STIG Viewer\n"
-			"  --report <file>\r\t\t\t\t - Write HTML report into file.\n"
-			"  --oval-results\r\t\t\t\t - Save OVAL results.\n"
-			"  --export-variables\r\t\t\t\t - Export OVAL external variables provided by XCCDF.\n"
-			"  --sce-results\r\t\t\t\t - Save SCE results. (DEPRECATED! use --check-engine-results)\n"
-			"  --check-engine-results\r\t\t\t\t - Save results from check engines loaded from plugins as well.\n"
-			"  --progress \r\t\t\t\t - Switch to sparse output suitable for progress reporting.\n"
-			"             \r\t\t\t\t   Format is \"$rule_id:$result\\n\".\n"
-			"  --verbose <verbosity_level>\r\t\t\t\t - Turn on verbose mode at specified verbosity level.\n"
-			"  --verbose-log-file <file>\r\t\t\t\t - Write verbose informations into file.\n"
+		"Options:\n"
+		"   --result-id                   - TestResult ID to be processed. Default is the most recent one.\n"
+		"   --skip-valid                  - Skip validation.\n"
+		"   --cpe <name>                  - Use given CPE dictionary or language (autodetected)\n"
+		"                                   for applicability checks.\n"
+		"   --fetch-remote-resources      - Download remote content referenced by XCCDF.\n"
+		"   --results <file>              - Write XCCDF Results into file.\n"
+		"   --results-arf <file>          - Write ARF (result data stream) into file.\n"
+		"   --stig-viewer <file>          - Writes XCCDF results into FILE in a format readable by DISA STIG Viewer\n"
+		"   --report <file>               - Write HTML report into file.\n"
+		"   --oval-results                - Save OVAL results.\n"
+		"   --export-variables            - Export OVAL external variables provided by XCCDF.\n"
+		"   --sce-results                 - Save SCE results. (DEPRECATED! use --check-engine-results)\n"
+		"   --check-engine-results        - Save results from check engines loaded from plugins as well.\n"
+		"   --progress                    - Switch to sparse output suitable for progress reporting.\n"
+		"                                   Format is \"$rule_id:$result\\n\".\n"
+		"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
+		"   --verbose-log-file <file>     - Write verbose informations into file.\n"
 	,
 	.opt_parser = getopt_xccdf,
 	.func = app_xccdf_remediate
@@ -212,7 +212,7 @@ static struct oscap_module XCCDF_REMEDIATE = {
 
 #define GEN_OPTS \
         "Generate options:\n" \
-        "   --profile <profile-id>\r\t\t\t\t - Apply profile with given ID to the Benchmark before further processing takes place.\n"
+	"   --profile <profile-id>        - Apply profile with given ID to the Benchmark before further processing takes place.\n"
 
 static struct oscap_module XCCDF_GENERATE = {
     .name = "generate",
@@ -231,11 +231,11 @@ static struct oscap_module XCCDF_GEN_REPORT = {
     .summary = "Generate results report",
     .usage = "[options] xccdf-file.xml",
     .help = GEN_OPTS
-        "\nReport Options:\n"
-        "   --result-id <id>\r\t\t\t\t - TestResult ID to be processed. Default is the most recent one.\n"
-        "   --show <result-type*>\r\t\t\t\t - Rule results to show. Defaults to everything but notselected and notapplicable.\n"
-        "   --output <file>\r\t\t\t\t - Write the document into file.\n"
-        "   --oval-template <template-string> - Template which will be used to obtain OVAL result files.\n",
+		"\nReport Options:\n"
+		"   --result-id <id>              - TestResult ID to be processed. Default is the most recent one.\n"
+		"   --show <result-type*>         - Rule results to show. Defaults to everything but notselected and notapplicable.\n"
+		"   --output <file>               - Write the document into file.\n"
+		"   --oval-template <template-string> - Template which will be used to obtain OVAL result files.\n",
     .opt_parser = getopt_xccdf,
     .user = "xccdf-report.xsl",
     .func = app_xccdf_xslt
@@ -247,11 +247,11 @@ static struct oscap_module XCCDF_GEN_GUIDE = {
     .summary = "Generate security guide",
     .usage = "[options] xccdf-file.xml",
     .help = GEN_OPTS
-        "\nGuide Options:\n"
-        "   --output <file>\r\t\t\t\t - Write the document into file.\n"
-        "   --hide-profile-info\r\t\t\t\t - Do not output additional information about selected profile.\n"
-		"   --benchmark-id <id> \r\t\t\t\t - ID of XCCDF Benchmark in some component in the datastream that should be used.\n"
-		"                   \r\t\t\t\t   (only applicable for source datastreams)\n",
+		"\nGuide Options:\n"
+		"   --output <file>               - Write the document into file.\n"
+		"   --hide-profile-info           - Do not output additional information about selected profile.\n"
+		"   --benchmark-id <id>           - ID of XCCDF Benchmark in some component in the datastream that should be used.\n"
+		"                                   (only applicable for source datastreams)\n",
     .opt_parser = getopt_xccdf,
     .user = "xccdf-guide.xsl",
     .func = app_xccdf_xslt
@@ -264,18 +264,18 @@ static struct oscap_module XCCDF_GEN_FIX = {
     .usage = "[options] xccdf-file.xml",
     .help = GEN_OPTS
         "\nFix Options:\n"
-		"   --fix-type <type>\r\t\t\t\t - Fix type. Should be one of: bash, ansible, puppet, anaconda (default: bash).\n"
-        "   --output <file>\r\t\t\t\t - Write the script into file.\n"
-        "   --result-id <id>\r\t\t\t\t - Fixes will be generated for failed rule-results of the specified TestResult.\n"
-		"   --template <id|filename>\r\t\t\t\t - Fix template. (default: bash)\n"
-		"   --benchmark-id <id> \r\t\t\t\t - ID of XCCDF Benchmark in some component in the datastream that should be used.\n"
-		"                   \r\t\t\t\t   (only applicable for source datastreams)\n"
-		"   --xccdf-id <id> \r\t\t\t\t - ID of component-ref with XCCDF in the datastream that should be evaluated.\n"
-		"                   \r\t\t\t\t   (only applicable for source datastreams)\n"
-		"   --tailoring-file <file>\r\t\t\t\t - Use given XCCDF Tailoring file.\n"
-		"                   \r\t\t\t\t   (only applicable for source datastreams)\n"
-		"   --tailoring-id <component-id>\r\t\t\t\t - Use given DS component as XCCDF Tailoring file.\n"
-		"                   \r\t\t\t\t   (only applicable for source datastreams)\n",
+		"   --fix-type <type>             - Fix type. Should be one of: bash, ansible, puppet, anaconda (default: bash).\n"
+		"   --output <file>               - Write the script into file.\n"
+		"   --result-id <id>              - Fixes will be generated for failed rule-results of the specified TestResult.\n"
+		"   --template <id|filename>      - Fix template. (default: bash)\n"
+		"   --benchmark-id <id>           - ID of XCCDF Benchmark in some component in the datastream that should be used.\n"
+		"                                   (only applicable for source datastreams)\n"
+		"   --xccdf-id <id>               - ID of component-ref with XCCDF in the datastream that should be evaluated.\n"
+		"                                   (only applicable for source datastreams)\n"
+		"   --tailoring-file <file>       - Use given XCCDF Tailoring file.\n"
+		"                                   (only applicable for source datastreams)\n"
+		"   --tailoring-id <component-id> - Use given DS component as XCCDF Tailoring file.\n"
+		"                                   (only applicable for source datastreams)\n",
     .opt_parser = getopt_xccdf,
     .user = "legacy-fix.xsl",
     .func = app_generate_fix
@@ -287,9 +287,9 @@ static struct oscap_module XCCDF_GEN_CUSTOM = {
     .summary = "Generate a custom output (depending on given XSLT file) from an XCCDF file",
     .usage = "--stylesheet <file> [--output <file>] xccdf-file.xml",
     .help = GEN_OPTS
-        "\nCustom Options:\n"
-        "   --stylesheet <file>\r\t\t\t\t - Specify an absolute path to a custom stylesheet to format the output.\n"
-        "   --output <file>\r\t\t\t\t - Write the document into file.\n",
+		"\nCustom Options:\n"
+		"   --stylesheet <file>           - Specify an absolute path to a custom stylesheet to format the output.\n"
+		"   --output <file>               - Write the document into file.\n",
     .opt_parser = getopt_xccdf,
     .user = NULL,
     .func = app_xccdf_xslt

--- a/utils/oscap.c
+++ b/utils/oscap.c
@@ -63,9 +63,9 @@ struct oscap_module OSCAP_ROOT_MODULE = {
     .summary = "OpenSCAP command-line tool",
     .help =
 		"oscap options:\n"
-		"   -h --help\r\t\t\t\t - show this help\n"
-		"   -q --quiet\r\t\t\t\t - quiet mode\n"
-		"   -V --version\r\t\t\t\t - print info about supported SCAP versions",
+		"   -h --help                     - show this help\n"
+		"   -q --quiet                    - quiet mode\n"
+		"   -V --version                  - print info about supported SCAP versions",
     .opt_parser = getopt_root,
     .submodules = OSCAP_ROOT_SUBMODULES
 };


### PR DESCRIPTION
Instead of a hack with '\r\t\t\t\t' we will indent the help options manually.
Fixes #1023.