### PR TITLE
Fix issues with trailing whitespaces in op_assign_str()

### DIFF
--- a/src/OVAL/probes/unix/xinetd_probe.c
+++ b/src/OVAL/probes/unix/xinetd_probe.c
@@ -1307,17 +1307,16 @@ int op_assign_str(void *var, char *val)
 	while(isspace(*val)) ++val;
 
 	if (*val != '\0') {
-		/* if trailing whitespaces exist strip them */
-		if ((strend = strchr(val, ' ')) || (strend = strchr(val, '\t'))) {
-			strend = strrchr(strend, '\0');
-			do {
-				strend--;
-			} while(isspace(*strend));
-			assert((strend-val) > 0);
-			*((char **)(var)) = strndup(val, (strend-val+1));
-		} else {
-			*((char **)(var)) = strdup(val);
-                }
+		strend = strrchr(val, '\0');
+		/* strip trailing whitespaces */
+		do {
+			strend--;
+		} while(isspace(*strend));
+		if((strend-val) < 0) {
+			dE("Error stripping white space from string '%s'", val);
+			return (-1);
+		}
+		*((char **)(var)) = strndup(val, (strend-val+1));
 		return (0);
 	} else
 		return (-1);

--- a/src/OVAL/probes/unix/xinetd_probe.c
+++ b/src/OVAL/probes/unix/xinetd_probe.c
@@ -1298,6 +1298,7 @@ int op_merge_u16(void *dst, void *src, int type)
 
 int op_assign_str(void *var, char *val)
 {
+	char *strend = NULL;
 	if (var == NULL) {
 		return -1;
 	}
@@ -1306,7 +1307,17 @@ int op_assign_str(void *var, char *val)
 	while(isspace(*val)) ++val;
 
 	if (*val != '\0') {
-		*((char **)(var)) = strdup(val);
+		/* if trailing whitespaces exist strip them */
+		if ((strend = strchr(val, ' ')) || (strend = strchr(val, '\t'))) {
+			strend = strrchr(strend, '\0');
+			do {
+				strend--;
+			} while(isspace(*strend));
+			assert((strend-val) > 0);
+			*((char **)(var)) = strndup(val, (strend-val+1));
+		} else {
+			*((char **)(var)) = strdup(val);
+                }
 		return (0);
 	} else
 		return (-1);


### PR DESCRIPTION
This fixes issues with the test_probe_xinetd_duplicates unit test should
there be no /etc/services for whatever reason.