### PR TITLE
Plug memory leaks

### DIFF
--- a/src/OVAL/probes/independent/textfilecontent54_probe.c
+++ b/src/OVAL/probes/independent/textfilecontent54_probe.c
@@ -347,11 +347,12 @@ int textfilecontent54_probe_main(probe_ctx *ctx, void *arg)
         SEXP_t *ent_val;
         ent_val = probe_ent_getval(patt_ent);
 	pfd.pattern = SEXP_string_cstr(ent_val);
-	if (pfd.pattern == NULL) {
-		return -1;
-	}
         SEXP_free(patt_ent);
         SEXP_free(ent_val);
+	if (pfd.pattern == NULL) {
+		ret = -1;
+		goto cleanup;
+	}
 
         /* wtf?
 	i_val = s_val = "0";


### PR DESCRIPTION
openscap-1.3.0_alpha1/src/OVAL/probes/independent/textfilecontent54_probe.c:335:
alloc_fn: Storage is returned from allocation function
"probe_obj_getent".
openscap-1.3.0_alpha1/src/OVAL/probes/probe-api.c:425:2: alloc_fn:
Storage is returned from allocation function "SEXP_list_nth".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1147:9:
alloc_fn: Storage is returned from allocation function "SEXP_ref".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1613:9:
alloc_fn: Storage is returned from allocation function "SEXP_new".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1587:16:
alloc_fn: Storage is returned from allocation function "malloc".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1587:16:
var_assign: Assigning: "s_exp" = "malloc(16UL)".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1596:9:
return_alloc: Returning allocated memory "s_exp".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1613:9:
var_assign: Assigning: "s_exp_r" = "SEXP_new()".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1619:9:
return_alloc: Returning allocated memory "s_exp_r".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1147:9:
return_alloc_fn: Directly returning storage allocated by "SEXP_ref".
openscap-1.3.0_alpha1/src/OVAL/probes/probe-api.c:425:2: var_assign:
Assigning: "ent" = "SEXP_list_nth(objents, i425)".
openscap-1.3.0_alpha1/src/OVAL/probes/probe-api.c:426:3: noescape:
Resource "ent" is not freed or pointed-to in function "SEXP_list_first".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:979:40:
noescape: "SEXP_list_first(SEXP_t const *)" does not free or save its
parameter "list".
openscap-1.3.0_alpha1/src/OVAL/probes/probe-api.c:454:2: return_alloc:
Returning allocated memory "ent".
openscap-1.3.0_alpha1/src/OVAL/probes/independent/textfilecontent54_probe.c:335:
var_assign: Assigning: "bh_ent" = storage returned from
"probe_obj_getent(probe_in, "behaviors", 1U)".
openscap-1.3.0_alpha1/src/OVAL/probes/independent/textfilecontent54_probe.c:351:
leaked_storage: Variable "bh_ent" going out of scope leaks the storage
it points to.
 349|   	pfd.pattern = SEXP_string_cstr(ent_val);
  350|   	if (pfd.pattern == NULL) {
  351|-> 		return -1;
  352|   	}
  353|           SEXP_free(patt_ent);

A similar situation for path_ent, file_ent, inst_ent, patt_ent,
filepath_ent, bh_ent, ent_val variables.