### PR TITLE
Fix 2 Coverity problems

### DIFF
--- a/src/CVRF/cvrf_priv.c
+++ b/src/CVRF/cvrf_priv.c
@@ -512,7 +512,6 @@ struct cvrf_vulnerability *cvrf_vulnerability_clone(const struct cvrf_vulnerabil
 }
 
 int cvrf_vulnerability_filter_by_product(struct cvrf_vulnerability *vuln, const char *prod) {
-	struct oscap_stringlist *filtered_ids = oscap_stringlist_new();
 	int ret = 0;
 
 	struct cvrf_product_status_iterator *statuses = cvrf_vulnerability_get_product_statuses(vuln);
@@ -520,6 +519,7 @@ int cvrf_vulnerability_filter_by_product(struct cvrf_vulnerability *vuln, const 
 		struct cvrf_product_status *stat = cvrf_product_status_iterator_next(statuses);
 
 		struct oscap_string_iterator *products = cvrf_product_status_get_ids(stat);
+		struct oscap_stringlist *filtered_ids = oscap_stringlist_new();
 		while (oscap_string_iterator_has_more(products)) {
 			const char *product_id = oscap_string_iterator_next(products);
 			if (oscap_str_startswith(product_id, prod))

--- a/src/OVAL/probes/unix/linux/iflisteners.c
+++ b/src/OVAL/probes/unix/linux/iflisteners.c
@@ -353,7 +353,7 @@ static int get_interface(const int ent_ifindex, struct interface_t *interface) {
 				*(interface->hw_address) = '\0';
 			}
 			else {
-				if (fscanf(fd, "%s\n", buf) < 1)
+				if (fscanf(fd, "%254s\n", buf) < 1)
 					*buf = '\0';
 
 				snprintf(interface->hw_address, sizeof interface->hw_address, "%s", buf);


### PR DESCRIPTION

* Plug a memory leak in CVRF

If there is 0 iterations of the outer while loop, the 'filtered_ids'
variable isn't freed. Fortunately, we can allocate it inside
the while loop. If it's not free'd in this function, it is free'd
in cvrf_product_status_free.


* Specify size of the buffer in fscanf

The terminating null byte is not included in the length.

