### PR TITLE
OVAL/probes/SEAP/seap-command.c: fixed memory leaks

### DIFF
--- a/src/OVAL/probes/SEAP/seap-command.c
+++ b/src/OVAL/probes/SEAP/seap-command.c
@@ -231,10 +231,10 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                        SEAP_cmdfn_t   func,
                        void          *funcarg)
 {
-        SEAP_desc_t   *dsc;
-        SEAP_cmdrec_t *rec;
+        SEAP_desc_t   *dsc = NULL;
+        SEAP_cmdrec_t *rec = NULL;
         SEAP_cmdtbl_t *tbl[2];
-        SEXP_t        *res;
+        SEXP_t        *res = NULL;
         int8_t i;
 
         _A(ctx != NULL);
@@ -348,14 +348,17 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                                 dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: already registered.",
                                    rec->code, (void *)dsc->cmd_w_table, sd);
                                 SEAP_cmdrec_free (rec);
+				SEAP_packet_free(packet);
                                 return (NULL);
                         case -1:
                                 dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: errno=%u, %s.",
                                    rec->code, (void *)dsc->cmd_w_table, sd, errno, strerror (errno));
                                 SEAP_cmdrec_free (rec);
+				SEAP_packet_free(packet);
                                 return (NULL);
                         default:
                                 SEAP_cmdrec_free (rec);
+				SEAP_packet_free(packet);
                                 errno = EDOOFUS;
                                 return (NULL);
                         }
@@ -364,7 +367,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                                 protect_errno {
                                         dI("FAIL: errno=%u, %s.", errno, strerror (errno));
                                         SEAP_cmdtbl_del(dsc->cmd_w_table, rec);
-                                        SEAP_packet_free (packet);
+                                        SEAP_packet_free(packet);
                                 }
                                 return (NULL);
                         }
@@ -389,6 +392,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
 
                                         if (SEAP_packet_recv(ctx, sd, &packet_rcv) != 0) {
                                                 dI("FAIL: ctx=%p, sd=%d, errno=%u, %s.", ctx, sd, errno, strerror(errno));
+						SEAP_packet_free(packet);
                                                 return(NULL);
                                         }
 
@@ -399,6 +403,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                                                         SEAP_packet_free(packet_rcv);
                                                         break;
                                                 default:
+							SEAP_packet_free(packet);
                                                         errno = EDOOFUS;
                                                         return(NULL);
                                                 }
@@ -445,7 +450,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                         pthread_mutex_unlock (&(h.mtx));
                         pthread_cond_destroy (&(h.cond));
                         pthread_mutex_destroy (&(h.mtx));
-                        SEAP_packet_free (packet);
+                        SEAP_packet_free(packet);
 
                         return (res);
                 }
@@ -465,14 +470,17 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                                 dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: already registered.",
                                    rec->code, (void *)dsc->cmd_w_table, sd);
                                 SEAP_cmdrec_free (rec);
+				SEAP_packet_free(packet);
                                 return (NULL);
                         case -1:
                                 dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: errno=%u, %s.",
                                    rec->code, (void *)dsc->cmd_w_table, sd, errno, strerror (errno));
-                                SEAP_cmdrec_free (rec);
+                                SEAP_cmdrec_free(rec);
+				SEAP_packet_free(packet);
                                 return (NULL);
                         default:
-                                SEAP_cmdrec_free (rec);
+                                SEAP_cmdrec_free(rec);
+				SEAP_packet_free(packet);
                                 errno = EDOOFUS;
                                 return (NULL);
                         }
@@ -481,17 +489,17 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                                 protect_errno {
                                         dI("FAIL: errno=%u, %s.", errno, strerror (errno));
                                         SEAP_cmdtbl_del(dsc->cmd_w_table, rec);
-                                        SEAP_cmdrec_free(rec);
-                                        SEAP_packet_free (packet);
+                                        SEAP_packet_free(packet);
                                 }
                                 return (NULL);
                         }
 
-                        SEAP_packet_free (packet);
+                        SEAP_packet_free(packet);
 
                         return (args);
                 default:
                         errno = EINVAL;
+			SEAP_packet_free(packet);
                         return (NULL);
                 }
         }


### PR DESCRIPTION
Fixed memory leaks in `OVAL/probes/SEAP/seap-command.c` caused by not freeing the allocated memory before returning from the function `SEAP_cmd_exec`.

```
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command.c:308: alloc_fn: Storage is returned from allocation function "SEAP_packet_new".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-packet.c:46:19: alloc_fn: Storage is returned from allocation function "malloc".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-packet.c:46:19: var_assign: Assigning: "p" = "malloc(40UL)".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-packet.c:47:9: noescape: Resource "p" is not freed or pointed-to in function "memset". [Note: The source code implementation of the function has been overridden by a builtin model.]
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-packet.c:50:9: return_alloc: Returning allocated memory "p".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command.c:308: var_assign: Assigning: "packet" = storage returned from "SEAP_packet_new()".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command.c:309: identity_transfer: Passing "packet" as argument 1 to function "SEAP_packet_settype", which returns an offset off that argument.
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-packet.c:69:17: return_parm: Returning parameter "packet".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command.c:309: noescape: Resource "packet" is not freed or pointed-to in "SEAP_packet_settype".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-packet.c:58:43: noescape: "SEAP_packet_settype(SEAP_packet_t *, uint8_t)" does not free or save its parameter "packet".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command.c:309: var_assign: Assigning: "cmdptr" = storage returned from "SEAP_packet_settype(packet, 3)".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command.c:346: leaked_storage: Variable "packet" going out of scope leaks the storage it points to.
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/seap-command.c:346: leaked_storage: Variable "cmdptr" going out of scope leaks the storage it points to.
```