### PR TITLE
Remove validate-xml submodule from CPE, OVAL, XCCDF modules

### DIFF
--- a/tests/API/CPE/inbuilt/all.sh
+++ b/tests/API/CPE/inbuilt/all.sh
@@ -48,7 +48,7 @@ function validate_inbuilt_dict(){
 	[ -f $path ]
 	$OSCAP cpe validate $path 2>&1 > $output
 	[ -f $output ]; [ ! -s $output ]
-	$OSCAP cpe validate-xml $path 2>&1 > $output
+	$OSCAP cpe validate $path 2>&1 > $output
 	[ -f $output ]; [ ! -s $output ]
 	rm $output
 }

--- a/tests/API/OVAL/unittests/test_oval_empty_variable_evaluation.sh
+++ b/tests/API/OVAL/unittests/test_oval_empty_variable_evaluation.sh
@@ -9,7 +9,7 @@ echo "Result file: $result"
 echo "Evaluating content."
 $OSCAP oval eval --results $result $srcdir/${name}.xml || [ $? == 2 ]
 echo "Validating results."
-$OSCAP oval validate-xml --results $result
+$OSCAP oval validate --results $result
 echo "Testing results values."
 [ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:x:tst:1"]/@result)')" == "false" ]
 [ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:x:tst:2"]/@result)')" == "true" ]

--- a/tests/API/OVAL/unittests/test_xsinil_envv58_pid.sh
+++ b/tests/API/OVAL/unittests/test_xsinil_envv58_pid.sh
@@ -9,7 +9,7 @@ echo "Result file: $result"
 echo "Evaluating content."
 $OSCAP oval eval --results $result $srcdir/${name}.oval.xml
 echo "Validating results."
-$OSCAP oval validate-xml --results --schematron $result
+$OSCAP oval validate --results --schematron $result
 echo "Testing results values."
 assert_exists 1 '/oval_results'
 assert_exists 1 '/oval_results/oval_definitions'

--- a/tests/API/OVAL/validate/all.sh
+++ b/tests/API/OVAL/validate/all.sh
@@ -3,7 +3,7 @@
 . $builddir/tests/test_common.sh
 
 function good-ok {
-	$OSCAP oval validate-xml ${srcdir}/oval-ok.xml
+	$OSCAP oval validate ${srcdir}/oval-ok.xml
 	ret=$?
 	if [ $ret -eq 0 ]; then
 		return 0
@@ -12,7 +12,7 @@ function good-ok {
 }
 
 function oval-no-xml {
-	$OSCAP oval validate-xml ${srcdir}/all.sh
+	$OSCAP oval validate ${srcdir}/all.sh
 	ret=$?
 	if [ $ret -eq 1 ]; then
 		return 0
@@ -21,7 +21,7 @@ function oval-no-xml {
 }
 
 function oval-schema-fail {
-	$OSCAP oval validate-xml ${srcdir}/oval-schema-fail.xml
+	$OSCAP oval validate ${srcdir}/oval-schema-fail.xml
 	ret=$?
 	if [ $ret -eq 2 ]; then
 		return 0
@@ -30,7 +30,7 @@ function oval-schema-fail {
 }
 
 function oval-schematron-fail {
-	$OSCAP oval validate-xml --schematron ${srcdir}/oval-schematron-fail.xml
+	$OSCAP oval validate --schematron ${srcdir}/oval-schematron-fail.xml
 	ret=$?
 	if [ $ret -eq 2 ]; then
 		return 0

--- a/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval.sh
+++ b/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval.sh
@@ -14,7 +14,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 8 '//rule-result'
 assert_exists 8 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval2.sh
+++ b/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval2.sh
@@ -14,7 +14,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 2 '//rule-result'
 assert_exists 2 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval_multicheck.sh
+++ b/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval_multicheck.sh
@@ -14,7 +14,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 8 '//rule-result'
 assert_exists 8 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_empty_variable.sh
+++ b/tests/API/XCCDF/unittests/test_empty_variable.sh
@@ -15,7 +15,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_fix_instance.sh
+++ b/tests/API/XCCDF/unittests/test_fix_instance.sh
@@ -11,7 +11,7 @@ rm -f test_file
 
 $OSCAP xccdf eval --results $result $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/Rule/fix/instance'
 assert_exists 3 '//rule-result'
@@ -26,7 +26,7 @@ rm $result
 
 $OSCAP xccdf remediate --result-id xccdf_org.open-scap_testresult_default-profile --results $result $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/Rule/fix/instance'
 assert_exists 4 '//rule-result'

--- a/tests/API/XCCDF/unittests/test_multiple_oval_files_with_same_basename.sh
+++ b/tests/API/XCCDF/unittests/test_multiple_oval_files_with_same_basename.sh
@@ -14,7 +14,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 8 '//rule-result'
 assert_exists 8 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_oval_without_definition.sh
+++ b/tests/API/XCCDF/unittests/test_oval_without_definition.sh
@@ -16,7 +16,7 @@ echo "Result file = $result"
 [ $ret -eq 2 ]
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_remediation_amp_escaping.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_amp_escaping.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'
@@ -33,7 +33,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'

--- a/tests/API/XCCDF/unittests/test_remediation_bad_fix.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_bad_fix.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'
@@ -32,7 +32,7 @@ $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $st
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 [ ! -f test_file ]
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_remediation_cdata.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_cdata.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'
@@ -33,7 +33,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'

--- a/tests/API/XCCDF/unittests/test_remediation_fix_without_system.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_fix_without_system.sh
@@ -16,7 +16,7 @@ $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $st
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 [ ! -f test_file ]
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_remediation_invalid_characters.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_invalid_characters.sh
@@ -15,7 +15,7 @@ echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 [ -f $result ]; [ -s $result ]
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 "//message[contains(text(),'<tag>')]"
 

--- a/tests/API/XCCDF/unittests/test_remediation_simple.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_simple.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'
@@ -30,7 +30,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_plain_text.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_plain_text.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/plain-text'
 assert_exists 1 '/Benchmark/Rule'
@@ -34,7 +34,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/plain-text'
 assert_exists 1 '/Benchmark/Rule'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_plain_text_empty.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_plain_text_empty.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/plain-text'
 assert_exists 1 '/Benchmark/Rule'
@@ -34,7 +34,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/plain-text'
 assert_exists 1 '/Benchmark/Rule'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_unresolved.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_unresolved.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'
@@ -39,7 +39,7 @@ $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $st
 sed -i -E "/^W: oscap: The xccdf:rule-result\/xccdf:instance element was not found./d" "$stderr"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_refine_value.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_refine_value.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Value'
 assert_exists 4 '//Value/value'
@@ -36,7 +36,7 @@ $OSCAP xccdf eval --profile xccdf_moc.elpmaxe.www_profile_1 \
 	--remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Value'
 assert_exists 4 '//Value/value'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_take_first.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_take_first.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Value'
 assert_exists 3 '//Value/value'
@@ -36,7 +36,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Value'
 assert_exists 3 '//Value/value'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_title.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_title.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Value'
 assert_exists 1 '//Value/title'
@@ -37,7 +37,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Value'
 assert_exists 1 '//Value/title'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_without_selector.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_without_selector.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Value'
 assert_exists 3 '//Value/value'
@@ -36,7 +36,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Value'
 assert_exists 3 '//Value/value'

--- a/tests/API/XCCDF/unittests/test_remediation_xml_comments.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_xml_comments.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'
@@ -33,7 +33,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'

--- a/tests/API/XCCDF/unittests/test_single_rule.sh
+++ b/tests/API/XCCDF/unittests/test_single_rule.sh
@@ -23,7 +23,7 @@ $OSCAP xccdf eval --results $result --profile $prof1 \
 	$srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"pass\"]"
@@ -35,7 +35,7 @@ $OSCAP xccdf eval --results $result --profile $prof1 \
 	--rule $rule_pass $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"
@@ -48,7 +48,7 @@ $OSCAP xccdf eval --results $result --rule $rule_pass \
 	$srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"
@@ -61,7 +61,7 @@ $OSCAP xccdf eval --results $result --rule $rule_fail \
 [ $ret -eq 2 ]
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"notselected\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"fail\"]"
@@ -73,7 +73,7 @@ $OSCAP xccdf eval --results $result --profile $prof1 \
 	--rule $rule_fail $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"notselected\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"pass\"]"
@@ -101,7 +101,7 @@ $OSCAP xccdf eval --results $result --profile $prof1 \
 	--rule $rule_pass $srcdir/${name}.ds.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"
@@ -115,7 +115,7 @@ $OSCAP xccdf eval --tailoring-file $srcdir/${name}-tailoring.xml \
 	--rule $rule_pass $srcdir/${name}.ds.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"

--- a/tests/API/XCCDF/unittests/test_xccdf_check_content_ref_without_name_attr.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_content_ref_without_name_attr.sh
@@ -12,7 +12,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/status[not(@date)]'
 assert_exists 1 '//rule-result'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_multi_check.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_multi_check.sh
@@ -14,7 +14,7 @@ echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 [ "`cat $stdout`" == "XCCDF Results are exported correctly." ]; rm $stdout
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 0 '//check[not(@multi-check)]'
 assert_exists 1 '//Rule[@id="xccdf_moc.elpmaxe.www_rule_1"]/check[@multi-check="true"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_multi_check2.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_multi_check2.sh
@@ -19,7 +19,7 @@ grep '^Result.*pass$' $stdout
 grep '^Result.*fail$' $stdout
 rm $stdout
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Rule[@id="xccdf_moc.elpmaxe.www_rule_1"]/check[@multi-check="true"]'
 assert_exists 1 '//check-content-ref[not(@name)]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_multi_check_zero_definitions.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_multi_check_zero_definitions.sh
@@ -18,7 +18,7 @@ echo "Result file = $result"
 grep '^Result.*unknown$' $stdout
 rm $stdout
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Rule[@id="xccdf_moc.elpmaxe.www_rule_1"]/check[@multi-check="true"]'
 assert_exists 2 '//check-content-ref'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_negate.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_negate.sh
@@ -12,7 +12,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 0 '//complex-check'
 assert_exists 1 '//Rule/check[@negate="true"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_processing_complex_priority.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_processing_complex_priority.sh
@@ -16,7 +16,7 @@ for args in "" "--profile xccdf_moc.elpmaxe.www_profile_1"; do
 	echo "Result file = $result"
 	[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-	$OSCAP xccdf validate-xml $result || [ $? == 2 ]
+	$OSCAP xccdf validate $result || [ $? == 2 ]
 
 	assert_exists 1 '//rule-result'
 	assert_exists 1 '//rule-result/result[text()="pass"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_processing_invalid_content_refs.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_processing_invalid_content_refs.sh
@@ -18,7 +18,7 @@ echo "Result file = $result"
 grep '^Result.*notchecked$' $stdout
 rm $stdout
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Rule[@id="xccdf_moc.elpmaxe.www_rule_1"]/check[@multi-check="true"]'
 assert_exists 2 '//check-content-ref[not(@name)]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_bad.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_bad.sh
@@ -14,7 +14,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result[text()="pass"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_empty.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_empty.sh
@@ -14,7 +14,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_unsupported_check_system.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_unsupported_check_system.sh
@@ -10,7 +10,7 @@ $OSCAP xccdf eval --results $result $srcdir/test_xccdf_check_unsupported_check_s
 echo "Stderr file = $stderr"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result[@idref="xccdf_moc.elpmaxe.www_rule_1"]/result[text()="notchecked"]'
 rm $result

--- a/tests/API/XCCDF/unittests/test_xccdf_check_without_content_refs.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_without_content_refs.sh
@@ -12,7 +12,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '/Benchmark/status[not(@date)]'
 assert_exists 1 '//rule-result'

--- a/tests/API/XCCDF/unittests/test_xccdf_complex_check_and_notchecked.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_complex_check_and_notchecked.sh
@@ -16,7 +16,7 @@ echo "Result file = $result"
 [ "WARNING: Skipping $srcdir/_non_existent_.oval.xml file which is referenced from XCCDF content" == "`cat $stderr`" ]
 rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 2 '//complex-check'
 assert_exists 2 '//complex-check[@operator="AND"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_fix_attr_export.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_fix_attr_export.sh
@@ -14,7 +14,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 3 '//fix'
 assert_exists 3 '//fix/@id'

--- a/tests/API/XCCDF/unittests/test_xccdf_multiple_testresults.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_multiple_testresults.sh
@@ -19,7 +19,7 @@ for i in {1..5}; do
 	[ "`cat $stderr`" == "WARNING: Skipping $tmpdir/non_existent.oval.xml file which is referenced from XCCDF content" ]
 	:> $stderr
 
-	$OSCAP xccdf validate-xml $result
+	$OSCAP xccdf validate $result
 
 	assert_exists $i '//TestResult'
 	assert_exists $i '//TestResult/rule-result/result[text()="notchecked"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_notchecked_has_check.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_notchecked_has_check.sh
@@ -16,7 +16,7 @@ echo "Result file = $result"
 [ "WARNING: Skipping $srcdir/_non_existent_.oval.xml file which is referenced from XCCDF content" == "`cat $stderr`" ]
 rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_xccdf_refine_rule.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_refine_rule.sh
@@ -13,7 +13,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 0 '//refine-rule[@weight]'
 assert_exists 1 '//refine-rule[not(@weight)]'

--- a/tests/API/XCCDF/unittests/test_xccdf_refine_rule_refine.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_refine_rule_refine.sh
@@ -131,7 +131,7 @@ $OSCAP xccdf eval --profile child --results $result $xccdf > $stdout 2> $stderr 
 
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 RULE_COUNT=17
 

--- a/tests/API/XCCDF/unittests/test_xccdf_refine_value_bad.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_refine_value_bad.sh
@@ -15,6 +15,6 @@ echo "Result file = $result"
 grep -q "^OpenSCAP Error: Invalid selector '20' for xccdf:value/@id='var-passwd_min_len'. Using null value instead." $stderr
 rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 rm $result

--- a/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.sh
@@ -15,7 +15,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 $OSCAP ds rds-validate $resultArf
 
 $OSCAP info $resultArf > $stdout 2> $stderr

--- a/tests/API/XCCDF/unittests/test_xccdf_role_unchecked.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_role_unchecked.sh
@@ -13,7 +13,7 @@ $OSCAP xccdf eval --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_xccdf_role_unscored.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_role_unscored.sh
@@ -15,7 +15,7 @@ echo "Report file = $report"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 [ -f $report ]; [ -s $report ]; rm $report
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster1.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster1.sh
@@ -14,7 +14,7 @@ echo "Output file = $output"
 echo "Result file = $result"
 [ -f $output ]; [ "`cat $output`" == "XCCDF Results are exported correctly." ]; rm $output
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Profile'
 assert_exists 2 '//Profile/select'

--- a/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster2.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster2.sh
@@ -16,7 +16,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Profile'
 assert_exists 1 '//Profile/select'

--- a/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster3.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster3.sh
@@ -16,7 +16,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//Benchmark'
 assert_exists 1 '//Benchmark[@resolved="1"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_sub_title.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_sub_title.sh
@@ -18,7 +18,7 @@ $OSCAP xccdf eval \
 	--results $result --report $report $srcdir/${name}.xccdf.xml > $stdout 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
 cat $stdout | grep "This title is variable: No profile"; :> $stdout
-$OSCAP xccdf validate-xml $result; :> $result
+$OSCAP xccdf validate $result; :> $result
 grep 'This description is substituted according to the selected policy:.*No profile' $report
 grep 'This title is variable:.*No profile' $report
 grep 'sub ' $report || x=1; [ "x$x" == "x1" ]; unset x; :> $report
@@ -31,7 +31,7 @@ $OSCAP xccdf eval --profile xccdf_moc.elpmaxe.www_profile_1 \
 	--results $result --report $report $srcdir/${name}.xccdf.xml > $stdout 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
 cat $stdout | grep "This title is variable: The First Profile"; :> $stdout
-$OSCAP xccdf validate-xml $result; :> $result
+$OSCAP xccdf validate $result; :> $result
 grep 'This description is substituted according to the selected policy:.*The First Profile' $report
 grep 'This title is variable:.*The First Profile' $report
 grep 'sub ' $report || x=1; [ "x$x" == "x1" ]; unset x; :> $report
@@ -44,7 +44,7 @@ $OSCAP xccdf eval --profile xccdf_moc.elpmaxe.www_profile_2 \
 	--results $result --report $report $srcdir/${name}.xccdf.xml > $stdout 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
 cat $stdout | grep "This title is variable: The Second Profile"; rm $stdout
-$OSCAP xccdf validate-xml $result; rm $result
+$OSCAP xccdf validate $result; rm $result
 grep 'This description is substituted according to the selected policy:.*The Second Profile' $report
 grep 'This title is variable:.*The Second Profile' $report
 grep 'sub ' $report || x=1; [ "x$x" == "x1" ]; unset x; rm $report

--- a/tests/API/XCCDF/unittests/test_xccdf_test_system.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_test_system.sh
@@ -15,7 +15,7 @@ echo "Result file = $result"
 
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate-xml $result
+$OSCAP xccdf validate $result
 
 assert_exists 1 '//TestResult'
 assert_exists 1 '//TestResult[@test-system]'

--- a/tests/API/XCCDF/variable_instance/all.sh
+++ b/tests/API/XCCDF/variable_instance/all.sh
@@ -40,7 +40,7 @@ function xccdf_export_1_multival() {
 	[ -f $stderr ]; [ ! -s $stderr ]
 	[ -f $variables0 ]
 	[ ! -f $variables1 ]
-	$OSCAP oval validate-xml --schematron $variables0
+	$OSCAP oval validate --schematron $variables0
 	assert_exists 1 '/oval_variables'
 	assert_exists 1 '/oval_variables/variables'
 	assert_exists 1 '/oval_variables/variables/variable'
@@ -73,8 +73,8 @@ function xccdf_export_2_multiset(){
 	[ -f $variables0 ]
 	[ -f $variables1 ]
 	[ ! -f $variables2 ]
-	$OSCAP oval validate-xml --schematron $variables0
-	$OSCAP oval validate-xml --schematron $variables1
+	$OSCAP oval validate --schematron $variables0
+	$OSCAP oval validate --schematron $variables1
 	local result="$variables0"
 	assert_exists 1 '/oval_variables'
 	assert_exists 1 '/oval_variables/variables'
@@ -112,7 +112,7 @@ function xccdf_export_3_twice_same(){
 	[ -f $stderr ]; [ ! -s $stderr ]
 	[ -f $variables0 ]
 	[ ! -f $variables1 ]
-	$OSCAP oval validate-xml --schematron $variables0
+	$OSCAP oval validate --schematron $variables0
 	local result="$variables0"
 	assert_exists 1 '/oval_variables'
 	assert_exists 1 '/oval_variables/variables'
@@ -142,7 +142,7 @@ function xccdf_export_4_two_same(){
 	[ -f $stderr ]; [ ! -s $stderr ]
 	[ -f $variables0 ]
 	[ ! -f $variables1 ]
-	$OSCAP oval validate-xml --schematron $variables0
+	$OSCAP oval validate --schematron $variables0
 	local result="$variables0"
 	assert_exists 1 '/oval_variables'
 	assert_exists 1 '/oval_variables/variables'
@@ -171,7 +171,7 @@ function xccdf_export_5_multival_twice(){
 	[ -f $stderr ]; [ ! -s $stderr ]
 	[ -f $variables0 ]
 	[ ! -f $variables1 ]
-	$OSCAP oval validate-xml --schematron $variables0
+	$OSCAP oval validate --schematron $variables0
 	local result="$variables0"
 	assert_exists 1 '/oval_variables'
 	assert_exists 1 '/oval_variables/variables'
@@ -204,8 +204,8 @@ function xccdf_export_6_multiset_multival(){
 	[ -f $variables0 ]
 	[ -f $variables1 ]
 	[ ! -f $variables2 ]
-	$OSCAP oval validate-xml --schematron $variables0
-	$OSCAP oval validate-xml --schematron $variables1
+	$OSCAP oval validate --schematron $variables0
+	$OSCAP oval validate --schematron $variables1
 	local result="$variables0"
 	assert_exists 1 '/oval_variables'
 	assert_exists 1 '/oval_variables/variables'
@@ -246,7 +246,7 @@ function xccdf_export_7_shuffled_multival(){
 	[ -f $stderr ]; [ ! -s $stderr ]
 	[ -f $variables0 ]
 	[ ! -f $variables1 ]
-	$OSCAP oval validate-xml --schematron $variables0
+	$OSCAP oval validate --schematron $variables0
 	local result="$variables0"
 	assert_exists 1 '/oval_variables'
 	assert_exists 1 '/oval_variables/variables'
@@ -279,7 +279,7 @@ function xccdf_export_8_shuffled_multival(){
 	[ -f $stderr ]; [ ! -s $stderr ]
 	[ -f $variables0 ]
 	[ ! -f $variables1 ]
-	$OSCAP oval validate-xml --schematron $variables0
+	$OSCAP oval validate --schematron $variables0
 	local result="$variables0"
 	assert_exists 1 '/oval_variables'
 	assert_exists 1 '/oval_variables/variables'
@@ -313,8 +313,8 @@ function xccdf_export_9_first_subset(){
 	[ -f $variables0 ]
 	[ -f $variables1 ]
 	[ ! -f $variables2 ]
-	$OSCAP oval validate-xml --schematron $variables0
-	$OSCAP oval validate-xml --schematron $variables1
+	$OSCAP oval validate --schematron $variables0
+	$OSCAP oval validate --schematron $variables1
 	local result="$variables0"
 	assert_exists 1 '/oval_variables'
 	assert_exists 1 '/oval_variables/variables'
@@ -358,8 +358,8 @@ function xccdf_export_A_second_subset(){
 	[ -f $variables0 ]
 	[ -f $variables1 ]
 	[ ! -f $variables2 ]
-	$OSCAP oval validate-xml --schematron $variables0
-	$OSCAP oval validate-xml --schematron $variables1
+	$OSCAP oval validate --schematron $variables0
+	$OSCAP oval validate --schematron $variables1
 	local result="$variables0"
 	assert_exists 1 '/oval_variables'
 	assert_exists 1 '/oval_variables/variables'
@@ -413,9 +413,9 @@ function xccdf_eval_2_multiset(){
 	[ -f $variables0 ]
 	[ -f $variables1 ]
 	[ ! -f $variables2 ]
-	$OSCAP oval validate-xml --schematron $variables0
-	$OSCAP oval validate-xml --schematron $variables1
-	$OSCAP oval validate-xml --schematron $oval_result
+	$OSCAP oval validate --schematron $variables0
+	$OSCAP oval validate --schematron $variables1
+	$OSCAP oval validate --schematron $oval_result
 	local result="$xccdf_result"
 	assert_exists 1 '/Benchmark/TestResult'
 	assert_exists 1 '/Benchmark/TestResult/profile'
@@ -574,9 +574,9 @@ function xccdf_eval_1_multiset_syschar(){
 	[ -f $variables0 ]
 	[ -f $variables1 ]
 	[ ! -f $variables2 ]
-	$OSCAP oval validate-xml --schematron $variables0
-	$OSCAP oval validate-xml --schematron $variables1
-	$OSCAP oval validate-xml --schematron $oval_result
+	$OSCAP oval validate --schematron $variables0
+	$OSCAP oval validate --schematron $variables1
+	$OSCAP oval validate --schematron $oval_result
 	result="$variables0"
 	assert_exists 1 '/oval_variables'
 	assert_exists 1 '/oval_variables/variables'

--- a/tests/bz2/test_bz2_datastream.sh
+++ b/tests/bz2/test_bz2_datastream.sh
@@ -23,7 +23,7 @@ bzip2 $xccdf
 $OSCAP info "${xccdf}.bz2" 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
 
-$OSCAP xccdf validate-xml "${xccdf}.bz2" > $stderr
+$OSCAP xccdf validate "${xccdf}.bz2" > $stderr
 [ ! -s $stderr ]
 bash $builddir/run ./test_bz2_memory_source "${xccdf}.bz2" | grep 'XCCDF Checklist'
 

--- a/tests/probes/maskattr/test_object_entity_mask.sh
+++ b/tests/probes/maskattr/test_object_entity_mask.sh
@@ -15,7 +15,7 @@ echo "Evaluating content."
 $OSCAP oval eval --results $result $srcdir/${name}.xml || [ $? == 2 ]
 
 echo "Validating results."
-$OSCAP oval validate-xml --results $result
+$OSCAP oval validate --results $result
 
 echo "Testing that oval_definitions are not altered"
 assert_exists 1 '/oval_results/oval_definitions/objects/unix-def:file_object/unix-def:filepath[text()="/etc/passwd"]'

--- a/tests/probes/maskattr/test_object_entity_mask_oval_5_9.sh
+++ b/tests/probes/maskattr/test_object_entity_mask_oval_5_9.sh
@@ -15,7 +15,7 @@ echo "Evaluating content."
 $OSCAP oval eval --results $result $srcdir/${name}.xml || [ $? == 2 ]
 
 echo "Validating results."
-$OSCAP oval validate-xml --results $result
+$OSCAP oval validate --results $result
 
 echo "Testing that oval_definitions are altered"
 assert_exists 0 '/oval_results/oval_definitions/objects/unix-def:file_object/unix-def:filepath[text()="/etc/passwd"]'

--- a/tests/probes/maskattr/test_object_entity_nomask.sh
+++ b/tests/probes/maskattr/test_object_entity_nomask.sh
@@ -15,7 +15,7 @@ echo "Evaluating content."
 $OSCAP oval eval --results $result $srcdir/${name}.xml || [ $? == 2 ]
 
 echo "Validating results."
-$OSCAP oval validate-xml --results $result
+$OSCAP oval validate --results $result
 
 echo "Testing results values."
 [ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:x:tst:1"]/@result)')" == "true" ]

--- a/tests/probes/rpmverify/test_not_equals_operation.sh
+++ b/tests/probes/rpmverify/test_not_equals_operation.sh
@@ -14,7 +14,7 @@ echo "Result file: $result"
 echo "Evaluating content."
 $OSCAP oval eval --results $result $srcdir/${name}.xml || [ $? == 2 ]
 echo "Validating results."
-$OSCAP oval validate-xml --results $result
+$OSCAP oval validate --results $result
 echo "Testing results values."
 [ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:x:tst:1"]/@result)')" == "true" ]
 echo "Testing syschar values."

--- a/tests/probes/sql57/unsupported_engine.sh
+++ b/tests/probes/sql57/unsupported_engine.sh
@@ -14,7 +14,7 @@ $OSCAP oval eval --results $result $srcdir/${name}.oval.xml 2> $stderr
 sed -i -E "/^E: probe_sql57: DB engine not supported: sqlserver/d" "$stderr"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 echo "Validating results."
-#$OSCAP oval validate-xml --results --schematron $result
+#$OSCAP oval validate --results --schematron $result
 echo "Testing results values."
 assert_exists 1 '/oval_results'
 assert_exists 1 '/oval_results/oval_definitions'

--- a/tests/probes/textfilecontent54/test_behavior_multiline.sh
+++ b/tests/probes/textfilecontent54/test_behavior_multiline.sh
@@ -18,7 +18,7 @@ echo "line3" >> "${tmpdir}/textfile"
 echo "Evaluating content."
 $OSCAP oval eval --results $result $input || [ $? == 2 ]
 echo "Validating results."
-$OSCAP oval validate-xml --results $result
+$OSCAP oval validate --results $result
 echo "Testing syschar values."
 # filename
 [ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:filename:tst:1"]/@result)')" == "true" ]

--- a/tests/probes/textfilecontent54/test_symlinks.sh
+++ b/tests/probes/textfilecontent54/test_symlinks.sh
@@ -18,7 +18,7 @@ ln -s ${tmpdir} ${tmpdir}/sl3
 echo "Evaluating content."
 $OSCAP oval eval --results $result $input || [ $? == 2 ]
 echo "Validating results."
-$OSCAP oval validate-xml --results $result
+$OSCAP oval validate --results $result
 echo "Testing syschar values."
 [ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:x:tst:1"]/@result)')" == "true" ]
 [ "$($XPATH $result 'string(/oval_results/results/system/tests/test[@test_id="oval:x:tst:2"]/@result)')" == "false" ]

--- a/tests/probes/textfilecontent54/test_validation_of_various_oval_versions.sh
+++ b/tests/probes/textfilecontent54/test_validation_of_various_oval_versions.sh
@@ -21,21 +21,21 @@ function tfc54_validation {
 	for i in $LST_VALID; do
 		i="${srcdir}/$i"
 		echo "Validating definitions '$i'."
-		$OSCAP oval validate-xml "$i" \
+		$OSCAP oval validate "$i" \
 			|| { echo "Validation failed."; ret=1; continue; }
 		echo "Evaluating definitions '$i'."
 		r="$(basename $i .xml)-results.xml"
 		$OSCAP oval eval --results "$r" "$i" \
 			|| { echo "Evaluation failed."; ret=1; continue; }
 		echo "Validating results '$r'."
-		$OSCAP oval validate-xml --results "$r" \
+		$OSCAP oval validate --results "$r" \
 			|| { echo "Validation failed."; ret=1; }
 	done
 
 	echo "*** Validating incorrect OVAL content:"
 	for i in $LST_INVALID; do
 		echo "Validating content '$i'."
-		$OSCAP oval validate-xml "$i" \
+		$OSCAP oval validate "$i" \
 			&& { echo "Validation incorrectly succeeded."; ret=1; }
 	done
 

--- a/utils/oscap-cpe.c
+++ b/utils/oscap-cpe.c
@@ -40,7 +40,7 @@
 
 #include "oscap-tool.h"
 
-#define CPE_SUBMODULES_NUM 5 /* See actual CPE_SUBMODULES array
+#define CPE_SUBMODULES_NUM 4 /* See actual CPE_SUBMODULES array
 				initialization below. */
 static struct oscap_module* CPE_SUBMODULES[CPE_SUBMODULES_NUM];
 bool getopt_cpe(int argc, char **argv, struct oscap_action *action);
@@ -75,16 +75,6 @@ static struct oscap_module CPE_CHECK_MODULE = {
     .func = app_cpe_check
 };
 
-static struct oscap_module CPE_VALIDATE_XML = {
-    .name = "validate-xml",
-    .parent = &OSCAP_CPE_MODULE,
-    .summary = "Validate CPE Dictionary content",
-    .usage = "cpe-dict.xml",
-    .help = NULL,
-    .opt_parser = getopt_cpe,
-    .func = app_cpe_validate
-};
-
 static struct oscap_module CPE_VALIDATE = {
     .name = "validate",
     .parent = &OSCAP_CPE_MODULE,
@@ -99,7 +89,6 @@ static struct oscap_module* CPE_SUBMODULES[CPE_SUBMODULES_NUM] = {
     &CPE_MATCH_MODULE,
     &CPE_CHECK_MODULE,
     &CPE_VALIDATE,
-    &CPE_VALIDATE_XML,
     NULL
 };
 
@@ -124,7 +113,7 @@ bool getopt_cpe(int argc, char **argv, struct oscap_action *action) {
 		action->cpe_action->name=argv[3];
 	}
 
-	if ((action->module == &CPE_VALIDATE) || action->module == &CPE_VALIDATE_XML) {
+	if (action->module == &CPE_VALIDATE) {
 		if( argc != 4 ) {
 			oscap_module_usage(action->module, stderr, "Wrong number of parameters.\n");
 			return false;

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -71,7 +71,7 @@ static bool getopt_oval_report(int argc, char **argv, struct oscap_action *actio
 
 static bool valid_inputs(const struct oscap_action *action);
 
-#define OVAL_SUBMODULES_NUM	8
+#define OVAL_SUBMODULES_NUM	7
 #define OVAL_GEN_SUBMODULES_NUM 2 /* See actual OVAL_GEN_SUBMODULES and
 				OVAL_SUBMODULES arrays initialization below. */
 static struct oscap_module* OVAL_SUBMODULES[OVAL_SUBMODULES_NUM];
@@ -82,22 +82,6 @@ struct oscap_module OSCAP_OVAL_MODULE = {
     .parent = &OSCAP_ROOT_MODULE,
     .summary = "Open Vulnerability and Assessment Language",
     .submodules = OVAL_SUBMODULES
-};
-
-static struct oscap_module OVAL_VALIDATE_XML = {
-    .name = "validate-xml",
-    .parent = &OSCAP_OVAL_MODULE,
-    .summary = "Validate OVAL XML content",
-    .usage = "[options] oval-file.xml",
-    .help =
-	"Options:\n"
-	"   --definitions                 - Validate OVAL Definitions\n"
-	"   --variables                   - Validate external OVAL Variables\n"
-	"   --syschar                     - Validate OVAL System Characteristics\n"
-	"   --results                     - Validate OVAL Results\n"
-	"   --schematron                  - Use schematron-based validation in addition to XML Schema\n",
-    .opt_parser = getopt_oval_validate,
-    .func = app_oval_validate
 };
 
 static struct oscap_module OVAL_VALIDATE = {
@@ -224,7 +208,6 @@ static struct oscap_module* OVAL_SUBMODULES[OVAL_SUBMODULES_NUM] = {
 #endif
     &OVAL_ANALYSE,
     &OVAL_VALIDATE,
-    &OVAL_VALIDATE_XML,
     &OVAL_GENERATE,
 #if defined(OVAL_PROBES_ENABLED)
     &OVAL_LIST_PROBES,

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -78,7 +78,7 @@ static bool getopt_generate(int argc, char **argv, struct oscap_action *action);
 static int app_xccdf_xslt(const struct oscap_action *action);
 static int app_generate_fix(const struct oscap_action *action);
 
-#define XCCDF_SUBMODULES_NUM		8
+#define XCCDF_SUBMODULES_NUM		7
 #define XCCDF_GEN_SUBMODULES_NUM	5 /* See actual arrays
 						initialization below. */
 static struct oscap_module* XCCDF_SUBMODULES[XCCDF_SUBMODULES_NUM];
@@ -102,18 +102,6 @@ static struct oscap_module XCCDF_RESOLVE = {
 		"   --force                       - Force resolving XCCDF document even if it is aleready marked as resolved.",
     .opt_parser = getopt_xccdf,
     .func = app_xccdf_resolve
-};
-
-static struct oscap_module XCCDF_VALIDATE_XML = {
-    .name = "validate-xml",
-    .parent = &OSCAP_XCCDF_MODULE,
-    .summary = "Validate XCCDF XML content",
-    .usage = "xccdf-file.xml",
-    .opt_parser = getopt_xccdf,
-	.func = app_xccdf_validate,
-	.help = "Options:\n"
-		"   --schematron                  - Use schematron-based validation in addition to XML Schema\n"
-	,
 };
 
 static struct oscap_module XCCDF_VALIDATE = {
@@ -321,7 +309,6 @@ static struct oscap_module* XCCDF_SUBMODULES[XCCDF_SUBMODULES_NUM] = {
     &XCCDF_EVAL,
     &XCCDF_RESOLVE,
     &XCCDF_VALIDATE,
-    &XCCDF_VALIDATE_XML,
     &XCCDF_EXPORT_OVAL_VARIABLES,
     &XCCDF_GENERATE,
 	&XCCDF_REMEDIATE,


### PR DESCRIPTION
The 'validate-xml' and 'validate' submodules provide the same functionality.
Their output is the same. Therefore it makes sense to keep only one of them.
This commit also replaces all ocurrences of 'validate-xml' by 'validate'
in the test suite.