### PR TITLE
Fixed a memory leak, introduced Stable_free.

### DIFF
--- a/src/OVAL/probes/SEAP/seap-command-backendS.c
+++ b/src/OVAL/probes/SEAP/seap-command-backendS.c
@@ -85,6 +85,19 @@ static Stable_t *Stable_new (size_t capacity)
         return (t);
 }
 
+static void Stable_free(Stable_t *table)
+{
+	if (table != NULL) {
+		for (i = 0; i < table->t_size; ++i) {
+			if (table->t_recs[i].c_size > 0)
+				sm_free(table->t_recs[i].c_recs);
+		}
+
+		sm_free(table->t_recs);
+		sm_free(table);
+	}
+}
+
 static int Stable_add (Stable_t *t, SEAP_cmdrec_t *r)
 {
         Stable_rec_t *t_r;
@@ -138,10 +151,11 @@ int  SEAP_cmdtbl_backendS_add (SEAP_cmdtbl_t *t, SEAP_cmdrec_t *r)
                 n = Stable_new (SEAP_CMDTBL_LARGE_TRESHOLD);
                 ret = SEAP_cmdtbl_backendL_apply (t, &Stable_conv, (void *)n);
                 
-                if (ret != 0) {
-                        SEAP_cmdtbl_backendS_free (t);
-                        return (ret);
-                }
+		if (ret != 0) {
+			SEAP_cmdtbl_backendS_free(t);
+			Stable_free(n);
+			return ret;
+		}
                 
                 SEAP_cmdtbl_backendL_free (t);
                 t->table = n;
@@ -180,24 +194,17 @@ int  SEAP_cmdtbl_backendS_cmp (SEAP_cmdrec_t *a, SEAP_cmdrec_t *b)
         return (a->code - b->code);
 }
 
-void SEAP_cmdtbl_backendS_free (SEAP_cmdtbl_t *t)
+void SEAP_cmdtbl_backendS_free(SEAP_cmdtbl_t *t)
 {
         size_t    i;
         Stable_t *St;
-        
+
         St = (Stable_t *)(t->table);
-        
-        if (St != NULL) {
-                for (i = 0; i < St->t_size; ++i)
-                        if (St->t_recs[i].c_size > 0)
-                                sm_free (St->t_recs[i].c_recs);
-                
-                sm_free (St->t_recs);
-                sm_free (St);
-                
-                t->table = NULL;
-        }
-        return;
+
+	if (St != NULL) {
+		Stable_free(St);
+		t->table = NULL;
+	}
 }
 
 int SEAP_cmdtbl_backendS_apply (SEAP_cmdtbl_t *t, int (*func) (SEAP_cmdrec_t *r, void *), void *arg)


### PR DESCRIPTION
`Stable_free` complements `Stable_new`.

Original Coverity finding:

```
Error: RESOURCE_LEAK (CWE-772): [#def18]
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command-backendS.c:137: alloc_fn: Storage is returned from allocation function "Stable_new".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command-backendS.c:78:2: alloc_fn: Storage is returned from allocation function "malloc".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command-backendS.c:78:2: var_assign: Assigning: "t" = "malloc(16UL)".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command-backendS.c:85:9: return_alloc: Returning allocated memory "t".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command-backendS.c:137: var_assign: Assigning: "n" = storage returned from "Stable_new(32UL)".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command-backendS.c:138: noescape: Resource "(void *)n" is not freed or pointed-to in "SEAP_cmdtbl_backendL_apply".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command-backendL.c:60:97: noescape: "SEAP_cmdtbl_backendL_apply(SEAP_cmdtbl_t *, int (*)(SEAP_cmdrec_t *, void *), void *)" does not free or save its parameter "arg".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command-backendS.c:142: leaked_storage: Variable "n" going out of scope leaks the storage it points to.
#  140|                   if (ret != 0) {
#  141|                           SEAP_cmdtbl_backendS_free (t);
#  142|->                         return (ret);
#  143|                   }
#  144|       
```