### PR TITLE
Prevent duplicate variables in Ansible Playbooks

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -733,26 +733,17 @@ static int _xccdf_policy_rule_get_fix_text(struct xccdf_policy *policy, struct x
 
 static int _xccdf_policy_rule_generate_fix(struct xccdf_policy *policy, struct xccdf_rule *rule, const char *template, int output_fd, unsigned int current, unsigned int total)
 {
-	char *fix_text = NULL;
-	int ret = _xccdf_policy_rule_get_fix_text(policy, rule, template, &fix_text);
-	if (fix_text == NULL || ret != 0) {
-		ret = _write_fix_header_to_fd(template, output_fd, rule, current, total);
-		if (ret != 0) {
-			return ret;
-		}
-		ret = _write_fix_missing_warning_to_fd(template, output_fd, rule);
-		if (ret != 0) {
-			return ret;
-		}
-		ret = _write_fix_footer_to_fd(template, output_fd, rule);
-		return ret;
-	}
-	ret = _write_fix_header_to_fd(template, output_fd, rule, current, total);
+	int ret = _write_fix_header_to_fd(template, output_fd, rule, current, total);
 	if (ret != 0) {
-		free(fix_text);
 		return ret;
 	}
-	ret = _write_remediation_to_fd_and_free(output_fd, template, fix_text);
+	char *fix_text = NULL;
+	ret = _xccdf_policy_rule_get_fix_text(policy, rule, template, &fix_text);
+	if (fix_text == NULL || ret != 0) {
+		ret = _write_fix_missing_warning_to_fd(template, output_fd, rule);
+	} else {
+		ret = _write_remediation_to_fd_and_free(output_fd, template, fix_text);
+	}
 	if (ret != 0) {
 		return ret;
 	}

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -731,7 +731,7 @@ static int _xccdf_policy_rule_get_fix_text(struct xccdf_policy *policy, struct x
 	return 0;
 }
 
-static int _xccdf_policy_rule_generate_fix(struct xccdf_policy *policy, struct xccdf_rule *rule, const char *template, int output_fd, unsigned int current, unsigned int total, bool ansible_variable_mode)
+static int _xccdf_policy_rule_generate_fix(struct xccdf_policy *policy, struct xccdf_rule *rule, const char *template, int output_fd, unsigned int current, unsigned int total)
 {
 	char *fix_text = NULL;
 	int ret = _xccdf_policy_rule_get_fix_text(policy, rule, template, &fix_text);
@@ -1016,7 +1016,7 @@ int xccdf_policy_generate_fix(struct xccdf_policy *policy, struct xccdf_result *
 		struct oscap_iterator *rules_to_fix_it = oscap_iterator_new(rules_to_fix);
 		while (oscap_iterator_has_more(rules_to_fix_it)) {
 			struct xccdf_rule *rule = (struct xccdf_rule*)oscap_iterator_next(rules_to_fix_it);
-			ret = _xccdf_policy_rule_generate_fix(policy, rule, sys, output_fd, current++, total, false);
+			ret = _xccdf_policy_rule_generate_fix(policy, rule, sys, output_fd, current++, total);
 			if (ret != 0)
 				break;
 		}


### PR DESCRIPTION
The same XCCDF value can appear in multiple rules, which means
there can be same variable in multiple Ansible task. But when
we generate a Playbook we should put the variable only once.
Ansible produces a warning if there are multiple definitions
of the same variable.

See https://github.com/OpenSCAP/openscap/pull/896 for further context if you are interested.