### PR TITLE
Increased flexibility of the Python remediation script runner.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1103,6 +1103,12 @@ AC_ARG_WITH([crypto],
      [],
      [crypto=gcrypt])
 
+AC_ARG_WITH([preferred-python],
+	[AS_HELP_STRING([--with-preferred-python], [Set the preferred Python interpreter for oscap-docker and remediations [default=autodetection]])],
+	[preferred_python="$withval"],
+	[preferred_python=:])
+
+
 if test "x${libexecdir}" = xNONE; then
 	probe_dir="/usr/local/libexec/openscap"
 else
@@ -1314,9 +1320,7 @@ test "x$HAVE_PYTHON2" = xyes && PYTHON="$PYTHON2"
 test "x$HAVE_PYTHON3" = xyes && PYTHON="$PYTHON3"
 AC_SUBST([PYTHON])
 
-preferred_python=:
-
-AS_IF([test "x$util_oscap_docker" = xyes],
+AS_IF([test "x$util_oscap_docker" = xyes -a "x$preferred_python" = :],
 	[_ATTEMPT_TO_SET_PREFERRED_PYTHON_FOR_OSCAP_DOCKER(2)
 	_ATTEMPT_TO_SET_PREFERRED_PYTHON_FOR_OSCAP_DOCKER(3)
 	AS_IF([test "$preferred_python" = :],
@@ -1326,12 +1330,20 @@ AS_IF([test "x$util_oscap_docker" = xyes],
 			preferred_python="$PYTHON"],
 			[AC_MSG_ERROR([Not found a working Python interpreter and oscap-docker needs it. Aborting, as oscap-docker has been requested.])])])])
 
+# No preferred python, but also no oscap_docker required
+AS_IF([test "$preferred_python" = :],
+	[AS_IF([test "$PYTHON" != :],
+		[AC_MSG_NOTICE([Setting the preferred python interpreter to '$PYTHON'.])
+		preferred_python="$PYTHON"],
+		[AC_MSG_NOTICE([Not found a working Python interpreter, so Python remediations aren't supported.])])])
+
 # oscap-docker determine python dir on default python version
 OSCAPDOCKER_PYTHONDIR=`$preferred_python -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(0,0,prefix='$' '{prefix}'))"`
 # oscap-docker uses preferred_python substitution
 AC_SUBST([preferred_python])
 AC_SUBST(oscapdocker_pythondir, $OSCAPDOCKER_PYTHONDIR)
-
+AS_IF([test "$preferred_python" != :],
+	[AC_DEFINE_UNQUOTED([PREFERRED_PYTHON_PATH], ["$preferred_python"], [Path to the preferred Python interpreter executable.])])
 
 AM_CONDITIONAL([probe_family_enabled], test "$probe_family_req_deps_ok" = yes)
 probe_family_enabled=$probe_family_req_deps_ok

--- a/m4/python.m4
+++ b/m4/python.m4
@@ -161,6 +161,7 @@ AC_DEFUN([AM_PATH_PYTHON_OF_MAJOR_VERSION],
 	AS_IF([test "$PYTHON$1" = :],
 		[m4_default([$4], [AC_MSG_ERROR([no suitable Python$1 interpreter found])])
 ], [
+		AC_DEFINE_UNQUOTED([PYTHON$1_PATH], ["$PYTHON$1"], [Path to the Python $1 interpreter executable.])
 		dnl Query Python for its major.minor version numbers.
 		dnl Getting [:2] seems to be the best way to do this;
 		dnl it's what "site.py" does in the standard library.

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -18,7 +18,7 @@
  *
  */
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #include <string.h>
@@ -182,7 +182,15 @@ static const char *_get_supported_interpret(const char *sys, const struct _inter
 		{"urn:xccdf:fix:commands",		"/bin/bash"},
 		{"urn:xccdf:fix:script:sh",		"/bin/bash"},
 		{"urn:xccdf:fix:script:perl",		"/usr/bin/perl"},
-		{"urn:xccdf:fix:script:python",		"/usr/bin/python"},
+#ifdef PREFERRED_PYTHON_PATH
+		{"urn:xccdf:fix:script:python",		PREFERRED_PYTHON_PATH},
+#endif
+#ifdef PYTHON2_PATH
+		{"urn:xccdf:fix:script:python2",	PYTHON2_PATH},
+#endif
+#ifdef PYTHON3_PATH
+		{"urn:xccdf:fix:script:python3",	PYTHON3_PATH},
+#endif
 		{"urn:xccdf:fix:script:csh",		"/bin/csh"},
 		{"urn:xccdf:fix:script:tclsh",		"/usr/bin/tclsh"},
 		{"urn:xccdf:fix:script:javascript",	"/usr/bin/js"},

--- a/tests/API/XCCDF/unittests/test_remediate_python.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_remediate_python.xccdf.xml
@@ -8,7 +8,7 @@
 import os
 def touch(fname, times=None):
     if not os.path.exists(fname):
-	open(fname, 'w').close()
+        open(fname, 'w').close()
 
 touch('test_file')
     </fix>

--- a/tests/API/XCCDF/unittests/test_remediate_python_subs.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_remediate_python_subs.xccdf.xml
@@ -5,7 +5,7 @@
 import os
 def touch(fname, times=None):
     if not os.path.exists(fname):
-	open(fname, 'w').close()
+        open(fname, 'wb').close()
   </plain-text>
   <version>1.0</version>
   <Value id="xccdf_moc.elpmaxe.www_value_1">


### PR DESCRIPTION
* Added possibility to specify Python interpreter for `urn:xccdf:fix:script:python` using `--with-preferred-python` configure argument.
* Added support for explicit `urn:xccdf:fix:script:python2` and `urn:xccdf:fix:script:python3`.
* Fixed tests that were broken for Python3.