### PR TITLE
Add unimplemented functions from CVRF public API

### DIFF
--- a/src/CVRF/cvrf_priv.c
+++ b/src/CVRF/cvrf_priv.c
@@ -431,6 +431,8 @@ OSCAP_IGETINS_GEN(cvrf_remediation, cvrf_vulnerability, remediations, remediatio
 OSCAP_ITERATOR_REMOVE_F(cvrf_remediation)
 OSCAP_IGETINS_GEN(cvrf_threat, cvrf_vulnerability, threats, threat)
 OSCAP_ITERATOR_REMOVE_F(cvrf_threat)
+OSCAP_IGETINS_GEN(cvrf_vulnerability_cwe, cvrf_vulnerability, cwes, cwe)
+OSCAP_ITERATOR_REMOVE_F(cvrf_vulnerability_cwe)
 
 struct oscap_iterator *cvrf_vulnerability_get_references(struct cvrf_vulnerability *vuln) {
 	return oscap_iterator_new(vuln->references);

--- a/src/CVRF/public/cvrf.h
+++ b/src/CVRF/public/cvrf.h
@@ -686,14 +686,14 @@ struct cvrf_vulnerability_cwe_iterator;
  * @param vulnerability_cwe CWE structure to be added to the Vulnerability
  * @return true on success
  */
-OSCAP_API bool cvrf_vulnerability_add_vulnerability_cwe(struct cvrf_vulnerability *vuln, struct cvrf_vulnerability_cwe *vulnerability_cwe);
+OSCAP_API bool cvrf_vulnerability_add_cwe(struct cvrf_vulnerability *vuln, struct cvrf_vulnerability_cwe *vulnerability_cwe);
 
 /**
  * @memberof cvrf_vulnerability
  * @param vuln CVRF Vulnerability structure
  * @return Iterator representing list of all CWEs in the Vulnerability
  */
-OSCAP_API struct cvrf_vulnerability_cwe_iterator *cvrf_vulnerability_get_vulnerability_cwes(const struct cvrf_vulnerability *vuln);
+OSCAP_API struct cvrf_vulnerability_cwe_iterator *cvrf_vulnerability_get_cwes(const struct cvrf_vulnerability *vuln);
 
 /**
  * @memberof cvrf_vulnerability_cwe_iterator


### PR DESCRIPTION
These functions had prototypes in header file, but they had
no implementation. Also, there was an incosistent naming of
cwe member of cvrf_vulnerability structure. These functions
are not defined normally, but they are defined using
OSCAP_IGETINS_GEN. I don't like this approach at all.