### PR TITLE
Plug memory leaks

### DIFF
--- a/src/OVAL/probes/independent/textfilecontent54.c
+++ b/src/OVAL/probes/independent/textfilecontent54.c
@@ -211,6 +211,8 @@ static SEXP_t *create_item(const char *path, const char *filename, char *pattern
                 SEXP_free (r0);
 	}
 
+	SEXP_free(se_filepath);
+	SEXP_free(se_instance);
 	return item;
 }
 


### PR DESCRIPTION
Error: RESOURCE_LEAK (CWE-772): [#def28]
openscap-1.3.0_alpha1/src/OVAL/probes/independent/textfilecontent54_probe.c:144:
alloc_fn: Storage is returned from allocation function
"SEXP_string_newf".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:616:9: alloc_fn:
Storage is returned from allocation function "SEXP_new".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1587:16:
alloc_fn: Storage is returned from allocation function "malloc".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1587:16:
var_assign: Assigning: "s_exp" = "malloc(16UL)".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1596:9:
return_alloc: Returning allocated memory "s_exp".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:616:9:
var_assign: Assigning: "sexp" = "SEXP_new()".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:618:9:
identity_transfer: Passing "sexp" as argument 1 to function
"SEXP_string_newf_rv", which returns that argument.
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip_r.c:288:9:
return_parm: Returning parameter "sexp_mem".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:618:9: noescape:
Resource "sexp" is not freed or pointed-to in function
"SEXP_string_newf_rv".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip_r.c:243:37:
noescape: "SEXP_string_newf_rv(SEXP_t *, char const *, va_list)" does
not free or save its parameter "sexp_mem".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:618:9:
var_assign: Assigning: "sexp" = "SEXP_string_newf_rv(sexp, format, ap)".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:621:9:
return_alloc: Returning allocated memory "sexp".
openscap-1.3.0_alpha1/src/OVAL/probes/independent/textfilecontent54_probe.c:144:
var_assign: Assigning: "se_filepath" = storage returned from
"SEXP_string_newf("%s%s", path, filename)".
openscap-1.3.0_alpha1/src/OVAL/probes/independent/textfilecontent54_probe.c:150:
noescape: Resource "se_filepath" is not freed or pointed-to in
"probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/independent/textfilecontent54_probe.c:165:
leaked_storage: Variable "se_filepath" going out of scope leaks the
storage it points to.
  163|   	}
  164|
  165|-> 	return item;
  166|   }
  167|

A similar situation for se_instance variable.