### PR TITLE
Disable probes in SWIG

### DIFF
--- a/swig/openscap.i
+++ b/swig/openscap.i
@@ -264,9 +264,11 @@
 %include "../../src/OVAL/public/oval_session.h"
 %include "../../src/OVAL/public/oval_types.h"
 %include "../../src/OVAL/public/oval_variables.h"
+#if defined(ENABLE_PROBES)
 %include "../../src/OVAL/public/oval_probe.h"
 %include "../../src/OVAL/public/oval_probe_handler.h"
 %include "../../src/OVAL/public/oval_probe_session.h"
+#endif
 
 %module openscap
 %{


### PR DESCRIPTION
If probes are not enabled but building with python3 is, SWIG fails due to probe bindings. This fixes that.