### PR TITLE
Refactored the oscap-docker script.

### DIFF
--- a/utils/oscap-docker.in
+++ b/utils/oscap-docker.in
@@ -26,31 +26,18 @@ import sys
 from requests import exceptions
 
 
-class OscapDocker(object):
-    ''' Generic class to call the scans '''
-    def __init__(self):
-        pass
+def cve_scan(scan_target, other_scan_args):
+    ''' Wrapper function for container/image scanning '''
+    OS = OscapScan()
+    result = OS.scan_cve(scan_target, other_scan_args)
+    return result
 
-    def set_args(self, args, unknown):
-        '''
-        Sets arguments for argparse into the oscapDocker class
-        '''
-        self.args = args
-        self.unknown_args = unknown
 
-    def cve_scan(self):
-        ''' Wrapper function for container/image scanning '''
-        OS = OscapScan()
-        result = OS.scan_cve(self.args.scan_target, self.unknown_args)
-        if result is not None:
-            print(result)
-
-    def scan(self):
-        ''' Wrapper functiopn to scan with openscap'''
-        OS = OscapScan()
-        result = OS.scan(self.args.scan_target, self.unknown_args)
-        if result is not None:
-            print(result)
+def scan(scan_target, other_scan_args):
+    ''' Wrapper function to scan with openscap'''
+    OS = OscapScan()
+    result = OS.scan(scan_target, other_scan_args)
+    return result
 
 
 def ping_docker():
@@ -63,10 +50,8 @@ def ping_docker():
         client = docker.Client()
     client.ping()
 
+
 if __name__ == '__main__':
-
-    OD = OscapDocker()
-
     parser = argparse.ArgumentParser(description='oscap docker',
                                      epilog='See `man oscap` to learn \
                                      more about OSCAP-ARGUMENTS')
@@ -75,7 +60,7 @@ if __name__ == '__main__':
     # Scan CVEs in image
     image_cve = subparser.add_parser('image-cve', help='Scan a docker image \
                                     for known vulnerabilities.')
-    image_cve.set_defaults(func=OD.cve_scan)
+    image_cve.set_defaults(func=cve_scan)
     image_cve.add_argument('scan_target', help='Container or image to scan')
 
     # Scan an Image
@@ -83,24 +68,24 @@ if __name__ == '__main__':
     image.add_argument('scan_target',
                        help='Container or image to scan')
 
-    image.set_defaults(func=OD.scan)
+    image.set_defaults(func=scan)
     # Scan a container
     container = subparser.add_parser('container', help='Scan a running docker\
                                       container of given name.')
     container.add_argument('scan_target',
                            help='Container or image to scan')
-    container.set_defaults(func=OD.scan)
+    container.set_defaults(func=scan)
 
     # Scan CVEs in container
     container_cve = subparser.add_parser('container-cve', help='Scan a \
                                          running container for known \
                                          vulnerabilities.')
 
-    container_cve.set_defaults(func=OD.cve_scan)
+    container_cve.set_defaults(func=cve_scan)
     container_cve.add_argument('scan_target',
                                help='Container or image to scan')
 
-    args, unknown = parser.parse_known_args()
+    args, leftover_args = parser.parse_known_args()
 
     if "func" not in args:
         parser.print_help()
@@ -113,5 +98,10 @@ if __name__ == '__main__':
         print("The docker daemon does not appear to be running")
         sys.exit(1)
 
-    OD.set_args(args, unknown)
-    args.func()
+    try:
+        rc = args.func(args.scan_target, leftover_args)
+    except Exception as exc:
+        sys.exit(255)
+        raise exc
+
+    sys.exit(rc)


### PR DESCRIPTION
* Streamlined the code.
* Propagate the oscap return code as script's return code.

Before, the command returned 1 if `oscap` returned other than 0 or 2. The return value of the scanning routine was the `oscap`'s `stdout`.
Now, both the `stdout` and `stderr` are forwarded to the console, and the `oscap`'s return code is propagated.

As this changes return code backwards-compatibility, I am not sure whether this fix is feasible.