### PR TITLE
fileextendedattribute_probe requires xattr header, only enable it if …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ check_include_file(shadow.h HAVE_SHADOW_H)
 check_include_file(sys/systeminfo.h HAVE_SYS_SYSTEMINFO_H)
 check_include_file(getopt.h HAVE_GETOPT_H)
 check_include_file(sys/uio.h HAVE_UIO_H)
+check_include_file(attr/xattr.h HAVE_XATTR_H)
 
 # HAVE_ATOMIC_BUILTINS
 check_c_source_compiles("#include <stdint.h>\nint main() {uint16_t foovar=0; uint16_t old=1; uint16_t new=2;__sync_bool_compare_and_swap(&foovar,old,new); return __sync_fetch_and_add(&foovar, 1); __sync_fetch_and_add(&foovar, 1);}" HAVE_ATOMIC_BUILTINS)
@@ -205,7 +206,7 @@ cmake_dependent_option(OPENSCAP_PROBE_INDEPENDENT_XMLFILECONTENT "Independent xm
 # UNIX PROBES
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_DNSCACHE "Unix dnscache probe" ON "ENABLE_PROBES_UNIX" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_FILE "Unix file probe" ON "ENABLE_PROBES_UNIX" OFF)
-cmake_dependent_option(OPENSCAP_PROBE_UNIX_FILEEXTENDEDATTRIBUTE "Unix fileextendedattribute probe" ON "ENABLE_PROBES_UNIX" OFF)
+cmake_dependent_option(OPENSCAP_PROBE_UNIX_FILEEXTENDEDATTRIBUTE "Unix fileextendedattribute probe" ON "ENABLE_PROBES_UNIX; HAVE_XATTR_H" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_GCONF "Unix gconf probe" ON "ENABLE_PROBES_UNIX; GCONF_FOUND" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_INTERFACE "Unix interface probe" ON "ENABLE_PROBES_UNIX" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_PASSWORD "Unix password probe" ON "ENABLE_PROBES_UNIX" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,8 @@ check_include_file(shadow.h HAVE_SHADOW_H)
 check_include_file(sys/systeminfo.h HAVE_SYS_SYSTEMINFO_H)
 check_include_file(getopt.h HAVE_GETOPT_H)
 check_include_file(sys/uio.h HAVE_UIO_H)
-check_include_file(attr/xattr.h HAVE_XATTR_H)
+check_include_file(sys/xattr.h HAVE_SYS_XATTR_H)
+check_include_file(attr/xattr.h HAVE_ATTR_XATTR_H)
 
 # HAVE_ATOMIC_BUILTINS
 check_c_source_compiles("#include <stdint.h>\nint main() {uint16_t foovar=0; uint16_t old=1; uint16_t new=2;__sync_bool_compare_and_swap(&foovar,old,new); return __sync_fetch_and_add(&foovar, 1); __sync_fetch_and_add(&foovar, 1);}" HAVE_ATOMIC_BUILTINS)
@@ -206,7 +207,7 @@ cmake_dependent_option(OPENSCAP_PROBE_INDEPENDENT_XMLFILECONTENT "Independent xm
 # UNIX PROBES
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_DNSCACHE "Unix dnscache probe" ON "ENABLE_PROBES_UNIX" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_FILE "Unix file probe" ON "ENABLE_PROBES_UNIX" OFF)
-cmake_dependent_option(OPENSCAP_PROBE_UNIX_FILEEXTENDEDATTRIBUTE "Unix fileextendedattribute probe" ON "ENABLE_PROBES_UNIX; HAVE_XATTR_H" OFF)
+cmake_dependent_option(OPENSCAP_PROBE_UNIX_FILEEXTENDEDATTRIBUTE "Unix fileextendedattribute probe" ON "ENABLE_PROBES_UNIX; (HAVE_SYS_XATTR_H OR HAVE_ATTR_XATTR_H)" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_GCONF "Unix gconf probe" ON "ENABLE_PROBES_UNIX; GCONF_FOUND" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_INTERFACE "Unix interface probe" ON "ENABLE_PROBES_UNIX" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_PASSWORD "Unix password probe" ON "ENABLE_PROBES_UNIX" OFF)

--- a/config.h.in
+++ b/config.h.in
@@ -75,6 +75,8 @@
 #cmakedefine HAVE_SYS_ACL_H
 #cmakedefine HAVE_GETOPT_H
 #cmakedefine HAVE_UIO_H
+#cmakedefine HAVE_ATTR_XATTR_H
+#cmakedefine HAVE_SYS_XATTR_H
 
 #cmakedefine HAVE_STRSEP
 #cmakedefine HAVE_FLOCK

--- a/docs/developer/developer.adoc
+++ b/docs/developer/developer.adoc
@@ -46,7 +46,7 @@ On RHEL / Fedora / CentOS, the command to install the build dependencies is:
 ----
 sudo yum install \
 cmake dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel \
-libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel make openldap-devel \
+libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel \
 pcre-devel perl-XML-Parser perl-XML-XPath perl-devel python-devel rpm-devel swig \
 bzip2-devel gcc-c++
 ----

--- a/src/OVAL/probes/unix/fileextendedattribute_probe.c
+++ b/src/OVAL/probes/unix/fileextendedattribute_probe.c
@@ -41,10 +41,12 @@
 #include <limits.h>
 
 #include <sys/types.h>
-#ifdef OS_APPLE
-#include <sys/xattr.h>
+#if defined(HAVE_SYS_XATTR_H)
+#  include <sys/xattr.h>
+#elif defined(HAVE_ATTR_XATTR_H)
+#  include <attr/xattr.h>
 #else
-#include <attr/xattr.h>
+#  error "This probe requires sys/xattr.h or attr/xattr.h, none were found!"
 #endif
 
 #include <probe/probe.h>


### PR DESCRIPTION
Prevents:
```
[1/122] Building C object src/OVAL/probes/unix/CMakeFiles/unix_probes_object.dir/fileextendedattribute_probe.c.o
FAILED: src/OVAL/probes/unix/CMakeFiles/unix_probes_object.dir/fileextendedattribute_probe.c.o 
/usr/lib64/ccache/cc -DHAVE_CONFIG_H -DOSCAP_BUILD_SHARED -I../compat -I../src -I../src/common -I../src/common/public -I../src/CCE/public -I../src/CPE/public -I../src/CVE/public -I../src/CVRF/public -I../src/CVSS/public -I../src/DS/public -I../src/OVAL/public -I../src/OVAL/probes/public -I../src/OVAL/probes/SEAP -I../src/OVAL/probes/SEAP/public -I../src/OVAL -I../src/source/public -I../src/XCCDF -I../src/XCCDF/public -I../src/XCCDF_POLICY -I../src/XCCDF_POLICY/public -I. -I/usr/include/libxml2 -I../src/OVAL/probes/. -pipe -std=c99 -W -Wall -Wnonnull -Wshadow -Wformat -Wundef -Wno-unused-parameter -Wmissing-prototypes -Wno-unknown-pragmas -D_GNU_SOURCE -D_POSIX_C_SOURCE=200112L -fPIC -MD -MT src/OVAL/probes/unix/CMakeFiles/unix_probes_object.dir/fileextendedattribute_probe.c.o -MF src/OVAL/probes/unix/CMakeFiles/unix_probes_object.dir/fileextendedattribute_probe.c.o.d -o src/OVAL/probes/unix/CMakeFiles/unix_probes_object.dir/fileextendedattribute_probe.c.o   -c ../src/OVAL/probes/unix/fileextendedattribute_probe.c
../src/OVAL/probes/unix/fileextendedattribute_probe.c:44:10: fatal error: attr/xattr.h: No such file or directory
 #include <attr/xattr.h>
          ^~~~~~~~~~~~~~
```