### PR TITLE
Check if system has enough memory

### DIFF
--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -109,6 +109,7 @@ oval_agent_session_t * oval_agent_new_session(struct oval_definition_model *mode
 	if (ret != 0) {
 		oval_probe_session_destroy(ag_sess->psess);
 		oval_syschar_model_free(ag_sess->sys_model);
+		free(ag_sess->filename);
 		free(ag_sess);
 		return NULL;
 	}

--- a/src/OVAL/probes/probe/icache.c
+++ b/src/OVAL/probes/probe/icache.c
@@ -502,16 +502,9 @@ static int probe_cobj_memcheck()
  */
 int probe_item_collect(struct probe_ctx *ctx, SEXP_t *item)
 {
-	SEXP_t *cobj_content;
-	size_t  cobj_itemcnt;
-
 	assume_d(ctx != NULL, -1);
 	assume_d(ctx->probe_out != NULL, -1);
 	assume_d(item != NULL, -1);
-
-	cobj_content = SEXP_listref_nth(ctx->probe_out, 3);
-	cobj_itemcnt = SEXP_list_length(cobj_content);
-	SEXP_free(cobj_content);
 
 	if (probe_cobj_memcheck() != 0) {
 

--- a/src/common/memusage.c
+++ b/src/common/memusage.c
@@ -51,6 +51,8 @@ static int read_common_sizet(void *szp, char *strval)
 		return (-1);
 
 	*end = '\0';
+
+	errno = 0;
 	*(size_t *)szp = strtoll(strval, NULL, 10);
 
 	if (errno == EINVAL ||


### PR DESCRIPTION
As a team effort we tried to mitigate `oscap` memory consumption.
We found out that there is already code that checks for memory
limits, but unfortunately it was never run, because a wrong SEXP
was measured. We will instead count items collected by each thread
and every 100 collections we will check if the system has enough
free memory.