### PR TITLE
Set CPE lang and dict origin_file accessors as private

### DIFF
--- a/src/CPE/cpedict.c
+++ b/src/CPE/cpedict.c
@@ -67,19 +67,6 @@ struct cpe_dict_model *cpe_dict_model_import_source(struct oscap_source *source)
 	return dict;
 }
 
-bool cpe_dict_model_set_origin_file(struct cpe_dict_model* dict, const char* origin_file)
-{
-	free(dict->origin_file);
-	dict->origin_file = oscap_strdup(origin_file);
-
-	return true;
-}
-
-const char* cpe_dict_model_get_origin_file(const struct cpe_dict_model* dict)
-{
-	return dict->origin_file;
-}
-
 void cpe_dict_model_export(const struct cpe_dict_model *dict, const char *file)
 {
 

--- a/src/CPE/cpedict_priv.c
+++ b/src/CPE/cpedict_priv.c
@@ -1288,6 +1288,19 @@ static void cpe_notes_export(const struct cpe_notes *notes, xmlTextWriterPtr wri
 	xmlTextWriterEndElement(writer);
 }
 
+bool cpe_dict_model_set_origin_file(struct cpe_dict_model* dict, const char* origin_file)
+{
+	free(dict->origin_file);
+	dict->origin_file = oscap_strdup(origin_file);
+
+	return true;
+}
+
+const char* cpe_dict_model_get_origin_file(const struct cpe_dict_model* dict)
+{
+	return dict->origin_file;
+}
+
 /* End of private export functions
  * */
 /***************************************************************************/

--- a/src/CPE/cpedict_priv.h
+++ b/src/CPE/cpedict_priv.h
@@ -120,6 +120,20 @@ void cpe_item_export(const struct cpe_item *item, xmlTextWriterPtr writer, int b
  */
 void cpe_vendor_export(const struct cpe_vendor *vendor, xmlTextWriterPtr writer);
 
+/**
+ * Sets the origin file hint
+ * @see cpe_dict_model_get_origin_file
+ */
+bool cpe_dict_model_set_origin_file(struct cpe_dict_model* dict, const char* origin_file);
+
+/**
+ * Gets the file the CPE dict model was loaded from
+ * This is necessary to figure out the full OVAL file path for applicability
+ * testing. We can't do applicability here in the CPE module because that
+ * would create awful interdependencies.
+ */
+const char* cpe_dict_model_get_origin_file(const struct cpe_dict_model* dict);
+
 /* <cpe-list>
  * */
 struct cpe_dict_model {		// the main node

--- a/src/CPE/cpelang_priv.h
+++ b/src/CPE/cpelang_priv.h
@@ -123,6 +123,21 @@ void cpe_testexpr_export(const struct cpe_testexpr *expr, xmlTextWriterPtr write
 
 char *cpe_lang_model_detect_version_priv(xmlTextReader *reader);
 
+/**
+ * Sets the origin file hint
+ * @see cpe_lang_model_get_origin_file
+ */
+bool cpe_lang_model_set_origin_file(struct cpe_lang_model* lang_model, const char* origin_file);
+
+/**
+ * Gets the file the CPE dict model was loaded from
+ * This is necessary to figure out the full OVAL file path for applicability
+ * testing. We can't do applicability here in the CPE module because that
+ * would create awful interdependencies.
+ */
+const char* cpe_lang_model_get_origin_file(const struct cpe_lang_model* lang_model);
+
+
 /** 
  * @cond INTERNAL
  */

--- a/src/CPE/public/cpe_dict.h
+++ b/src/CPE/public/cpe_dict.h
@@ -904,22 +904,6 @@ OSCAP_API void cpe_dict_model_export(const struct cpe_dict_model *dict, const ch
 OSCAP_API struct cpe_dict_model *cpe_dict_model_import_source(struct oscap_source *source);
 
 
-/**
- * Sets the origin file hint
- * @note This is intended for internal use only!
- * @see cpe_dict_model_get_origin_file
- */
-OSCAP_API bool cpe_dict_model_set_origin_file(struct cpe_dict_model* dict, const char* origin_file);
-
-/**
- * Gets the file the CPE dict model was loaded from
- * @internal
- * This is necessary to figure out the full OVAL file path for applicability
- * testing. We can't do applicability here in the CPE module because that
- * would create awful interdependencies.
- */
-OSCAP_API const char* cpe_dict_model_get_origin_file(const struct cpe_dict_model* dict);
-
 /** @} */
 
 /** @} */

--- a/src/CPE/public/cpe_lang.h
+++ b/src/CPE/public/cpe_lang.h
@@ -374,22 +374,6 @@ OSCAP_API bool cpe_platform_match_cpe(struct cpe_name **cpe, size_t n, const str
 OSCAP_API struct cpe_lang_model *cpe_lang_model_import_source(struct oscap_source *source);
 
 /**
- * Sets the origin file hint
- * @note This is intended for internal use only!
- * @see cpe_lang_model_get_origin_file
- */
-OSCAP_API bool cpe_lang_model_set_origin_file(struct cpe_lang_model* lang_model, const char* origin_file);
-
-/**
- * Gets the file the CPE dict model was loaded from
- * @internal
- * This is necessary to figure out the full OVAL file path for applicability
- * testing. We can't do applicability here in the CPE module because that
- * would create awful interdependencies.
- */
-OSCAP_API const char* cpe_lang_model_get_origin_file(const struct cpe_lang_model* lang_model);
-
-/**
  * Write the lang_model to a file.
  * @memberof cpe_lang_model
  * @param spec CPE lang model

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -41,6 +41,7 @@
 
 #include "cpe_lang.h"
 #include "CPE/cpe_session_priv.h"
+#include "CPE/cpedict_priv.h"
 
 #include "oscap_source.h"
 #include "oval_agent_api.h"

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -39,7 +39,7 @@
 #include "public/xccdf_benchmark.h"
 #include "public/oscap_text.h"
 
-#include "cpe_lang.h"
+#include "CPE/cpelang_priv.h"
 #include "CPE/cpe_session_priv.h"
 #include "CPE/cpedict_priv.h"
 


### PR DESCRIPTION
Move accessors functions for `cpe_lang_model.origin_file` and `cpe_dict_model.origin_file` to private headers.

They are used to set references files of CPE dictionary files in OVAL check references.