### PR TITLE
Add OL8 CPE name to OpenSCAP dictionary

### DIFF
--- a/cpe/openscap-cpe-dict.xml
+++ b/cpe/openscap-cpe-dict.xml
@@ -33,6 +33,10 @@
             <title xml:lang="en-us">Oracle Linux 7</title>
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.ol:def:7</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:oracle:linux:8">
+            <title xml:lang="en-us">Oracle Linux 8</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.ol:def:8</check>
+      </cpe-item>
       <cpe-item name="cpe:/o:centos:centos:5">
             <title xml:lang="en-us">Community Enterprise Operating System 5</title>
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.rhel:def:1005</check>

--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -120,6 +120,19 @@
                         <criterion comment="Oracle Linux 7 is installed" test_ref="oval:org.open-scap.cpe.ol:tst:7"/>
                   </criteria>
             </definition>
+            <definition class="inventory" id="oval:org.open-scap.cpe.ol:def:8" version="1">
+                  <metadata>
+                        <title>Oracle Linux 8</title>
+                        <affected family="unix">
+                              <platform>Oracle Linux 8</platform>
+                        </affected>
+                        <reference ref_id="cpe:/o:oracle:linux:8" source="CPE"/>
+                        <description>The operating system installed on the system is Oracle Linux 8</description>
+                  </metadata>
+                  <criteria>
+                        <criterion comment="Oracle Linux 8 is installed" test_ref="oval:org.open-scap.cpe.ol:tst:8"/>
+                  </criteria>
+            </definition>
             <definition class="inventory" id="oval:org.open-scap.cpe.rhel:def:1005" version="1">
                   <metadata>
                         <title>Community Enterprise Operating System 5</title>
@@ -757,6 +770,11 @@
                   <object object_ref="oval:org.open-scap.cpe.oraclelinux-release:obj:1"/>
                   <state state_ref="oval:org.open-scap.cpe.ol:ste:7"/>
             </rpminfo_test>
+            <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.ol:tst:8" version="1" check="at least one" comment="oraclelinux-release is version 8"
+                  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+                  <object object_ref="oval:org.open-scap.cpe.oraclelinux-release:obj:1"/>
+                  <state state_ref="oval:org.open-scap.cpe.ol:ste:8"/>
+            </rpminfo_test>
             <rpmverifyfile_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:1005" version="1" check="at least one" comment="centos-release is version 5"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <object object_ref="oval:org.open-scap.cpe.redhat-release:obj:3"/>
@@ -1120,6 +1138,10 @@
             <rpminfo_state id="oval:org.open-scap.cpe.ol:ste:7" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <name operation="pattern match">^oraclelinux-release</name>
                   <version operation="pattern match">^7</version>
+            </rpminfo_state>
+            <rpminfo_state id="oval:org.open-scap.cpe.ol:ste:8" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+                  <name operation="pattern match">^oraclelinux-release</name>
+                  <version operation="pattern match">^8</version>
             </rpminfo_state>
             <rpminfo_state id="oval:org.open-scap.cpe.fedora:ste:16" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <version operation="pattern match">^16$</version>


### PR DESCRIPTION
Extends openscap built-in CPE dictionary with Oracle Linux 8 support.

Checked patch to work on Oracle Linux 8 OS.