### PR TITLE
[WIP] [HELP WANTED] Container builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,15 @@ matrix:
       script:
         - docker run openscap_$BASE_IMAGE:latest
     - os: linux
+      env: BASE_IMAGE="fedora_clang"
+      sudo: required
+      services:
+        - docker
+      before_install:
+        - docker build --no-cache --tag openscap_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
+      script:
+        - docker run openscap_$BASE_IMAGE:latest
+    - os: linux
       env: BASE_IMAGE="fedora_ssg"
       sudo: required
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,51 @@ matrix:
       script:
         - cmake -DENABLE_PROBES=false ../
         - make -j 4
+    - os: linux
+      env: BASE_IMAGE="gcc_latest"
+      sudo: required
+      services:
+        - docker
+      before_install:
+        - docker build --no-cache --tag openscap_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
+      script:
+        - docker run openscap_$BASE_IMAGE:latest
+    - os: linux
+      env: BASE_IMAGE="gcc_7"
+      sudo: required
+      services:
+        - docker
+      before_install:
+        - docker build --no-cache --tag openscap_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
+      script:
+        - docker run openscap_$BASE_IMAGE:latest
+    - os: linux
+      env: BASE_IMAGE="gcc_6"
+      sudo: required
+      services:
+        - docker
+      before_install:
+        - docker build --no-cache --tag openscap_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
+      script:
+        - docker run openscap_$BASE_IMAGE:latest
+    - os: linux
+      env: BASE_IMAGE="gcc_5"
+      sudo: required
+      services:
+        - docker
+      before_install:
+        - docker build --no-cache --tag openscap_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
+      script:
+        - docker run openscap_$BASE_IMAGE:latest
+    - os: linux
+      env: BASE_IMAGE="gcc_4"
+      sudo: required
+      services:
+        - docker
+      before_install:
+        - docker build --no-cache --tag openscap_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
+      script:
+        - docker run openscap_$BASE_IMAGE:latest
 
 addons:
   sonarcloud:

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,15 @@ matrix:
         - docker build --no-cache --tag openscap_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
       script:
         - docker run openscap_$BASE_IMAGE:latest
+    - os: linux
+      env: BASE_IMAGE="fedora_ssg"
+      sudo: required
+      services:
+        - docker
+      before_install:
+        - docker build --no-cache --tag openscap_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
+      script:
+        - docker run openscap_$BASE_IMAGE:latest
 
 addons:
   sonarcloud:

--- a/Dockerfiles/fedora_clang
+++ b/Dockerfiles/fedora_clang
@@ -1,0 +1,29 @@
+FROM fedora:rawhide
+
+ENV OSCAP_USERNAME oscap
+ENV OSCAP_DIR openscap
+ENV BUILD_JOBS 4
+
+RUN true \
+        && dnf -y upgrade --refresh \
+	&& dnf -y install cmake dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre-devel perl-XML-Parser perl-XML-XPath perl-devel python-devel rpm-devel swig bzip2-devel clang \
+	&& mkdir -p /home/$OSCAP_USERNAME \
+	&& dnf clean all \
+	&& rm -rf /usr/share/doc /usr/share/doc-base \
+	          /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+	&& true
+
+WORKDIR /home/$OSCAP_USERNAME
+
+COPY . $OSCAP_DIR/
+
+# clean the build dir in case the user is also building OpenSCAP locally
+RUN rm -rf $OSCAP_DIR/build/*
+
+WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
+
+CMD true \
+        && cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .. \
+        && make -j $BUILD_JOBS \
+        && ctest --output-on-failure -j $BUILD_JOBS -R API -E 'API/(OVAL|XCCDF)/unittests/all.sh' \
+        && true

--- a/Dockerfiles/fedora_ssg
+++ b/Dockerfiles/fedora_ssg
@@ -1,0 +1,36 @@
+FROM fedora:28
+
+ENV OSCAP_USERNAME oscap
+ENV OSCAP_DIR openscap
+ENV BUILD_JOBS 4
+
+RUN true \
+        && dnf -y upgrade --refresh \
+	&& dnf -y install cmake dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre-devel perl-XML-Parser perl-XML-XPath perl-devel python-devel rpm-devel swig bzip2-devel gcc-c++ \
+	&& dnf -y install cmake ninja-build python3-jinja2 python3-PyYAML ansible python3-pytest git \
+	&& mkdir -p /home/$OSCAP_USERNAME \
+	&& dnf clean all \
+	&& rm -rf /usr/share/doc /usr/share/doc-base \
+	          /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+	&& true
+
+WORKDIR /home/$OSCAP_USERNAME
+
+COPY . $OSCAP_DIR/
+
+# clean the build dir in case the user is also building OpenSCAP locally
+RUN rm -rf $OSCAP_DIR/build/*
+
+WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
+
+CMD true \
+        && cmake .. \
+        && make -j $BUILD_JOBS \
+        && make install \
+        && cd /home/$OSCAP_USERNAME \
+        && git clone https://github.com/OpenSCAP/scap-security-guide \
+        && cd /home/$OSCAP_USERNAME/scap-security-guide/build \
+        && cmake .. \
+        && make -j $BUILD_JOBS \
+        && ctest --output-on-failure -j $BUILD_JOBS \
+        && true

--- a/Dockerfiles/gcc_4
+++ b/Dockerfiles/gcc_4
@@ -1,0 +1,30 @@
+FROM gcc:4
+
+ENV OSCAP_USERNAME oscap
+ENV OSCAP_DIR openscap
+ENV BUILD_JOBS 4
+
+RUN true \
+	&& apt-get -qq update \
+	&& apt-get -qq install cmake libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev python-dev swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev librpm-dev \
+	&& mkdir -p /home/$OSCAP_USERNAME \
+	&& apt-get autoremove \
+	&& apt-get clean \
+	&& apt-get autoclean \
+	&& rm -rf /usr/share/doc /usr/share/doc-base /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+	&& true
+
+WORKDIR /home/$OSCAP_USERNAME
+
+COPY . $OSCAP_DIR/
+
+# clean the build dir in case the user is also building OpenSCAP locally
+RUN rm -rf $OSCAP_DIR/build/*
+
+WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
+
+CMD true \
+	&& cmake .. \
+	&& make -j $BUILD_JOBS \
+	&& ctest --output-on-failure -j $BUILD_JOBS -R API -E 'API/(OVAL|XCCDF)/unittests/all.sh' \
+	&& true

--- a/Dockerfiles/gcc_5
+++ b/Dockerfiles/gcc_5
@@ -1,0 +1,30 @@
+FROM gcc:5
+
+ENV OSCAP_USERNAME oscap
+ENV OSCAP_DIR openscap
+ENV BUILD_JOBS 4
+
+RUN true \
+	&& apt-get -qq update \
+	&& apt-get -qq install cmake libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev python-dev swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev librpm-dev \
+	&& mkdir -p /home/$OSCAP_USERNAME \
+	&& apt-get autoremove \
+	&& apt-get clean \
+	&& apt-get autoclean \
+	&& rm -rf /usr/share/doc /usr/share/doc-base /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+	&& true
+
+WORKDIR /home/$OSCAP_USERNAME
+
+COPY . $OSCAP_DIR/
+
+# clean the build dir in case the user is also building OpenSCAP locally
+RUN rm -rf $OSCAP_DIR/build/*
+
+WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
+
+CMD true \
+	&& cmake .. \
+	&& make -j $BUILD_JOBS \
+	&& ctest --output-on-failure -j $BUILD_JOBS -R API -E 'API/(OVAL|XCCDF)/unittests/all.sh' \
+	&& true

--- a/Dockerfiles/gcc_6
+++ b/Dockerfiles/gcc_6
@@ -1,0 +1,30 @@
+FROM gcc:6
+
+ENV OSCAP_USERNAME oscap
+ENV OSCAP_DIR openscap
+ENV BUILD_JOBS 4
+
+RUN true \
+	&& apt-get -qq update \
+	&& apt-get -qq install cmake libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev python-dev swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev librpm-dev \
+	&& mkdir -p /home/$OSCAP_USERNAME \
+	&& apt-get autoremove \
+	&& apt-get clean \
+	&& apt-get autoclean \
+	&& rm -rf /usr/share/doc /usr/share/doc-base /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+	&& true
+
+WORKDIR /home/$OSCAP_USERNAME
+
+COPY . $OSCAP_DIR/
+
+# clean the build dir in case the user is also building OpenSCAP locally
+RUN rm -rf $OSCAP_DIR/build/*
+
+WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
+
+CMD true \
+	&& cmake .. \
+	&& make -j $BUILD_JOBS \
+	&& ctest --output-on-failure -j $BUILD_JOBS -R API -E 'API/(OVAL|XCCDF)/unittests/all.sh' \
+	&& true

--- a/Dockerfiles/gcc_7
+++ b/Dockerfiles/gcc_7
@@ -1,0 +1,30 @@
+FROM gcc:7
+
+ENV OSCAP_USERNAME oscap
+ENV OSCAP_DIR openscap
+ENV BUILD_JOBS 4
+
+RUN true \
+	&& apt-get -qq update \
+	&& apt-get -qq install cmake libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev python-dev swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev librpm-dev \
+	&& mkdir -p /home/$OSCAP_USERNAME \
+	&& apt-get autoremove \
+	&& apt-get clean \
+	&& apt-get autoclean \
+	&& rm -rf /usr/share/doc /usr/share/doc-base /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+	&& true
+
+WORKDIR /home/$OSCAP_USERNAME
+
+COPY . $OSCAP_DIR/
+
+# clean the build dir in case the user is also building OpenSCAP locally
+RUN rm -rf $OSCAP_DIR/build/*
+
+WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
+
+CMD true \
+	&& cmake .. \
+	&& make -j $BUILD_JOBS \
+	&& ctest --output-on-failure -j $BUILD_JOBS -R API -E 'API/(OVAL|XCCDF)/unittests/all.sh' \
+	&& true

--- a/Dockerfiles/gcc_latest
+++ b/Dockerfiles/gcc_latest
@@ -1,0 +1,30 @@
+FROM gcc:latest
+
+ENV OSCAP_USERNAME oscap
+ENV OSCAP_DIR openscap
+ENV BUILD_JOBS 4
+
+RUN true \
+	&& apt-get -qq update \
+	&& apt-get -qq install cmake libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev python-dev swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev librpm-dev \
+	&& mkdir -p /home/$OSCAP_USERNAME \
+	&& apt-get autoremove \
+	&& apt-get clean \
+	&& apt-get autoclean \
+	&& rm -rf /usr/share/doc /usr/share/doc-base /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+	&& true
+
+WORKDIR /home/$OSCAP_USERNAME
+
+COPY . $OSCAP_DIR/
+
+# clean the build dir in case the user is also building OpenSCAP locally
+RUN rm -rf $OSCAP_DIR/build/*
+
+WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
+
+CMD true \
+	&& cmake .. \
+	&& make -j $BUILD_JOBS \
+	&& ctest --output-on-failure -j $BUILD_JOBS -R API -E 'API/(OVAL|XCCDF)/unittests/all.sh' \
+	&& true


### PR DESCRIPTION
This adds several new container builds to Travis CI for PR gating:

 - gcc 4
 - gcc 5
 - gcc 6
 - gcc 7
 - ggc latest
 - clang (`fedora:rawhide`)
 - SSG Integration test

I'm not sure if we want all of these, but they're added anyways. I'm guessing between rhel6, rhel7, older Ubuntu/Debian, and new Fedoras, a majority of these compilers are still being supported / used frequently in the wild.

The integration test might be preferable to run as a nightly test as it does take a while to run, longer than the other jobs, but that's up for discussion. 


Thoughts? 