### PR TITLE
Expand the sysctl test blacklist so it passes.

### DIFF
--- a/tests/probes/sysctl/test_sysctl_probe_all.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_all.sh
@@ -11,6 +11,8 @@ PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 # non root users are not able to access some kernel params, so they get blacklisted
 SYSCTL_BLACKLIST='
 	fs.protected_hardlinks
+	fs.protected_fifos
+	fs.protected_regular
 	fs.protected_symlinks
 	kernel.cad_pid
 	kernel.unprivileged_userns_apparmor_policy


### PR DESCRIPTION
Complements #1265, fixes #1263.