### PR TITLE
Fix SCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ find_program(GIT_EXECUTABLE git)
 
 # ---------- CORE FEATURE SWITCHES
 
-option(ENABLE_SCE "enables Script Check Engine - an alternative checking engine that lets you use executables instead of OVAL for checks" FALSE)
+option(ENABLE_SCE "enables Script Check Engine - an alternative checking engine that lets you use executables instead of OVAL for checks" ON)
 
 # ---------- OVAL FEATURE SWITCHES
 

--- a/src/SCE/CMakeLists.txt
+++ b/src/SCE/CMakeLists.txt
@@ -1,7 +1,12 @@
 file(GLOB_RECURSE SCE_SOURCES "*.c")
 file(GLOB_RECURSE SCE_PUBLIC_HEADERS "public/*.h")
 
-add_library(openscap_sce SHARED ${SCE_SOURCES})
+add_library(openscap_sce SHARED
+	"${SCE_SOURCES}"
+	"${CMAKE_SOURCE_DIR}/src/common/list.c"
+	"${CMAKE_SOURCE_DIR}/src/common/oscap_string.c"
+	"${CMAKE_SOURCE_DIR}/src/common/oscap_buffer.c"
+)
 target_include_directories(openscap_sce PUBLIC public)
 set_target_properties(openscap_sce PROPERTIES VERSION ${SONAME} SOVERSION ${SOVERSION})
 target_link_libraries(openscap_sce PRIVATE openscap)


### PR DESCRIPTION
Fix SCE runtime crash

47878e9 has fixed symbol visibilty.
However, it has completely broken SCE. SCE uses some private API
functions. When the symbol visibility wasn't set correctly, it was able
to find the private functions in libopenscap.so. After we have fixed
visibility, SCE engine cannot resolve the symbols it needs to run.
Instead of making these functions public, we can add the source files
containing the problematic symbols to the source file list for SCE
library.


Build SCE by default

Downstream distributions as RHEL or Fedora build it anyway.
SCE library doesn't require any special dependencies.
By building SCE by default we will increase the probability
of running SCE tests and discovering potential issue.
