### PR TITLE
Cleanup CPE API Evaluators

### DIFF
--- a/src/CPE/cpedict.c
+++ b/src/CPE/cpedict.c
@@ -121,22 +121,6 @@ bool cpe_name_match_dict(struct cpe_name * cpe, struct cpe_dict_model * dict)
 	return ret;
 }
 
-bool cpe_name_match_dict_str(const char *cpestr, struct cpe_dict_model * dict)
-{
-	__attribute__nonnull__(cpestr);
-	__attribute__nonnull__(dict);
-
-	bool ret;
-	if (cpestr == NULL)
-		return false;
-	struct cpe_name *cpe = cpe_name_new(cpestr);
-	if (cpe == NULL)
-		return false;
-	ret = cpe_name_match_dict(cpe, dict);
-	cpe_name_free(cpe);
-	return ret;
-}
-
 bool cpe_name_applicable_dict(struct cpe_name *cpe, struct cpe_dict_model *dict, cpe_check_fn cb, void* usr)
 {
 	// FIXME: We could match faster by matching per component and storing all

--- a/src/CPE/cpelang.c
+++ b/src/CPE/cpelang.c
@@ -55,53 +55,6 @@ void cpe_lang_model_export(const struct cpe_lang_model *spec, const char *file)
 	cpe_lang_model_export_xml(spec, file);
 }
 
-/*
- * Add new platform entry to @a platformspec
- * @note @a platformspec will take over memory management of @a platform
- * @param platformspec list of platforms being extended
- * @param platform platform to add to the list
- * @return true on success
- */
-static bool cpe_language_match_expr(struct cpe_name **cpe, size_t n, const struct cpe_testexpr *expr)
-{
-	__attribute__nonnull__(cpe);
-	__attribute__nonnull__(expr);
-
-	bool ret = false;
-
-	switch (cpe_testexpr_get_oper(expr) & CPE_LANG_OPER_MASK) {
-	case CPE_LANG_OPER_AND:
-		ret = true;
-		OSCAP_FOREACH(cpe_testexpr, cur, cpe_testexpr_get_meta_expr(expr),
-			if (!cpe_language_match_expr(cpe, n, cur)) {
-				ret = false;
-				break;
-			}
-		)
-		break;
-	case CPE_LANG_OPER_OR:
-		OSCAP_FOREACH(cpe_testexpr, cur, cpe_testexpr_get_meta_expr(expr),
-			if (cpe_language_match_expr(cpe, n, cur)) {
-				ret = true;
-				break;
-			}
-		)
-		break;
-	case CPE_LANG_OPER_MATCH:
-		ret = cpe_name_match_cpes(cpe_testexpr_get_meta_cpe(expr), n, cpe);
-		break;
-	default:
-		assert(false);
-	}
-
-	return (cpe_testexpr_get_oper(expr) & CPE_LANG_OPER_NOT ? !ret : ret);
-}
-
-bool cpe_platform_match_cpe(struct cpe_name ** cpe, size_t n, const struct cpe_platform * platform)
-{
-	return cpe_language_match_expr(cpe, n, cpe_platform_get_expr(platform));
-}
-
 const char * cpe_lang_model_supported(void)
 {
         return CPE_LANG_SUPPORTED;

--- a/src/CPE/cpename.c
+++ b/src/CPE/cpename.c
@@ -559,35 +559,6 @@ bool cpe_name_match_cpes(const struct cpe_name * name, size_t n, struct cpe_name
 	return false;
 }
 
-int cpe_name_match_strs(const char *candidate, size_t n, char **targets)
-{
-	__attribute__nonnull__(candidate);
-	__attribute__nonnull__(targets);
-
-	int i;
-	struct cpe_name *ccpe, *tcpe;
-
-	ccpe = cpe_name_new(candidate);	// candidate cpe
-	if (ccpe == NULL)
-		return -2;
-
-	for (i = 0; i < (int)n; ++i) {
-		tcpe = cpe_name_new(targets[i]);	// target cpe
-
-		if (cpe_name_match_one(ccpe, tcpe)) {
-			// CPE matched
-			cpe_name_free(ccpe);
-			cpe_name_free(tcpe);
-			return i;
-		}
-
-		cpe_name_free(tcpe);
-	}
-
-	cpe_name_free(ccpe);
-	return -1;
-}
-
 cpe_format_t cpe_name_get_format_of_str(const char *str)
 {
 	if (str == NULL)

--- a/src/CPE/cpename.c
+++ b/src/CPE/cpename.c
@@ -544,21 +544,6 @@ bool cpe_name_match_one(const struct cpe_name * cpe, const struct cpe_name * aga
 	return true;
 }
 
-bool cpe_name_match_cpes(const struct cpe_name * name, size_t n, struct cpe_name ** namelist)
-{
-
-	__attribute__nonnull__(name);
-	__attribute__nonnull__(namelist);
-
-	if (name == NULL || namelist == NULL)
-		return false;
-
-	for (size_t i = 0; i < n; ++i)
-		if (cpe_name_match_one(name, namelist[i]))
-			return true;
-	return false;
-}
-
 cpe_format_t cpe_name_get_format_of_str(const char *str)
 {
 	if (str == NULL)

--- a/src/CPE/public/cpe_dict.h
+++ b/src/CPE/public/cpe_dict.h
@@ -861,16 +861,6 @@ OSCAP_API const char * cpe_dict_model_supported(void);
  */
 OSCAP_API bool cpe_name_match_dict(struct cpe_name *cpe, struct cpe_dict_model *dict);
 
-/** 
- * Verify if CPE given by string is known according to specified dictionary
- * @memberof cpe_name
- * @memberof cpe_dict_model
- * @param cpe CPE to verify
- * @param dict used CPE dictionary
- * @return true if dictionary contains given CPE
- */
-OSCAP_API bool cpe_name_match_dict_str(const char *cpe, struct cpe_dict_model *dict);
-
 /**
  * Verify whether given CPE is applicable to current platform by evaluating checks associated with it
  *

--- a/src/CPE/public/cpe_lang.h
+++ b/src/CPE/public/cpe_lang.h
@@ -355,15 +355,6 @@ OSCAP_API void cpe_platform_free(struct cpe_platform *platform);
  */
 OSCAP_API const char * cpe_lang_model_supported(void);
 
-/**
- * Function to match cpe in platform
- * @param cpe to be matched with
- * @param n size
- * @param platform CPE platform
- * @memberof cpe_platform
- */
-OSCAP_API bool cpe_platform_match_cpe(struct cpe_name **cpe, size_t n, const struct cpe_platform *platform);
-
 /************************************************************/
 /** @} End of Evaluators group */
 

--- a/src/CPE/public/cpe_name.h
+++ b/src/CPE/public/cpe_name.h
@@ -325,18 +325,6 @@ OSCAP_API cpe_format_t cpe_name_get_format_of_str(const char *str);
 OSCAP_API bool cpe_name_check(const char *str);
 
 /**
- * Match CPE URI @a candidate against list of @a n CPE URIs given by @a targets.
- * @memberof cpe_name
- * @param candidate candidarte CPE URI as string
- * @param n number of items in targets
- * @param targets list of CPE URIs to be candidate matched against
- * @return index of first URI in targets, that matched
- * @retval -1 on mismatch
- * @retval -2 invalid CPE URI was given as parameter
- */
-OSCAP_API int cpe_name_match_strs(const char *candidate, size_t n, char **targets);
-
-/**
  * Get supported version of CPE uri XML
  * @return version of XML file format
  * @memberof cpe_name

--- a/src/CPE/public/cpe_name.h
+++ b/src/CPE/public/cpe_name.h
@@ -291,16 +291,6 @@ OSCAP_API bool cpe_name_set_other(struct cpe_name *cpe, const char *newval);
 OSCAP_API bool cpe_name_match_one(const struct cpe_name *cpe, const struct cpe_name *against);
 
 /**
- * Check if CPE @a name matches any CPE in @a namelist.
- * @memberof cpe_name
- * @param name name to be looked-up
- * @param n number of items in namelist
- * @param namelist list of names to search in
- * @return true if @a name was found within @a namelist
- */
-OSCAP_API bool cpe_name_match_cpes(const struct cpe_name *name, size_t n, struct cpe_name **namelist);
-
-/**
  * Write CPE URI @a cpe to file a descriptor @a f
  * @memberof cpe_name
  * @param cpe cpe to write

--- a/tests/API/CPE/dict/test_api_cpe_dict.c
+++ b/tests/API/CPE/dict/test_api_cpe_dict.c
@@ -199,7 +199,7 @@ int main(int argc, char **argv)
 
 		ret_val_1 = cpe_name_match_dict(name, dict_model);
 
-        ret_val = (ret_val_1 == false) ? 1 : 0;
+		ret_val = (ret_val_1 == false) ? 1 : 0;
 
 		cpe_name_free(name);
 		cpe_dict_model_free(dict_model);

--- a/tests/API/CPE/dict/test_api_cpe_dict.c
+++ b/tests/API/CPE/dict/test_api_cpe_dict.c
@@ -198,14 +198,8 @@ int main(int argc, char **argv)
 		name = cpe_name_new(argv[4]);
 
 		ret_val_1 = cpe_name_match_dict(name, dict_model);
-		ret_val_2 = cpe_name_match_dict_str(argv[4], dict_model);
 
-		if (ret_val_1 != ret_val_2) {
-			fprintf(stderr, "%s was not matched correctly!\n",
-				argv[4]);
-			ret_val = 2;
-		} else
-			ret_val = (ret_val_1 == false) ? 1 : 0;
+        ret_val = (ret_val_1 == false) ? 1 : 0;
 
 		cpe_name_free(name);
 		cpe_dict_model_free(dict_model);

--- a/tests/API/CPE/dict/test_api_cpe_dict.c
+++ b/tests/API/CPE/dict/test_api_cpe_dict.c
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
 
 	struct cpe_name *name = NULL;
 	int ret_val = 0;
-	bool ret_val_1 = false, ret_val_2 = false;
+	bool ret_val_1 = false;
 
 	if (argc == 2 && !strcmp(argv[1], "--help"))
 		print_usage(argv[0], stdout);

--- a/tests/API/CPE/lang/test_api_cpe_lang.c
+++ b/tests/API/CPE/lang/test_api_cpe_lang.c
@@ -232,7 +232,7 @@ void print_usage(const char *program_name, FILE * out)
 		"  %s --set-new CPE_LANG_XML ENCODING NS_PREFIX NS_HREF (PLATFORM_ID)*\n"
 		"  %s --smoke-test\n",
 		program_name, program_name, program_name, program_name,
-		program_name, program_name, program_name, program_name);
+		program_name, program_name, program_name);
 }
 
 // Print expression in prefix form.

--- a/tests/API/CPE/lang/test_api_cpe_lang.c
+++ b/tests/API/CPE/lang/test_api_cpe_lang.c
@@ -208,42 +208,6 @@ int main (int argc, char *argv[])
 		cpe_lang_model_export(lang_model, argv[4]);
 		cpe_lang_model_free(lang_model);
 	}
-	else if (argc == 6 && !strcmp(argv[1], "--match-cpe")) {
-		if ((lang_model = cpe_lang_model_import_source(source)) == NULL) {
-			oscap_source_free(source);
-			return 1;
-		}
-
-		struct cpe_name *name1 = NULL;
-		struct cpe_name *name2 = NULL;
-		char * uri = NULL;
-
-		// make cpe_name
-		name1 = cpe_name_new(argv[4]);
-		name2 = cpe_name_new(argv[5]);
-		if ( (uri = cpe_name_get_as_str(name1)) == NULL ) return 1;
-		if ( (uri = cpe_name_get_as_str(name2)) == NULL ) return 1;
-		// actually we need array of cpe_name-s
-		struct cpe_name ** names = (struct cpe_name **) malloc(2*sizeof(struct cpe_name *)); // <-- just for clear what I'm doing
-		names[0] = name1;
-		names[1] = name2;
-
-		// let's get platform cpe's to match
-		platform_it = cpe_lang_model_get_platforms(lang_model);
-		platform = cpe_platform_iterator_next(platform_it); // we just need first one (no more there)
-		cpe_platform_iterator_free(platform_it);
-
-		ret_val = !cpe_platform_match_cpe(names, 2, platform);
-
-		cpe_name_free(name1);
-		cpe_name_free(name2);
-		free(names);
-
-		cpe_lang_model_free(lang_model);
-
-		oscap_source_free(source);
-		return ret_val;
-	}
 	else {
 		print_usage(argv[0], stderr);
 		ret_val = 1;
@@ -266,7 +230,6 @@ void print_usage(const char *program_name, FILE * out)
 		"  %s --set-all CPE_LANG_XML ENCODING NS_PREFIX NS_HREF (PLATFORM_ID)*\n"
 		"  %s --set-key CPE_LANG_XML ENCODING KEY ID (TITLE)*\n"
 		"  %s --set-new CPE_LANG_XML ENCODING NS_PREFIX NS_HREF (PLATFORM_ID)*\n"
-		"  %s --match-cpe CPE_LANG_XML ENCODING CPE_NAME1 CPE_NAME2\n"
 		"  %s --smoke-test\n",
 		program_name, program_name, program_name, program_name,
 		program_name, program_name, program_name, program_name);

--- a/tests/API/CPE/lang/test_api_cpe_lang.sh
+++ b/tests/API/CPE/lang/test_api_cpe_lang.sh
@@ -130,21 +130,6 @@ function test_api_cpe_lang_export_namespace {
     return $ret_val
 }
 
-function test_api_cpe_lang_match {
-    echo '<?xml version="1.0"  encoding="UTF-8"?>' > export.xml.out.0
-    echo '<cpe:platform-specification xmlns:cpe="http://cpe.mitre.org/language/2.0">' >> export.xml.out.0
-    echo '<cpe:platform id="123">' >> export.xml.out.0
-    echo 'e<cpe:title xml:lang="en">Microsoft Windows XP with Adobe Reader</cpe:title>' >> export.xml.out.0
-    echo '<cpe:logical-test operator="AND" negate="FALSE">' >> export.xml.out.0
-    echo '<cpe:fact-ref name="cpe:/o:microsoft:windows_xp" />' >> export.xml.out.0
-    echo '<cpe:fact-ref name="cpe:/a:adobe:reader" />' >> export.xml.out.0
-    echo '</cpe:logical-test>' >> export.xml.out.0
-    echo '</cpe:platform>' >> export.xml.out.0
-    echo '</cpe:platform-specification>' >> export.xml.out.0
-
-    ./test_api_cpe_lang --match-cpe export.xml.out.0 "UTF-8" "cpe:/a:adobe:reader" "cpe:/o:microsoft:windows_xp"
-}
-
 # Testing.
 
 test_init
@@ -157,7 +142,6 @@ if [ -z ${CUSTOM_OSCAP+x} ] ; then
     # test_run "test_api_cpe_lang_export_empty" test_api_cpe_lang_export_empty
     # test_run "test_api_cpe_lang_export_ecoding" test_api_cpe_lang_export_encoding
     # test_run "test_api_cpe_lang_export_namespace" test_api_cpe_lang_export_namespace
-    test_run "test_api_cpe_lang_match" test_api_cpe_lang_match
 fi
 
 test_exit 

--- a/tests/API/CPE/name/test_api_cpe_uri.c
+++ b/tests/API/CPE/name/test_api_cpe_uri.c
@@ -32,8 +32,7 @@ int main(int argc, char **argv)
 	FILE *f;
 	int ret_val = 1, i;
 	char *cpe_uri = NULL;
-	bool match_result_b = false, match_result_c =
-	    false;
+	bool match_result_b = false;
 
 	if (argc == 2 && !strcmp(argv[1], "--help")) {
 		print_usage(argv[0], stdout);
@@ -128,17 +127,10 @@ int main(int argc, char **argv)
 								  cpes[i]);
 				}
 
-				// Match check agains all loaded CPEs.
-				match_result_c =
-				    cpe_name_match_cpes(candidate_cpe, argc - 3,
-							cpes);
-
 				// Report result - all should be the same.
-				if (match_result_b
-				    && match_result_c)
+				if (match_result_b)
 					printf("Match\n"), ret_val = 0;
-				if (!match_result_b
-				    && !match_result_c)
+				if (!match_result_b)
 					printf("Mismatch\n"), ret_val = 0;
 
 			} else

--- a/tests/API/CPE/name/test_api_cpe_uri.c
+++ b/tests/API/CPE/name/test_api_cpe_uri.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
 	FILE *f;
 	int ret_val = 1, i;
 	char *cpe_uri = NULL;
-	bool match_result_a = false, match_result_b = false, match_result_c =
+	bool match_result_b = false, match_result_c =
 	    false;
 
 	if (argc == 2 && !strcmp(argv[1], "--help")) {
@@ -111,11 +111,6 @@ int main(int argc, char **argv)
 	// Match candidate CPE URI agains the others.
 	else if (argc >= 4 && strcmp(argv[1], "--matching") == 0) {
 
-		// Check match directly using CPE URIs.
-		match_result_a =
-		    cpe_name_match_strs(argv[2], argc - 2,
-					&(argv[3])) >= 0 ? true : false;
-
 		// Load candidate CPE.
 		if ((candidate_cpe = cpe_name_new(argv[2])) != NULL) {
 			if ((cpes =
@@ -139,10 +134,10 @@ int main(int argc, char **argv)
 							cpes);
 
 				// Report result - all should be the same.
-				if (match_result_a && match_result_b
+				if (match_result_b
 				    && match_result_c)
 					printf("Match\n"), ret_val = 0;
-				if (!match_result_a && !match_result_b
+				if (!match_result_b
 				    && !match_result_c)
 					printf("Mismatch\n"), ret_val = 0;
 


### PR DESCRIPTION
This removes CPE evaluator functions not used within openscap.


