### PR TITLE
Do not build the documentation on every build

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_custom_target(docs ALL
+add_custom_target(docs
     COMMENT "Generating documentation and manuals in HTML format"
 )
 


### PR DESCRIPTION
Makes the 'docs' an independent target, which does not depend on
'ALL' pseudotarget. This brings us back fast incremental rebuilds,
which is useful for developing and debugging. Users can still build
the documentations easily using 'make docs'.