### PR TITLE
Clean up implementation of strto_ functions

### DIFF
--- a/src/OVAL/probes/SEAP/generic/strto.h
+++ b/src/OVAL/probes/SEAP/generic/strto.h
@@ -32,60 +32,9 @@ uint8_t strto_uint8_hex (const char *str, size_t len, char **endptr);
 uint16_t strto_uint16_hex (const char *str, size_t len, char **endptr);
 uint32_t strto_uint32_hex (const char *str, size_t len, char **endptr);
 int64_t strto_int64 (const char *str, size_t len, char **endptr, int base);
-int64_t strto_int64_bin (const char *str, size_t len, char **endptr);
-int64_t strto_int64_oct (const char *str, size_t len, char **endptr);
-int64_t strto_int64_dec (const char *str, size_t len, char **endptr);
-int64_t strto_int64_hex (const char *str, size_t len, char **endptr);
 
 uint64_t strto_uint64 (const char *str, size_t len, char **endptr, int base);
-uint64_t strto_uint64_bin (const char *str, size_t len, char **endptr);
-uint64_t strto_uint64_oct (const char *str, size_t len, char **endptr);
-uint64_t strto_uint64_dec (const char *str, size_t len, char **endptr);
-uint64_t strto_uint64_hex (const char *str, size_t len, char **endptr);
 
 double strto_double (const char *str, size_t len, char **endptr);
-
-OSCAP_HIDDEN_START;
-
-int8_t strto_int8 (const char *str, size_t len, char **endptr, int base);
-int8_t strto_int8_bin (const char *str, size_t len, char **endptr);
-int8_t strto_int8_oct (const char *str, size_t len, char **endptr);
-int8_t strto_int8_dec (const char *str, size_t len, char **endptr);
-int8_t strto_int8_hex (const char *str, size_t len, char **endptr);
-
-uint8_t strto_uint8 (const char *str, size_t len, char **endptr, int base);
-uint8_t strto_uint8_bin (const char *str, size_t len, char **endptr);
-uint8_t strto_uint8_oct (const char *str, size_t len, char **endptr);
-uint8_t strto_uint8_dec (const char *str, size_t len, char **endptr);
-
-int16_t strto_int16 (const char *str, size_t len, char **endptr, int base);
-int16_t strto_int16_bin (const char *str, size_t len, char **endptr);
-int16_t strto_int16_oct (const char *str, size_t len, char **endptr);
-int16_t strto_int16_dec (const char *str, size_t len, char **endptr);
-int16_t strto_int16_hex (const char *str, size_t len, char **endptr);
-
-uint16_t strto_uint16 (const char *str, size_t len, char **endptr, int base);
-uint16_t strto_uint16_bin (const char *str, size_t len, char **endptr);
-uint16_t strto_uint16_oct (const char *str, size_t len, char **endptr);
-uint16_t strto_uint16_dec (const char *str, size_t len, char **endptr);
-
-int32_t strto_int32 (const char *str, size_t len, char **endptr, int base);
-int32_t strto_int32_bin (const char *str, size_t len, char **endptr);
-int32_t strto_int32_oct (const char *str, size_t len, char **endptr);
-int32_t strto_int32_dec (const char *str, size_t len, char **endptr);
-int32_t strto_int32_hex (const char *str, size_t len, char **endptr);
-
-uint32_t strto_uint32 (const char *str, size_t len, char **endptr, int base);
-uint32_t strto_uint32_bin (const char *str, size_t len, char **endptr);
-uint32_t strto_uint32_oct (const char *str, size_t len, char **endptr);
-uint32_t strto_uint32_dec (const char *str, size_t len, char **endptr);
-
-intmax_t strto_intmax (const char *str, size_t len, char **endptr, int base);
-intmax_t strto_intmax_bin (const char *str, size_t len, char **endptr);
-intmax_t strto_intmax_oct (const char *str, size_t len, char **endptr);
-intmax_t strto_intmax_dec (const char *str, size_t len, char **endptr);
-intmax_t strto_intmax_hex (const char *str, size_t len, char **endptr);
-
-OSCAP_HIDDEN_END;
 
 #endif /* STRTO_H */

--- a/src/OVAL/probes/SEAP/sexp-parser.c
+++ b/src/OVAL/probes/SEAP/sexp-parser.c
@@ -807,7 +807,7 @@ SEXP_t *SEXP_parse (const SEXP_psetup_t *psetup, char *buffer, size_t buflen, SE
                 cur_c   = spb_octet (e_dsc.p_buffer, e_dsc.p_bufoff + e_dsc.p_explen);
 
                 if (e_dsc.p_numclass == SEXP_NUMCLASS_UINT) {
-                        uint64_t explen = strto_uint64_dec ((char *)nbuffer, e_dsc.p_explen, NULL);
+                        uint64_t explen = strto_uint64((char *)nbuffer, e_dsc.p_explen, NULL, 10);
 
                         if (explen == 0 && (errno == EINVAL || errno == ERANGE)) {
                                 ret_p = SEXP_PRET_EINVAL;
@@ -848,7 +848,7 @@ SEXP_t *SEXP_parse (const SEXP_psetup_t *psetup, char *buffer, size_t buflen, SE
 
                         switch (e_dsc.p_numclass) {
                         case SEXP_NUMCLASS_INT: {
-                                int64_t number = strto_int64_dec ((char *)nbuffer, e_dsc.p_explen, NULL);
+                                int64_t number = strto_int64((char *)nbuffer, e_dsc.p_explen, NULL, 10);
 
                                 switch (errno) {
                                 case ERANGE:
@@ -907,7 +907,7 @@ SEXP_t *SEXP_parse (const SEXP_psetup_t *psetup, char *buffer, size_t buflen, SE
                                 }
                         }       break;
                         case SEXP_NUMCLASS_UINT: {
-                                uint64_t number = strto_uint64_dec ((char *)nbuffer, e_dsc.p_explen, NULL);
+                                uint64_t number = strto_uint64((char *)nbuffer, e_dsc.p_explen, NULL, 10);
 
                                 switch (errno) {
                                 case ERANGE:

--- a/tests/API/SEAP/test_api_seap_parser.c
+++ b/tests/API/SEAP/test_api_seap_parser.c
@@ -71,7 +71,9 @@ int main (int argc, char *argv[])
                                 SEXP_free (s_exp);
                         }
                         
-                        /* FIXME: getline/fgetln leak */
+                        free(input);
+                        input = NULL;
+                        inlen = 0;
                 }
         } else {
                 int i;


### PR DESCRIPTION
Because `strtoll`/`strtoull` take a null-terminated
C-string, keep the `strto_` functions as wrappers,
but explicitly null-terminate inputs. This is useful
in the parser, where inputs to `strto_`* are length
terminated substrs of the input.

Fixes the SEAP parser test case failure on gcc 8.1.1
by removing the internal implementation and using `strtoll`
instead.

Signed-off-by: Alexander Scheel <ascheel@redhat.com>


I can redo this PR against `maint-1.2` if you prefer, but I removed a number of unimplemented functions in the header (I'm not sure if it is public or not), so I proposed it against `master`.