### PR TITLE
Fix install commands in CMake

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -1,3 +1,3 @@
 if(NOT WIN32)
-	install(DIRECTORY "bash_completion.d" DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
+	install(DIRECTORY "bash_completion.d" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}")
 endif()

--- a/src/SCE/CMakeLists.txt
+++ b/src/SCE/CMakeLists.txt
@@ -1,4 +1,5 @@
 file(GLOB_RECURSE SCE_SOURCES "*.c")
+file(GLOB_RECURSE SCE_PUBLIC_HEADERS "public/*.h")
 
 add_library(openscap_sce SHARED ${SCE_SOURCES})
 target_include_directories(openscap_sce PUBLIC public)
@@ -7,3 +8,4 @@ target_link_libraries(openscap_sce PRIVATE openscap)
 
 install(TARGETS openscap_sce
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES ${SCE_PUBLIC_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/openscap")


### PR DESCRIPTION
1) Install sce_engine_api.h
We have forgotten to add an install command for SCE public header.


2) Install Bash completion to a right directory
It should be usually installed to '/etc', not to '/prefix/etc'.