### PR TITLE
Add some missing free calls to prevent possible memory leaks

### DIFF
--- a/src/CVRF/cvrf_priv.c
+++ b/src/CVRF/cvrf_priv.c
@@ -1980,6 +1980,7 @@ struct cvrf_product_tree *cvrf_product_tree_parse(xmlTextReaderPtr reader) {
 	struct cvrf_product_tree *tree = cvrf_product_tree_new();
 	if (xmlTextReaderIsEmptyElement(reader) == 1) {
 		cvrf_set_parsing_error("ProductTree");
+		cvrf_product_tree_free(tree);
 		return NULL;
 	}
 	xmlTextReaderNextElementWE(reader, TAG_PRODUCT_TREE);
@@ -2085,6 +2086,7 @@ struct cvrf_note *cvrf_note_parse(xmlTextReaderPtr reader) {
 	struct cvrf_note *note = cvrf_note_new();
 	if (xmlTextReaderIsEmptyElement(reader) == 1) {
 		cvrf_set_parsing_error("Note");
+		cvrf_note_free(note);
 		return NULL;
 	}
 
@@ -2143,6 +2145,7 @@ struct cvrf_doc_tracking *cvrf_doc_tracking_parse(xmlTextReaderPtr reader) {
 	struct cvrf_doc_tracking *tracking = cvrf_doc_tracking_new();
 	if (xmlTextReaderIsEmptyElement(reader) == 1) {
 		cvrf_set_parsing_error("DocumentTracking");
+		cvrf_doc_tracking_free(tracking);
 		return NULL;
 	}
 
@@ -2214,6 +2217,7 @@ struct cvrf_doc_publisher *cvrf_doc_publisher_parse(xmlTextReaderPtr reader) {
 	publisher->type = cvrf_doc_publisher_type_parse(reader);
 	if (publisher->type == CVRF_DOC_PUBLISHER_UNKNOWN && xmlTextReaderIsEmptyElement(reader) == 1) {
 		cvrf_set_parsing_error("DocumentPublisher");
+		cvrf_doc_publisher_free(publisher);
 		return NULL;
 	}
 	publisher->vendor_id = (char *)xmlTextReaderGetAttribute(reader, ATTR_VENDOR_ID);

--- a/src/OVAL/oval_message.c
+++ b/src/OVAL/oval_message.c
@@ -65,7 +65,7 @@ struct oval_message *oval_message_clone(struct oval_message *old_message)
 	oval_message_level_t level = oval_message_get_level(old_message);
 	oval_message_set_level(new_message, level);
 	char *text = oval_message_get_text(old_message);
-	oval_message_set_text(new_message, oscap_strdup(text));
+	oval_message_set_text(new_message, text);
 	return new_message;
 }
 

--- a/src/OVAL/oval_sysEnt.c
+++ b/src/OVAL/oval_sysEnt.c
@@ -77,7 +77,7 @@ struct oval_sysent *oval_sysent_clone(struct oval_syschar_model *new_model, stru
 
 	char *old_value = oval_sysent_get_value(old_item);
 	if (old_value) {
-		oval_sysent_set_value(new_item, oscap_strdup(old_value));
+		oval_sysent_set_value(new_item, old_value);
 	}
 
 	char *old_name = oval_sysent_get_name(old_item);

--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -408,6 +408,7 @@ fsdev_t *fsdev_strinit(const char *fs_names)
 	e = errno;
 	free(fs_arr);
 	errno = e;
+	free(pstr);
 
 	return (lfs);
 }

--- a/src/OVAL/probes/independent/textfilecontent.c
+++ b/src/OVAL/probes/independent/textfilecontent.c
@@ -373,8 +373,8 @@ int probe_main(probe_ctx *ctx, void *arg)
 	SEXP_t *ent_val;
 	ent_val = probe_ent_getval(line_ent);
 	pattern = SEXP_string_cstr(ent_val);
-	assume_d(pattern != NULL, -1);
 	SEXP_vfree(line_ent, ent_val, NULL);
+	assume_d(pattern != NULL, -1);
 
         /* behaviours are not important if filepath is used */
         if(filepath_ent != NULL && behaviors_ent != NULL) {

--- a/src/OVAL/probes/independent/textfilecontent54.c
+++ b/src/OVAL/probes/independent/textfilecontent54.c
@@ -406,9 +406,9 @@ int probe_main(probe_ctx *ctx, void *arg)
         SEXP_t *ent_val;
         ent_val = probe_ent_getval(patt_ent);
 	pfd.pattern = SEXP_string_cstr(ent_val);
-	assume_d(pfd.pattern != NULL, -1);
         SEXP_free(patt_ent);
         SEXP_free(ent_val);
+	assume_d(pfd.pattern != NULL, -1);
 
         /* wtf?
 	i_val = s_val = "0";


### PR DESCRIPTION
Fix some defects, which could lead to memory leaks.

There are some variables which have allocated memory but they aren't free before 'return' from function.