### PR TITLE
Plug  memory leaks in digest.c

### DIFF
--- a/src/OVAL/probes/crapi/digest.c
+++ b/src/OVAL/probes/crapi/digest.c
@@ -170,6 +170,7 @@ int crapi_mdigest_fd (int fd, int num, ... /* crapi_alg_t alg, void *dst, size_t
                 goto fail;
         default:
 		if (ret <= 0) {
+			free(ctbl);
 			return -1;
 		}
 

--- a/src/OVAL/probes/crapi/digest.c
+++ b/src/OVAL/probes/crapi/digest.c
@@ -86,6 +86,7 @@ int crapi_mdigest_fd (int fd, int num, ... /* crapi_alg_t alg, void *dst, size_t
 
 	if (num <= 0 || fd <= 0) {
 		errno = EINVAL;
+		free(ctbl);
 		return -1;
 	}
         for (i = 0; i < num; ++i)


### PR DESCRIPTION

Plug a memory leak

openscap-1.3.0_alpha1/src/OVAL/probes/crapi/digest.c:78: alloc_fn:
Storage is returned from allocation function "malloc".
openscap-1.3.0_alpha1/src/OVAL/probes/crapi/digest.c:78: var_assign:
Assigning: "ctbl" = storage returned from "malloc(num * 40UL)".
openscap-1.3.0_alpha1/src/OVAL/probes/crapi/digest.c:89: leaked_storage:
Variable "ctbl" going out of scope leaks the storage it points to.
   87|   	if (num <= 0 || fd <= 0) {
   88|   		errno = EINVAL;
   89|-> 		return -1;
   90|   	}
   91|           for (i = 0; i < num; ++i)



Plug a memory leak

openscap-1.3.0_alpha1/src/OVAL/probes/crapi/digest.c:78: alloc_fn:
Storage is returned from allocation function "malloc".
openscap-1.3.0_alpha1/src/OVAL/probes/crapi/digest.c:78: var_assign:
Assigning: "ctbl" = storage returned from "malloc(num * 40UL)".
openscap-1.3.0_alpha1/src/OVAL/probes/crapi/digest.c:172:
leaked_storage: Variable "ctbl" going out of scope leaks the storage it
points to.
  170|           default:
  171|   		if (ret <= 0) {
  172|-> 			return -1;
  173|   		}
  174|

