### PR TITLE
Add a guide for writing and running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ make install
 ```
 
 
+## Contributing
+
+We welcome all contributions to the OpenSCAP project. If you would like to contribute, either by fixing existing issues or adding new features, please check out our [contribution guide](docs/contribute/contribute.adoc) to get started. If you would like to discuss anything, ask questions, or if you need additional help getting started, you can either send a message to our FreeNode IRC channel, **#openscap**, or to our [mailing list](https://www.redhat.com/mailman/listinfo/open-scap-list).
+
+
 ## Use cases
 
 ### SCAP Content Validation

--- a/docs/contribute/contribute.adoc
+++ b/docs/contribute/contribute.adoc
@@ -4,58 +4,84 @@ This document is meant for new OpenSCAP contributors and it describes how to
 contribute to the OpenSCAP project. Let's suppose that you already have an
 active Github's account with a user name _adam_ and you want to fix one of the
 issue from the link:https://github.com/OpenSCAP/openscap/issues[tracker]. Let's
-say that we want to fix the isuues with number _455_ and the fix will go into
-the _maint-1.0_ branch.
+say that you want to fix the issue with number _455_ and the fix will go into
+the `maint-1.2` branch.
 
-== Fork the OpenSCAP repository
+NOTE: This guide also applies for adding a new feature, the process is the same
+as for fixing an issue described below.
+
+
+== Fork and setup the OpenSCAP repository
 Before you start working on a fix it's a good practice to leave a
 comment in the issue that you work on the fix so other contributors know that
 the fix is in progress.  Next thing you have to do is to fork the OpenSCAP
-repository. You can do that by pressing the **Fork** button in the top-right
+repository. You can do that by pressing the *'Fork'* button in the top-right
 corner on the Github's link:https://github.com/OpenSCAP/openscap[OpenSCAP page].
 It will create a copy of the original repository which you can use for
-proposing changes.
-
-== Choose the right branch
-Before you start working of the fix it's necessary to determine which branch the
-fix will go into. If you are not familiar with the OpenSCAP's branches or
-versions yet please have a look at the link:versioning.adoc[versioning]
-document. Be aware that the fact that an issue description says that the fix
-should go to a _maint-1.2_ branch doesn't have to be true. It's a good practice
-to investigate the correct branch first or ask experienced developers on our
-FreeNode IRC channel called `#openscap` or
-link:https://www.redhat.com/mailman/listinfo/open-scap-list[mailing list].
-
-Once you have forked the repository and decided what branch the fix will go into
-you can clone your forked repository.
+proposing changes. Then you can clone your forked repository:
 [[app-listing]]
 [source,bash]
 ----
 $ git clone git@github.com:adam/openscap.git
 ----
 
+Sometimes you will need to update your forked repository with the latest
+upstream changes. To be able to do so you need to add a remote (we will name it
+upstream) which will track the upstream OpenSCAP repository:
+[[app-listing]]
+[source,bash]
+----
+$ cd openscap/
+# add remote name 'upstream' to refer to the upstream's repository
+$ git remote add upstream git@github.com:OpenSCAP/openscap.git
+----
 
-Now you can create a new branch, which we will call _fix_455_, where you can work on the fix. Remember that
-the name of the new branch will appear in the commit message when your fix is
-merged so choose the name wisely.
+NOTE: In the code snippets, lines starting with # are comments and lines
+starting with $ are commands.
+
+
+== Choose the right branch
+Before you start working on the fix it's necessary to determine which branch the
+fix will go into. If you are not familiar with the OpenSCAP's branches or
+versions yet please have a look at the link:versioning.adoc[versioning]
+document. Be aware that the fact that an issue description says that the fix
+should go to the `maint-1.2` branch doesn't have to be true. It's a good practice
+to investigate the correct branch first or ask experienced developers on our
+FreeNode IRC channel called `#openscap` or
+link:https://www.redhat.com/mailman/listinfo/open-scap-list[mailing list].
+
+NOTE: The default branch of the openscap repository is set to the `maint-1.2`.
+
+Once you have forked the repository and decided that the fix will go into the
+`maint-1.2` branch you can create a new branch from it, which we will call
+_fix_455_, where you can work on the fix. Remember that the name of the new
+branch will appear in the commit message when your fix is merged so choose the
+name wisely:
 
 [[app-listing]]
 [source,bash]
 ----
-# checkout to the maint-1.0 branch
-$ git checkout maint-1.0
+$ git checkout maint-1.2
 # create a new branch
 $ git checkout -b fix_455
 ----
 
-NOTE: The default branch of the openscap repository is set to the `maint-1.2`.
-Our fix will go into the `maint-1.0` so we have to switch to this branch before
-creating a new one.
+On the other hand, if you decided that the fix will go into the `master` branch
+you have to switch to this branch first before creating a new one:
+[[app-listing]]
+[source,bash]
+----
+# create a new local branch to track the remote master branch
+$ git checkout -b master remotes/origin/master
+# and now create a new branch from the master branch which will contain your fix
+$ git checkout -b fix_455
+----
+
 
 == Fix the issue
-NOTE: OpenSCAP is licensed under LGPLv2. Any fixes or improvements must be licensed
-under the same license to be included. Check the COPYING file in the repository
-for more details.
+NOTE: OpenSCAP is licensed under _LGPL v2.1_. Any fixes or improvements must be
+licensed under the same license to be included. Check the COPYING file in the
+repository for more details.
 
 Now you can work on the fix. Try to create small commits which can be easily
 reviewed and make self-explaining commit messages. The
@@ -63,67 +89,76 @@ link:http://chris.beams.io/posts/git-commit/[How to Write a Git Commit
 Message] article could help you with that. Nobody will review a pull request
 which contains a four thousand new lines of code.
 
-NOTE: Since we're fixing an issue number 455 make sure that your commit message
-contain a
+NOTE: Since you're fixing issue number 455 make sure that your commit
+message contain a
 link:https://help.github.com/articles/closing-issues-via-commit-messages/[keyword]
 which will close the issue automatically when your pull request is merged.
 
-
 Let's say that you've fixed the issue, made a few commits to your local fix_455
-branch and you think it's ready to be review by other contributors. Before you
+branch and you think it's ready to be reviewed by other contributors. Before you
 push your local changes to your remote forked repository it's necessary to check
 if your changes will be applicable and won't be in a conflict with some work that
-  other contributors could publish while you were working on the fix.
+other contributors could have published while you were working on the fix.
 
 
 == Rebase before pull request
-If some other contributor pushed some code to the maint-1.0 branch while you was
-working of the fix then it's necessary to pull those changes and rebase our fix
-on top of them. First we need to make sure that our local maint-1.0 branch is
-up-to date.
+If some other contributor pushed some code to the `maint-1.2` branch while you
+were working on the fix and if there would be a conflict between your changes
+then it might be necessary to fetch those changes and rebase your fix on top
+of them. First you need to make sure that your local `maint-1.2` branch is
+up-to date:
 
 [[app-listing]]
 [source,bash]
 ----
-# add remote name 'upstream' to refer to the upstream's repository
-$ git remote add upstream git@github.com:OpenSCAP/openscap.git
-# checkout to branch 'maint-1.0' in your local forked repository
-$ git checkout maint-1.0
-# download and apply any upstream changes to your local maint-1.0 branch
-$ git pull --ff-only upstream maint-1.0
+# checkout to branch 'maint-1.2' in your local forked repository
+$ git checkout maint-1.2
+# download and apply any upstream changes to your local maint-1.2 branch
+$ git pull upstream maint-1.2
+# now you can optionally also push these changes to your fork on Github (recommended)
+$ git push origin maint-1.2
 ----
 
 Now you can go back to your local branch with the fix and try to rebase your
-changes on top of your local updated maint-1.0 branch. If there are no conflicts
-then you can push your branch with the fix to your remote forked repository.
+changes on top of your local updated `maint-1.2` branch:
 
 [[app-listing]]
 [source,bash]
 ----
 # checkout back to your branch with the fix
 $ git checkout fix_455
-# rebase your changes on the top of the updated maint-1.0 branch
-$ git rebase maint-1.0
-# push your changes to your remote forked repository
-$ git push origin fix_455
-# note about --force
+# rebase your changes on the top of the updated maint-1.2 branch
+$ git rebase maint-1.2
 ----
 
-NOTE: If you've already push the branch to your remote repository then made some
-changes and know you want to rewrite the fix_455 branch then the `--force`
-option may come in handy but be aware that it will rewrite your fix_455 branch
-so please use wisely.
+If there are no conflicts then you can push your branch with the fix to your
+remote forked repository:
+
+[[app-listing]]
+[source,bash]
+----
+# push your changes to your remote forked repository (also see the note below)
+$ git push origin fix_455
+----
+
+NOTE: The previous `git push` command will not work if you've already pushed the
+branch to your remote repository. If this is the case, but you made some new
+changes/updates and you want to push them into the fix_455 branch then append
+the `--force` after the `git push` command. Be aware that it will rewrite your
+fix_455 branch in your remote forked repository.
+
 
 == Create a new pull request
 Once you have pushed your local fix_455 branch to your remote forked repository
 you can link:https://help.github.com/articles/creating-a-pull-request/[create] a
 new pull request. You can create the pull request on the OpenSCAP's
 link:https://github.com/OpenSCAP/openscap/pulls[github page] when you click on
-the `Pull requests` in the right menu then you see the green *New pull request*
-button. In the branch menu choose the branch that contains your fix. That is the
-fix_455 branch and also don't forget to set maint-1.0 as the base branch. The
-base branch is the one that your fix_455 will be compared to. If there are no
-conflicts add some description and hit the *Create pull request* button.
+the *'Pull requests'* in the right menu then you see the green
+*'New pull request'* button. In the branch menu choose the branch that contains
+your fix. That is the fix_455 branch and also don't forget to set `maint-1.2`
+as the base branch. The base branch is the one that your fix_455 will be
+compared to. If there are no conflicts add some description and hit the
+*'Create pull request'* button.
 
 Developers and contributor that watch the repository should now
 receive an email about a new pull request. They will review your code and
@@ -135,40 +170,53 @@ After the review is done and one or more experienced developers is complaining
 about your code you have to do some changes. There are two ways to change your
 code in a submitted pull request:
 
- . Add a new commit or,
- . edit existing commits.
+ . Add a new commit,
+ . or edit existing commits.
 
 ==== Add a new commit
-Adding a new commit is easy and I would choose this option if I would have to
-add something new like a function or a new module.
+Adding a new commit is easy and it is a good option if you have to add something
+new like a function or a new module.
 
 ==== Edit existing commits
-If you just need to fix a typo or add a condition I would choose to go back to
-the commit, where the change is needed, and use commit's `--ammed` option to
-change the commit. You can use following steps to do that.
+If you just need to fix something (for example a typo) you need to go back to
+the commit where the change is needed and use commit's `--amend` option to
+change the commit. You can use the following steps to do that:
 
 [[app-listing]]
 [source,bash]
 ----
 # show all the commits in your fix_455 branch
-$ git rebase -i maint-1.0
-# replace 'pick' with 'e' at a line with commit you'd like to change
+$ git rebase -i maint-1.2
+# replace 'pick' with 'e' at the line with commit(s) you'd like to edit
 # make your changes
 # vim my_source_file.c
 # commit your new changes
 $ git commit --amend
-# get back to your last commit
+# move to the next commit which you selected for editing using 'e' in the
+# 'git rebase' command
 $ git rebase --continue
+----
+
+When you are finished with editing commits you can force push all the changes
+into your remote repository to update it with your latest edits. The pull
+request will be updated automatically too:
+
+[[app-listing]]
+[source,bash]
+----
+$ git push --force origin fix_455
 ----
 
 === Closing the pull request
 Once the pull request has been merged to upstream's branch the pull request will
 be closed automatically. The issue will be also closed if you used the right
-keyword in the commit message. Now you can delete your `fix_455` branch.
+keyword in the commit message. Now you can delete your `fix_455` branch:
 
 [[app-listing]]
 [source,bash]
 ----
-# detele the fix_455 branch
+# detele the fix_455 branch locally
 $ git branch -d fix_455
+# optionally also delete the fix_455 branch from your remote forked repository
+$ git push origin --delete fix_455
 ----

--- a/docs/contribute/contribute.adoc
+++ b/docs/contribute/contribute.adoc
@@ -101,6 +101,18 @@ if your changes will be applicable and won't be in a conflict with some work tha
 other contributors could have published while you were working on the fix.
 
 
+== Optional: Write an automated test for your code
+There is a big chance that the code you've fixed or the code that you've added
+has no test coverage. We encourage you to write a new test or extend the
+existing one to cover the changes/additions to OpenSCAP that you have made.
+It is not mandatory, so reviewer will not require you to write a test, but keep
+in mind that providing a test might uncover some unexpected issues with the
+code. We also run these tests on every pull request so adding a test for your
+fix or new feature might prevent someone from breaking it in the future. If you
+decided to add a test please see our
+link:testing.adoc[guide for writing and running tests].
+
+
 == Rebase before pull request
 If some other contributor pushed some code to the `maint-1.2` branch while you
 were working on the fix and if there would be a conflict between your changes

--- a/docs/contribute/testing.adoc
+++ b/docs/contribute/testing.adoc
@@ -1,0 +1,319 @@
+= Writing and running tests for OpenSCAP
+
+This document should help you with writing and running tests for your pull
+requests. It is recommended to add a new test if a new functionality is added
+or if a code that is not covered by any test is updated. Another recommendation
+is to add your test in a separate commit.
+
+All the tests reside in the link:../../tests[tests] directory. It has multiple
+subdirectories which should represent various parts of the OpenSCAP library and
+its utilities. When you contribute to some part of the OpenSCAP project you
+should put a test for your contribution into the corresponding subdirectory
+in the link:../../tests[tests] directory. Use your best judgement when deciding
+where to put the test for your pull request and if you are not sure don't be
+affraid to ask in the pull request, someone will definitely help you with that.
+
+NOTE: OpenSCAP project uses the **GNU automake** which has built-in
+link:https://www.gnu.org/software/automake/manual/html_node/Tests.html[support
+for test suites].
+
+
+== Preparing test environment and running tests
+To run a specific test or all tests you first need to compile the OpenSCAP
+library and then install additional packages required for testing. See the
+*Compilation* section in the link:../../README.md[README.md] for more details.
+
+
+== Writing a new test
+In this guide we will use an example to describe the process of writing a test
+for the OpenSCAP project. Let's suppose you want to write a new test for
+the Script Check Engine (SCE) to test its basic functionality. SCE allows you
+to define your own scripts (usually written in Bash or Python) to extend XCCDF
+rule checking capabilities. Custom check scripts can be referenced from
+an XCCDF rule using `<check-content-ref>` element, for example:
+[[app-listing]]
+[subs=+quotes]
+----
+<check system="http://open-scap.org/page/SCE">
+    <check-content-ref href="YOUR_BASH_SCRIPT.sh"/>
+</check>
+----
+
+
+=== Deciding where to put a new test
+In our example, we are testing the SCE module, therefore we will look for
+its subdirectory in the link:../../tests[tests] direcotory and we will find it
+at the following link: link:../../tests/sce[tests/sce]. We will add our new test
+into this subdirectory.
+
+
+==== Scenario A: There is a suitable directory for my new test
+This will happen most of the times. As stated above in our example we will place
+our test into the link:../../tests/sce[tests/sce] directory.
+
+
+==== Scenario B: There is no suitable directory for my new test
+This might happen if your test covers a part of the OpenSCAP which has no tests
+at all. In this case you would need to add a new directory with suitable name
+into the link:../../tests[tests] directory structure and create/update
+Makefiles.
+
+To have an example also for this scenario, let's suppose we want to add the
+`foo` subdirectory into the link:../../tests[tests] directory. We need to:
+
+. Create the `foo` subdirectory in the link:../../tests[tests] directory.
+. Add a new entry for `foo` subdirectory into the `SUBDIRS` variable in
+  the link:../../tests/Makefile.am[tests/Makefile.am].
+. Create `Makefile.am` inside the `tests/foo` directory and list all
+  your test scripts inside that directory in the `TESTS` variable.
+
+Please see the GNU automake
+link:https://www.gnu.org/software/automake/manual/html_node/Tests.html[
+documentation about test suites] for more details.
+
+
+=== Common test library
+When writing tests for OpenSCAP you should use the common test library which is
+located at link:../../tests/test_common.sh.in[tests/test_common.sh.in].
+
+NOTE: The `configure` script will generate the `tests/test_common.sh` file from
+the link:../../tests/test_common.sh.in[tests/test_common.sh.in] adding
+configuration specific settings.
+
+You will need to source the `tests/test_common.sh` in your test scripts to use
+the functions which it provides. When sourcing the file, you need to specify
+a relative path to it from the directory with your test script. For example,
+when your test script will be in the `tests/foo` directory:
+[[app-listing]]
+[source,bash]
+----
+#!/usr/bin/env bash
+
+set -o pipefail
+
+. ../test_common.sh
+
+test1
+test2
+...
+----
+
+
+==== Global variables exported by test library
+Always use `$OSCAP` variable instead of the plain `oscap` in your tests when
+calling the `oscap` command line tool. This is because tests might be run with
+`CUSTOM_OSCAP` variable.
+
+You can use `$XMLDIFF` in your tests which will call the
+link:../../tests/xmldiff.pl[tests/xmldiff.pl] script.
+
+It is also possible to do XPath queries using `$XPATH` variable, the usage is:
+[[app-listing]]
+[source,bash]
+----
+$XPATH FILE 'QUERY'
+----
+
+
+==== Best practices when writing bash tests
+It is always good to set `pipefail` option for all your test scripts so you
+accidentally don't lose non-zero exit statuses of commands in a pipeline:
+[[app-listing]]
+[source,bash]
+----
+set -o pipefail
+----
+
+The next option you can consider is `errexit` which exits your script
+immediately if a command exits with a non-zero status. You might want to use
+this option if tests are somehow dependent and it doesn't make sense to continue
+testing after one test fails.
+[[app-listing]]
+[source,bash]
+----
+set -e
+----
+
+
+==== test_init function
+The function expects that you provide it with a name of a test log file.
+All tests which will be run after `test_init` using `test_run` function
+will report results into this log file:
+[[app-listing]]
+[source,bash]
+----
+test_init test_foo.log
+----
+
+NOTE: The specified log file will contain output of both `stdout` and `stderr`
+of every test executed by the `test_run` function.
+
+
+==== test_run function
+The function is responsible for executing a test script file or a function and
+logging its result into the log file created by the `test_init` function.
+[[app-listing]]
+[source,bash]
+----
+test_run "DESCRIPTION" TEST_FUNCTION|$srcdir/TEST_SCRIPT_FILE ARG [ARG...]
+----
+The `$srcdir` variable contains the path to the directory with the test script.
+The `test_run` function reports the following results into the log file:
+
+* *PASS* when script/function returns *0*,
+* *FAIL* when script/function returns *1*,
+* *SKIP* when script/function returns *255*,
+* *WARN* when script/function returns none of the above exit statuses.
+
+The result of every test executed by the `test_run` function will be reported
+in the log file in a following way:
+[[app-listing]]
+[source,bash]
+----
+TEST: DESCRIPTION
+<test stdout + stderr output>
+RESULT: PASS/FAIL/SKIP/WARN
+----
+
+
+==== test_exit function
+NOTE: This function should be called after the `test_init` function.
+
+The function is responsible for cleaning-up the testing environment. You can
+call it without arguments or with one argument -- a script/function which will
+do additional clean-up tasks.
+[[app-listing]]
+[source,bash]
+----
+test_exit [CLEAN_SCRIPT|CLEAN_FUNCTION]
+----
+
+
+==== require function
+Checks if requirements are in the `$PATH`, use it as follows:
+[[app-listing]]
+[source,bash]
+----
+require 'program' || return 255
+----
+
+
+==== probecheck function
+Checks if probe exists, use it as follows:
+[[app-listing]]
+[source,bash]
+----
+probecheck 'probe' || return 255
+----
+
+
+==== verify_results function
+Verifies that there is the `COUNT` number of results of selected OVAL `TYPE` in
+a `RESULTS_FILE`:
+[[app-listing]]
+[source,bash]
+----
+verify_results TYPE CONTENT_FILE RESULTS_FILE COUNT
+----
+
+NOTE: This function expects that the OVAL `TYPE` is numbered from `1` to `COUNT`
+in the `RESULTS_FILE`.
+
+
+==== assert_exists function
+Does an XPath query to a file specified in the `$result` variable and checks if
+number of results matches with an expected number specified as an argument:
+[[app-listing]]
+[source,bash]
+----
+result="relative_path_to_file"
+assert_exists EXPECTED_NUMBER_OF_RESULTS XPATH_QUERY_STRING
+----
+
+For example, let's say you want to check that in the `results.xml` file the
+result of the rule `xccdf_com.example.www_rule_test` is fail:
+[[app-listing]]
+[source,bash]
+----
+result="./results.xml"
+my_rule_="xccdf_com.example.www_rule_test"
+assert_exists 1 "//rule-result[@idref=\"$my_rule\"]/result[text()=\"fail\"]"
+----
+
+
+=== Adding test files
+Now, as we know where a new test should go and what functions and capabilities
+are provided by the common test library, we can add test files which will
+contain test scripts and content required for testing.
+
+To sum up, we are adding a tests to check the basic functionality of the Script
+Check Engine (SCE) and we have decided that the test will go into the
+link:../../tests/sce[tests/sce] directory.
+
+We will add the link:../../tests/sce/test_sce.sh[tests/sce/test_sce.sh]
+script which will contain our test and
+link:../../tests/sce/sce_xccdf.xml[tests/sce/sce_xccdf.xml], an XML file with
+XCCDF rules which are referencing various check scripts (grep the
+`check-content-ref` element to see the referenced files). All the referenced
+check script files are set to always pass and the
+link:../../tests/sce/test_sce.sh[tests/sce/test_sce.sh] script will perform
+evaluation of the link:../../tests/sce/sce_xccdf.xml[tests/sce/sce_xccdf.xml]
+XCCDF document file and it will check that all rule results are `pass`.
+
+
+=== Plugging your new test into the test library
+You need to plug your test into the test library so it will be run automatically
+everytime `make check` is run. To do this, you need to add all the test files
+into the `Makefile.am`. The `Makefile.am` which you need to modify is located
+in the same directory as your test files.
+
+We will demonstrate this on our example with the SCE test. We have prepared our
+test script, the XML document file with custom rules and various check scripts
+for testing. We placed all our test files into the
+link:../../tests/sce[tests/sce] directory. Now we will modify the
+link:../../tests/sce/Makefile.am[tests/sce/Makefile.am] and we will add all our
+test files into the `EXTRA_DIST` variable and our test script into the `TESTS`
+variable which will make sure that our test will be executed by the `make check`:
+[[app-listing]]
+[subs=+quotes]
+----
+...
+
+TESTS = *test_sce.sh* \
+		...
+
+...
+
+EXTRA_DIST = *test_sce.sh \
+		sce_xccdf.xml \
+		bash_passer.sh \
+		python_passer.py \
+		python_is16.py \
+		lua_passer.lua \*
+		...
+----
+
+
+=== Running your new test
+To run your new test you first need to compile the OpenSCAP library. See the
+*Compilation* section in the link:../../README.md[README.md] for more details.
+Also you don't need to run all the tests, only tests in a directory where you
+have added your new test. To do so, first change directory to the directory
+with your test and then run `make check` from there, for example:
+[[app-listing]]
+[source,bash]
+----
+$ cd tests/sce
+$ make check
+----
+
+Log file with your test results can be located under the name which is set
+using the `test_init` function in your test script. In our example,
+in the link:../../tests/sce/test_sce.sh[tests/sce/test_sce.sh] test script,
+the log file is set as `test_sce.log`.
+
+NOTE: Our Jenkins runs `make distcheck` instead of `make check` so please make
+sure that your test works for both of these modes. More details about the GNU
+Build System build tree and source tree can be found in the
+link:https://www.gnu.org/software/automake/manual/html_node/Checking-the-Distribution.html[GNU automake documentation].
+

--- a/docs/contribute/versioning.adoc
+++ b/docs/contribute/versioning.adoc
@@ -1,57 +1,99 @@
 = Versioning
 
-openscap release versions have the common *$major.$minor.$patch* format.
+OpenSCAP release versions have the common *$major.$minor.$patch* format.
 
-Most of bleeding edge unstable development happens in the *master* branch. This branch is likely to break API and ABI and is likely not suitable for anyone but the developers. Only release candidates or other test releases are tagged from the master branch.
+Most of the bleeding edge unstable development happens in the *master* branch.
+This branch is likely to break API and ABI and is likely not suitable for anyone
+but the developers. Only release candidates or other test releases are tagged
+from the master branch.
 
-*$major.$minor* together (e.g.: 1.0) are called *feature releases*. As the name suggests, once a feature release is made, no new features are added to it. For example once 1.0.0 is released, 1.0.1, 1.0.2, 1.0.3, etc. shall not have more features than 1.0.0. Patch version 0 (e.g.: 1.0.0) establishes the feature set.
+*$major.$minor* together (e.g.: `1.2`) are called *feature releases*. As the
+name suggests, once a feature release is made, no new features are added to it.
+For example once `1.2.0` is released, `1.2.1`, `1.2.2`, `1.2.3`, etc. shall not
+have more features than `1.2.0`. Patch version 0 (e.g.: `1.2.0`) establishes
+the feature set.
 
-Feature releases form a maintenance branch that we call *maint-$major.$minor*. For example the maintenance branch for 1.0.x is called maint-1.0 in the git repository. This means that all releases with version 1.0.x shall be tagged from the maint-1.0 branch.
+Feature releases form a maintenance branch that we call *maint-$major.$minor*.
+For example the maintenance branch for `1.2.x` is called `maint-1.2` in the git
+repository. This means that all releases with version `1.2.x` shall be tagged
+from the `maint-1.2` branch.
 
 Releases from the same maintenance branch are called *sibling releases*.
 
 == Maintenance branch rules
 
-Library users tend to use released versions, because that is the only sure way to avoid rebuilds, breakages and/or mysterious bugs caused by ABI incompatibility. To make sure our released versions do not suffer from these we maintain them in a separate branch and only allow commits that pass very strict rules.
+Library users tend to use released versions, because that is the only sure way
+to avoid rebuilds, breakages and/or mysterious bugs caused by ABI
+incompatibility. To make sure our released versions do not suffer from these we
+maintain them in a separate branch and only allow commits that pass very strict
+rules.
 
 === No API/ABI breaks!
 
-Only changes that do not break API and ABI can be applied to the maintenance branch. This is a non-negotiable rule! If a breaking change is applied to maintenance branch by mistake it has to be reverted. ABI checking should be done before releases using abi-compliance-checker.
+Only changes that do not break API and ABI can be applied to the maintenance
+branch. This is a non-negotiable rule! If a breaking change is applied
+to a maintenance branch by mistake it has to be reverted. ABI checking should
+be done before releases using abi-compliance-checker.
 
 === No changes to documented behavior
 
-If a certain behavior of the library or tools is documented it cannot be changed in the maintenance branch even if it is considered broken or wrong. Only changes that make the implementation more compliant to documentation can be considered - these changes are most commonly bugfixes.
+If a certain behavior of the library or tools is documented it cannot be changed
+in the maintenance branch even if it is considered broken or wrong. Only changes
+that make the implementation more compliant to documentation can be considered
+- these changes are most commonly bugfixes.
 
-Incompatible improvements shall always be done in a development branch if they are done at all. The commits should be accompanied with appropriate changes in documentation.
+Incompatible improvements shall always be done in the development (`master`)
+branch if they are done at all. The commits should be accompanied with
+appropriate changes in documentation.
 
-Of course there is a gray area in this rule. In cases where the documentation is vague and permits multiple interpretations we prefer to make the documentation explicit and consistent with established behavior. In other words: changing documentation is preferred to changing behavior.
+Of course there is a gray area in this rule. In cases where the documentation
+is vague and permits multiple interpretations we prefer to make the
+documentation explicit and consistent with established behavior. In other
+words: changing documentation is preferred to changing behavior.
 
 === Only careful changes of supporting files (XSD schemas, XSLT)
 
-Only small non-invasive changes should be considered. Make sure old use-cases aren't broken.
+Only small non-invasive changes should be considered. Make sure old use-cases
+aren't broken.
 
-As an example the report XSLT may get a small usability improvement - it will show number of notchecked rules along with all the other information. However we may not remove or replace information from it in the maintenance branch - users may be relying on it being there. Radically moving information around in the report is also discouraged. It's very hard to lay formal rules surrounding this so please use your best judgement.
+As an example the report XSLT may get a small usability improvement - it will
+show number of notchecked rules along with all the other information. However
+we may not remove or replace information from it in the maintenance branch
+- users may be relying on it being there. Radically moving information around
+in the report is also discouraged. It's very hard to lay formal rules
+surrounding this so please use your best judgement.
 
 === All applied changes must be propagated
 
-Bugfixes applied to maintenance branches must be merged up. For example a bugfix applied to maint-1.0 shall be merged to maint-1.2 which then shall be merged to master.
+Bugfixes applied to maintenance branches must be merged up. For example,
+a bugfix applied to `maint-1.2` shall be merged to `maint-1.x` (where `x > 2`)
+which then shall be merged to `master`.
 
 This rule makes sure we always carry bugfixes to new feature releases.
 
-In cases where the bugfix does not make sense in newer feature releases, a noop merge shall be done. For example a fix for functionality that was removed in newer feature release.
+In cases where the bugfix does not make sense in newer feature releases, a noop
+merge shall be done. For example, a fix for functionality that was removed in
+a newer feature release.
 
 == Frozen branches
 
-Maintenance branches can be frozen which further restricts the changes that can be applied to them. Only bugfixes are permitted in frozen branches.
+Maintenance branches can be frozen which further restricts the changes that can
+be applied to them. Only bugfixes are permitted in frozen branches.
 
 == Maintenance status
 
 	* 1.2.x: supported
 	* 1.1.x: unsupported since 2015-10-16
-	* 1.0.x: supported, frozen since 2016-01-07
+	* 1.0.x: unsupported since 2017-06-01
 
 == Feature release
 
-A new feature release will typically contain new symbols and ABI breaking changes in existing symbols, although this is not a rule. Therefore it will likely but not necessarily have incompatible ABI (and thus different soname).
+A new feature release will typically contain new symbols and ABI breaking
+changes in existing symbols, although this is not a rule. Therefore it will
+likely but not necessarily have incompatible ABI (and thus different soname).
 
-Deprecated symbols from feature release N shall be removed in feature release N + 1. For example deprecated symbols from 1.0.x shall be removed from 1.1.x. In other words, deprecated symbols shall not be carried to future feature releases. 
+Deprecated symbols from feature release `N` shall be removed in feature release
+`N + 1`. For example, deprecated symbols from `1.1.x` shall be removed from
+`1.2.x`. In other words, deprecated symbols shall not be carried to the future
+feature releases.
+

--- a/tests/test_common.sh.in
+++ b/tests/test_common.sh.in
@@ -86,7 +86,7 @@ function test_run {
 	echo -e "RESULT: PASSED\n" >&2
 	return 0;
     elif [ $ret_val -eq 1 ]; then
-        result=$[$result + $ret_val]
+	result=$(($result + $ret_val))
 	echo "[ FAIL ]"; 
 	echo -e "RESULT: FAILED\n" >&2
 	return 1;
@@ -95,7 +95,7 @@ function test_run {
 	echo -e "RESULT: SKIPPED\n" >&2
 	return 0; 
     else
-        result=$[$result + $ret_val]
+	result=$(($result + $ret_val))
 	echo "[ WARN ]"; 
 	echo -e "RESULT: WARNING (unknown exist status $ret_val)\n" >&2
 	return 1;
@@ -174,10 +174,10 @@ function verify_results {
 	
 	if [ ! $RES = $CMT ]; then
 	    echo "Result of ${OVAL_ID} should be ${CMT} and is ${RES}"
-	    ret_val=$[$ret_val + 1]
+	    ret_val=$(($ret_val + 1))
 	fi
-	
-	ID=$[$ID+1]
+
+	ID=$(($ID+1))
     done
 
     return $([ $ret_val -eq 0 ])


### PR DESCRIPTION
We are missing a guide on how to write tests and where to put them which makes it hard for contributors to add tests for their PRs.

WIP progress:
* updated `docs/contribute/contribute.adoc`
* updated `README.md` to ling to `docs/contribute/contribute.adoc`
* updated `docs/contribute/versioning.adoc`