### PR TITLE
Free "g_rpm" variable in src/OVAL/probes/unix/linux/rpmverifypackage_probe.c

### DIFF
--- a/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
@@ -335,6 +335,8 @@ void *rpmverifypackage_probe_init(void)
 	if (CHROOT_IS_SET()) {
 		rpmLibsPreload();
 		if (CHROOT_ENTER() < 0) {
+			probe_chroot_free(&g_rpm->chr);
+			free(g_rpm);
 			return (NULL);
 		}
 	}


### PR DESCRIPTION
Free `g_rpm` structure - free `probe_chroot` (close fd + free scan_path)  and free memory.


Only for master branch, because `g_rpm` is static variable in maint-1.2.