### PR TITLE
OVAL/probes/SEAP/sexp-manip.c: fixed false positives reported by coverity

### DIFF
--- a/src/OVAL/probes/SEAP/sexp-manip.c
+++ b/src/OVAL/probes/SEAP/sexp-manip.c
@@ -932,7 +932,10 @@ SEXP_t *SEXP_list_new (SEXP_t *memb, ...)
 
         va_start(ap, memb);
         list = SEXP_new ();
-        list = SEXP_list_new_rv(list, memb, ap);
+        if (SEXP_list_new_rv(list, memb, ap) == NULL) {
+		SEXP_free(list);
+		list = NULL;
+	}
         va_end(ap);
 
         return (list);
@@ -1035,7 +1038,10 @@ SEXP_t *SEXP_list_rest  (const SEXP_t *list)
 	SEXP_t *sexp;
 
 	sexp = SEXP_new();
-	sexp = SEXP_list_rest_r(sexp, list);
+	if (SEXP_list_rest_r(sexp, list) == NULL) {
+		SEXP_free(sexp);
+		sexp = NULL;
+	}
 
 	return (sexp);
 }


### PR DESCRIPTION
Coverity reports 2 false positives:
```
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:934: overwrite_var: Overwriting "list" in "list = SEXP_list_new_rv(list, memb, ap)" leaks the storage that "list" points to.
```
and
```
openscap-1.3.0_alpha1/src/OVAL/probes/SEAP/sexp-manip.c:1037: overwrite_var: Overwriting "sexp" in "sexp = SEXP_list_rest_r(sexp, list)" leaks the storage that "sexp" points to.
```

In both cases pointer variable is passed as an argument to a function which only accesses that pointer but does not modify it.