### PR TITLE
Set CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 2.6)
 
+# Inspired and referenced from https://blog.kitware.com/cmake-and-the-default-build-type
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+	message(STATUS "Setting build type to 'Release' as none was specified.")
+	set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+		"MinSizeRel" "RelWithDebInfo")
+endif()
+
 project("openscap")
 set(OPENSCAP_VERSION_MAJOR "1")
 set(OPENSCAP_VERSION_MINOR "3")


### PR DESCRIPTION
- When CMAKE_BUILD_TYPE is not specified, it is set to none which causes problems for
  builds on different operating systems.