### PR TITLE
Add Windows CPEs

### DIFF
--- a/cpe/openscap-cpe-dict.xml
+++ b/cpe/openscap-cpe-dict.xml
@@ -222,4 +222,8 @@
             <title xml:lang="en-us">Microsoft Windows Server 2012</title>
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.windows:def:2012</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:microsoft:windows_server_2016">
+            <title xml:lang="en-us">Microsoft Windows Server 2016</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.windows:def:2016</check>
+      </cpe-item>
 </cpe-list>

--- a/cpe/openscap-cpe-dict.xml
+++ b/cpe/openscap-cpe-dict.xml
@@ -198,4 +198,28 @@
             <title xml:lang="en-us">Wind River Linux 8</title>
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.wrlinux:def:8</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:microsoft:windows_7">
+            <title xml:lang="en-us">Microsoft Windows 7</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.windows:def:7</check>
+      </cpe-item>
+      <cpe-item name="cpe:/o:microsoft:windows_8">
+            <title xml:lang="en-us">Microsoft Windows 8</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.windows:def:8</check>
+      </cpe-item>
+      <cpe-item name="cpe:/o:microsoft:windows_8.1">
+            <title xml:lang="en-us">Microsoft Windows 8.1</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.windows:def:81</check>
+      </cpe-item>
+      <cpe-item name="cpe:/o:microsoft:windows_10">
+            <title xml:lang="en-us">Microsoft Windows 10</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.windows:def:10</check>
+      </cpe-item>
+      <cpe-item name="cpe:/o:microsoft:windows_server_2008">
+            <title xml:lang="en-us">Microsoft Windows Server 2008</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.windows:def:2008</check>
+      </cpe-item>
+      <cpe-item name="cpe:/o:microsoft:windows_server_2012">
+            <title xml:lang="en-us">Microsoft Windows Server 2012</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.windows:def:2012</check>
+      </cpe-item>
 </cpe-list>

--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -676,6 +676,19 @@
                         <criterion comment="Microsoft Windows Server 2012 is installed" test_ref="oval:org.open-scap.cpe.windows:tst:2012" />
                   </criteria>
             </definition>
+            <definition class="inventory" id="oval:org.open-scap.cpe.windows:def:2016" version="1">
+                  <metadata>
+                        <title>Microsoft Windows Server 2016</title>
+                        <affected family="windows">
+                              <platform>Microsoft Windows Server 2016</platform>
+                        </affected>
+                        <reference ref_id="cpe:/o:microsoft:windows_server_2016" source="CPE"/>
+                        <description>The operating system installed on the system is Microsoft Windows Server 2016</description>
+                  </metadata>
+                  <criteria operator="OR">
+                        <criterion comment="Microsoft Windows Server 2016 is installed" test_ref="oval:org.open-scap.cpe.windows:tst:2016" />
+                  </criteria>
+            </definition>
       </definitions>
       <tests>
             <rpmverifyfile_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:2" version="1" check="at least one" comment="/etc/redhat-release is provided by redhat-release package"
@@ -951,6 +964,10 @@
                   <object object_ref="oval:org.open-scap.cpe.windows:obj:1"/>
                   <state state_ref="oval:org.open-scap.cpe.windows:ste:2012"/>
             </registry_test>
+            <registry_test id="oval:org.open-scap.cpe.windows:tst:2016" version="1" comment="Windows Server 2016 is installed" check_existence="at_least_one_exists" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <object object_ref="oval:org.open-scap.cpe.windows:obj:1"/>
+                  <state state_ref="oval:org.open-scap.cpe.windows:ste:2016"/>
+            </registry_test>
       </tests>
       <objects>
             <family_object id="oval:org.open-scap.cpe.unix:obj:1" version="1"  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"/>
@@ -1182,6 +1199,9 @@
             </registry_state>
             <registry_state id="oval:org.open-scap.cpe.windows:ste:2012" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
                   <value operation="pattern match">^.*2012.*$</value>
+            </registry_state>
+            <registry_state id="oval:org.open-scap.cpe.windows:ste:2016" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <value operation="pattern match">^.*2016.*$</value>
             </registry_state>
       </states>
 </oval_definitions>

--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -598,6 +598,84 @@
                         <criterion comment="Wind River Linux version is 8." test_ref="oval:org.open-scap.cpe.wrlinux:tst:8" />
                   </criteria>
             </definition>
+            <definition class="inventory" id="oval:org.open-scap.cpe.windows:def:7" version="1">
+                  <metadata>
+                        <title>Microsoft Windows 7</title>
+                        <affected family="windows">
+                              <platform>Microsoft Windows 7</platform>
+                        </affected>
+                        <reference ref_id="cpe:/o:microsoft:windows_7" source="CPE"/>
+                        <description>The operating system installed on the system is Microsoft Windows 7</description>
+                  </metadata>
+                  <criteria operator="OR">
+                        <criterion comment="Microsoft Windows 7 is installed" test_ref="oval:org.open-scap.cpe.windows:tst:7" />
+                  </criteria>
+            </definition>
+            <definition class="inventory" id="oval:org.open-scap.cpe.windows:def:8" version="1">
+                  <metadata>
+                        <title>Microsoft Windows 8</title>
+                        <affected family="windows">
+                              <platform>Microsoft Windows 8</platform>
+                        </affected>
+                        <reference ref_id="cpe:/o:microsoft:windows_8" source="CPE"/>
+                        <description>The operating system installed on the system is Microsoft Windows 8</description>
+                  </metadata>
+                  <criteria operator="OR">
+                        <criterion comment="Microsoft Windows 8 is installed" test_ref="oval:org.open-scap.cpe.windows:tst:8" />
+                  </criteria>
+            </definition>
+            <definition class="inventory" id="oval:org.open-scap.cpe.windows:def:81" version="1">
+                  <metadata>
+                        <title>Microsoft Windows 8.1</title>
+                        <affected family="windows">
+                              <platform>Microsoft Windows 8.1</platform>
+                        </affected>
+                        <reference ref_id="cpe:/o:microsoft:windows_8.1" source="CPE"/>
+                        <description>The operating system installed on the system is Microsoft Windows 8.1</description>
+                  </metadata>
+                  <criteria operator="OR">
+                        <criterion comment="Microsoft Windows 8.1 is installed" test_ref="oval:org.open-scap.cpe.windows:tst:81" />
+                  </criteria>
+            </definition>
+            <definition class="inventory" id="oval:org.open-scap.cpe.windows:def:10" version="1">
+                  <metadata>
+                        <title>Microsoft Windows 10</title>
+                        <affected family="windows">
+                              <platform>Microsoft Windows 10</platform>
+                        </affected>
+                        <reference ref_id="cpe:/o:microsoft:windows_10" source="CPE"/>
+                        <description>The operating system installed on the system is Microsoft Windows 10</description>
+                  </metadata>
+                  <criteria operator="OR">
+                        <criterion comment="Microsoft Windows 10 is installed" test_ref="oval:org.open-scap.cpe.windows:tst:10" />
+                  </criteria>
+            </definition>
+            <definition class="inventory" id="oval:org.open-scap.cpe.windows:def:2008" version="1">
+                  <metadata>
+                        <title>Microsoft Windows Server 2008</title>
+                        <affected family="windows">
+                              <platform>Microsoft Windows Server 2008</platform>
+                        </affected>
+                        <reference ref_id="cpe:/o:microsoft:windows_server_2008" source="CPE"/>
+                        <description>The operating system installed on the system is Microsoft Windows Server 2008</description>
+                  </metadata>
+                  <criteria operator="OR">
+                        <criterion comment="Microsoft Windows Server 2008 is installed" test_ref="oval:org.open-scap.cpe.windows:tst:2008" />
+                  </criteria>
+            </definition>
+            <definition class="inventory" id="oval:org.open-scap.cpe.windows:def:2012" version="1">
+                  <metadata>
+                        <title>Microsoft Windows Server 2012</title>
+                        <affected family="windows">
+                              <platform>Microsoft Windows Server 2012</platform>
+                        </affected>
+                        <reference ref_id="cpe:/o:microsoft:windows_server_2012" source="CPE"/>
+                        <description>The operating system installed on the system is Microsoft Windows Server 2012</description>
+                  </metadata>
+                  <criteria operator="OR">
+                        <criterion comment="Microsoft Windows Server 2012 is installed" test_ref="oval:org.open-scap.cpe.windows:tst:2012" />
+                  </criteria>
+            </definition>
       </definitions>
       <tests>
             <rpmverifyfile_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:2" version="1" check="at least one" comment="/etc/redhat-release is provided by redhat-release package"
@@ -849,6 +927,30 @@
                   <object object_ref="oval:org.open-scap.cpe.rhevh:obj:2" />
                   <state state_ref="oval:org.open-scap.cpe.rhevh:ste:2" />
             </textfilecontent54_test>
+            <registry_test id="oval:org.open-scap.cpe.windows:tst:7" version="1" comment="Windows 7 is installed" check_existence="at_least_one_exists" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <object object_ref="oval:org.open-scap.cpe.windows:obj:1"/>
+                  <state state_ref="oval:org.open-scap.cpe.windows:ste:7"/>
+            </registry_test>
+            <registry_test id="oval:org.open-scap.cpe.windows:tst:8" version="1" comment="Windows 8 is installed" check_existence="at_least_one_exists" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <object object_ref="oval:org.open-scap.cpe.windows:obj:1"/>
+                  <state state_ref="oval:org.open-scap.cpe.windows:ste:8"/>
+            </registry_test>
+            <registry_test id="oval:org.open-scap.cpe.windows:tst:81" version="1" comment="Windows 8.1 is installed" check_existence="at_least_one_exists" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <object object_ref="oval:org.open-scap.cpe.windows:obj:1"/>
+                  <state state_ref="oval:org.open-scap.cpe.windows:ste:81"/>
+            </registry_test>
+            <registry_test id="oval:org.open-scap.cpe.windows:tst:10" version="1" comment="Windows 10 is installed" check_existence="at_least_one_exists" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <object object_ref="oval:org.open-scap.cpe.windows:obj:1"/>
+                  <state state_ref="oval:org.open-scap.cpe.windows:ste:10"/>
+            </registry_test>
+            <registry_test id="oval:org.open-scap.cpe.windows:tst:2008" version="1" comment="Windows Server 2008 is installed" check_existence="at_least_one_exists" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <object object_ref="oval:org.open-scap.cpe.windows:obj:1"/>
+                  <state state_ref="oval:org.open-scap.cpe.windows:ste:2008"/>
+            </registry_test>
+            <registry_test id="oval:org.open-scap.cpe.windows:tst:2012" version="1" comment="Windows Server 2012 is installed" check_existence="at_least_one_exists" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <object object_ref="oval:org.open-scap.cpe.windows:obj:1"/>
+                  <state state_ref="oval:org.open-scap.cpe.windows:ste:2012"/>
+            </registry_test>
       </tests>
       <objects>
             <family_object id="oval:org.open-scap.cpe.unix:obj:1" version="1"  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"/>
@@ -902,6 +1004,11 @@
             <rpminfo_object id="oval:org.open-scap.cpe.oraclelinux-release:obj:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <name>oraclelinux-release</name>
             </rpminfo_object>
+            <registry_object id="oval:org.open-scap.cpe.windows:obj:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" >
+                  <hive>HKEY_LOCAL_MACHINE</hive>
+                  <key>SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+                  <name>ProductName</name>
+            </registry_object>
       </objects>
       <states>
             <family_state id="oval:org.open-scap.cpe.unix:ste:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
@@ -1058,5 +1165,23 @@
             <textfilecontent54_state id="oval:org.open-scap.cpe.rhevh:ste:2" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
                   <subexpression operation="pattern match">7</subexpression>
             </textfilecontent54_state>
+            <registry_state id="oval:org.open-scap.cpe.windows:ste:7" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <value operation="pattern match">^Windows 7.*$</value>
+            </registry_state>
+            <registry_state id="oval:org.open-scap.cpe.windows:ste:8" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <value operation="pattern match">^Windows 8.*$</value>
+            </registry_state>
+            <registry_state id="oval:org.open-scap.cpe.windows:ste:81" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <value operation="pattern match">^Windows 8\.1.*$</value>
+            </registry_state>
+            <registry_state id="oval:org.open-scap.cpe.windows:ste:10" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <value operation="pattern match">^Windows 10.*$</value>
+            </registry_state>
+            <registry_state id="oval:org.open-scap.cpe.windows:ste:2008" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <value operation="pattern match">^.*2008.*$</value>
+            </registry_state>
+            <registry_state id="oval:org.open-scap.cpe.windows:ste:2012" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows">
+                  <value operation="pattern match">^.*2012.*$</value>
+            </registry_state>
       </states>
 </oval_definitions>

--- a/src/XCCDF/benchmark.c
+++ b/src/XCCDF/benchmark.c
@@ -126,6 +126,11 @@ struct xccdf_benchmark *xccdf_benchmark_clone(const struct xccdf_benchmark *old_
 	return XBENCHMARK(new_benchmark);
 }
 
+static void _xccdf_benchmark_add_platform(struct xccdf_item *benchmark, xmlTextReaderPtr reader)
+{
+	oscap_list_add(benchmark->item.platforms, xccdf_attribute_copy(reader, XCCDFA_IDREF));
+}
+
 bool xccdf_benchmark_parse(struct xccdf_item * benchmark, xmlTextReaderPtr reader)
 {
 	XCCDF_ASSERT_ELEMENT(reader, XCCDFE_BENCHMARK);
@@ -160,7 +165,7 @@ bool xccdf_benchmark_parse(struct xccdf_item * benchmark, xmlTextReaderPtr reade
 				oscap_list_add(benchmark->sub.benchmark.rear_matter, oscap_text_new_parse(XCCDF_TEXT_HTMLSUB, reader));
 			break;
 		case XCCDFE_PLATFORM:
-			oscap_list_add(benchmark->item.platforms, xccdf_attribute_copy(reader, XCCDFA_IDREF));
+			_xccdf_benchmark_add_platform(benchmark, reader);
 			break;
 		case XCCDFE_MODEL:
 			parsed_model = xccdf_model_new_xml(reader);

--- a/src/XCCDF/benchmark.c
+++ b/src/XCCDF/benchmark.c
@@ -25,6 +25,7 @@
 #endif
 
 #include <string.h>
+#include <pcre.h>
 
 #include "oscap_text.h"
 #include "item.h"
@@ -41,6 +42,11 @@
 #include "CPE/cpe_ctx_priv.h"
 
 #define XCCDF_SUPPORTED "1.2"
+
+/* According to `man 3 pcreapi`, the number passed in ovecsize should always
+ * be a multiple of three.
+ */
+#define OVECTOR_LEN 30
 
 static struct oscap_htable *xccdf_benchmark_find_target_htable(const struct xccdf_benchmark *, xccdf_type_t);
 static xmlNode *xccdf_plain_text_to_dom(const struct xccdf_plain_text *ptext, xmlDoc *doc, xmlNode *parent, const struct xccdf_version_info* version_info);
@@ -128,7 +134,44 @@ struct xccdf_benchmark *xccdf_benchmark_clone(const struct xccdf_benchmark *old_
 
 static void _xccdf_benchmark_add_platform(struct xccdf_item *benchmark, xmlTextReaderPtr reader)
 {
-	oscap_list_add(benchmark->item.platforms, xccdf_attribute_copy(reader, XCCDFA_IDREF));
+	char *platform_idref = xccdf_attribute_copy(reader, XCCDFA_IDREF);
+
+	/* Official Windows 7 CPE according to National Vulnerability Database
+	 * CPE Dictionary as of 2018-08-29 is 'cpe:/o:microsoft:windows_7'.
+	 * However, content exported from Microsoft Security Compliance Manager
+	 * as of version 4.0.0.1 in CAB archive using 'Export in SCAP 1.0' is
+	 * 'cpe:/o:microsoft:windows7'. If this pattern is matched, we will add
+	 * an underscore to workaround the situation that this XCCDF benchmark is
+	 * not applicable.
+	 */
+	const char *pcreerror = NULL;
+	int erroffset = 0;
+	pcre *regex = pcre_compile("^(cpe:/o:microsoft:windows)(7.*)", 0, &pcreerror, &erroffset, NULL);
+	int ovector[OVECTOR_LEN];
+	int rc = pcre_exec(regex, NULL, platform_idref, strlen(platform_idref), 0, 0, ovector, OVECTOR_LEN);
+	/* 1 pattern + 2 groups = 3 */
+	if (rc == 3) {
+		int match_len = ovector[1] - ovector[0];
+		/* match_len + 1 underscore + 1 zero byte */
+		char *alternate_platform_idref = malloc(match_len + 1 + 1);
+		int first_group_start = ovector[2];
+		int first_group_end = ovector[3];
+		size_t first_group_len = first_group_end - first_group_start;
+		int second_group_start = ovector[4];
+		int second_group_end = ovector[5];
+		size_t second_group_len = second_group_end - second_group_start;
+		char *aptr = alternate_platform_idref;
+		strncpy(aptr, platform_idref + first_group_start, first_group_len);
+		aptr += first_group_len;
+		*aptr = '_';
+		aptr++;
+		strncpy(aptr, platform_idref + second_group_start, second_group_len);
+		aptr += second_group_len;
+		*aptr = '\0';
+		oscap_list_add(benchmark->item.platforms, alternate_platform_idref);
+	}
+
+	oscap_list_add(benchmark->item.platforms, platform_idref);
 }
 
 bool xccdf_benchmark_parse(struct xccdf_item * benchmark, xmlTextReaderPtr reader)

--- a/src/XCCDF/item.c
+++ b/src/XCCDF/item.c
@@ -770,11 +770,11 @@ void xccdf_item_add_applicable_platform(struct xccdf_item *item, xmlTextReaderPt
 		size_t match_len = ovector[1] - ovector[0];
 		/* match_len + 1 underscore + 1 zero byte */
 		char *alternate_platform_idref = malloc(match_len + 1 + 1);
-		int first_group_start = ovector[2];
-		int first_group_end = ovector[3];
+		const int first_group_start = ovector[2];
+		const int first_group_end = ovector[3];
 		size_t first_group_len = first_group_end - first_group_start;
-		int second_group_start = ovector[4];
-		int second_group_end = ovector[5];
+		const int second_group_start = ovector[4];
+		const int second_group_end = ovector[5];
 		size_t second_group_len = second_group_end - second_group_start;
 		char *aptr = alternate_platform_idref;
 		strncpy(aptr, platform_idref + first_group_start, first_group_len);

--- a/src/XCCDF/item.c
+++ b/src/XCCDF/item.c
@@ -838,7 +838,7 @@ bool xccdf_item_process_element(struct xccdf_item * item, xmlTextReaderPtr reade
         oscap_list_add(item->item.rationale, oscap_text_new_parse(XCCDF_TEXT_HTMLSUB, reader));
 		return true;
         case XCCDFE_PLATFORM:
-        oscap_list_add(item->item.platforms, xccdf_attribute_copy(reader, XCCDFA_IDREF));
+		xccdf_item_add_applicable_platform(item, reader);
                 return true;
 	case XCCDFE_QUESTION:
         oscap_list_add(item->item.question, oscap_text_new_parse(XCCDF_TEXT_PLAIN, reader));

--- a/src/XCCDF/item.c
+++ b/src/XCCDF/item.c
@@ -767,7 +767,7 @@ void xccdf_item_add_applicable_platform(struct xccdf_item *item, xmlTextReaderPt
 	int rc = pcre_exec(regex, NULL, platform_idref, strlen(platform_idref), 0, 0, ovector, OVECTOR_LEN);
 	/* 1 pattern + 2 groups = 3 */
 	if (rc == 3) {
-		int match_len = ovector[1] - ovector[0];
+		size_t match_len = ovector[1] - ovector[0];
 		/* match_len + 1 underscore + 1 zero byte */
 		char *alternate_platform_idref = malloc(match_len + 1 + 1);
 		int first_group_start = ovector[2];

--- a/src/XCCDF/item.h
+++ b/src/XCCDF/item.h
@@ -520,6 +520,8 @@ void xccdf_reparent_item(struct xccdf_item * item, struct xccdf_item * parent);
 
 void xccdf_texts_to_dom(struct oscap_text_iterator *texts, xmlNode *parent, const char *elname);
 
+void xccdf_item_add_applicable_platform(struct xccdf_item *item, xmlTextReaderPtr reader);
+
 #include "unused.h"
 
 


### PR DESCRIPTION
This commit adds CPEs for Windows systems (Windows 7, 8, 8.1, 10,
Server 2008, Server 2012) to OpenSCAP CPE dictionary.

The PR doesn't fix #1181 though, because according to NVD the CPE for Windows 7 is `cpe:/o:microsoft:windows_7`, not `cpe:/o:microsoft:windows7`