### PR TITLE
Ensure there are no unresolved symbols in libopenscap_sce.so

### DIFF
--- a/src/SCE/CMakeLists.txt
+++ b/src/SCE/CMakeLists.txt
@@ -3,9 +3,12 @@ file(GLOB_RECURSE SCE_PUBLIC_HEADERS "public/*.h")
 
 add_library(openscap_sce SHARED
 	${SCE_SOURCES}
+	"${CMAKE_SOURCE_DIR}/src/common/error.c"
+	"${CMAKE_SOURCE_DIR}/src/common/err_queue.c"
 	"${CMAKE_SOURCE_DIR}/src/common/list.c"
 	"${CMAKE_SOURCE_DIR}/src/common/oscap_string.c"
 	"${CMAKE_SOURCE_DIR}/src/common/oscap_buffer.c"
+	"${CMAKE_SOURCE_DIR}/src/common/util.c"
 )
 target_include_directories(openscap_sce PUBLIC public)
 set_target_properties(openscap_sce PROPERTIES VERSION ${SONAME} SOVERSION ${SOVERSION})


### PR DESCRIPTION
After installing the library to /usr/lib64/ oscap wasn't able to find
SCE plugin and SCE was not shown in list of plugins in `oscap -V`. That
was because the `libopenscap_sce.so` library could not be loaded because
it contained unresolved symbol `__oscap_seterr`. We need to add
`error.c` and its dependencies to make sure `ldd` doesn't report any
unresolved symbols.