### PR TITLE
Make sure that intermediate results are freed.

### DIFF
--- a/src/OVAL/probes/probe-api.c
+++ b/src/OVAL/probes/probe-api.c
@@ -1390,6 +1390,11 @@ static SEXP_t *probe_item_optimize(const SEXP_t *item)
 	return SEXP_ref(item);
 }
 
+/**
+ * The order of (value_name, value_type, *value) argument tuples passed as
+ * e.g. 3rd to 5th arguments matters. If you change ordering of those tuples,
+ * it will have consequences.
+ */
 SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t *item_attributes[],
                           /* const char *value_name, oval_datatype_t value_type, void *value, */ ...)
 {

--- a/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
+++ b/src/OVAL/probes/unix/linux/selinuxsecuritycontext.c
@@ -103,6 +103,66 @@ static void split_range(const char *range, char **l_s, char **l_c, char **h_s, c
 	}
 }
 
+static SEXP_t *create_process_probe_item_with_range(
+		const char *range, const char *user, const char *role, const char *type,
+		int pid_number) {
+	char *l_sensitivity, *l_category, *h_sensitivity, *h_category;
+	SEXP_t *item;
+
+	split_range(range, &l_sensitivity, &l_category, &h_sensitivity, &h_category);
+	item = probe_item_create(OVAL_LINUX_SELINUXSECURITYCONTEXT, NULL,
+		"pid",     OVAL_DATATYPE_INTEGER, (int64_t)pid_number,
+
+		"user",     OVAL_DATATYPE_STRING, user,
+		"role",     OVAL_DATATYPE_STRING, role,
+		"type",     OVAL_DATATYPE_STRING, type,
+		"low_sensitivity", OVAL_DATATYPE_STRING, l_sensitivity,
+		"low_category", OVAL_DATATYPE_STRING, l_category,
+		"high_sensitivity", OVAL_DATATYPE_STRING, h_sensitivity,
+		"high_category", OVAL_DATATYPE_STRING, h_category,
+		NULL);
+	free(l_sensitivity);
+	free(l_category);
+	free(h_sensitivity);
+	free(h_category);
+
+	return item;
+}
+
+
+static SEXP_t *create_file_probe_item_with_range(
+		const char *range, const char *user, const char *role, const char *type,
+		const char *pbuf, const char *p, const char *f) {
+	char *l_sensitivity, *l_category, *h_sensitivity, *h_category;
+	SEXP_t *item;
+
+	split_range(range, &l_sensitivity, &l_category, &h_sensitivity, &h_category);
+	item = probe_item_create(OVAL_LINUX_SELINUXSECURITYCONTEXT, NULL,
+		"filepath", OVAL_DATATYPE_STRING, pbuf,
+		"path",     OVAL_DATATYPE_STRING, p,
+		"filename", OVAL_DATATYPE_STRING, f,
+
+		"user",     OVAL_DATATYPE_STRING, user,
+		"role",     OVAL_DATATYPE_STRING, role,
+		"type",     OVAL_DATATYPE_STRING, type,
+		"low_sensitivity", OVAL_DATATYPE_STRING, l_sensitivity,
+		"low_category", OVAL_DATATYPE_STRING, l_category,
+		"high_sensitivity", OVAL_DATATYPE_STRING, h_sensitivity,
+		"high_category", OVAL_DATATYPE_STRING, h_category,
+
+		"rawlow_sensitivity", OVAL_DATATYPE_STRING, l_sensitivity,
+		"rawlow_category", OVAL_DATATYPE_STRING, l_category,
+		"rawhigh_sensitivity", OVAL_DATATYPE_STRING, h_sensitivity,
+		"rawhigh_category", OVAL_DATATYPE_STRING, h_category,
+		NULL);
+	free(l_sensitivity);
+	free(l_category);
+	free(h_sensitivity);
+	free(h_category);
+
+	return item;
+}
+
 static int selinuxsecuritycontext_process_cb (SEXP_t *pid_ent, probe_ctx *ctx) {
 
 	SEXP_t *pid_sexp, *item;
@@ -112,7 +172,6 @@ static int selinuxsecuritycontext_process_cb (SEXP_t *pid_ent, probe_ctx *ctx) {
 	DIR *proc;
 	struct dirent *dir_entry;
 	const char *user, *role, *type, *range;
-	char *l_sensitivity, *l_category, *h_sensitivity, *h_category;
 
 	if ((proc = opendir("/proc")) == NULL) {
 		dE("Can't open /proc dir: %s", strerror(errno));
@@ -143,17 +202,7 @@ static int selinuxsecuritycontext_process_cb (SEXP_t *pid_ent, probe_ctx *ctx) {
 			type = context_type_get(context);
 			range = context_range_get(context);
 			if (range != NULL) {
-				split_range(range, &l_sensitivity, &l_category, &h_sensitivity, &h_category);
-				item = probe_item_create(OVAL_LINUX_SELINUXSECURITYCONTEXT, NULL,
-					"pid",     OVAL_DATATYPE_INTEGER, (int64_t)pid_number,
-					"user",     OVAL_DATATYPE_STRING, user,
-					"role",     OVAL_DATATYPE_STRING, role,
-					"type",     OVAL_DATATYPE_STRING, type,
-					"low_sensitivity", OVAL_DATATYPE_STRING, l_sensitivity,
-					"low_category", OVAL_DATATYPE_STRING, l_category,
-					"high_sensitivity", OVAL_DATATYPE_STRING, h_sensitivity,
-					"high_category", OVAL_DATATYPE_STRING, h_category,
-					NULL);
+				item = create_process_probe_item_with_range(range, user, role, type, pid_number);
 			}
 			else {
 				item = probe_item_create(OVAL_LINUX_SELINUXSECURITYCONTEXT, NULL,
@@ -188,7 +237,6 @@ static int selinuxsecuritycontext_file_cb(const char *prefix, const char *p, con
 	int file_context_size;
 	context_t context;
 	const char *user, *role, *type, *range;
-	char *l_sensitivity, *l_category, *h_sensitivity, *h_category;
 	int err = 0;
 
 	/* directory */
@@ -244,23 +292,7 @@ static int selinuxsecuritycontext_file_cb(const char *prefix, const char *p, con
 		range = context_range_get(context);
 
 		if (range != NULL) {
-			split_range(range, &l_sensitivity, &l_category, &h_sensitivity, &h_category);
-			item = probe_item_create(OVAL_LINUX_SELINUXSECURITYCONTEXT, NULL,
-							"filepath", OVAL_DATATYPE_STRING, pbuf,
-							"path",     OVAL_DATATYPE_STRING, p,
-							"filename", OVAL_DATATYPE_STRING, f,
-							"user",     OVAL_DATATYPE_STRING, user,
-							"role",     OVAL_DATATYPE_STRING, role,
-							"type",     OVAL_DATATYPE_STRING, type,
-							"low_sensitivity", OVAL_DATATYPE_STRING, l_sensitivity,
-							"low_category", OVAL_DATATYPE_STRING, l_category,
-							"high_sensitivity", OVAL_DATATYPE_STRING, h_sensitivity,
-							"high_category", OVAL_DATATYPE_STRING, h_category,
-							"rawlow_sensitivity", OVAL_DATATYPE_STRING, l_sensitivity,
-							"rawlow_category", OVAL_DATATYPE_STRING, l_category,
-							"rawhigh_sensitivity", OVAL_DATATYPE_STRING, h_sensitivity,
-							"rawhigh_category", OVAL_DATATYPE_STRING, h_category,
-							NULL);
+			item = create_file_probe_item_with_range(range, user, role, type, pbuf, p, f);
 		}
 		else {
 			item = probe_item_create(OVAL_LINUX_SELINUXSECURITYCONTEXT, NULL,


### PR DESCRIPTION
Also extracted non-trivial generation of probe items to functions.

Original Coverity report (applies to the `master` branch:

```
Error: RESOURCE_LEAK (CWE-772): [#def70]
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:147: alloc_arg: "split_range" allocates memory that is stored into "h_category".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:102:3: alloc_arg: "split_level" allocates memory that is stored into "*h_c".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:71:3: alloc_fn: Storage is returned from allocation function "strdup".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:71:3: var_assign: Assigning: "*category" = "strdup(level_split + 1)".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:148: noescape: Resource "h_category" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:148: noescape: Resource "h_category" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:177: leaked_storage: Variable "h_category" going out of scope leaks the storage it points to.
#  175|   	closedir(proc);
#  176|   
#  177|-> 	return 0;
#  178|   }
#  179|   

Error: RESOURCE_LEAK (CWE-772): [#def71]
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:147: alloc_arg: "split_range" allocates memory that is stored into "h_sensitivity".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:102:3: alloc_arg: "split_level" allocates memory that is stored into "*h_s".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:66:3: alloc_fn: Storage is returned from allocation function "strdup".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:66:3: var_assign: Assigning: "*sensitivity" = "strdup(level)".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:148: noescape: Resource "h_sensitivity" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:148: noescape: Resource "h_sensitivity" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:177: leaked_storage: Variable "h_sensitivity" going out of scope leaks the storage it points to.
#  175|   	closedir(proc);
#  176|   
#  177|-> 	return 0;
#  178|   }
#  179|   

Error: RESOURCE_LEAK (CWE-772): [#def72]
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:147: alloc_arg: "split_range" allocates memory that is stored into "l_category".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:90:3: alloc_arg: "split_level" allocates memory that is stored into "*l_c".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:71:3: alloc_fn: Storage is returned from allocation function "strdup".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:71:3: var_assign: Assigning: "*category" = "strdup(level_split + 1)".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:148: noescape: Resource "l_category" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:177: leaked_storage: Variable "l_category" going out of scope leaks the storage it points to.
#  175|   	closedir(proc);
#  176|   
#  177|-> 	return 0;
#  178|   }
#  179|   

Error: RESOURCE_LEAK (CWE-772): [#def73]
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:147: alloc_arg: "split_range" allocates memory that is stored into "l_sensitivity".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:90:3: alloc_arg: "split_level" allocates memory that is stored into "*l_s".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:66:3: alloc_fn: Storage is returned from allocation function "strdup".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:66:3: var_assign: Assigning: "*sensitivity" = "strdup(level)".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:148: noescape: Resource "l_sensitivity" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:177: leaked_storage: Variable "l_sensitivity" going out of scope leaks the storage it points to.
#  175|   	closedir(proc);
#  176|   
#  177|-> 	return 0;
#  178|   }
#  179|   

Error: RESOURCE_LEAK (CWE-772): [#def74]
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:248: alloc_arg: "split_range" allocates memory that is stored into "h_category".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:102:3: alloc_arg: "split_level" allocates memory that is stored into "*h_c".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:71:3: alloc_fn: Storage is returned from allocation function "strdup".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:71:3: var_assign: Assigning: "*category" = "strdup(level_split + 1)".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:249: noescape: Resource "h_category" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:249: noescape: Resource "h_category" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:284: leaked_storage: Variable "h_category" going out of scope leaks the storage it points to.
#  282|   		freecon(file_context);
#  283|   
#  284|-> 	return (err);
#  285|   }
#  286|   

Error: RESOURCE_LEAK (CWE-772): [#def75]
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:248: alloc_arg: "split_range" allocates memory that is stored into "h_sensitivity".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:102:3: alloc_arg: "split_level" allocates memory that is stored into "*h_s".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:66:3: alloc_fn: Storage is returned from allocation function "strdup".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:66:3: var_assign: Assigning: "*sensitivity" = "strdup(level)".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:249: noescape: Resource "h_sensitivity" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:249: noescape: Resource "h_sensitivity" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:284: leaked_storage: Variable "h_sensitivity" going out of scope leaks the storage it points to.
#  282|   		freecon(file_context);
#  283|   
#  284|-> 	return (err);
#  285|   }
#  286|   

Error: RESOURCE_LEAK (CWE-772): [#def76]
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:248: alloc_arg: "split_range" allocates memory that is stored into "l_category".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:90:3: alloc_arg: "split_level" allocates memory that is stored into "*l_c".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:71:3: alloc_fn: Storage is returned from allocation function "strdup".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:71:3: var_assign: Assigning: "*category" = "strdup(level_split + 1)".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:249: noescape: Resource "l_category" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:249: noescape: Resource "l_category" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:284: leaked_storage: Variable "l_category" going out of scope leaks the storage it points to.
#  282|   		freecon(file_context);
#  283|   
#  284|-> 	return (err);
#  285|   }
#  286|   

Error: RESOURCE_LEAK (CWE-772): [#def77]
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:248: alloc_arg: "split_range" allocates memory that is stored into "l_sensitivity".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:90:3: alloc_arg: "split_level" allocates memory that is stored into "*l_s".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:66:3: alloc_fn: Storage is returned from allocation function "strdup".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:66:3: var_assign: Assigning: "*sensitivity" = "strdup(level)".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:249: noescape: Resource "l_sensitivity" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:249: noescape: Resource "l_sensitivity" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:284: leaked_storage: Variable "l_sensitivity" going out of scope leaks the storage it points to.
#  282|   		freecon(file_context);
#  283|   
#  284|-> 	return (err);
#  285|   }
#  286|   
```