### PR TITLE
dpkginfo_init doesn't check if dpkg cache initialization has succeeded.

### DIFF
--- a/src/OVAL/probes/unix/linux/dpkginfo.c
+++ b/src/OVAL/probes/unix/linux/dpkginfo.c
@@ -62,16 +62,23 @@
 
 
 struct dpkginfo_global {
+        int init_done;
         pthread_mutex_t mutex;
 };
 
-static struct dpkginfo_global g_dpkg;
+static struct dpkginfo_global g_dpkg = {
+        .init_done = -1,
+};
 
 
 void *probe_init(void)
 {
         pthread_mutex_init (&(g_dpkg.mutex), NULL);
-        dpkginfo_init();
+
+        g_dpkg.init_done = dpkginfo_init();
+        if (g_dpkg.init_done < 0) {
+                dE("dpkginfo_init has failed.");
+        }
 
         return ((void *)&g_dpkg);
 }
@@ -96,6 +103,11 @@ int probe_main (probe_ctx *ctx, void *arg)
 	if (arg == NULL) {
 		return PROBE_EINIT;
 	}
+
+        if (g_dpkg.init_done < 0) {
+                probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_UNKNOWN);
+                return 0;
+        }
 
 	obj = probe_ctx_getobject(ctx);
 	ent = probe_obj_getent(obj, "name", 1);


### PR DESCRIPTION
It may happen that 'Dir::Cache::pkgcache' is set to an empty string
to save some space (e.g. Ubuntu Xenial docker image does that), and in
such case calling dpkginfo_probe_main will end up in a SEGFAULT.

This commit checks if dpkg initialization has succeded before performing
any check.

This issue affects 1.2 and 1.3 versions of OpenSCAP.

Fix for 1.3 - https://github.com/OpenSCAP/openscap/pull/1270