### PR TITLE
Remove unused hexadecimal logic in SEXP double quote parsing

### DIFF
--- a/src/OVAL/probes/SEAP/sexp-parser.c
+++ b/src/OVAL/probes/SEAP/sexp-parser.c
@@ -1480,8 +1480,6 @@ __PARSE_RT SEXP_parse_ul_string_dq (__PARSE_PT(dsc))
                              case '0': /* Null byte */
                                      oct = '\0';
                                      break;
-                             case 'x': /* Hexadecimal - two more character needed */
-                                     abort ();
                              case 'a': /* Alert (beep) */
                                      oct = '\a';
                                      break;


### PR DESCRIPTION
Fixes error discovered by fuzzing:

	./tests/API/SEAP/test_api_seap_parser '"\x'

will segfault due to out of bounds access, expecting more
characters due to \x denoting the start of a hexadecimal
encoding of a character. Because this is unused/unimplemented
(as referenced by the `abort()`), remove this functionality.

Signed-off-by: Alexander Scheel <ascheel@redhat.com>


This should be ported to `master` afterwards.