### PR TITLE
Remove --probe-root option

### DIFF
--- a/src/OVAL/oval_session.c
+++ b/src/OVAL/oval_session.c
@@ -334,18 +334,9 @@ static int oval_session_setup_agent(struct oval_session *session)
 	return 0;
 }
 
-int oval_session_evaluate_id(struct oval_session *session, char *probe_root, const char *id, oval_result_t *result)
+int oval_session_evaluate_id(struct oval_session *session, const char *id, oval_result_t *result)
 {
 	__attribute__nonnull__(session);
-
-#if defined(OVAL_PROBES_ENABLED)
-	if (probe_root) {
-		if (setenv("OSCAP_PROBE_ROOT", probe_root, 1) != 0) {
-			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Failed to set the OSCAP_PROBE_ROOT environment variable.");
-			return 1;
-		}
-	}
-#endif
 
 	if (id == NULL) {
 		oscap_seterr(OSCAP_EFAMILY_OVAL, "No OVAL Definion id set.");
@@ -368,19 +359,9 @@ int oval_session_evaluate_id(struct oval_session *session, char *probe_root, con
 	return 0;
 }
 
-int oval_session_evaluate(struct oval_session *session, char *probe_root, agent_reporter fn, void *arg)
+int oval_session_evaluate(struct oval_session *session, agent_reporter fn, void *arg)
 {
 	__attribute__nonnull__(session);
-
-#if defined(OVAL_PROBES_ENABLED)
-	if (probe_root) {
-		if (setenv("OSCAP_PROBE_ROOT", probe_root, 1) != 0) {
-			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Failed to set the OSCAP_PROBE_ROOT environment variable.");
-			return 1;
-		}
-		dI("OSCAP_PROBE_ROOT environment variable set to '%s'.", probe_root);
-	}
-#endif
 
 	if (oval_session_setup_agent(session) != 0) {
 		return 1;

--- a/src/OVAL/public/oval_session.h
+++ b/src/OVAL/public/oval_session.h
@@ -175,7 +175,6 @@ OSCAP_API int oval_session_load(struct oval_session *session);
  *
  * @memberof oval_session
  * @param session an \ref oval_session
- * @param probe_root FIXME:
  * @param id id of an OVAL Definition
  * @param result variable to write the result into
  *
@@ -183,7 +182,7 @@ OSCAP_API int oval_session_load(struct oval_session *session);
  * @retval 1 on an internal error (use \ref oscap_err_desc or \ref
  * oscap_err_get_full_error to get more details)
  */
-OSCAP_API int oval_session_evaluate_id(struct oval_session *session, char *probe_root, const char *id, oval_result_t *result);
+OSCAP_API int oval_session_evaluate_id(struct oval_session *session, const char *id, oval_result_t *result);
 
 /**
  * Evaluate OVAL Definitions. Optionally you can set a callback function which
@@ -194,7 +193,6 @@ OSCAP_API int oval_session_evaluate_id(struct oval_session *session, char *probe
  *
  * @memberof oval_session
  * @param session an \ref oval_session
- * @param probe_root FIXME:
  * @param fn a callback function
  * @param arg an optional argument for your callback function
  *
@@ -202,7 +200,7 @@ OSCAP_API int oval_session_evaluate_id(struct oval_session *session, char *probe
  * @retval 1 on an internal error (use \ref oscap_err_desc or \ref
  * oscap_err_get_full_error to get more details)
  */
-OSCAP_API int oval_session_evaluate(struct oval_session *session, char *probe_root, agent_reporter fn, void *arg);
+OSCAP_API int oval_session_evaluate(struct oval_session *session, agent_reporter fn, void *arg);
 
 /**
  * Export result to a file. Results can be represented as OVAL System

--- a/utils/oscap-chroot
+++ b/utils/oscap-chroot
@@ -61,7 +61,6 @@ function usage()
     echo "  --skip-valid"
     echo "  --datastream-id"
     echo "  --oval-id"
-    echo "  --probe-root"
     echo
     echo "$ oscap-chroot CHROOT_PATH oval collect [options] INPUT_CONTENT"
     echo

--- a/utils/oscap-chroot.8
+++ b/utils/oscap-chroot.8
@@ -39,7 +39,6 @@ supported oscap oval eval options are:
   --skip-valid
   --datastream-id
   --oval-id
-  --probe-root
 
 .SS Collection of OVAL System Characteristic
 $ oscap-chroot CHROOT_PATH oval collect [options] INPUT_CONTENT

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -362,12 +362,12 @@ int app_evaluate_oval(const struct oscap_action *action)
 
 	/* evaluation */
 	if (action->id) {
-		if ((oval_session_evaluate_id(session, NULL, action->id, &eval_result)) != 0)
+		if ((oval_session_evaluate_id(session, action->id, &eval_result)) != 0)
 			goto cleanup;
 		printf("Definition %s: %s\n", action->id, oval_result_get_text(eval_result));
 	}
 	else {
-		if ((oval_session_evaluate(session, NULL, app_oval_callback, NULL)) != 0)
+		if ((oval_session_evaluate(session, app_oval_callback, NULL)) != 0)
 			goto cleanup;
 	}
 

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -113,7 +113,6 @@ static struct oscap_module OVAL_EVAL = {
 	"                                   (only applicable for source datastreams)\n"
 	"   --oval-id <id>                - ID of the OVAL component ref in the datastream to use.\n"
 	"                                   (only applicable for source datastreams)\n"
-	"   --probe-root <dir>            - Change the root directory before scanning the system.\n"
 	"   --verbose <verbosity_level>   - Turn on verbose mode at specified verbosity level.\n"
 	"   --verbose-log-file <file>     - Write verbose information into file.\n",
     .opt_parser = getopt_oval_eval,
@@ -363,12 +362,12 @@ int app_evaluate_oval(const struct oscap_action *action)
 
 	/* evaluation */
 	if (action->id) {
-		if ((oval_session_evaluate_id(session, action->probe_root, action->id, &eval_result)) != 0)
+		if ((oval_session_evaluate_id(session, NULL, action->id, &eval_result)) != 0)
 			goto cleanup;
 		printf("Definition %s: %s\n", action->id, oval_result_get_text(eval_result));
 	}
 	else {
-		if ((oval_session_evaluate(session, action->probe_root, app_oval_callback, NULL)) != 0)
+		if ((oval_session_evaluate(session, NULL, app_oval_callback, NULL)) != 0)
 			goto cleanup;
 	}
 
@@ -517,9 +516,6 @@ enum oval_opt {
     OVAL_OPT_DATASTREAM_ID,
     OVAL_OPT_OVAL_ID,
     OVAL_OPT_OUTPUT = 'o',
-#if defined(OVAL_PROBES_ENABLED)
-	OVAL_OPT_PROBE_ROOT,
-#endif
 	OVAL_OPT_VERBOSE,
 	OVAL_OPT_VERBOSE_LOG_FILE
 };
@@ -528,7 +524,6 @@ enum oval_opt {
 bool getopt_oval_eval(int argc, char **argv, struct oscap_action *action)
 {
 	action->doctype = OSCAP_DOCUMENT_OVAL_DEFINITIONS;
-	action->probe_root = NULL;
 
 	/* Command-options */
 	struct option long_options[] = {
@@ -541,7 +536,6 @@ bool getopt_oval_eval(int argc, char **argv, struct oscap_action *action)
 		{ "datastream-id",required_argument, NULL, OVAL_OPT_DATASTREAM_ID},
 		{ "oval-id",    required_argument, NULL, OVAL_OPT_OVAL_ID},
 		{ "skip-valid",	no_argument, &action->validate, 0 },
-		{ "probe-root", required_argument, NULL, OVAL_OPT_PROBE_ROOT},
 		{ "verbose", required_argument, NULL, OVAL_OPT_VERBOSE },
 		{ "verbose-log-file", required_argument, NULL, OVAL_OPT_VERBOSE_LOG_FILE },
 		{ "fetch-remote-resources", no_argument, &action->remote_resources, 1},
@@ -558,7 +552,6 @@ bool getopt_oval_eval(int argc, char **argv, struct oscap_action *action)
 		case OVAL_OPT_DIRECTIVES: action->f_directives = optarg; break;
 		case OVAL_OPT_DATASTREAM_ID: action->f_datastream_id = optarg;	break;
 		case OVAL_OPT_OVAL_ID: action->f_oval_id = optarg;	break;
-		case OVAL_OPT_PROBE_ROOT: action->probe_root = optarg; break;
 		case OVAL_OPT_VERBOSE:
 			action->verbosity_level = optarg;
 			break;

--- a/utils/oscap-ssh
+++ b/utils/oscap-ssh
@@ -67,7 +67,6 @@ function usage()
     echo "  --skip-valid"
     echo "  --datastream-id"
     echo "  --oval-id"
-    echo "  --probe-root (has to be remote probe root!)"
     echo
     echo "$ oscap-ssh user@host 22 oval collect [options] INPUT_CONTENT"
     echo

--- a/utils/oscap-ssh.8
+++ b/utils/oscap-ssh.8
@@ -46,7 +46,6 @@ Supported options are:
   --skip-valid
   --datastream-id
   --oval-id
-  --probe-root (has to be remote path)
 
 .SS Collection of OVAL System Characteristic
 $ oscap-ssh user@host 22 oval collect [options] INPUT_CONTENT

--- a/utils/oscap-tool.h
+++ b/utils/oscap-tool.h
@@ -167,7 +167,6 @@ struct oscap_action {
 	int check_engine_results;
 	int export_variables;
         int list_dynamic;
-	char *probe_root;
 	char *verbosity_level;
 	char *fix_type;
 };

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -60,7 +60,6 @@ function usage()
     echo "  --skip-valid"
     echo "  --datastream-id"
     echo "  --oval-id"
-    echo "  --probe-root"
     echo
     echo "$ oscap-vm image VM_STORAGE_IMAGE oval collect [options] INPUT_CONTENT"
     echo "$ oscap-vm domain VM_DOMAIN oval collect [options] INPUT_CONTENT"

--- a/utils/oscap-vm.8
+++ b/utils/oscap-vm.8
@@ -90,7 +90,6 @@ Supported oscap oval eval options are:
   \-\-skip-valid
   \-\-datastream-id <id>
   \-\-oval-id <id>
-  \-\-probe-root <dir>
   \-\-verbose <verbosity_level>
   \-\-verbose\-log\-file <file>
 


### PR DESCRIPTION
Dropping `--probe-root` option from `oscap oval eval`. It only sets
an environment variable which users can set themselves. Moreover,
it clashes with utilities like oscap-chroot or oscap-docker.