### PR TITLE
Fix leak in OVAL/probes/probe/ncache.c

### DIFF
--- a/src/OVAL/probes/probe/ncache.c
+++ b/src/OVAL/probes/probe/ncache.c
@@ -143,6 +143,7 @@ SEXP_t *probe_ncache_add (probe_ncache_t *cache, const char *name)
 
 	/* TODO: check if this is really needed */
 	if (cache->name == NULL || cache->size <= cache->real) {
+		SEXP_free(ref);
 		return NULL;
 	}
 


### PR DESCRIPTION
Free newly created SEXP `ref` before returning.

The leak was found after assume_d macro was replace by if code.