### PR TITLE
Fixed memory leaks in a test.

### DIFF
--- a/tests/API/probes/oval_fts_list.c
+++ b/tests/API/probes/oval_fts_list.c
@@ -83,6 +83,12 @@ static int create_filename_sexpr(char *arg_operation, char *arg_argument, SEXP_t
 		SEXP_list_add(*result, s_filename_argument);
 	}
 
+	SEXP_free(s_filename_str);
+	SEXP_free(s_operation_str);
+	SEXP_free(s_operation_number);
+	SEXP_free(s_filename_argument);
+	SEXP_free(s_inner_list);
+
 	return 0;
 }
 


### PR DESCRIPTION
The Coverity reported only one omission, but IMO there were much more:

```
Error: RESOURCE_LEAK (CWE-772): [#def4]
openscap-1.3.0/tests/API/probes/oval_fts_list.c:69: alloc_fn: Storage is returned from allocation function "SEXP_string_new".
openscap-1.3.0/src/OVAL/probes/SEAP/sexp-manip.c:605:9: alloc_fn: Storage is returned from allocation function "SEXP_new".
openscap-1.3.0/src/OVAL/probes/SEAP/sexp-manip.c:1593:16: alloc_fn: Storage is returned from allocation function "malloc".
openscap-1.3.0/src/OVAL/probes/SEAP/sexp-manip.c:1593:16: var_assign: Assigning: "s_exp" = "malloc(16UL)".
openscap-1.3.0/src/OVAL/probes/SEAP/sexp-manip.c:1602:9: return_alloc: Returning allocated memory "s_exp".
openscap-1.3.0/src/OVAL/probes/SEAP/sexp-manip.c:605:9: var_assign: Assigning: "sexp" = "SEXP_new()".
openscap-1.3.0/src/OVAL/probes/SEAP/sexp-manip.c:606:9: identity_transfer: Passing "sexp" as argument 1 to function "SEXP_string_new_r", which returns that argument.
openscap-1.3.0/src/OVAL/probes/SEAP/sexp-manip_r.c:228:9: return_parm: Returning parameter "sexp_mem".
openscap-1.3.0/src/OVAL/probes/SEAP/sexp-manip.c:606:9: noescape: Resource "sexp" is not freed or pointed-to in function "SEXP_string_new_r".
openscap-1.3.0/src/OVAL/probes/SEAP/sexp-manip_r.c:206:37: noescape: "SEXP_string_new_r(SEXP_t *, void const *, size_t)" does not free or save its parameter "sexp_mem".
openscap-1.3.0/src/OVAL/probes/SEAP/sexp-manip.c:606:9: var_assign: Assigning: "sexp" = "SEXP_string_new_r(sexp, string, length)".
openscap-1.3.0/src/OVAL/probes/SEAP/sexp-manip.c:608:9: return_alloc: Returning allocated memory "sexp".
openscap-1.3.0/tests/API/probes/oval_fts_list.c:69: var_assign: Assigning: "s_filename_argument" = storage returned from "SEXP_string_new("", 0UL)".
openscap-1.3.0/tests/API/probes/oval_fts_list.c:86: leaked_storage: Variable "s_filename_argument" going out of scope leaks the storage it points to.
#   84|   	}
#   85|   
#   86|-> 	return 0;
#   87|   }
#   88|   
```