### PR TITLE
Add IP addresses in XCCDF results on Windows

### DIFF
--- a/src/XCCDF/result.c
+++ b/src/XCCDF/result.c
@@ -36,11 +36,10 @@
 #endif
 #include <WinSock2.h>
 #include <Iphlpapi.h>
-#include <Windows.h>
+#include <windows.h>
 #include <ws2def.h>
 #include <io.h>
 #include <winternl.h>
-#include <io.h>
 #include <lmcons.h>
 #else
 #include <unistd.h>


### PR DESCRIPTION
I found this code in my `git stash`, so I think it would be useful
to create a commit from it and share it on Github.
There is a second place where we collect IP addresses of the
scanned machine. These are saved to XCCDF results and are shown
in HTML report. So this change is very visible.
I understand that XCCDF and OVAL are different things, however
I don't like that this copies a lot of code from the system info
probe.