### PR TITLE
Add maint-1.3 to Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ version: master-{build}
 branches:
   only:
   - master
+  - maint-1.3
 image: Visual Studio 2017
 configuration: Release
 clone_folder: c:\projects\openscap


### PR DESCRIPTION
Adds maint-1.3 to the list because AppVeyor CI only builds branches
specified in `appveyor.yml`.