### PR TITLE
Remove CMAKE_BUILD_TYPE=Release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ before_build:
 - cmd: >-
     cd build
 
-    cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_PYTHON3=FALSE -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+    cmake -DENABLE_PYTHON3=FALSE -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
 build:
   project: c:\projects\openscap\build\openscap.sln
   verbosity: minimal


### PR DESCRIPTION
After we have made a default build type Release in da92c1b8a3
we don't need this in AppVeyor anymore.