### PR TITLE
Plug a memory leak

### DIFF
--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -140,6 +140,7 @@ static int oval_pdtbl_add(oval_pdtbl_t *tbl, oval_subtype_t type, int sd, const 
 	tbl->memb = realloc(tbl->memb, sizeof(oval_pd_t *) * (++tbl->count));
 
 	if (tbl->memb == NULL) {
+		free(pd->uri);
 		free(pd);
 		return -1;
 	}

--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -140,6 +140,7 @@ static int oval_pdtbl_add(oval_pdtbl_t *tbl, oval_subtype_t type, int sd, const 
 	tbl->memb = realloc(tbl->memb, sizeof(oval_pd_t *) * (++tbl->count));
 
 	if (tbl->memb == NULL) {
+		free(pd);
 		return -1;
 	}
 


### PR DESCRIPTION
```
Error: RESOURCE_LEAK (CWE-772): [#def15]
openscap-1.3.0_alpha1/src/OVAL/oval_probe_ext.c:134: alloc_fn: Storage
is returned from allocation function "malloc".
openscap-1.3.0_alpha1/src/OVAL/oval_probe_ext.c:134: var_assign:
Assigning: "pd" = storage returned from "malloc(16UL)".
openscap-1.3.0_alpha1/src/OVAL/oval_probe_ext.c:142: leaked_storage:
Variable "pd" going out of scope leaks the storage it points to.
  140|
  141|   	if (tbl->memb == NULL) {
  142|-> 		return -1;
  143|   	}
  144|
```