### PR TITLE
Add ssize_t header for macOS build

### DIFF
--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -39,6 +39,7 @@
 #include <string.h>
 #include <time.h>
 #include <stdbool.h>
+#include <sys/types.h>
 
 #include "oval_definitions_impl.h"
 #include "adt/oval_collection_impl.h"

--- a/src/OVAL/probes/SEAP/public/strbuf.h
+++ b/src/OVAL/probes/SEAP/public/strbuf.h
@@ -27,6 +27,7 @@
 #include <stddef.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/OVAL/probes/crapi/digest.c
+++ b/src/OVAL/probes/crapi/digest.c
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <assume.h>
 #include <errno.h>
+#include <sys/types.h>
 
 #include "crapi.h"
 #include "digest.h"

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Helps with #1085 probably... (no macOS to test on).

Add `#include <sys/types.h>` to a bunch of files that are missing it for `ssize_t`. According to [here](https://opensource.apple.com/source/xnu/xnu-344/bsd/sys/types.h) -- a really out of date source -- it should have that header, and `ssize_t` is defined in that header. 