### PR TITLE
Coverity fixes related to oscap_...name

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -859,7 +859,7 @@ void xccdf_session_set_custom_oval_files(struct xccdf_session *session, char **o
 
 	for (int i = 0; oval_filenames[i];) {
 		resources[i] = malloc(sizeof(struct oval_content_resource));
-		resources[i]->href = oscap_strdup(oscap_basename(oval_filenames[i]));
+		resources[i]->href = oscap_basename(oval_filenames[i]);
 		resources[i]->source = oscap_source_new_from_file(oval_filenames[i]);
 		resources[i]->source_owned = true;
 		i++;

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -368,6 +368,7 @@ char *oscap_acquire_guess_realpath(const char *filepath)
 		if (real_dir == NULL) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Cannot guess realpath for %s, directory: %s does not exists!", filepath, dir_name);
 			free(copy);
+			free(dir_name);
 			return NULL;
 		}
 		free(dir_name);


### PR DESCRIPTION
* Added free of `dir_name` in `oscap_acquire_guess_realpath`: Unlike `dirname`, `oscap_dirname` allocates space for the result on the heap.

* Removed redundant `oscap_strdup`: Unlike `basename`, `oscap_basename` already allocates space for the result on the heap.