### PR TITLE
Don't free oscap_source when parsing cvrf_xml

### DIFF
--- a/src/CVRF/cvrf_priv.c
+++ b/src/CVRF/cvrf_priv.c
@@ -2332,7 +2332,6 @@ struct cvrf_index *cvrf_index_parse_xml(struct oscap_source *index_source) {
 	}
 	struct cvrf_index *index = cvrf_index_new();
 	cvrf_index_set_index_file(index, oscap_source_readable_origin(index_source));
-	oscap_source_free(index_source);
 	return index;
 }
 

--- a/utils/oscap-cvrf.c
+++ b/utils/oscap-cvrf.c
@@ -151,9 +151,7 @@ static int app_cvrf_export(const struct oscap_action *action) {
 		if (oscap_err())
 			fprintf(stderr, "%s %s\n", OSCAP_ERR_MSG, oscap_err_desc());
 
-	/* TODO: Refactor, cvrf_index_parse_xml (called by oscap_source_new_from_file) frees its argument as an unexpected side-effect.
-	 * oscap_source_free(import_source);
-	 */
+	oscap_source_free(import_source);
 	free(action->cvrf_action);
 	return result;
 }


### PR DESCRIPTION
Do not free oscap_source when parsing cvrf_xml for index.
It should not be the duty of cvrf xml parsing function to free its
source of input.

Plus, cvrf_index_import is also called in function
cvrf_session_new_from_source. In cvrf_session structure,
the import source is part of the strucutre along with cvrf index, it
make no sense to free it.