### PR TITLE
Fixed some Coverity issues

### DIFF
--- a/src/OVAL/probes/unix/process.c
+++ b/src/OVAL/probes/unix/process.c
@@ -98,6 +98,9 @@ static void report_finding(struct result_info *res, probe_ctx *ctx)
                                  "tty",          OVAL_DATATYPE_STRING, res->tty,
                                  "user_id",    OVAL_DATATYPE_INTEGER, (int64_t)res->user_id,
                                  NULL);
+	if (se_ruid) {
+		SEXP_free(se_ruid);
+	}
 
         probe_item_collect(ctx, item);
 }

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -378,7 +378,7 @@ static inline int _xccdf_fix_execute(struct xccdf_rule_result *rr, struct xccdf_
 		goto cleanup;
 	}
 
-	if (_write_text_to_fd_and_free(fd, fix_text) != 0) {
+	if (_write_text_to_fd(fd, fix_text) != 0) {
 		_rule_add_info_message(rr, "Could not write to the temp file: %s", strerror(errno));
 		(void) close(fd);
 		goto cleanup;
@@ -440,6 +440,7 @@ static inline int _xccdf_fix_execute(struct xccdf_rule_result *rr, struct xccdf_
 
 cleanup:
 	oscap_acquire_cleanup_dir(&temp_dir);
+	free(fix_text);
 	return result;
 }
 


### PR DESCRIPTION
* Refactored cleanup section of `_xccdf_fix_execute`:
   `fix_text` is allocated in `_xccdf_fix_decode_xml` and was possibly freed in `_write_text_to_fd_and_free`, but in meantime could have been be jumped over free, causing a memory leak.

* Improved freeing process of the env_values array: 
  Extracted the process into a function and called it where it was missing.
* Freed a se_ruid sexp that is deep-copied by probe_item_create.