### PR TITLE
Warn about non-registered check systems

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -28,6 +28,7 @@
 #endif
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <libgen.h>
 
@@ -572,11 +573,32 @@ _xccdf_policy_rule_get_applicable_check(struct xccdf_policy *policy, struct xccd
 			// If the refined selector does not match, checks without selector shall be used.
 			candidate_it = xccdf_rule_get_checks_filtered(rule, NULL);
 		}
+
+		bool print_general_warning = false;
+		bool print_oval_warning = false;
+		char *warning_check_system;
 		// Check Processing Algorithm -- Check.System
 		while (xccdf_check_iterator_has_more(candidate_it)) {
 			struct xccdf_check *check = xccdf_check_iterator_next(candidate_it);
-			if (_xccdf_policy_is_engine_registered(policy, (char *) xccdf_check_get_system(check)))
+			if (_xccdf_policy_is_engine_registered(policy, (char *) xccdf_check_get_system(check))) {
 				result = check;
+			} else if (strcmp("http://oval.mitre.org/XMLSchema/oval-definitions-5", check->system) == 0) {
+				print_oval_warning = true;
+			} else {
+				print_general_warning = true;
+				warning_check_system = check->system;
+			}
+		}
+
+		// Only print a warning if we didn't select a check but could've otherwise.
+		if (print_oval_warning) {
+			printf("WARNING: Skipping rule that uses OVAL but is possibly malformed; "
+			       "an incorrect content reference prevents this check from being evaluated.\n");
+		} else if (print_general_warning && result == NULL) {
+			printf("WARNING: Skipping rule that requires an unregistered check system "
+			       "or incorrect content reference to evaluate. "
+			       "Please consider providing a valid SCAP/OVAL instead of %s\n",
+				warning_check_system);
 		}
 		xccdf_check_iterator_free(candidate_it);
 	}

--- a/tests/API/XCCDF/parser/Makefile.am
+++ b/tests/API/XCCDF/parser/Makefile.am
@@ -22,10 +22,11 @@ TESTS_ENVIRONMENT = \
 		OSCAP_FULL_VALIDATION=1 \
 		$(top_builddir)/run
 
-TESTS = test_api_xccdf.sh
+TESTS = test_api_xccdf.sh test_extensions.sh
 check_PROGRAMS = test_api_xccdf
 
 test_api_xccdf_SOURCES = test_api_xccdf.c
 
-EXTRA_DIST = test_api_xccdf.sh xccdf11.xml xccdf12.xml xccdf11-results.xml
+EXTRA_DIST = test_api_xccdf.sh test_extensions.sh xccdf11.xml xccdf12.xml xccdf11-results.xml \
+             test_known_extensions.xml test_malformed_extensions.xml test_proprietary_extensions.xml
 

--- a/tests/API/XCCDF/parser/test_extensions.sh
+++ b/tests/API/XCCDF/parser/test_extensions.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Red Hat Inc., Durham, North Carolina.
+# All Rights Reserved.
+#
+# OpenScap XCCDF Module Test Suite.
+#
+# Authors:
+#      Peter Vrabec <pvrabec@redhat.com>
+#      Alexander Scheel <ascheel@redhat.com>
+
+. $builddir/tests/test_common.sh
+
+# Test cases.
+
+function test_known_extension {
+	local INPUT=$1
+
+	output=$(bash $builddir/run $builddir/utils/oscap xccdf eval $srcdir/$INPUT 2>&1)
+	has_warning=$(echo "$output" | grep -i "Skipping rule")
+
+	return $([ "x$has_warning" == "x" ])
+}
+
+
+
+function test_malformed_extension {
+	local INPUT=$1
+
+	output=$(bash $builddir/run $builddir/utils/oscap xccdf eval $srcdir/$INPUT 2>&1)
+	has_warning=$(echo "$output" | grep -i "Skipping rule that uses OVAL")
+
+	return $([ "x$has_warning" != "x" ])
+}
+
+
+function test_unknown_extension {
+	local INPUT=$1
+
+	output=$(bash $builddir/run $builddir/utils/oscap xccdf eval $srcdir/$INPUT 2>&1)
+	has_warning=$(echo "$output" | grep -i "Skipping rule that requires")
+
+	return $([ "x$has_warning" != "x" ])
+}
+
+# Testing.
+
+test_init "test_xccdf_check_extensions.log"
+
+if [ -z ${CUSTOM_OSCAP+x} ] ; then
+    test_run "known check extension" test_known_extension test_known_extensions.xml
+    test_run "malformed check extension" test_malformed_extension test_malformed_extensions.xml
+    test_run "unknown check extension" test_unknown_extension test_proprietary_extensions.xml
+fi
+
+test_exit

--- a/tests/API/XCCDF/parser/test_known_extensions.xml
+++ b/tests/API/XCCDF/parser/test_known_extensions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="RHEL-6" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="0" xml:lang="en-US">
+  <status date="2011-12-08">draft</status>
+  <title xml:lang="en-US">Sample XCCDF using open extensions</title>
+  <description xml:lang="en-US">Open extensions will appear the XCCDF report</description>
+  <version>0.1</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <model system="urn:xccdf:scoring:flat"/>
+  <Group id="bash-passer" hidden="false">
+    <title xml:lang="en-US">Check with a hint of OVAL</title>
+    <description xml:lang="en-US">Be Sure To Drink Your OVALtine.</description>
+    <Rule id="rule-1000" selected="true" weight="10.000000">
+      <title xml:lang="en-US">TEST (open)</title>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref href="../tailoring/simple-oval.xml" name="oval:x:def:1"/>
+      </check>
+    </Rule>
+  </Group>
+</Benchmark>

--- a/tests/API/XCCDF/parser/test_malformed_extensions.xml
+++ b/tests/API/XCCDF/parser/test_malformed_extensions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="RHEL-6" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="0" xml:lang="en-US">
+  <status date="2011-12-08">draft</status>
+  <title xml:lang="en-US">Sample XCCDF using open extensions</title>
+  <description xml:lang="en-US">Open extensions will appear the XCCDF report</description>
+  <version>0.1</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <model system="urn:xccdf:scoring:flat"/>
+  <Group id="bash-passer" hidden="false">
+    <title xml:lang="en-US">Check with a hint of OVAL</title>
+    <description xml:lang="en-US">Be Sure To Drink Your OVALtine.</description>
+    <Rule id="rule-1000" selected="true" weight="10.000000">
+      <title xml:lang="en-US">TEST (open)</title>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref href="../some/arbitrary/path/which/will/never/really/exist/on/real/systems.xml" name="oval:x:def:1"/>
+      </check>
+    </Rule>
+  </Group>
+</Benchmark>

--- a/tests/API/XCCDF/parser/test_proprietary_extensions.xml
+++ b/tests/API/XCCDF/parser/test_proprietary_extensions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="RHEL-6" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="0" xml:lang="en-US">
+  <status date="2011-12-08">draft</status>
+  <title xml:lang="en-US">Sample XCCDF using proprietary extensions</title>
+  <description xml:lang="en-US">Proprietary extensions WILL NOT appear the XCCDF report</description>
+  <version>0.1</version>
+  <model system="urn:xccdf:scoring:default"/>
+  <model system="urn:xccdf:scoring:flat"/>
+  <Group id="bash-passer" hidden="false">
+    <title xml:lang="en-US">Check with a hint of Mint</title>
+    <description xml:lang="en-US">Mint tea consumed during the making of this test</description>
+    <Rule id="rule-1000" selected="true" weight="10.000000">
+      <title xml:lang="en-US">TEST (proprietary)</title>
+      <check system="https://www.bigelowtea.com/Teas/Flavors/Mint">
+        <check-content-ref href="mint.tea"/>
+      </check>
+    </Rule>
+  </Group>
+</Benchmark>


### PR DESCRIPTION
When evaluating XCCDF, if a check uses a system that is not registered (and no other checks can be selected), emit a warning. (Targets maint-1.2 versus master)

Closes: #768 
Replaces: #1054 

Per @mpreisler's comment on #1054:
@shawndwells what do you think about the wording?