### PR TITLE
Remove deprecated option --sce-results

### DIFF
--- a/dist/bash_completion.d/oscap
+++ b/dist/bash_completion.d/oscap
@@ -31,7 +31,7 @@ function _oscap {
     opts[oscap:oval:analyse]="--variables --directives --verbose --verbose-log-file"
     opts[oscap:oval:collect]="--variables --verbose --verbose-log-file"
     opts[oscap:oval:generate:report]="-o --output"
-    opts[oscap:xccdf:eval]="--benchmark-id --check-engine-results --cpe --datastream-id --export-variables --fetch-remote-resources --oval-results --profile --progress --remediate --report --results --results-arf --rule --sce-results --skip-valid --stig-viewer --tailoring-file --tailoring-id --thin-results --verbose --verbose-log-file --without-syschar --xccdf-id"
+    opts[oscap:xccdf:eval]="--benchmark-id --check-engine-results --cpe --datastream-id --export-variables --fetch-remote-resources --oval-results --profile --progress --remediate --report --results --results-arf --rule --skip-valid --stig-viewer --tailoring-file --tailoring-id --thin-results --verbose --verbose-log-file --without-syschar --xccdf-id"
     opts[oscap:xccdf:validate]="--schematron"
     opts[oscap:xccdf:export-oval-variables]="--datastream-id --xccdf-id --profile --skip-valid --fetch-remote-resources --cpe"
     opts[oscap:xccdf:remediate]="--result-id --skip-valid --fetch-remote-resources --results --results-arf --report --oval-results --export-variables --cpe"

--- a/utils/oscap-chroot
+++ b/utils/oscap-chroot
@@ -39,7 +39,6 @@ function usage()
     echo "  --tailoring-id"
     echo "  --cpe (external OVAL dependencies are not supported yet!)"
     echo "  --oval-results"
-    echo "  --sce-results"
     echo "  --check-engine-results"
     echo "  --results"
     echo "  --results-arf"

--- a/utils/oscap-chroot.8
+++ b/utils/oscap-chroot.8
@@ -16,7 +16,6 @@ supported oscap xccdf eval options are:
   --tailoring-id
   --cpe (external OVAL dependencies are not supported yet!)
   --oval-results
-  --sce-results
   --check-engine-results
   --results
   --results-arf

--- a/utils/oscap-ssh
+++ b/utils/oscap-ssh
@@ -42,7 +42,7 @@ function usage()
     echo "  --tailoring-file"
     echo "  --tailoring-id"
     echo "  --cpe (external OVAL dependencies are not supported yet!)"
-    # --sce-results and --check-engine-results are not supported
+    # --check-engine-results is not supported
     # use --results-arf instead
     echo "  --oval-results"
     echo "  --results"

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -37,7 +37,6 @@ function usage()
     echo "  --tailoring-id"
     echo "  --cpe (external OVAL dependencies are not supported yet!)"
     echo "  --oval-results"
-    echo "  --sce-results"
     echo "  --check-engine-results"
     echo "  --results"
     echo "  --results-arf"

--- a/utils/oscap-vm.8
+++ b/utils/oscap-vm.8
@@ -50,7 +50,6 @@ Supported oscap xccdf eval options are:
   \-\-tailoring-id <component-id>
   \-\-cpe <name> (external OVAL dependencies are not supported yet!)
   \-\-oval-results
-  \-\-sce-results
   \-\-check-engine-results
   \-\-results <file>
   \-\-results-arf <file>

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -166,7 +166,6 @@ static struct oscap_module XCCDF_EVAL = {
 		"   --cpe <name>                  - Use given CPE dictionary or language (autodetected)\n"
 		"                                   for applicability checks.\n"
 		"   --oval-results                - Save OVAL results as well.\n"
-		"   --sce-results                 - Save SCE results as well. (DEPRECATED! use --check-engine-results)\n"
 		"   --check-engine-results        - Save results from check engines loaded from plugins as well.\n"
 		"   --export-variables            - Export OVAL external variables provided by XCCDF.\n"
 		"   --results <file>              - Write XCCDF Results into file.\n"
@@ -213,7 +212,6 @@ static struct oscap_module XCCDF_REMEDIATE = {
 		"   --report <file>               - Write HTML report into file.\n"
 		"   --oval-results                - Save OVAL results.\n"
 		"   --export-variables            - Export OVAL external variables provided by XCCDF.\n"
-		"   --sce-results                 - Save SCE results. (DEPRECATED! use --check-engine-results)\n"
 		"   --check-engine-results        - Save results from check engines loaded from plugins as well.\n"
 		"   --progress                    - Switch to sparse output suitable for progress reporting.\n"
 		"                                   Format is \"$rule_id:$result\\n\".\n"
@@ -1132,7 +1130,6 @@ bool getopt_xccdf(int argc, char **argv, struct oscap_action *action)
 	// flags
 		{"force",		no_argument, &action->force, 1},
 		{"oval-results",	no_argument, &action->oval_results, 1},
-		{"sce-results",	no_argument, &action->check_engine_results, 1},
 		{"check-engine-results", no_argument, &action->check_engine_results, 1},
 		{"skip-valid",		no_argument, &action->validate, 0},
 		{"fetch-remote-resources", no_argument, &action->remote_resources, 1},


### PR DESCRIPTION
This option has been deprecated and has been replaced by --check-engine-results,
which is more generic. With upcoming major release we can remove it.