### PR TITLE
Add gcc-c++ to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ cd openscap
 
 2) To build the library you will also need the following build dependencies
 (some of these are optional, if they are not detected, openscap will be compiled
-without respective optional features):
-```
-cmake \
-dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel \
-libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel make openldap-devel \
-pcre-devel perl-XML-Parser perl-XML-XPath perl-devel python-devel rpm-devel swig \
-bzip2-devel
+without respective optional features). On RHEL 7 / Fedora, the command to
+install these packages is:
+```bash
+sudo yum install cmake dbus-devel GConf2-devel libacl-devel libblkid-devel \
+libcap-devel libcurl-devel libgcrypt-devel libselinux-devel libxml2-devel \
+libxslt-devel make openldap-devel pcre-devel perl-XML-Parser perl-XML-XPath \
+perl-devel python-devel rpm-devel swig bzip2-devel gcc-c++
 ```
 On Ubuntu 16.04 the command to install these package is
 ```code
-sudo apt-get install -y autoconf automake libtool make libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev python-dev swig libxml-parser-perl libxml-xpath-perl libperl5.22 python-dev libbz2-dev librpm-dev swig
+sudo apt-get install -y autoconf automake libtool make libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev python-dev swig libxml-parser-perl libxml-xpath-perl libperl5.22 python-dev libbz2-dev librpm-dev swig g++
 ```
 
 When you have all the build dependencies installed you can run the following


### PR DESCRIPTION
- The build fails without `gcc-c++` installed on the system:

```
$ cmake ..
-- The C compiler identification is GNU 8.1.1
-- The CXX compiler identification is unknown
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at CMakeLists.txt:3 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.


-- Configuring incomplete, errors occurred!
See also "/home/ascheel/GitHub/openscap/openscap/build/CMakeFiles/CMakeOutput.log".
See also "/home/ascheel/GitHub/openscap/openscap/build/CMakeFiles/CMakeError.log".
```
- Also clarifies that the package list is for Fedora / RHEL, as next section identifies Ubuntu packages. 