### PR TITLE
Fix some coverity issues for maint-1.2

### DIFF
--- a/src/OVAL/oval_sexp.c
+++ b/src/OVAL/oval_sexp.c
@@ -831,6 +831,8 @@ static struct oval_sysent *oval_sexp_to_sysent(struct oval_syschar_model *model,
 	    oval_message_set_text(msg, txt);
 	    oval_sysitem_add_message(item, msg);
 
+	    free(key);
+
 	    return (NULL);
 	}
 

--- a/src/OVAL/probes/probe-api.c
+++ b/src/OVAL/probes/probe-api.c
@@ -259,7 +259,6 @@ bool probe_item_filtered(const SEXP_t *item, const SEXP_t *filters)
 			}
 
 			if (SEXP_list_length(elm_res) > 0) {
-				free(elm_name);
 				r0 = probe_ent_getattrval(felm, "entity_check");
 
 				if (r0 == NULL)
@@ -270,13 +269,13 @@ bool probe_item_filtered(const SEXP_t *item, const SEXP_t *filters)
 				SEXP_free(r0);
 
 				ores = probe_ent_result_bychk(elm_res, ochk);
-				SEXP_free(elm_res);
 			} else {
-				SEXP_free(elm_res);
 				ores = OVAL_RESULT_FALSE;
 			}
 			SEXP_list_add(ste_res, r0 = SEXP_number_newi_32(ores));
 			SEXP_free(r0);
+			SEXP_free(elm_res);
+			free(elm_name);
 		}
 
 		r0 = probe_ent_getattrval(ste, "operator");

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -512,8 +512,6 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 
 		if (fork_result == 0)
 		{
-			free_env_values(env_values, index_of_first_env_value_not_compiled_in, env_value_count);
-
 			// we won't read from the pipes, so close the reading fd
 			close(stdout_pipefd[0]);
 			close(stderr_pipefd[0]);
@@ -539,6 +537,8 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 
 			// we are the child process
 			execve(tmp_href, argvp, env_values);
+
+			free_env_values(env_values, index_of_first_env_value_not_compiled_in, env_value_count);
 
 			// no need to check the return value of execve, if it returned at all we are in trouble
 			printf("Unexpected error when executing script '%s'. Error message follows.\n", href);


### PR DESCRIPTION
Fix:
 - free `key` from `src/OVAL/oval_sexp.c`
 - `elm_name` and `elm_res` from `src/OVAL/probes/probe-api.c`
 - `free_env_values` from `src/SCE/sce_engine.c`