### PR TITLE
Removed redundant free.

### DIFF
--- a/swig/src/openscap.i
+++ b/swig/src/openscap.i
@@ -87,7 +87,6 @@
     }
     $1[i] = 0;
   } else {
-    free($1);
     PyErr_SetString(PyExc_TypeError,"not a list");
     SWIG_fail;
   }


### PR DESCRIPTION
The free is not needed after PR #1238 was merged and the memory is freed in the `fail` section.