### PR TITLE
Do not include build-win32 directory in the source tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,7 @@ set(CPACK_SOURCE_GENERATOR "TGZ")
 set(CPACK_SOURCE_IGNORE_FILES
 	"\\\\.git.*"
 	"build/"
+	"build-win32/"
 	"~$"
 	"\\\\CMakeLists.txt.user"
 )


### PR DESCRIPTION
Similarly to build directory, the build-win32 directory contains
build binaries and therefore it shouldn't be a part of source
tarball.