### PR TITLE
Show details in HTML report by default if --results-arf is given

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1327,7 +1327,7 @@ int xccdf_session_export_xccdf(struct xccdf_session *session)
 
 	struct oscap_source* results = session->xccdf.result_source;
 	struct oscap_source* arf = NULL;
-	if (session->export.oval_results) {
+	if (session->export.oval_results || session->export.arf_file) {
 		arf = xccdf_session_create_arf_source(session);
 		if (arf == NULL) {
 			return 1;


### PR DESCRIPTION
This commit changes the `oscap` behavior in the following way:
If `oscap xccdf eval` is called with both `--results-arf` and
`--report` the HTML report will contain `OVAL details` section
even if `--oval-results` is not given by the user.
I think we can do it because the ARF file already contains OVAL
results anyway. I think it's not convenient to type `--oval-results`
explicitly.