### PR TITLE
Plug a memory leak

### DIFF
--- a/src/CVRF/cvrf_priv.c
+++ b/src/CVRF/cvrf_priv.c
@@ -1656,7 +1656,9 @@ struct cvrf_score_set *cvrf_score_set_parse(xmlTextReaderPtr reader) {
 		if (xmlStrcmp(xmlTextReaderConstLocalName(reader), TAG_VECTOR) == 0) {
 			score_set->vector = oscap_element_string_copy(reader);
 		} else if (xmlStrcmp(xmlTextReaderConstLocalName(reader), TAG_PRODUCT_ID) == 0) {
-			oscap_stringlist_add_string(score_set->product_ids, oscap_element_string_copy(reader));
+			char *product_id = oscap_element_string_copy(reader);
+			oscap_stringlist_add_string(score_set->product_ids, product_id);
+			free(product_id);
 		} else if (xmlStrcmp(xmlTextReaderConstLocalName(reader), TAG_BASE_SCORE) == 0) {
 			cvrf_score_set_add_metric(score_set, CVSS_BASE, oscap_element_string_copy(reader));
 		} else if (xmlStrcmp(xmlTextReaderConstLocalName(reader), TAG_ENVIRONMENTAL_SCORE) == 0) {


### PR DESCRIPTION
Error: RESOURCE_LEAK (CWE-772): [#def9]
openscap-1.3.0_alpha1/src/CVRF/cvrf_priv.c:1659: alloc_fn: Storage is
returned from allocation function "oscap_element_string_copy".
openscap-1.3.0_alpha1/src/common/elements.c:134:3: alloc_fn: Storage is
returned from allocation function "calloc".
openscap-1.3.0_alpha1/src/common/elements.c:134:3: return_alloc_fn:
Directly returning storage allocated by "calloc".
openscap-1.3.0_alpha1/src/CVRF/cvrf_priv.c:1659: noescape: Resource
"oscap_element_string_copy(reader)" is not freed or pointed-to in
"oscap_stringlist_add_string".
openscap-1.3.0_alpha1/src/common/list.c:353:77: noescape:
"oscap_stringlist_add_string(struct oscap_stringlist *, char const *)"
does not free or save its parameter "str".
openscap-1.3.0_alpha1/src/CVRF/cvrf_priv.c:1659: leaked_storage: Failing
to save or free storage allocated by "oscap_element_string_copy(reader)"
leaks it.
 1657|   			score_set->vector =
oscap_element_string_copy(reader);
 1658|   		} else if
(xmlStrcmp(xmlTextReaderConstLocalName(reader), TAG_PRODUCT_ID) == 0) {
 1659|->
oscap_stringlist_add_string(score_set->product_ids,
oscap_element_string_copy(reader));
 1660|   		} else if
(xmlStrcmp(xmlTextReaderConstLocalName(reader), TAG_BASE_SCORE) == 0) {
 1661|   			cvrf_score_set_add_metric(score_set,
CVSS_BASE, oscap_element_string_copy(reader));