### PR TITLE
Add Windows build to the upstream release guide

### DIFF
--- a/release_tools/README.adoc
+++ b/release_tools/README.adoc
@@ -60,7 +60,6 @@ Finally, it will bump version numbers in `versions.sh` to be ready for the next 
 +
 --
 The Windows build process is described in link:../docs/developer/developer.adoc[Developer Manual].
-Don't forget about setting the build type to Release using `-DCMAKE_BUILD_TYPE=Release`.
 
 The Windows Installer can be built by running `cpack` in the `build` directory.
 CPack will produce 2 files:

--- a/release_tools/README.adoc
+++ b/release_tools/README.adoc
@@ -56,6 +56,20 @@ The last commit before the release has to have the `openscap-<version>` message 
 This will create and push version tags, create new GitHub release and handle milestones swap.
 Finally, it will bump version numbers in `versions.sh` to be ready for the next upstream release.
 
+. Build OpenSCAP for Windows
++
+--
+The Windows build process is described in link:../docs/developer/developer.adoc[Developer Manual].
+Don't forget about setting the build type to Release using `-DCMAKE_BUILD_TYPE=Release`.
+
+The Windows Installer can be built by running `cpack` in the `build` directory.
+CPack will produce 2 files:
+
+* `OpenSCAP-${version}-win32.msi` which is the installer package
+* `OpenSCAP-${version}-win32.msi.sha512` that contains SHA512 checksum of the installer
+
+Upload both of the files to the GitHub release.
+--
 
 == To be done ==
 


### PR DESCRIPTION
As we have discussed in Issue #434, providing Windows binaries
can be achieved by including the Windows build in the release
process. Also, the build is already described in Developers
Manual, so we need to link it and describe only how to build
the Installer package.

Fixes #434.