### PR TITLE
RHBZ#1642283: Segmentation fault in CVRF

### DIFF
--- a/src/CVRF/cvrf_eval.c
+++ b/src/CVRF/cvrf_eval.c
@@ -89,10 +89,14 @@ struct cvrf_session *cvrf_session_new_from_source_model(struct oscap_source *sou
 	if (source == NULL)
 		return NULL;
 
+	struct cvrf_model *model = cvrf_model_import(source);
+	if (model == NULL) {
+		return NULL;
+	}
 	struct cvrf_session *ret = malloc(sizeof(struct cvrf_session));
 	ret->source = source;
 	ret->index = NULL;
-	ret->model = cvrf_model_import(source);
+	ret->model = model;
 	ret->os_name = NULL;
 	ret->product_ids = oscap_stringlist_new();
 	ret->def_model = oval_definition_model_new();
@@ -225,6 +229,9 @@ struct oscap_source *cvrf_model_get_results_source(struct oscap_source *import_s
 	if (import_source == NULL)
 		return NULL;
 	struct cvrf_session *session = cvrf_session_new_from_source_model(import_source);
+	if (session == NULL) {
+		return NULL;
+	}
 	cvrf_session_set_os_name(session, os_name);
 
 	if (find_all_cvrf_product_ids_from_cpe(session) != 0) {

--- a/utils/oscap-cvrf.c
+++ b/utils/oscap-cvrf.c
@@ -99,20 +99,29 @@ static int app_cvrf_evaluate(const struct oscap_action *action) {
 	// themselves
 	const char *os_name = "Red Hat Enterprise Linux Desktop Supplementary (v. 6)";
 	struct oscap_source *import_source = oscap_source_new_from_file(action->cvrf_action->f_cvrf);
+
+	int ret = oscap_source_validate(import_source, reporter, (void *) action);
+	if (ret != 0) {
+		result = OSCAP_ERROR;
+		goto cleanup;
+	}
+
 	struct oscap_source *export_source = cvrf_model_get_results_source(import_source, os_name);
-	if (export_source == NULL)
-		return -1;
+	if (export_source == NULL) {
+		result = OSCAP_ERROR;
+		goto cleanup;
+	}
 
 	if (oscap_source_save_as(export_source, action->cvrf_action->f_results) == -1) {
 		result = OSCAP_ERROR;
 		goto cleanup;
 	}
+	oscap_source_free(export_source);
 
 	cleanup:
 		if (oscap_err())
 			fprintf(stderr, "%s %s\n", OSCAP_ERR_MSG, oscap_err_desc());
 
-	oscap_source_free(export_source);
 	free(action->cvrf_action);
 	return result;
 }


### PR DESCRIPTION
Addressing:
```
 #0  0x00007ffff4b486e9 in cvrf_model_filter_by_cpe (model=0x0,
    cpe=0x600c0000bde0 "Red Hat Enterprise Linux Desktop Supplementary
(v. 6)")
    at cvrf_priv.c:1293
 #1  0x00007ffff4b4d35e in find_all_cvrf_product_ids_from_cpe (
    session=session@entry=0x60080000a4d0) at cvrf_eval.c:172
 #2  0x00007ffff4b4debe in cvrf_model_get_results_source
(import_source=<optimized out>,
    os_name=os_name@entry=0x555555584660 "Red Hat Enterprise Linux
Desktop Supplementary (v. 6)") at cvrf_eval.c:230
 #3  0x0000555555574c58 in app_cvrf_evaluate (action=0x7fffffffe2c0) at
oscap-cvrf.c:102
 #4  0x0000555555566e16 in oscap_module_call (action=0x7fffffffe2c0) at
oscap-tool.c:261
 #5  oscap_module_process (module=0x55555578ffc0 <CVRF_EVALUATE_MODULE>,
    module@entry=0x55555578a120 <OSCAP_ROOT_MODULE>, argc=argc@entry=4,
    argv=argv@entry=0x7fffffffe5b8) at oscap-tool.c:346
 #6  0x0000555555564c32 in main (argc=4, argv=0x7fffffffe5b8) at
oscap.c:83
```