### PR TITLE
Add missing va_end

### DIFF
--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -745,6 +745,7 @@ int oval_probe_sys_handler(oval_subtype_t type, void *ptr, int act, ...)
                 }
 
 		if (pd == NULL) {
+			va_end(ap);
 			return -1;
 		}
 		ret = oval_probe_sys_eval(pext->pdtbl->ctx, pd, *(pext->model), inf);


### PR DESCRIPTION
openscap-1.3.0_alpha1/src/OVAL/oval_probe_ext.c:725: va_init:
Initializing va_list "ap".
openscap-1.3.0_alpha1/src/OVAL/oval_probe_ext.c:747: missing_va_end:
va_end was not called for "ap".
  745|
  746|   		if (pd == NULL) {
  747|-> 			return -1;
  748|   		}
  749|   		ret = oval_probe_sys_eval(pext->pdtbl->ctx, pd,
*(pext->model), inf);