### PR TITLE
Public headers

### DIFF
--- a/src/OVAL/probes/public/probe-api.h
+++ b/src/OVAL/probes/public/probe-api.h
@@ -450,8 +450,6 @@ typedef struct probe_ctx probe_ctx;
 
 OSCAP_API bool probe_item_filtered(const SEXP_t *item, const SEXP_t *filters);
 
-OSCAP_API int probe_result_additem(SEXP_t *result, SEXP_t *item);
-
 /**
  * Collect generated item (i.e. add it to the collected object)
  * The function takes ownership of the item reference and takes


### PR DESCRIPTION
This brings the headers and exported symbols further into alignment.

 - Removes several unimplemented functions. 

I believe the SEXP/SEAP and probes related issues will disappear with @jan-cerny's #1150.

This leaves:
```
oscap_basename
oscap_dirname
oscap_enum_to_string
oscap_realpath
oscap_split
oscap_sprintf
oscap_strcasecmp
oscap_strerror_r
oscap_string_to_enum
oscap_strncasecmp
oscap_strtok_r
```

These are all defined in `src/common/util.h` -- I am fine moving these to `src/common/public/openscap.h`, however, several of these have comments along the lines of `FIXME: make private` (e.g., `oscap_sprintf`) or a comment about their usage in probes.

Thoughts? 