### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,32 @@ language: c
 matrix:
   include:
     - os: linux
-      sudo: required
-      before_install:
-        - sudo apt-get -qq update
-        - sudo apt-get install -y cmake lcov libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt-dev libselinux1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev swig libxml-parser-perl libxml-xpath-perl libperl-dev librpm-dev swig librtmp-dev xsltproc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - cmake
+            - lcov
+            - libdbus-1-dev
+            - libdbus-glib-1-dev
+            - libcurl4-openssl-dev
+            - libgcrypt-dev
+            - libselinux1-dev
+            - libgconf2-dev
+            - libacl1-dev
+            - libblkid-dev
+            - libcap-dev
+            - libxml2-dev
+            - swig
+            - libxml-parser-perl
+            - libxml-xpath-perl
+            - libperl-dev
+            - librpm-dev
+            - swig
+            - librtmp-dev
+            - xsltproc
+            - gcc-7
       before_script:
         - export CC=gcc-7 GCOV=gcov-7
         - cd build

--- a/docs/developer/developer.adoc
+++ b/docs/developer/developer.adoc
@@ -60,7 +60,7 @@ On Ubuntu 16.04, the command to install the build dependencies is:
 sudo apt-get install -y cmake libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev \
 libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev \
 libcap-dev libxml2-dev libldap2-dev libpcre3-dev python-dev swig libxml-parser-perl \
-libxml-xpath-perl libperl5.22 libbz2-dev librpm-dev g++
+libxml-xpath-perl libperl-dev libbz2-dev librpm-dev g++
 ----
 
 When you have all the build dependencies installed you can build the library.


### PR DESCRIPTION
A few Travis improvements copied from #1156. Install dependencies via the `apt` addon seems less error prone than the previous method.

Also includes a documentation fix.  