### PR TITLE
Added GitHub issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,35 @@
+- Is this an issue with SCAP Workbench?
+    - If so, report it here: https://github.com/OpenSCAP/scap-workbench/issues
+- Is this an issue with SCAP Security Guide (i.e., related to the content of scans, not the scanner proper)?
+    - If so, report it here: https://github.com/OpenSCAP/scap-security-guide/issues
+- Is this an issue during the OS installation process?
+    - If so, report it here: https://github.com/OpenSCAP/oscap-anaconda-addon/issues
+
+Thanks!
+
+
+#### Description of Problem:
+
+
+#### OpenSCAP Version:
+
+
+#### Operating System & Version:
+
+
+#### Steps to Reproduce:
+
+1. 
+2. 
+3. 
+
+
+#### Actual Results:
+
+
+#### Expected Results:
+
+
+#### Additional Information / Debugging Steps:
+
+


### PR DESCRIPTION
Largely similar to the one in [scap-security-guide](https://github.com/OpenSCAP/scap-security-guide/blob/master/.github/issue_template.md), but includes directions of where to report issues at the top. 
