### PR TITLE
Skip sysctl probe test if no SysV services are found

### DIFF
--- a/tests/probes/runlevel/test_probes_runlevel.sh
+++ b/tests/probes/runlevel/test_probes_runlevel.sh
@@ -25,7 +25,7 @@ function test_probes_runlevel_A {
     require "egrep" || return 255
     require "awk" || return 255
 
-    local services_list=`get_services_list`
+    local services_list="$(get_services_list)"
     [ -n "$services_list" ] || return 255
 
     local ret_val=0;

--- a/tests/probes/runlevel/test_probes_runlevel.sh
+++ b/tests/probes/runlevel/test_probes_runlevel.sh
@@ -25,6 +25,9 @@ function test_probes_runlevel_A {
     require "egrep" || return 255
     require "awk" || return 255
 
+    local services_list=`get_services_list`
+    [ -n "$services_list" ] || return 255
+
     local ret_val=0;
     local DF="test_probes_runlevel_A.xml"
     local RF="results_A.xml"


### PR DESCRIPTION
If the list of services returned by `chkconfig --list` is empty,
then the generated OVAL file would be invalid. Since there would
not be anything to test in that situation, it would be better
to skip the test instead. This situation can happen on modern
Linux distributions that have only native systemd services.