### PR TITLE
Fix leak in textfilecontent_probe

### DIFF
--- a/src/OVAL/probes/independent/textfilecontent_probe.c
+++ b/src/OVAL/probes/independent/textfilecontent_probe.c
@@ -311,11 +311,15 @@ int textfilecontent_probe_main(probe_ctx *ctx, void *arg)
 	SEXP_t *ent_val;
 	ent_val = probe_ent_getval(line_ent);
 	pattern = SEXP_string_cstr(ent_val);
-	if (pattern == NULL) {
-		return -1;
-	}
 	SEXP_free(line_ent);
 	SEXP_free(ent_val);
+	if (pattern == NULL) {
+		SEXP_free(path_ent);
+		SEXP_free(filename_ent);
+		SEXP_free(filepath_ent);
+		SEXP_free(behaviors_ent);
+		return -1;
+	}
 
         /* behaviours are not important if filepath is used */
         if(filepath_ent != NULL && behaviors_ent != NULL) {


### PR DESCRIPTION
The leak was found after assume_d macro was replace by if code.

- Move the free for line_ent and ent_val before check for error condition,
they should be freed anyway.
- Add free for other leaking SEXP variables.