### PR TITLE
Change test_sysctl_probe_all to succeed for non-root users

### DIFF
--- a/tests/probes/sysctl/test_sysctl_probe_all.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_all.sh
@@ -4,6 +4,13 @@
 
 set -e -o pipefail
 
+# on some systems sysctl might live in sbin, which can cause problems for
+# non root users
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
+
+# non root users are not able to access some kernel params, so they get blacklisted
+SYSCTL_BLACKLIST='stable_secret\|vm.stat_refresh\|fs.protected_hardlinks\|fs.protected_symlinks\|kernel.cad_pid\|kernel.unprivileged_userns_apparmor_policy\|kernel.usermodehelper.bset\|kernel.usermodehelper.inheritable\|net.core.bpf_jit_harden\|net.core.bpf_jit_kallsyms\|net.ipv4.tcp_fastopen_key\|vm.mmap_rnd_bits\|vm.mmap_rnd_compat_bits'
+
 function perform_test {
 probecheck "sysctl" || return 255
 
@@ -24,9 +31,9 @@ $OSCAP oval eval --results $result $srcdir/test_sysctl_probe_all.oval.xml > /dev
 # sysctl has duplicities in output
 # hide permission errors like: "sysctl: permission denied on key 'fs.protected_hardlinks'"
 # kernel parameters might use "/" and "." separators interchangeably - normalizing
-sysctl -aN --deprecated 2> /dev/null | tr "/" "." | sort -u > "$sysctlNames"
+sysctl -aN --deprecated 2> /dev/null | grep -v $SYSCTL_BLACKLIST | tr "/" "." | sort -u > "$sysctlNames"
 
-grep unix-sys:name "$result" | sed -E 's;.*>(.*)<.*;\1;g' | sort > "$ourNames"
+grep unix-sys:name "$result" | grep -v $SYSCTL_BLACKLIST | sed -E 's;.*>(.*)<.*;\1;g' | sort > "$ourNames"
 
 # If procps_ver > 3.3.12 we need to filter *stable_secret and vm.stat_refresh
 # options from the sysctl output, for more details see


### PR DESCRIPTION
- add blacklist for confidential kernel params
- set PATH explicitly to make sure sysctl is found

fix for #1263