### PR TITLE
Move "fsdev" out of public API

### DIFF
--- a/docs/modules
+++ b/docs/modules
@@ -24,7 +24,6 @@
  *      @defgroup PROBEHANDLERS Probe handler API
  *      @defgroup PROBESESSION Probe session API
  *      @defgroup PROBEAPI Common probe API - object, entity, item manipulation
- *      @defgroup PROBEAUXAPI Auxilirary functions for probes
  *      @defgroup SEXPRESSIONS SEAP and S-expression API
  *   @}
  * @}

--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -3,8 +3,6 @@
  * @brief  fsdev API implementation
  * @author "Daniel Kopecek" <dkopecek@redhat.com>
  *
- * @addtogroup PROBEAUXAPI
- * @{
  */
 /*
  * Copyright 2009 Red Hat Inc., Durham, North Carolina.
@@ -467,4 +465,3 @@ int fsdev_fd(fsdev_t * lfs, int fd)
 
 	return fsdev_search(lfs, &st.st_dev);
 }
-/// @}

--- a/src/OVAL/probes/fsdev.h
+++ b/src/OVAL/probes/fsdev.h
@@ -1,10 +1,8 @@
 /**
  * @file   fsdev.h
- * @brief  fsdev API public header file
+ * @brief  fsdev header file
  * @author "Daniel Kopecek" <dkopecek@redhat.com>
  *
- * @addtogroup PROBEAUXAPI
- * @{
  */
 /*
  * Copyright 2009 Red Hat Inc., Durham, North Carolina.
@@ -49,23 +47,23 @@ typedef struct {
  * Initialize the fsdev_t structure from an array of filesystem
  * names.
  */
-OSCAP_API fsdev_t *fsdev_init(const char **fs, size_t fs_cnt);
+fsdev_t *fsdev_init(const char **fs, size_t fs_cnt);
 
 /**
  * Initialize the fsdev_t structure from a string containing filesystem
  * names.
  */
-OSCAP_API fsdev_t *fsdev_strinit(const char *fs_names);
+fsdev_t *fsdev_strinit(const char *fs_names);
 
 /**
  * Free the fsdev_t structure.
  */
-OSCAP_API void fsdev_free(fsdev_t * lfs);
+void fsdev_free(fsdev_t *lfs);
 
 /**
  * Search an id in the fsdev_t structure.
  */
-OSCAP_API int fsdev_search(fsdev_t * lfs, void *id);
+int fsdev_search(fsdev_t *lfs, void *id);
 
 /**
  * Check whether a path points points to a place on any of the devices
@@ -76,7 +74,7 @@ OSCAP_API int fsdev_search(fsdev_t * lfs, void *id);
  * @retval 0 otherwise
  * @retval -1 error
  */
-OSCAP_API int fsdev_path(fsdev_t * lfs, const char *path);
+int fsdev_path(fsdev_t *lfs, const char *path);
 
 /**
  * Check whether a file descriptor is associated with a file that resides
@@ -87,7 +85,6 @@ OSCAP_API int fsdev_path(fsdev_t * lfs, const char *path);
  * @retval 0 otherwise
  * @retval -1 error
  */
-OSCAP_API int fsdev_fd(fsdev_t * lfs, int fd);
+int fsdev_fd(fsdev_t *lfs, int fd);
 
 #endif				/* FSDEV_H */
-/// @}

--- a/tests/API/probes/CMakeLists.txt
+++ b/tests/API/probes/CMakeLists.txt
@@ -12,6 +12,7 @@ target_include_directories(test_api_probes_smoke PUBLIC
 file(GLOB_RECURSE OVAL_RESULTS_SOURCES "${CMAKE_SOURCE_DIR}/src/OVAL/results/oval_cmp*.c")
 add_oscap_test_executable(oval_fts_list
 	"oval_fts_list.c"
+	"${CMAKE_SOURCE_DIR}/src/OVAL/probes/fsdev.c"
 	"${CMAKE_SOURCE_DIR}/src/OVAL/probes/oval_fts.c"
 	"${CMAKE_SOURCE_DIR}/src/common/error.c"
 	"${CMAKE_SOURCE_DIR}/src/common/err_queue.c"


### PR DESCRIPTION
This is a low level implementation detail which we probably
shouldn't publish in our public API.