### PR TITLE
Warn about non-registered check systems

### DIFF
--- a/tests/API/XCCDF/parser/CMakeLists.txt
+++ b/tests/API/XCCDF/parser/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_oscap_test_executable(test_api_xccdf "test_api_xccdf.c")
 add_oscap_test("test_api_xccdf.sh")
+add_oscap_test("test_extensions.sh")

--- a/tests/API/XCCDF/parser/test_extensions.sh
+++ b/tests/API/XCCDF/parser/test_extensions.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Red Hat Inc., Durham, North Carolina.
+# All Rights Reserved.
+#
+# OpenScap XCCDF Module Test Suite.
+#
+# Authors:
+#      Peter Vrabec <pvrabec@redhat.com>
+#      Alexander Scheel <ascheel@redhat.com>
+
+. $builddir/tests/test_common.sh
+
+# Test cases.
+
+function test_known_extension {
+	local INPUT=$1
+
+	output=$(bash $builddir/run $builddir/utils/oscap xccdf eval $srcdir/$INPUT 2>&1)
+	has_warning=$(echo "$output" | grep -i "Skipping rule")
+
+
+	return $([ "x$has_warning" == "x" ])
+}
+
+
+function test_unknown_extension {
+	local INPUT=$1
+
+	output=$(bash $builddir/run $builddir/utils/oscap xccdf eval $srcdir/$INPUT 2>&1)
+	has_warning=$(echo "$output" | grep -i "Skipping rule")
+
+	return $([ "x$has_warning" != "x" ])
+}
+
+# Testing.
+
+test_init "test_xccdf_check_extensions.log"
+
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "known check extension" test_known_extension test_known_extensions.xml
+    test_run "unknown check extension" test_unknown_extension test_proprietary_extensions.xml
+fi
+
+test_exit

--- a/tests/API/XCCDF/parser/test_known_extensions.xml
+++ b/tests/API/XCCDF/parser/test_known_extensions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="RHEL-6" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="0" xml:lang="en-US">
+  <status date="2011-12-08">draft</status>
+  <title xml:lang="en-US">Sample XCCDF using open extensions</title>
+  <description xml:lang="en-US">Open extensions will appear the XCCDF report</description>
+  <version>0.1</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <model system="urn:xccdf:scoring:flat"/>
+  <Group id="bash-passer" hidden="false">
+    <title xml:lang="en-US">Check with a hint of OVAL</title>
+    <description xml:lang="en-US">Be Sure To Drink Your OVALtine.</description>
+    <Rule id="rule-1000" selected="true" weight="10.000000">
+      <title xml:lang="en-US">TEST (open)</title>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref href="../tailoring/simple-oval.xml" name="oval:x:def:1"/>
+      </check>
+    </Rule>
+  </Group>
+</Benchmark>

--- a/tests/API/XCCDF/parser/test_proprietary_extensions.xml
+++ b/tests/API/XCCDF/parser/test_proprietary_extensions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="RHEL-6" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="0" xml:lang="en-US">
+  <status date="2011-12-08">draft</status>
+  <title xml:lang="en-US">Sample XCCDF using proprietary extensions</title>
+  <description xml:lang="en-US">Proprietary extensions WILL NOT appear the XCCDF report</description>
+  <version>0.1</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <model system="urn:xccdf:scoring:flat"/>
+  <Group id="bash-passer" hidden="false">
+    <title xml:lang="en-US">Check with a hint of Mint</title>
+    <description xml:lang="en-US">Mint tea consumed during the making of this test</description>
+    <Rule id="rule-1000" selected="true" weight="10.000000">
+      <title xml:lang="en-US">TEST (proprietary)</title>
+      <check system="https://www.bigelowtea.com/Teas/Flavors/Mint">
+        <check-content-ref href="mint.tea"/>
+      </check>
+    </Rule>
+  </Group>
+</Benchmark>


### PR DESCRIPTION
When evaluating XCCDF, if a check uses a system that is not registered (and no other checks can be selected), emit a warning. 

Closes: #768