### PR TITLE
Add libprocps-dev to Travis CI and Ubuntu dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       sudo: required
       before_install:
         - sudo apt-get -qq update
-        - sudo apt-get install -y cmake lcov libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt-dev libselinux1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev swig libxml-parser-perl libxml-xpath-perl libperl-dev librpm-dev swig librtmp-dev xsltproc
+        - sudo apt-get install -y cmake lcov libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt-dev libselinux1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev swig libxml-parser-perl libxml-xpath-perl libperl-dev librpm-dev swig librtmp-dev xsltproc libprocps-dev
       before_script:
         - export CC=gcc-7 GCOV=gcov-7
         - cd build

--- a/docs/developer/developer.adoc
+++ b/docs/developer/developer.adoc
@@ -57,7 +57,7 @@ On Ubuntu 16.04, the command to install the build dependencies is:
 sudo apt-get install -y cmake libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev \
 libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev \
 libcap-dev libxml2-dev libldap2-dev libpcre3-dev python-dev swig libxml-parser-perl \
-libxml-xpath-perl libperl5.22 libbz2-dev librpm-dev g++
+libxml-xpath-perl libperl5.22 libbz2-dev librpm-dev g++ libprocps-dev
 ----
 
 When you have all the build dependencies installed you can build the library.


### PR DESCRIPTION
libprocps-dev provides `proc/devname.h`, which provides `dev_to_tty`
function, which is used by process probe and process58 probe.
It is better to use the system library version than the custom
version from `compat` if the system version is available.
The Travis CI will now install this package and we will recommend
users to do that as well.