### PR TITLE
The function was freeing unowned memory using const pointers

### DIFF
--- a/src/CVRF/cvrf_priv.c
+++ b/src/CVRF/cvrf_priv.c
@@ -1681,9 +1681,6 @@ xmlNode *cvrf_score_set_to_dom(const struct cvrf_score_set *score_set) {
 	cvrf_element_add_child("Vector", score_set->vector, score_node);
 	cvrf_element_add_stringlist(score_set->product_ids, "ProductID", score_node);
 
-	free(base);
-	free(temporal);
-	free(environmental);
 	return score_node;
 }
 


### PR DESCRIPTION
```
[37/323] Building C object src/CVRF/CMakeFiles/cvrf_object.dir/cvrf_priv.c.o
../src/CVRF/cvrf_priv.c: In function ‘cvrf_score_set_to_dom’:
../src/CVRF/cvrf_priv.c:1684:7: warning: passing argument 1 of ‘free’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  free(base);
       ^~~~
```