### PR TITLE
Move public symbols to a public header

### DIFF
--- a/src/CPE/cpe_session.c
+++ b/src/CPE/cpe_session.c
@@ -34,6 +34,7 @@
 #include "OVAL/public/oval_agent_api.h"
 #include "source/public/oscap_source.h"
 #include "source/oscap_source_priv.h"
+#include "oscap_helpers.h"
 
 static inline bool cpe_session_add_default_cpe(struct cpe_session *session)
 {

--- a/src/CPE/cpename.c
+++ b/src/CPE/cpename.c
@@ -42,6 +42,7 @@
 
 #include "cpe_name.h"
 #include "common/util.h"
+#include "oscap_helpers.h"
 
 #define CPE_URI_SUPPORTED "2.3"
 

--- a/src/CVRF/cvrf_priv.c
+++ b/src/CVRF/cvrf_priv.c
@@ -49,6 +49,7 @@
 
 #include "source/oscap_source_priv.h"
 #include "source/public/oscap_source.h"
+#include "oscap_helpers.h"
 
 
 /***************************************************************************

--- a/src/CVSS/cvss.c
+++ b/src/CVSS/cvss.c
@@ -41,6 +41,7 @@
 #include "public/cvss_score.h"
 #include "cvss_priv.h"
 #include "common/elements.h"
+#include "oscap_helpers.h"
 
 #define CVSS_SUPPORTED "2.0"
 #define NS_VULN_STR BAD_CAST "vuln"

--- a/src/DS/ds_common.c
+++ b/src/DS/ds_common.c
@@ -30,6 +30,7 @@
 #include "common/oscap_acquire.h"
 #include "source/oscap_source_priv.h"
 #include "source/public/oscap_source.h"
+#include "oscap_helpers.h"
 
 #include <libxml/tree.h>
 

--- a/src/DS/ds_sds_session.c
+++ b/src/DS/ds_sds_session.c
@@ -41,6 +41,7 @@
 #include "source/public/oscap_source.h"
 #include "source/xslt_priv.h"
 #include <libxml/tree.h>
+#include "oscap_helpers.h"
 
 struct ds_sds_session {
 	struct oscap_source *source;            ///< Source DataStream raw representation

--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -48,6 +48,7 @@
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
 #include <libxml/xpathInternals.h>
+#include "oscap_helpers.h"
 
 static const char* arf_ns_uri = "http://scap.nist.gov/schema/asset-reporting-format/1.1";
 static const char* core_ns_uri = "http://scap.nist.gov/schema/reporting-core/1.1";

--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -42,6 +42,7 @@
 #include "common/oscap_acquire.h"
 #include "source/oscap_source_priv.h"
 #include "source/public/oscap_source.h"
+#include "oscap_helpers.h"
 
 #include <sys/stat.h>
 #include <time.h>

--- a/src/OVAL/oval_session.c
+++ b/src/OVAL/oval_session.c
@@ -43,6 +43,7 @@
 #include "public/oval_session.h"
 #include "../DS/public/ds_sds_session.h"
 #include "oscap_source.h"
+#include "oscap_helpers.h"
 
 
 static const char *oscap_productname = "cpe:/a:open-scap:oscap";

--- a/src/OVAL/probes/independent/system_info_probe.c
+++ b/src/OVAL/probes/independent/system_info_probe.c
@@ -83,6 +83,7 @@
 #include <errno.h>
 #include <limits.h>
 #include "system_info_probe.h"
+#include "oscap_helpers.h"
 
 #if defined(OS_LINUX)
 #include <sys/socket.h>

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include <pcre.h>
 
+#include "oscap_helpers.h"
 #include "fsdev.h"
 #include "_probe-api.h"
 #include "probe/entcmp.h"

--- a/src/OVAL/probes/probe-api.c
+++ b/src/OVAL/probes/probe-api.c
@@ -53,6 +53,7 @@
 #include "probe/entcmp.h"
 #include "probe/probe.h"
 #include "SEAP/generic/strto.h"
+#include "oscap_helpers.h"
 
 extern probe_rcache_t  *OSCAP_GSYM(pcache);
 extern probe_ncache_t  *OSCAP_GSYM(ncache);

--- a/src/OVAL/probes/unix/linux/systemdshared.h
+++ b/src/OVAL/probes/unix/linux/systemdshared.h
@@ -37,6 +37,7 @@
 
 #include <dbus/dbus.h>
 #include "common/debug_priv.h"
+#include "oscap_helpers.h"
 
 // Old versions of libdbus API don't have DBusBasicValue and DBus8ByteStruct
 // as a public typedefs.

--- a/src/OVAL/probes/unix/process58_probe.c
+++ b/src/OVAL/probes/unix/process58_probe.c
@@ -102,6 +102,7 @@ extern char const *_cap_names[];
 #include <ctype.h>
 #include "common/oscap_buffer.h"
 #include "process58_probe.h"
+#include "oscap_helpers.h"
 
 #define CHUNK_SIZE 1024
 

--- a/src/OVAL/probes/unix/process_probe.c
+++ b/src/OVAL/probes/unix/process_probe.c
@@ -56,6 +56,7 @@
 #include "probe/entcmp.h"
 #include "common/debug_priv.h"
 #include "process_probe.h"
+#include "oscap_helpers.h"
 
 oval_schema_version_t over;
 

--- a/src/OVAL/probes/unix/symlink_probe.c
+++ b/src/OVAL/probes/unix/symlink_probe.c
@@ -39,6 +39,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <stdlib.h>
+#include "oscap_helpers.h"
 
 #include <probe/probe.h>
 #include <probe/option.h>

--- a/src/OVAL/probes/windows/registry_probe.c
+++ b/src/OVAL/probes/windows/registry_probe.c
@@ -32,6 +32,7 @@
 #include "probe/entcmp.h"
 #include "probe/probe.h"
 #include "registry_probe.h"
+#include "oscap_helpers.h"
 
 #define UNLIMITED_DEPTH -1
 

--- a/src/OVAL/probes/windows/wmi57_probe.c
+++ b/src/OVAL/probes/windows/wmi57_probe.c
@@ -38,6 +38,7 @@
 #include "oval_definitions.h"
 #include "oval_sexp.h"
 #include "wmi57_probe.h"
+#include "oscap_helpers.h"
 
 static struct oscap_list *get_wql_fields(WCHAR *wql)
 {

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -36,6 +36,7 @@
 #include "common/oscap_string.h"
 #include "common/debug_priv.h"
 #include "sce_engine_api.h"
+#include "oscap_helpers.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/XCCDF/profile.c
+++ b/src/XCCDF/profile.c
@@ -30,6 +30,7 @@
 #include "helpers.h"
 #include "xccdf_impl.h"
 #include "common/debug_priv.h"
+#include "oscap_helpers.h"
 
 struct xccdf_setvalue *xccdf_setvalue_new(void)
 {

--- a/src/XCCDF/resolve.c
+++ b/src/XCCDF/resolve.c
@@ -29,6 +29,7 @@
 #include "item.h"
 #include "helpers.h"
 #include "common/tsort.h"
+#include "oscap_helpers.h"
 
 typedef void (*xccdf_textresolve_func)(void *child, void *parent);
 

--- a/src/XCCDF/result.c
+++ b/src/XCCDF/result.c
@@ -65,6 +65,7 @@
 #include "oscap_text.h"
 #include "common/debug_priv.h"
 #include "source/oscap_source_priv.h"
+#include "oscap_helpers.h"
 
 #define XCCDF_NUMERIC_SIZE 32
 

--- a/src/XCCDF/rule.c
+++ b/src/XCCDF/rule.c
@@ -35,6 +35,7 @@
 #include "helpers.h"
 #include "xccdf_impl.h"
 #include "common/debug_priv.h"
+#include "oscap_helpers.h"
 
 bool xccdf_content_parse(xmlTextReaderPtr reader, struct xccdf_item *parent)
 {

--- a/src/XCCDF/value.c
+++ b/src/XCCDF/value.c
@@ -33,6 +33,7 @@
 #include "xccdf_impl.h"
 #include "common/elements.h"
 #include "common/debug_priv.h"
+#include "oscap_helpers.h"
 
 static struct xccdf_value_instance *xccdf_value_instance_new(xccdf_value_type_t type);
 static struct xccdf_value_instance *_xccdf_value_get_instance_by_selector_internal(const struct xccdf_value *value, const char *selector);

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -57,6 +57,7 @@
 #include "item.h"
 #include "public/xccdf_session.h"
 #include "XCCDF_POLICY/public/check_engine_plugin.h"
+#include "oscap_helpers.h"
 
 struct oval_content_resource {
 	char *href;					///< Coresponds with xccdf:check-content-ref/\@href.

--- a/src/XCCDF_POLICY/check_engine_plugin.c
+++ b/src/XCCDF_POLICY/check_engine_plugin.c
@@ -25,6 +25,7 @@
 
 #include "public/check_engine_plugin.h"
 #include "common/util.h"
+#include "oscap_helpers.h"
 #include "common/_error.h"
 
 #ifndef _WIN32

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -53,6 +53,7 @@
 #include "common/text_priv.h"
 #include "XCCDF/result_scoring_priv.h"
 #include "xccdf_policy_resolve.h"
+#include "oscap_helpers.h"
 
 /* Macros to generate iterators, getters and setters */
 OSCAP_GETTER(struct xccdf_benchmark *, xccdf_policy_model, benchmark)

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -46,6 +46,7 @@
 #include "xccdf_policy_priv.h"
 #include "xccdf_policy_model_priv.h"
 #include "public/xccdf_policy.h"
+#include "oscap_helpers.h"
 
 static int _rule_add_info_message(struct xccdf_rule_result *rr, ...)
 {

--- a/src/common/elements.c
+++ b/src/common/elements.c
@@ -43,6 +43,7 @@
 #include "_error.h"
 #include "debug_priv.h"
 #include "elements.h"
+#include "oscap_helpers.h"
 
 
 const struct oscap_string_map OSCAP_BOOL_MAP[] = {

--- a/src/common/error.c
+++ b/src/common/error.c
@@ -34,6 +34,7 @@
 #include "_error.h"
 #include "err_queue.h"
 #include "debug_priv.h"
+#include "oscap_helpers.h"
 
 #ifdef OSCAP_THREAD_SAFE
 static pthread_key_t __key;

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -48,6 +48,7 @@
 #include "common/oscap_buffer.h"
 #include "common/_error.h"
 #include "oscap_string.h"
+#include "oscap_helpers.h"
 
 #ifndef OSCAP_TEMP_DIR
 #define OSCAP_TEMP_DIR "/tmp"

--- a/src/common/oscapxml.c
+++ b/src/common/oscapxml.c
@@ -52,6 +52,7 @@
 #include "source/schematron_priv.h"
 #include "source/validate_priv.h"
 #include "source/xslt_priv.h"
+#include "oscap_helpers.h"
 
 const char *const OSCAP_SCHEMA_PATH = OSCAP_DEFAULT_SCHEMA_PATH;
 const char *const OSCAP_XSLT_PATH = OSCAP_DEFAULT_XSLT_PATH;

--- a/src/common/public/oscap_helpers.h
+++ b/src/common/public/oscap_helpers.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors:
+ *      Jan Černý <jcerny@redhat.com>
+ */
+
+#ifndef OSCAP_HELPERS_H
+#define OSCAP_HELPERS_H
+
+#include <stdarg.h>
+#include "oscap_export.h"
+
+/**
+ * Print to a newly allocated string using variable arguments.
+ * @param fmt printf-like format string
+ * @return a string
+ */
+OSCAP_API char *oscap_sprintf(const char *fmt, ...);
+
+/**
+ * Return the canonicalized absolute pathname.
+ * @param path path
+ * @param resolved_path pointer to a buffer
+ * @return resolved_path or NULL in case of error
+ */
+OSCAP_API char *oscap_realpath(const char *path, char *resolved_path);
+
+/**
+ * Return filename component of a path
+ * @param path path
+ * The function can modify the contents of path, so the caller should pass a copy of path.
+ * @return filename component of path
+ * The caller is responsible to free the returned buffer.
+ */
+OSCAP_API char *oscap_basename(char *path);
+
+/**
+ * Return directory component of a path
+ * @param path path
+ * The function can modify the contents of path, so the caller should pass a copy of path.
+ * @return dirname component of path
+ * The caller is responsible to free the returned buffer.
+ */
+OSCAP_API char *oscap_dirname(char *path);
+
+/**
+ * Extract tokens from strings
+ * @param str string
+ * @param delim st of delimiters
+ * @param saveptr Used to store position information between calls to strtok_s
+ * @return token
+ */
+OSCAP_API char *oscap_strtok_r(char *str, const char *delim, char **saveptr);
+
+#endif /* OSCAP_HELPERS_H */

--- a/src/common/text.c
+++ b/src/common/text.c
@@ -38,6 +38,7 @@
 #include "text_priv.h"
 #include "util.h"
 #include "list.h"
+#include "oscap_helpers.h"
 
 const char * const OSCAP_LANG_ENGLISH    = "en";
 const char * const OSCAP_LANG_ENGLISH_US = "en-US";

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -34,6 +34,7 @@
 #include "util.h"
 #include "_error.h"
 #include "oscap.h"
+#include "oscap_helpers.h"
 
 #ifdef _WIN32
 #include <stdlib.h>

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -361,11 +361,6 @@ char *oscap_trim(char *str);
 /// Print to a newly allocated string using a va_list.
 char *oscap_vsprintf(const char *fmt, va_list ap);
 
-// FIXME: This is there because of the SCE engine using this particular function
-
-/// Print to a newly allocated string using varialbe arguments.
-OSCAP_API char *oscap_sprintf(const char *fmt, ...);
-
 /**
  * Join 2 paths in an intelligent way.
  * Both paths are allowed to be NULL.
@@ -416,16 +411,13 @@ char *oscap_expand_ipv6(const char *input);
 #define protect_errno                                                   \
         for (int OSCAP_CONCAT(__e,__LINE__)=errno, OSCAP_CONCAT(__s,__LINE__)=1; OSCAP_CONCAT(__s,__LINE__)--; errno=OSCAP_CONCAT(__e,__LINE__))
 
-
-/* The following functions aren't hidden, because they're used by some probes. */
-
 /**
  * Convert a string to an enumeration constant.
  * @param map An array of oscap_string_map structures that defines mapping between constants and strings.
  * @param str string to be converted
  * @memberof oscap_string_map
  */
-OSCAP_API int oscap_string_to_enum(const struct oscap_string_map *map, const char *str);
+int oscap_string_to_enum(const struct oscap_string_map *map, const char *str);
 
 /**
  * Convert an enumeration constant to its corresponding string representation.
@@ -433,7 +425,7 @@ OSCAP_API int oscap_string_to_enum(const struct oscap_string_map *map, const cha
  * @param val value to be converted
  * @memberof oscap_string_map
  */
-OSCAP_API const char *oscap_enum_to_string(const struct oscap_string_map *map, int val);
+const char *oscap_enum_to_string(const struct oscap_string_map *map, int val);
 
 /**
  * Split a string.
@@ -443,33 +435,7 @@ OSCAP_API const char *oscap_enum_to_string(const struct oscap_string_map *map, i
  * @param str String we want to split
  * @param delim Delimiter of string parts
  */
-OSCAP_API char **oscap_split(char *str, const char *delim);
-
-/**
- * Return the canonicalized absolute pathname.
- * @param path path
- * @param resolved_path pointer to a buffer
- * @return resolved_path or NULL in case of error
- */
-OSCAP_API char *oscap_realpath(const char *path, char *resolved_path);
-
-/**
- * Return filename component of a path
- * @param path path
- * The function can modify the contents of path, so the caller should pass a copy of path.
- * @return filename component of path
- * The caller is responsible to free the returned buffer.
- */
-OSCAP_API char *oscap_basename(char *path);
-
-/**
- * Return directory component of a path
- * @param path path
- * The function can modify the contents of path, so the caller should pass a copy of path.
- * @return dirname component of path
- * The caller is responsible to free the returned buffer.
- */
-OSCAP_API char *oscap_dirname(char *path);
+char **oscap_split(char *str, const char *delim);
 
 /**
  * compare two strings ignoring case
@@ -479,7 +445,7 @@ OSCAP_API char *oscap_dirname(char *path);
  * after ignoring case, found to be less than, to match, or be greater
  * than s2,  respectively.
  */
-OSCAP_API int oscap_strcasecmp(const char *s1, const char *s2);
+int oscap_strcasecmp(const char *s1, const char *s2);
 
 /**
 * compare two strings ignoring case
@@ -490,16 +456,7 @@ OSCAP_API int oscap_strcasecmp(const char *s1, const char *s2);
 * after ignoring case, found to be less than, to match, or be greater
 * than s2,  respectively.
 */
-OSCAP_API int oscap_strncasecmp(const char *s1, const char *s2, size_t n);
-
-/**
- * Extract tokens from strings
- * @param str string
- * @param delim st of delimiters
- * @param saveptr Used to store position information between calls to strtok_s
- * @return token
- */
-OSCAP_API char *oscap_strtok_r(char *str, const char *delim, char **saveptr);
+int oscap_strncasecmp(const char *s1, const char *s2, size_t n);
 
 /**
  * Get string describing error number
@@ -507,7 +464,7 @@ OSCAP_API char *oscap_strtok_r(char *str, const char *delim, char **saveptr);
  * @param buf buffer to hold error string
  * @param buflen size of buffer
  */
-OSCAP_API char *oscap_strerror_r(int errnum, char *buf, size_t buflen);
+char *oscap_strerror_r(int errnum, char *buf, size_t buflen);
 
 #ifdef _WIN32
 /**

--- a/src/common/xml_iterate.c
+++ b/src/common/xml_iterate.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include "debug_priv.h"
 #include "xml_iterate.h"
+#include "oscap_helpers.h"
 
 
 static int xml_element_dfs_callback(xmlNode **node, xml_iterate_callback user_fn, void *user_data)

--- a/src/source/validate.c
+++ b/src/source/validate.c
@@ -38,6 +38,7 @@
 #include "oscap_source.h"
 #include "source/oscap_source_priv.h"
 #include "source/validate_priv.h"
+#include "oscap_helpers.h"
 
 struct ctxt {
 	xml_reporter reporter;

--- a/src/source/xslt.c
+++ b/src/source/xslt.c
@@ -41,6 +41,7 @@
 #include "oscap_source.h"
 #include "source/oscap_source_priv.h"
 #include "source/xslt_priv.h"
+#include "oscap_helpers.h"
 
 #define XCCDF11_NS "http://checklists.nist.gov/xccdf/1.1"
 #define XCCDF12_NS "http://checklists.nist.gov/xccdf/1.2"

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -47,7 +47,7 @@
 
 #include "oscap-tool.h"
 #include <oscap_debug.h>
-#include "util.h"
+#include "oscap_helpers.h"
 
 #define DS_SUBMODULES_NUM 8 /* See actual DS_SUBMODULES array
 				initialization below. */

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -42,7 +42,7 @@
 #include <limits.h>
 #include <cvss_score.h>
 #include <oscap_debug.h>
-#include "util.h"
+#include "oscap_helpers.h"
 
 #ifndef PATH_MAX
 # define PATH_MAX 1024

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -62,7 +62,7 @@
 #include "oscap.h"
 #include "oscap_source.h"
 #include <oscap_debug.h>
-#include "util.h"
+#include "oscap_helpers.h"
 
 #ifndef O_NOFOLLOW
 #define O_NOFOLLOW 0


### PR DESCRIPTION
Our header file src/common/util.h deifned both public and private
symbols. If they are used in probes, they can be made private.
Previously the probes used to be separated binaries, so all the
functions used in probes had to be made public. However, this is
no longer true, so these comments are not relevant anymore and they
should be removed. On the other hand, if some of the functions is
used in oscap utility, they need to be kept public. This commit
moves the symbols that need to be kept public to a new header file
src/common/public/oscap_helpers.h Moreover, the symbols that doesn't have
to be public won't be public anymore.