### PR TITLE
Add ENABLE_DOCS to control building documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,14 @@ cmake_dependent_option(ENABLE_PERL "if enabled, the perl swig bindings will be b
 set(WANT_BASE64 TRUE CACHE BOOL "wants builtin Base64")
 set(WANT_XBASE64 FALSE CACHE BOOL "wants builtin XBase64")
 
+# ---------- Documentation
+
+# Due to the time it takes to build documentation on every change,
+# we choose to disable documentation by default. Only when ENABLE_DOCS==TRUE
+# will docs be built and added to the `make install` target.
+
+option(ENABLE_DOCS "enables documentation building -- suggests doxygen, asciidoc" FALSE)
+
 # ---------- STATUS MESSAGES
 
 message(STATUS " ")
@@ -349,6 +357,12 @@ message(STATUS "Testing:")
 message(STATUS "tests: ${ENABLE_TESTS}")
 message(STATUS "valgrind: ${ENABLE_VALGRIND}")
 message(STATUS "MITRE: ${ENABLE_MITRE}")
+message(STATUS " ")
+
+message(STATUS "Documentation:")
+message(STATUS "enabled: ${ENABLE_DOCS}")
+message(STATUS "doxygen: ${DOXYGEN_EXECUTABLE}")
+message(STATUS "asciidoc: ${ASCIIDOC_EXECUTABLE}")
 
 # ---------- PATHS
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -12,10 +12,17 @@ if(ENABLE_DOCS)
         configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
 
         # note the option ALL which allows to build the docs together with the application
-        add_custom_target(doxygen_docs
+        add_custom_command(
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/html"
+            DEPENDS ${DOXYGEN_OUT}
             COMMAND "${DOXYGEN_EXECUTABLE}" "${DOXYGEN_OUT}"
             WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-            COMMENT "Generating API documentation with Doxygen")
+            COMMENT "Generating API documentation with Doxygen"
+        )
+        add_custom_target(
+            doxygen_docs
+            DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/html"
+        )
         add_dependencies(docs doxygen_docs)
         install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html"
             DESTINATION "${CMAKE_INSTALL_DOCDIR}"
@@ -23,28 +30,48 @@ if(ENABLE_DOCS)
     endif()
 
     if(ASCIIDOC_EXECUTABLE)
-        add_custom_target(user_manual
+        add_custom_command(
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/manual/manual.html"
+            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/manual/manual.adoc" "${CMAKE_CURRENT_SOURCE_DIR}/manual/images"
             COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/manual"
             COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/manual/manual.html" "${CMAKE_CURRENT_SOURCE_DIR}/manual/manual.adoc"
             COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/manual/images" "${CMAKE_CURRENT_BINARY_DIR}/manual/images"
             COMMENT "Generating OpenSCAP User Manual in HTML format"
         )
+        add_custom_target(
+            user_manual
+            DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/manual/manual.html"
+        )
         install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/manual"
             DESTINATION "${CMAKE_INSTALL_DOCDIR}"
         )
-        add_custom_target(developer_manual
+
+        add_custom_command(
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/developer/developer.html"
+            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/developer/developer.adoc"
             COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/developer"
             COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/developer/developer.html" "${CMAKE_CURRENT_SOURCE_DIR}/developer/developer.adoc"
             COMMENT "Generating OpenSCAP Developer Manual in HTML format"
         )
+        add_custom_target(
+            developer_manual
+            DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/developer/developer.html"
+        )
         # We are not installing the OpenSCAP Developer manual because it does not
         # make any sense to install this for end-users.
-        add_custom_target(contribute_docs
+
+        add_custom_command(
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/contribute/contribute.html" "${CMAKE_CURRENT_BINARY_DIR}/contribute/testing.html" "${CMAKE_CURRENT_BINARY_DIR}/contribute/versioning.html"
+            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/contribute/contribute.adoc" "${CMAKE_CURRENT_SOURCE_DIR}/contribute/testing.adoc" "${CMAKE_CURRENT_SOURCE_DIR}/contribute/versioning.adoc"
             COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/contribute"
             COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/contribute/contribute.html" "${CMAKE_CURRENT_SOURCE_DIR}/contribute/contribute.adoc"
             COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/contribute/testing.html" "${CMAKE_CURRENT_SOURCE_DIR}/contribute/testing.adoc"
             COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/contribute/versioning.html" "${CMAKE_CURRENT_SOURCE_DIR}/contribute/versioning.adoc"
             COMMENT "Generating contribute documentation in HTML format"
+        )
+        add_custom_target(
+            contribute_docs
+            DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/contribute/contribute.html" "${CMAKE_CURRENT_BINARY_DIR}/contribute/testing.html" "${CMAKE_CURRENT_BINARY_DIR}/contribute/versioning.html"
         )
         # We are not installing the contribute documentation because it does not
         # make any sense to install this for end-users.

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,52 +1,54 @@
-add_custom_target(docs
-    COMMENT "Generating documentation and manuals in HTML format"
-)
-
-if(DOXYGEN_FOUND)
-    # set input and output files
-    set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
-    set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
-
-    # request to configure the file
-    configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
-
-    # note the option ALL which allows to build the docs together with the application
-    add_custom_target(doxygen_docs
-        COMMAND "${DOXYGEN_EXECUTABLE}" "${DOXYGEN_OUT}"
-        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-        COMMENT "Generating API documentation with Doxygen")
-    add_dependencies(docs doxygen_docs)
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html"
-        DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+if(ENABLE_DOCS)
+    add_custom_target(docs ALL
+        COMMENT "Generating documentation and manuals in HTML format"
     )
-endif()
 
-if(ASCIIDOC_EXECUTABLE)
-    add_custom_target(user_manual
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/manual"
-        COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/manual/manual.html" "${CMAKE_CURRENT_SOURCE_DIR}/manual/manual.adoc"
-        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/manual/images" "${CMAKE_CURRENT_BINARY_DIR}/manual/images"
-        COMMENT "Generating OpenSCAP User Manual in HTML format"
-    )
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/manual"
-        DESTINATION "${CMAKE_INSTALL_DOCDIR}"
-    )
-    add_custom_target(developer_manual
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/developer"
-        COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/developer/developer.html" "${CMAKE_CURRENT_SOURCE_DIR}/developer/developer.adoc"
-        COMMENT "Generating OpenSCAP Developer Manual in HTML format"
-    )
-    # We are not installing the OpenSCAP Developer manual because it does not
-    # make any sense to install this for end-users.
-    add_custom_target(contribute_docs
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/contribute"
-        COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/contribute/contribute.html" "${CMAKE_CURRENT_SOURCE_DIR}/contribute/contribute.adoc"
-        COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/contribute/testing.html" "${CMAKE_CURRENT_SOURCE_DIR}/contribute/testing.adoc"
-        COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/contribute/versioning.html" "${CMAKE_CURRENT_SOURCE_DIR}/contribute/versioning.adoc"
-        COMMENT "Generating contribute documentation in HTML format"
-    )
-    # We are not installing the contribute documentation because it does not
-    # make any sense to install this for end-users.
+    if(DOXYGEN_FOUND)
+        # set input and output files
+        set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
+        set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 
-    add_dependencies(docs user_manual developer_manual contribute_docs)
+        # request to configure the file
+        configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
+
+        # note the option ALL which allows to build the docs together with the application
+        add_custom_target(doxygen_docs
+            COMMAND "${DOXYGEN_EXECUTABLE}" "${DOXYGEN_OUT}"
+            WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+            COMMENT "Generating API documentation with Doxygen")
+        add_dependencies(docs doxygen_docs)
+        install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html"
+            DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+        )
+    endif()
+
+    if(ASCIIDOC_EXECUTABLE)
+        add_custom_target(user_manual
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/manual"
+            COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/manual/manual.html" "${CMAKE_CURRENT_SOURCE_DIR}/manual/manual.adoc"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/manual/images" "${CMAKE_CURRENT_BINARY_DIR}/manual/images"
+            COMMENT "Generating OpenSCAP User Manual in HTML format"
+        )
+        install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/manual"
+            DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+        )
+        add_custom_target(developer_manual
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/developer"
+            COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/developer/developer.html" "${CMAKE_CURRENT_SOURCE_DIR}/developer/developer.adoc"
+            COMMENT "Generating OpenSCAP Developer Manual in HTML format"
+        )
+        # We are not installing the OpenSCAP Developer manual because it does not
+        # make any sense to install this for end-users.
+        add_custom_target(contribute_docs
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/contribute"
+            COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/contribute/contribute.html" "${CMAKE_CURRENT_SOURCE_DIR}/contribute/contribute.adoc"
+            COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/contribute/testing.html" "${CMAKE_CURRENT_SOURCE_DIR}/contribute/testing.adoc"
+            COMMAND "${ASCIIDOC_EXECUTABLE}" -b html5 -o "${CMAKE_CURRENT_BINARY_DIR}/contribute/versioning.html" "${CMAKE_CURRENT_SOURCE_DIR}/contribute/versioning.adoc"
+            COMMENT "Generating contribute documentation in HTML format"
+        )
+        # We are not installing the contribute documentation because it does not
+        # make any sense to install this for end-users.
+
+        add_dependencies(docs user_manual developer_manual contribute_docs)
+    endif()
 endif()


### PR DESCRIPTION
Closes: #1161

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

I'm not entirely sure why the diff is so ugly, but I guess that's fine.

Tested with:
```
BUILD_CMAKE_ARGS="-DENABLE_DOCS=ON -DCMAKE_INSTALL_PREFIX=/tmp/cmake_test" build clean prep build nopop && ninja install
BUILD_CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=/tmp/cmake_test_2" build clean prep build nopop && ninja install
```

Results:

```bash
$ find /tmp/cmake_test -type f | grep 'doc/openscap/html'
/tmp/cmake_test/share/doc/openscap/html/structprobe__icache__t.html
/tmp/cmake_test/share/doc/openscap/html/structxiconf__attr.html
/tmp/cmake_test/share/doc/openscap/html/sysctl__probe_8h_source.html
/tmp/cmake_test/share/doc/openscap/html/structxccdf__group__item.html
/tmp/cmake_test/share/doc/openscap/html/structxccdf__refine__rule__iterator.html
/tmp/cmake_test/share/doc/openscap/html/structcpe__language.html
/tmp/cmake_test/share/doc/openscap/html/oval__parser__impl_8h.html
/tmp/cmake_test/share/doc/openscap/html/oval__definitions_8h_source.html
/tmp/cmake_test/share/doc/openscap/html/dir_7ba0732ac79094b906f6bff374711599.html
/tmp/cmake_test/share/doc/openscap/html/sync_on.png
/tmp/cmake_test/share/doc/openscap/html/functions_vars_e.html
/tmp/cmake_test/share/doc/openscap/html/structoval__value__iterator.html
/tmp/cmake_test/share/doc/openscap/html/structdigest__ctbl__t.html
/tmp/cmake_test/share/doc/openscap/html/structcpe__dict__model.html
<snip>

$ find /tmp/cmake_test_2 -type f | grep 'doc/openscap/html'
$ find /tmp/cmake_test_2 -type f | grep 'doc'
/tmp/cmake_test_2/lib/python3.6/site-packages/oscap_docker_python/oscap_docker_util.py
/tmp/cmake_test_2/lib/python3.6/site-packages/oscap_docker_python/__init__.py
/tmp/cmake_test_2/lib/python3.6/site-packages/oscap_docker_python/get_cve_input.py
/tmp/cmake_test_2/share/man/man8/oscap-docker.8
/tmp/cmake_test_2/bin/oscap-docker
```