### PR TITLE
Fix broken file name in install command in SWIG Perl bindings

### DIFF
--- a/swig/perl/CMakeLists.txt
+++ b/swig/perl/CMakeLists.txt
@@ -11,5 +11,5 @@ target_include_directories(openscap_pm PUBLIC ${PERL_INCLUDE_PATH})
 
 install(TARGETS ${SWIG_MODULE_openscap_pm_REAL_NAME}
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/perl5/vendor_perl)
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/openscap.pm
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/openscap_pm.pm
 	DESTINATION ${CMAKE_INSTALL_DATADIR}/perl5/vendor_perl)


### PR DESCRIPTION
A correct file name should be openscap_pm.pm, according to
the target name. Addressing:
```
CMake Error at swig/perl/cmake_install.cmake:61 (file):
  file INSTALL cannot find
  "/home/jcerny/openscap/build/swig/perl/openscap.pm".
Call Stack (most recent call first):
  swig/cmake_install.cmake:42 (include)
  cmake_install.cmake:54 (include)
```