### PR TITLE
Always show OVAL details in HTML report

### DIFF
--- a/src/OVAL/results/oval_resultSystem.c
+++ b/src/OVAL/results/oval_resultSystem.c
@@ -426,30 +426,32 @@ xmlNode *oval_result_system_to_dom(struct oval_result_system * sys,
 
 	struct oval_smc *tstmap = oval_smc_new();
 
-	xmlNode *definitions_node = xmlNewTextChild(system_node, ns_results, BAD_CAST "definitions", NULL);
 	struct oval_definition_model *definition_model = oval_results_model_get_definition_model(results_model);
 	struct oval_definition_iterator *oval_definitions = oval_definition_model_get_definitions(definition_model);
-	while(oval_definition_iterator_has_more(oval_definitions)) {
-		struct oval_definition *oval_definition = oval_definition_iterator_next(oval_definitions);
+	if(oval_definition_iterator_has_more(oval_definitions)) {
+		xmlNode *definitions_node = xmlNewTextChild(system_node, ns_results, BAD_CAST "definitions", NULL);
+		while(oval_definition_iterator_has_more(oval_definitions)) {
+			struct oval_definition *oval_definition = oval_definition_iterator_next(oval_definitions);
 
-		oval_definition_class_t def_class = oval_definition_get_class(oval_definition);
-		class_dirs = oval_directives_model_get_classdir(directives_model, def_class);
-		directives = class_dirs ? class_dirs : def_dirs;
+			oval_definition_class_t def_class = oval_definition_get_class(oval_definition);
+			class_dirs = oval_directives_model_get_classdir(directives_model, def_class);
+			directives = class_dirs ? class_dirs : def_dirs;
 
-		bool exported = false;
-		struct oval_iterator *rslt_definitions_it = oval_smc_get_all_it(sys->definitions, oval_definition_get_id(oval_definition));
-		if (rslt_definitions_it != NULL) {
-			while (oval_collection_iterator_has_more(rslt_definitions_it)) {
-				struct oval_result_definition *rslt_definition = oval_collection_iterator_next(rslt_definitions_it);
-				_oval_result_definition_to_dom_based_on_directives(rslt_definition, directives, doc, definitions_node, tstmap);
-				exported = true;
+			bool exported = false;
+			struct oval_iterator *rslt_definitions_it = oval_smc_get_all_it(sys->definitions, oval_definition_get_id(oval_definition));
+			if (rslt_definitions_it != NULL) {
+				while (oval_collection_iterator_has_more(rslt_definitions_it)) {
+					struct oval_result_definition *rslt_definition = oval_collection_iterator_next(rslt_definitions_it);
+					_oval_result_definition_to_dom_based_on_directives(rslt_definition, directives, doc, definitions_node, tstmap);
+					exported = true;
+				}
+				oval_collection_iterator_free(rslt_definitions_it);
 			}
-			oval_collection_iterator_free(rslt_definitions_it);
-		}
-		if (!exported) {
-			struct oval_result_definition *rslt_definition = oval_result_system_get_new_definition(sys, oval_definition, 1);
-			if (rslt_definition) {
-				_oval_result_definition_to_dom_based_on_directives(rslt_definition, directives, doc, definitions_node, tstmap);
+			if (!exported) {
+				struct oval_result_definition *rslt_definition = oval_result_system_get_new_definition(sys, oval_definition, 1);
+				if (rslt_definition) {
+					_oval_result_definition_to_dom_based_on_directives(rslt_definition, directives, doc, definitions_node, tstmap);
+				}
 			}
 		}
 	}

--- a/tests/oval_details/test_oval_details.sh
+++ b/tests/oval_details/test_oval_details.sh
@@ -14,13 +14,15 @@ function test_oval_details_implicit {
   # Tests if OVAL Details are present in HTML report by default
   # without specifing --oval-results --results (new behavior)
   xccdffile=$srcdir/$1.xccdf.xml
-  resultfile=$output_dir/$1.result.xml
   reportfile=$output_dir/$1.report.html
+  resultfile="$1.result.xml"
   oval_resultfile="$1.oval.xml.result.xml"
   $OSCAP xccdf eval --report $reportfile $xccdffile
   [ -f $reportfile ]
   [ ! -f $resultfile ]
+  [ ! -f $output_dir/$resultfile ]
   [ ! -f $oval_resultfile ]
+  [ ! -f $output_dir/$oval_resultfile ]
   grep -i $2 $reportfile >/dev/null && grep -i $3 $reportfile >/dev/null
   rm $reportfile
 }

--- a/tests/oval_details/test_oval_details.sh
+++ b/tests/oval_details/test_oval_details.sh
@@ -10,13 +10,37 @@ output_dir=`mktemp -d -t oval_details_XXXXXX`
 
 # Test cases.
 
-function test_oval_details {
+function test_oval_details_implicit {
+  # Tests if OVAL Details are present in HTML report by default
+  # without specifing --oval-results --results (new behavior)
   xccdffile=$srcdir/$1.xccdf.xml
   resultfile=$output_dir/$1.result.xml
   reportfile=$output_dir/$1.report.html
+  oval_resultfile="$1.oval.xml.result.xml"
+  $OSCAP xccdf eval --report $reportfile $xccdffile
+  [ -f $reportfile ]
+  [ ! -f $resultfile ]
+  [ ! -f $oval_resultfile ]
+  grep -i $2 $reportfile >/dev/null && grep -i $3 $reportfile >/dev/null
+  rm $reportfile
+}
+
+function test_oval_details_explicit {
+  # Tests if OVAL details are present in HTML report when options
+  # --oval-results and --results are explicitely specified
+  # (backwards-compatible behavior)
+  xccdffile=$srcdir/$1.xccdf.xml
+  resultfile=$output_dir/$1.result.xml
+  reportfile=$output_dir/$1.report.html
+  oval_resultfile="$1.oval.xml.result.xml"
   $OSCAP xccdf eval --results $resultfile --oval-results --report $reportfile $xccdffile
   grep -i $2 $reportfile >/dev/null && grep -i $3 $reportfile >/dev/null
-  rm "$1.oval.xml.result.xml"
+  [ -f $reportfile ]
+  [ -f $resultfile ]
+  [ -f $oval_resultfile ]
+  rm $reportfile
+  rm $resultfile
+  rm $oval_resultfile
 }
 
 # Testing.
@@ -29,16 +53,24 @@ if ! [ -f foo.txt ] ; then
   cp $srcdir/foo.src.txt ./foo.txt
 fi
 
-test_run "test_oval_details_file_object" test_oval_details file "path.*UID.*permissions" "/dev/null"
-test_run "test_oval_details_partition_object" test_oval_details partition "mount point.*device.*uuid" "/"
-test_run "test_oval_details_rpminfo_object" test_oval_details rpminfo "name.*release.*version" "rpm"
+test_run "test_oval_details_file_object_implicit" test_oval_details_implicit file "path.*UID.*permissions" "/dev/null"
+test_run "test_oval_details_file_object_explicit" test_oval_details_explicit file "path.*UID.*permissions" "/dev/null"
+test_run "test_oval_details_partition_object_implicit" test_oval_details_implicit partition "mount point.*device.*uuid" "/"
+test_run "test_oval_details_partition_object_explicit" test_oval_details_explicit partition "mount point.*device.*uuid" "/"
+test_run "test_oval_details_rpminfo_object_implicit" test_oval_details_implicit rpminfo "name.*release.*version" "rpm"
+test_run "test_oval_details_rpminfo_object_explicit" test_oval_details_explicit rpminfo "name.*release.*version" "rpm"
 if ! pidof systemd > /dev/null ; then
-  test_run "test_oval_details_runlevel_object" test_oval_details runlevel "service name.*runlevel" "smartd"
+  test_run "test_oval_details_runlevel_object_implicit" test_oval_details_implicit runlevel "service name.*runlevel" "smartd"
+  test_run "test_oval_details_runlevel_object_explicit" test_oval_details_explicit runlevel "service name.*runlevel" "smartd"
 fi
-test_run "test_oval_details_sysctl_object" test_oval_details sysctl "name.*value" "net\.ipv4\.ip_forward"
-test_run "test_oval_details_textfilecontent54_object" test_oval_details textfilecontent54 "path.*content" "foo\.txt.*Hello"
-test_run "test_oval_details_variable_object" test_oval_details variable "var ref.*value" "oval:x:var:1.*42"
-test_run "test_oval_details_xmlfilecontent_object" test_oval_details xmlfilecontent "filepath.*xpath.*value of" "countries\.xml.*London"
+test_run "test_oval_details_sysctl_object_implicit" test_oval_details_implicit sysctl "name.*value" "net\.ipv4\.ip_forward"
+test_run "test_oval_details_sysctl_object_explicit" test_oval_details_explicit sysctl "name.*value" "net\.ipv4\.ip_forward"
+test_run "test_oval_details_textfilecontent54_object_implicit" test_oval_details_implicit textfilecontent54 "path.*content" "foo\.txt.*Hello"
+test_run "test_oval_details_textfilecontent54_object_explicit" test_oval_details_explicit textfilecontent54 "path.*content" "foo\.txt.*Hello"
+test_run "test_oval_details_variable_object_implicit" test_oval_details_implicit variable "var ref.*value" "oval:x:var:1.*42"
+test_run "test_oval_details_variable_object_explicit" test_oval_details_explicit variable "var ref.*value" "oval:x:var:1.*42"
+test_run "test_oval_details_xmlfilecontent_object_implicit" test_oval_details_implicit xmlfilecontent "filepath.*xpath.*value of" "countries\.xml.*London"
+test_run "test_oval_details_xmlfilecontent_object_explicit" test_oval_details_explicit xmlfilecontent "filepath.*xpath.*value of" "countries\.xml.*London"
 
 rm -rf $output_dir
 rm -f ./foo.txt ./countries.xml

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -147,12 +147,12 @@ Don't provide system characteristics in OVAL/ARF result files.
 .TP
 \fB\-\-report FILE\fR
 .RS
-Write HTML report into FILE. Add \fB\-\-oval-results\fR to enable detailed information in the report.
+Write HTML report into FILE.
 .RE
 .TP
 \fB\-\-oval-results\fR
 .RS
-Generate OVAL Result file for each OVAL session used for evaluation. File with name '\fIoriginal-oval-definitions-filename\fR.result.xml' will be generated for each referenced OVAL file in current working directory. This option (in conjunction with the \fB\-\-report\fR option) also enables inclusion of additional OVAL information in the XCCDF report. To change the directory where OVAL files are generated change the CWD using the `cd` command.
+Generate OVAL Result file for each OVAL session used for evaluation. File with name '\fIoriginal-oval-definitions-filename\fR.result.xml' will be generated for each referenced OVAL file in current working directory. To change the directory where OVAL files are generated change the CWD using the `cd` command.
 .RE
 .TP
 \fB\-\-check-engine-results\fR
@@ -238,12 +238,12 @@ This option should be used to generate results for DISA STIG Viewer older than 2
 .TP
 \fB\-\-report FILE\fR
 .RS
-Write HTML report into FILE. Add \fB\-\-oval-results\fR to enable detailed information in the report.
+Write HTML report into FILE.
 .RE
 .TP
 \fB\-\-oval-results\fR
 .RS
-Generate OVAL Result file for each OVAL session used for evaluation. File with name '\fIoriginal-oval-definitions-filename\fR.result.xml' will be generated for each referenced OVAL file. This option (with conjunction with the \fB\-\-report\fR option) also enables inclusion of additional OVAL information in the XCCDF report.
+Generate OVAL Result file for each OVAL session used for evaluation. File with name '\fIoriginal-oval-definitions-filename\fR.result.xml' will be generated for each referenced OVAL file.
 .RE
 .TP
 \fB\-\-check-engine-results\fR


### PR DESCRIPTION
Users will no longer need to specify `--oval-results` to get the OVAL details in HTML report. The OVAL details will be shown always.

I know this change is highly controversial, but it has been requested multiple times, for example in #1262.

Moreover, I have discovered that it isn't true that you have to specify `--results` together with report. Probably this statement has been forgotten in the man page during the HTML report redesign.