### PR TITLE
Make verbose mode a common option for all modules

### DIFF
--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -129,7 +129,7 @@ oscap_verbosity_levels oscap_verbosity_level_from_cstr(const char *level_name)
 	return oscap_string_to_enum(OSCAP_VERBOSITY_LEVELS, level_name);
 }
 
-bool oscap_set_verbose(const char *verbosity_level, const char *filename, bool is_probe)
+bool oscap_set_verbose(const char *verbosity_level, const char *filename)
 {
 	if (verbosity_level == NULL) {
 		verbosity_level = "WARNING";

--- a/src/common/public/oscap_debug.h
+++ b/src/common/public/oscap_debug.h
@@ -51,11 +51,9 @@ OSCAP_API void __oscap_dlprintf(int level, const char *file, const char *fn, siz
  * @param verbosity_level Verbosity level
  * @param filename Name of file used as output file for store debugging
  *                 and other additional information.
- * @param is_probe Determines whether the function is called
- *                 from a probe (true) or from the base library (false).
  * @return When an error occured, returns false, otherwise true.
  */
-OSCAP_API bool oscap_set_verbose(const char *verbosity_level, const char *filename, bool is_probe);
+OSCAP_API bool oscap_set_verbose(const char *verbosity_level, const char *filename);
 
 /**
  * Parse verbosity level from a string.

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -147,9 +147,7 @@ static struct oscap_module DS_RDS_VALIDATE_MODULE = {
 	.parent = &OSCAP_DS_MODULE,
 	.summary = "Validate given ResultDataStream",
 	.usage = "[options] result_datastream.xml",
-	.help = "Options:\n"
-		"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
-		"   --verbose-log-file <file>     - Write verbose informations into file.\n",
+	.help = NULL,
 	.opt_parser = getopt_ds,
 	.func = app_ds_rds_validate
 };
@@ -168,9 +166,7 @@ static struct oscap_module* DS_SUBMODULES[DS_SUBMODULES_NUM] = {
 enum ds_opt {
 	DS_OPT_DATASTREAM_ID = 1,
 	DS_OPT_XCCDF_ID,
-	DS_OPT_REPORT_ID,
-	DS_OPT_VERBOSE,
-	DS_OPT_VERBOSE_LOG_FILE,
+	DS_OPT_REPORT_ID
 };
 
 bool getopt_ds(int argc, char **argv, struct oscap_action *action) {
@@ -184,8 +180,6 @@ bool getopt_ds(int argc, char **argv, struct oscap_action *action) {
 		{"xccdf-id",		required_argument, NULL, DS_OPT_XCCDF_ID},
 		{"report-id",		required_argument, NULL, DS_OPT_REPORT_ID},
 		{"fetch-remote-resources", no_argument, &action->remote_resources, 1},
-		{"verbose", required_argument, NULL, DS_OPT_VERBOSE },
-		{"verbose-log-file", required_argument, NULL, DS_OPT_VERBOSE_LOG_FILE },
 	// end
 		{0, 0, 0, 0}
 	};
@@ -197,8 +191,6 @@ bool getopt_ds(int argc, char **argv, struct oscap_action *action) {
 		case DS_OPT_DATASTREAM_ID:	action->f_datastream_id = optarg;	break;
 		case DS_OPT_XCCDF_ID:	action->f_xccdf_id = optarg; break;
 		case DS_OPT_REPORT_ID:	action->f_report_id = optarg; break;
-		case DS_OPT_VERBOSE:	action->verbosity_level = optarg; break;
-		case DS_OPT_VERBOSE_LOG_FILE: action->f_verbose_log = optarg; break;
 		case 0: break;
 		default: return oscap_module_usage(action->module, stderr, NULL);
 		}
@@ -540,10 +532,6 @@ cleanup:
 
 int app_ds_rds_validate(const struct oscap_action *action) {
 	int ret = OSCAP_ERROR;
-
-	if (!oscap_set_verbose(action->verbosity_level, action->f_verbose_log, false)) {
-		return OSCAP_ERROR;
-	}
 
 	struct oscap_source *rds = oscap_source_new_from_file(action->ds_action->file);
 	if (oscap_source_validate(rds, reporter, (void *) action) != 0) {

--- a/utils/oscap-info.c
+++ b/utils/oscap-info.c
@@ -59,13 +59,11 @@ static int app_info(const struct oscap_action *action);
 struct oscap_module OSCAP_INFO_MODULE = {
     .name = "info",
     .parent = &OSCAP_ROOT_MODULE,
-    .summary = "info module",
+	.summary = "Print information about a SCAP file.",
     .usage = "some-file.xml",
-    .help = "Print information about a file\n"
-    "\n"
-    "Options:\n"
+	.help = "Options:\n"
 		"   --fetch-remote-resources      - Download remote content referenced by DataStream.\n"
-		"   --profile <id>                - Show info of the profile with the given ID..\n"
+		"   --profile <id>                - Show info of the profile with the given ID.\n"
 		"   --profiles                    - Show profiles from the input file in the <id>:<title> format, one line per profile.\n",
     .opt_parser = getopt_info,
     .func = app_info

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -112,9 +112,7 @@ static struct oscap_module OVAL_EVAL = {
 	"   --datastream-id <id>          - ID of the datastream in the collection to use.\n"
 	"                                   (only applicable for source datastreams)\n"
 	"   --oval-id <id>                - ID of the OVAL component ref in the datastream to use.\n"
-	"                                   (only applicable for source datastreams)\n"
-	"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
-	"   --verbose-log-file <file>     - Write verbose information into file.\n",
+	"                                   (only applicable for source datastreams)\n",
     .opt_parser = getopt_oval_eval,
     .func = app_evaluate_oval
 };
@@ -129,9 +127,7 @@ static struct oscap_module OVAL_COLLECT = {
 	"   --id <object>                 - Collect system characteristics ONLY for specified OVAL Object.\n"
 	"   --syschar <file>              - Write OVAL System Characteristic into file.\n"
 	"   --variables <file>            - Provide external variables expected by OVAL Definitions.\n"
-	"   --skip-valid                  - Skip validation.\n"
-	"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
-	"   --verbose-log-file <file>     - Write verbose information into file.\n",
+	"   --skip-valid                  - Skip validation.\n",
     .opt_parser = getopt_oval_collect,
     .func = app_collect_oval
 };
@@ -146,9 +142,7 @@ static struct oscap_module OVAL_ANALYSE = {
 	"Options:\n"
 	"   --variables <file>            - Provide external variables expected by OVAL Definitions.\n"
 	"   --directives <file>           - Use OVAL Directives content to specify desired results content.\n"
-	"   --skip-valid                  - Skip validation.\n"
-	"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
-	"   --verbose-log-file <file>     - Write verbose information into file.\n",
+	"   --skip-valid                  - Skip validation.\n",
     .opt_parser = getopt_oval_analyse,
     .func = app_analyse_oval
 };
@@ -209,11 +203,6 @@ int app_collect_oval(const struct oscap_action *action)
 	struct oval_probe_session	*pb_sess   = NULL;
 	struct oval_generator		*generator = NULL;
 	int ret = OSCAP_ERROR;
-
-	/* Turn on verbosity */
-	if (!oscap_set_verbose(action->verbosity_level, action->f_verbose_log, false)) {
-		goto cleanup;
-	}
 
 	/* validate inputs */
 	if (action->validate) {
@@ -331,11 +320,6 @@ int app_evaluate_oval(const struct oscap_action *action)
 	oval_result_t eval_result;
 	int ret = OSCAP_ERROR;
 
-	/* Turn on verbosity */
-	if (!oscap_set_verbose(action->verbosity_level, action->f_verbose_log, false)) {
-		goto cleanup;
-	}
-
 	/* create a new OVAL session */
 	if ((session = oval_session_new(action->f_oval)) == NULL) {
 		oscap_print_error();
@@ -398,11 +382,6 @@ static int app_analyse_oval(const struct oscap_action *action) {
  	struct oval_syschar_model	*sys_models[2];
 	struct oval_generator		*generator = NULL;
 	int ret = OSCAP_ERROR;
-
-	/* Turn on verbosity */
-	if (!oscap_set_verbose(action->verbosity_level, action->f_verbose_log, false)) {
-		goto cleanup;
-	}
 
 	/* validate inputs */
 	if (action->validate) {
@@ -515,9 +494,7 @@ enum oval_opt {
     OVAL_OPT_DIRECTIVES,
     OVAL_OPT_DATASTREAM_ID,
     OVAL_OPT_OVAL_ID,
-    OVAL_OPT_OUTPUT = 'o',
-	OVAL_OPT_VERBOSE,
-	OVAL_OPT_VERBOSE_LOG_FILE
+	OVAL_OPT_OUTPUT = 'o'
 };
 
 #if defined(OVAL_PROBES_ENABLED)
@@ -536,8 +513,6 @@ bool getopt_oval_eval(int argc, char **argv, struct oscap_action *action)
 		{ "datastream-id",required_argument, NULL, OVAL_OPT_DATASTREAM_ID},
 		{ "oval-id",    required_argument, NULL, OVAL_OPT_OVAL_ID},
 		{ "skip-valid",	no_argument, &action->validate, 0 },
-		{ "verbose", required_argument, NULL, OVAL_OPT_VERBOSE },
-		{ "verbose-log-file", required_argument, NULL, OVAL_OPT_VERBOSE_LOG_FILE },
 		{ "fetch-remote-resources", no_argument, &action->remote_resources, 1},
 		{ 0, 0, 0, 0 }
 	};
@@ -552,18 +527,9 @@ bool getopt_oval_eval(int argc, char **argv, struct oscap_action *action)
 		case OVAL_OPT_DIRECTIVES: action->f_directives = optarg; break;
 		case OVAL_OPT_DATASTREAM_ID: action->f_datastream_id = optarg;	break;
 		case OVAL_OPT_OVAL_ID: action->f_oval_id = optarg;	break;
-		case OVAL_OPT_VERBOSE:
-			action->verbosity_level = optarg;
-			break;
-		case OVAL_OPT_VERBOSE_LOG_FILE:
-			action->f_verbose_log = optarg;
-			break;
 		case 0: break;
 		default: return oscap_module_usage(action->module, stderr, NULL);
 		}
-	}
-	if (!check_verbose_options(action)) {
-		return false;
 	}
 
 	/* We should have Definitions file here */
@@ -586,8 +552,6 @@ bool getopt_oval_collect(int argc, char **argv, struct oscap_action *action)
 		{ "variables",	required_argument, NULL, OVAL_OPT_VARIABLES    },
 		{ "syschar",	required_argument, NULL, OVAL_OPT_SYSCHAR      },
 		{ "skip-valid",	no_argument, &action->validate, 0 },
-		{ "verbose", required_argument, NULL, OVAL_OPT_VERBOSE },
-		{ "verbose-log-file", required_argument, NULL, OVAL_OPT_VERBOSE_LOG_FILE },
 		{ 0, 0, 0, 0 }
 	};
 
@@ -597,18 +561,9 @@ bool getopt_oval_collect(int argc, char **argv, struct oscap_action *action)
 		case OVAL_OPT_ID: action->id = optarg; break;
 		case OVAL_OPT_VARIABLES: action->f_variables = optarg; break;
 		case OVAL_OPT_SYSCHAR: action->f_syschar = optarg; break;
-		case OVAL_OPT_VERBOSE:
-			action->verbosity_level = optarg;
-			break;
-		case OVAL_OPT_VERBOSE_LOG_FILE:
-			action->f_verbose_log = optarg;
-			break;
 		case 0: break;
 		default: return oscap_module_usage(action->module, stderr, NULL);
 		}
-	}
-	if (!check_verbose_options(action)) {
-		return false;
 	}
 
 	/* We should have Definitions file here */
@@ -630,8 +585,6 @@ bool getopt_oval_analyse(int argc, char **argv, struct oscap_action *action)
 		{ "variables",	required_argument, NULL, OVAL_OPT_VARIABLES    },
 		{ "directives",	required_argument, NULL, OVAL_OPT_DIRECTIVES   },
 		{ "skip-valid",	no_argument, &action->validate, 0 },
-		{ "verbose", required_argument, NULL, OVAL_OPT_VERBOSE },
-		{ "verbose-log-file", required_argument, NULL, OVAL_OPT_VERBOSE_LOG_FILE },
 		{ 0, 0, 0, 0 }
 	};
 
@@ -641,18 +594,9 @@ bool getopt_oval_analyse(int argc, char **argv, struct oscap_action *action)
 		case OVAL_OPT_RESULT_FILE: action->f_results = optarg; break;
 		case OVAL_OPT_VARIABLES: action->f_variables = optarg; break;
 		case OVAL_OPT_DIRECTIVES: action->f_directives = optarg; break;
-		case OVAL_OPT_VERBOSE:
-			action->verbosity_level = optarg;
-			break;
-		case OVAL_OPT_VERBOSE_LOG_FILE:
-			action->f_verbose_log = optarg;
-			break;
 		case 0: break;
 		default: return oscap_module_usage(action->module, stderr, NULL);
 		}
-	}
-	if (!check_verbose_options(action)) {
-		return false;
 	}
 
 	/* We should have Definitions file here */

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -375,7 +375,7 @@ int oscap_module_process(struct oscap_module *module, int argc, char **argv)
 			if (!check_verbose_options(&action)) {
 				goto cleanup;
 			}
-			if (!oscap_set_verbose(action.verbosity_level, action.f_verbose_log, false)) {
+			if (!oscap_set_verbose(action.verbosity_level, action.f_verbose_log)) {
 				goto cleanup;
 			}
             ret = oscap_module_call(&action);

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -185,6 +185,7 @@ bool oscap_module_usage(struct oscap_module *module, FILE *out, const char *err,
 static const char *common_opts_help =
 	"Common options:\n"
 	"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
+	"                                   Verbosity level must be one of: DEVEL, INFO, WARNING, ERROR.\n"
 	"   --verbose-log-file <file>     - Write verbose informations into file.\n";
 
 static void oscap_module_print_help(struct oscap_module *module, FILE *out)

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -67,12 +67,6 @@ static void oscap_action_release(struct oscap_action *action)
 	cvss_impact_free(action->cvss_impact);
 }
 
-
-static bool oscap_action_postprocess(struct oscap_action *action)
-{
-    return true;
-}
-
 static size_t paramlist_size(const char **p) { size_t s = 0; if (!p) return s; while (p[s]) s += 2; return s; }
 
 static size_t paramlist_cpy(const char **to, const char **p) {
@@ -267,9 +261,7 @@ int oscap_module_call(struct oscap_action *action)
     assert(action->module != NULL);
 
     if (action->module->func) {
-        if (oscap_action_postprocess(action))
-            return action->module->func(action);
-        else return OSCAP_ERR_FETCH;
+		return action->module->func(action);
     }
     return OSCAP_UNIMPL_MOD;
 }

--- a/utils/oscap-vm.8
+++ b/utils/oscap-vm.8
@@ -30,6 +30,10 @@ The rest of the options are passed directly to \fBoscap(8)\fR utility. For the d
 
 Last argument is SCAP content input file.
 
+Supported common options are:
+  \-\-verbose <verbosity_level>
+  \-\-verbose\-log\-file <file>
+
 .SS Evaluation of XCCDF content
 
 \fBxccdf eval\fR module evaluates XCCDF files or SCAP source datastreams. Result of each rule is printed to standard output, including rule title, rule id and security identifier (CVE, CCE).
@@ -62,8 +66,6 @@ Supported oscap xccdf eval options are:
   \-\-datastream-id <id>
   \-\-xccdf-id <id>
   \-\-benchmark-id <id>
-  \-\-verbose <verbosity_level>
-  \-\-verbose\-log\-file <file>
 
 Remediation of virtual machines is not supported.
 
@@ -90,8 +92,6 @@ Supported oscap oval eval options are:
   \-\-skip-valid
   \-\-datastream-id <id>
   \-\-oval-id <id>
-  \-\-verbose <verbosity_level>
-  \-\-verbose\-log\-file <file>
 
 .SS Collection of OVAL System Characteristic
 
@@ -111,8 +111,6 @@ Supported oscap oval collect options are:
   \-\-syschar <file>
   \-\-variables <file>
   \-\-skip-valid
-  \-\-verbose <verbosity_level>
-  \-\-verbose\-log\-file <file>
 
 .SH EXAMPLES
 

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -44,6 +44,19 @@ Common Vulnerability Scoring System
 \fBcve\fR
 Common Vulnerabilities and Exposures
 
+.SH COMMON OPTIONS FOR ALL MODULES
+.RE
+.TP
+\fB\-\-verbose VERBOSITY_LEVEL\fR
+.RS
+Turn on verbose mode at specified verbosity level. VERBOSITY_LEVEL is one of: DEVEL, INFO, WARNING, ERROR.
+.RE
+.TP
+\fB\-\-verbose-log-file FILE\fR
+.RS
+Set filename to write additional information.
+.RE
+
 .SH INFO OPERATIONS
 .TP
 [\fIoptions\fR] any-scap-file.xml
@@ -179,16 +192,6 @@ Allow download of remote OVAL content referenced from XCCDF by check-content-ref
 \fB\-\-remediate\fR
 .RS
 Execute XCCDF remediation in the process of XCCDF evaluation. This option automatically executes content of XCCDF fix elements for failed rules, and thus this shall be avoided unless for trusted content. Use of this option is always at your own risk.
-.RE
-.TP
-\fB\-\-verbose VERBOSITY_LEVEL\fR
-.RS
-Turn on verbose mode at specified verbosity level. VERBOSITY_LEVEL is one of: DEVEL, INFO, WARNING, ERROR.
-.RE
-.TP
-\fB\-\-verbose-log-file FILE\fR
-.RS
-Set filename to write additional information.
 .RE
 .RE
 .TP
@@ -433,13 +436,6 @@ Do not validate input/output files.
 \fB\-\-fetch-remote-resources\fR
 Allow download of remote components referenced from Datastream.
 .RE
-.TP
-\fB\-\-verbose VERBOSITY_LEVEL\fR
-Turn on verbose mode at specified verbosity level. VERBOSITY_LEVEL is one of: DEVEL, INFO, WARNING, ERROR.
-.TP
-\fB\-\-verbose-log-file FILE\fR
-Set filename to write additional information.
-.RE
 
 .TP
 .B collect\fR [\fIoptions\fR] definitions-file
@@ -459,11 +455,6 @@ Write OVAL System Characteristic into file.
 \fB\-\-skip-valid\fR
 Do not validate input/output files.
 .TP
-\fB\-\-verbose VERBOSITY_LEVEL\fR
-Turn on verbose mode at specified verbosity level. VERBOSITY_LEVEL is one of: DEVEL, INFO, WARNING, ERROR.
-.TP
-\fB\-\-verbose-log-file FILE\fR
-Set filename to write additional information.
 .RE
 
 .TP
@@ -479,12 +470,6 @@ Use OVAL Directives content to specify desired results content.
 .TP
 \fB\-\-skip-valid\fR
 Do not validate input/output files.
-.TP
-\fB\-\-verbose VERBOSITY_LEVEL\fR
-Turn on verbose mode at specified verbosity level. VERBOSITY_LEVEL is one of: DEVEL, INFO, WARNING, ERROR.
-.TP
-\fB\-\-verbose-log-file FILE\fR
-Set filename to write additional information.
 .RE
 
 .TP


### PR DESCRIPTION
Verbose mode was originally introduced first to `oscap oval` module, because the feature was focused to debugging OVAL evaluation. Later, it was extended to `xccdf eval` and then to various other modules.

To be able to extend the verbose mode, we will make the `--verbose` and `--verbose-log-file` global options. In other words, those 2 options will be applicable to all the modules.

A drawback of this approach could be that many parts of our code are not covered by any verbose messages, which means the verbose mode produces often (almost) empty output.

This PR also reflects this CLI change in manual pages.