### PR TITLE
fix pull request gating on Python3-only systems

### DIFF
--- a/tests/nist/nist_test.sh
+++ b/tests/nist/nist_test.sh
@@ -24,7 +24,7 @@ function test_nist {
 		if [ "x$test_dir" == "xR1200" ]; then
 			unset OSCAP_FULL_VALIDATION
 		fi
-		"${srcdir}/test_worker.py" --scanner "$OSCAP" --outputdir "${builddir}/tests/nist/$test_dir/" "${srcdir}/$test_dir/"
+		"$PREFERRED_PYTHON" "${srcdir}/test_worker.py" --scanner "$OSCAP" --outputdir "${builddir}/tests/nist/$test_dir/" "${srcdir}/$test_dir/"
 	)
 	ret_val=$?
 	if [ $ret_val -eq 1 ]; then

--- a/tests/test_common.sh.in
+++ b/tests/test_common.sh.in
@@ -11,6 +11,8 @@
 # Normalized path.
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
+PREFERRED_PYTHON=@preferred_python@
+
 # Some of the tests rely on the "C" locale and would fail with some locales.
 LC_ALL=C
 export LC_ALL


### PR DESCRIPTION
1. Use preferred python for NIST test
Recently we have realized that we want to run gating CI of PRs
of maint-1.2 branch on Python3-only operating systems. Therefore
we need to use the Python version found by configure script.