### PR TITLE
Avoid cmake swig deprecation warnings

### DIFF
--- a/swig/perl/CMakeLists.txt
+++ b/swig/perl/CMakeLists.txt
@@ -1,7 +1,11 @@
 include(UseSWIG)
 
 set(CMAKE_SWIG_FLAGS "-module" "openscap_pm")
-swig_add_module(openscap_pm perl5 ../openscap.i)
+if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
+	swig_add_module(openscap_pm perl5 ../openscap.i)
+else()
+	swig_add_library(openscap_pm LANGUAGE perl5 SOURCES ../openscap.i)
+endif()
 swig_link_libraries(openscap_pm openscap ${PERL_LIBRARY})
 target_include_directories(openscap_pm PUBLIC ${PERL_INCLUDE_PATH})
 

--- a/swig/python2/CMakeLists.txt
+++ b/swig/python2/CMakeLists.txt
@@ -6,7 +6,11 @@ include_directories(${PYTHON_INCLUDE_PATH})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set(CMAKE_SWIG_FLAGS "-module" "openscap_py")
-swig_add_module(openscap_py python ../openscap.i)
+if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
+	swig_add_module(openscap_py python ../openscap.i)
+else()
+	swig_add_library(openscap_py LANGUAGE python SOURCES ../openscap.i)
+endif()
 swig_link_libraries(openscap_py ${PYTHON_LIBRARIES} openscap ${LIBXML2_LIBRARIES} ${LIBXSLT_LIBRARIES} ${LIBXSLT_EXSLT_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES} ${BZIP2_LIBRARIES} ${RPM_LIBRARIES})
 
 add_custom_command(OUTPUT ${PYTHON_COMPILED_FILES}

--- a/swig/python3/CMakeLists.txt
+++ b/swig/python3/CMakeLists.txt
@@ -6,7 +6,11 @@ include_directories(${PYTHON_INCLUDE_PATH})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set(CMAKE_SWIG_FLAGS "-module" "openscap_py" "-py3")
-swig_add_module(openscap_py3 python ../openscap.i)
+if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
+	swig_add_module(openscap_py3 python ../openscap.i)
+else()
+	swig_add_library(openscap_py3 LANGUAGE python SOURCES ../openscap.i)
+endif()
 swig_link_libraries(openscap_py3 openscap ${LIBXML2_LIBRARIES} ${LIBXSLT_LIBRARIES} ${LIBXSLT_EXSLT_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES} ${BZIP2_LIBRARIES} ${RPM_LIBRARIES})
 
 execute_process(COMMAND


### PR DESCRIPTION
CMake Deprecation Warning at /usr/share/cmake/Modules/UseSWIG.cmake:272 (message):
  SWIG_ADD_MODULE is deprecated.  Use SWIG_ADD_LIBRARY instead.
Call Stack (most recent call first):
  swig/python2/CMakeLists.txt:9 (swig_add_module)