### PR TITLE
Plug a memory leak

### DIFF
--- a/src/OVAL/probes/unix/file_probe.c
+++ b/src/OVAL/probes/unix/file_probe.c
@@ -397,6 +397,8 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr, 
 		if (se_acl == NULL) {
 			probe_item_ent_add(item, "has_extended_acl", NULL, SEXP_number_newb(true));
 			probe_itement_setstatus(item, "has_extended_acl", 1, SYSCHAR_STATUS_DOES_NOT_EXIST);
+		} else {
+			SEXP_free(se_acl);
 		}
 
                 SEXP_free(se_grp_id);


### PR DESCRIPTION
Error: RESOURCE_LEAK (CWE-772): [#def68]
openscap-1.3.0_alpha1/src/OVAL/probes/unix/file_probe.c:368: alloc_fn:
Storage is returned from allocation function "has_extended_acl".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/file_probe.c:303:2: alloc_fn:
Storage is returned from allocation function "SEXP_number_newb".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:96:9: alloc_fn:
Storage is returned from allocation function "SEXP_new".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1587:16:
alloc_fn: Storage is returned from allocation function "malloc".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1587:16:
var_assign: Assigning: "s_exp" = "malloc(16UL)".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1596:9:
return_alloc: Returning allocated memory "s_exp".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:96:9:
var_assign: Assigning: "sexp" = "SEXP_new()".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:97:9:
identity_transfer: Passing "sexp" as argument 1 to function
"SEXP_number_newb_r", which returns that argument.
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip_r.c:203:9:
return_parm: Returning parameter "sexp_mem".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:97:9: noescape:
Resource "sexp" is not freed or pointed-to in function
"SEXP_number_newb_r".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip_r.c:180:36:
noescape: "SEXP_number_newb_r(SEXP_t *, _Bool)" does not free or save
its parameter "sexp_mem".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:97:9:
var_assign: Assigning: "sexp" = "SEXP_number_newb_r(sexp, n)".
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:99:9:
return_alloc: Returning allocated memory "sexp".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/file_probe.c:303:2:
return_alloc_fn: Directly returning storage allocated by
"SEXP_number_newb".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/file_probe.c:368: var_assign:
Assigning: "se_acl" = storage returned from
"has_extended_acl(st_path_with_prefix)".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/file_probe.c:372: noescape:
Resource "se_acl" is not freed or pointed-to in "probe_item_create".
openscap-1.3.0_alpha1/src/OVAL/probes/unix/file_probe.c:414:
leaked_storage: Variable "se_acl" going out of scope leaks the storage
it points to.
  412|   		 * (return code == 2)
  413|   		 */
  414|->                 return probe_item_collect(args->ctx, item) ==
2 ? 1 : 0;
  415|           }
  416|