### PR TITLE
Disable test_probes_rpmverifypackage_epoch for Suse based systems

### DIFF
--- a/tests/probes/rpmverifypackage/test_probes_rpmverifypackage.sh
+++ b/tests/probes/rpmverifypackage/test_probes_rpmverifypackage.sh
@@ -14,6 +14,8 @@
 set -e -o pipefail
 set -x
 
+[ -f /etc/os-release ] && . /etc/os-release
+
 function test_probes_rpmverifypackage {
 
     probecheck "rpmverifypackage" || return 255
@@ -79,7 +81,9 @@ function test_probes_rpmverifypackage_noepoch {
 
 test_init
 
+if [[ $ID_LIKE != *"suse"* ]]; then
 test_run "test_probes_rpmverifypackage_epoch" test_probes_rpmverifypackage_epoch
+fi
 test_run "test_probes_rpmverifypackage_noepoch" test_probes_rpmverifypackage_noepoch
 
 test_exit

--- a/tests/probes/rpmverifypackage/test_probes_rpmverifypackage.sh
+++ b/tests/probes/rpmverifypackage/test_probes_rpmverifypackage.sh
@@ -81,7 +81,7 @@ function test_probes_rpmverifypackage_noepoch {
 
 test_init
 
-if [[ $ID != *"sle"* && $ID != *"suse"* ]] then
+if [[ $ID != *"sle"* && $ID != *"suse"* ]]; then
 test_run "test_probes_rpmverifypackage_epoch" test_probes_rpmverifypackage_epoch
 fi
 test_run "test_probes_rpmverifypackage_noepoch" test_probes_rpmverifypackage_noepoch

--- a/tests/probes/rpmverifypackage/test_probes_rpmverifypackage.sh
+++ b/tests/probes/rpmverifypackage/test_probes_rpmverifypackage.sh
@@ -81,7 +81,7 @@ function test_probes_rpmverifypackage_noepoch {
 
 test_init
 
-if [[ $ID_LIKE != *"suse"* ]]; then
+if [[ $ID != *"sle"* && $ID != *"suse"* ]] then
 test_run "test_probes_rpmverifypackage_epoch" test_probes_rpmverifypackage_epoch
 fi
 test_run "test_probes_rpmverifypackage_noepoch" test_probes_rpmverifypackage_noepoch


### PR DESCRIPTION
Suse does not use epoch for rpms, therefor the test will always fail.

fix for #1264