### PR TITLE
Add Fedora 31 CPE

### DIFF
--- a/cpe/openscap-cpe-dict.xml
+++ b/cpe/openscap-cpe-dict.xml
@@ -117,6 +117,10 @@
             <title xml:lang="en-us">Fedora 30</title>
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.fedora:def:30</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:fedoraproject:fedora:31">
+            <title xml:lang="en-us">Fedora 31</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.fedora:def:31</check>
+      </cpe-item>
       <cpe-item name="cpe:/o:suse:sle">
             <title xml:lang="en-us">SUSE Linux Enterprise all versions</title>
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.sle:def:1</check>

--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -393,6 +393,20 @@
                         <criterion comment="Fedora 30 is installed" test_ref="oval:org.open-scap.cpe.fedora:tst:30"/>
                   </criteria>
             </definition>
+            <definition class="inventory" id="oval:org.open-scap.cpe.fedora:def:31" version="1">
+                  <metadata>
+                        <title>Fedora 31</title>
+                        <affected family="unix">
+                            <platform>Fedora 31</platform>
+                        </affected>
+                        <reference ref_id="cpe:/o:fedoraproject:fedora:31" source="CPE"/>
+                        <description>The operating system installed on the system is Fedora 31</description>
+                  </metadata>
+                  <criteria>
+                        <criterion comment="Fedora 31 is installed" test_ref="oval:org.open-scap.cpe.fedora:tst:31"/>
+                  </criteria>
+            </definition>
+
 
             <definition class="inventory" id="oval:org.open-scap.cpe.sle:def:1" version="1">
                   <metadata>
@@ -771,6 +785,11 @@
                   <object object_ref="oval:org.open-scap.cpe.fedora-release:obj:2"/>
                   <state state_ref="oval:org.open-scap.cpe.fedora:ste:30"/>
             </rpminfo_test>
+            <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.fedora:tst:31" version="1" check="at least one" comment="fedora-release is version Fedora 31"
+                  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+                  <object object_ref="oval:org.open-scap.cpe.fedora-release:obj:2"/>
+                  <state state_ref="oval:org.open-scap.cpe.fedora:ste:31"/>
+            </rpminfo_test>
             <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.sles:tst:1" version="1" check="at least one" comment="/etc/sles-release is provided by sles-release package"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <object object_ref="oval:org.open-scap.cpe.sles-release:obj:1"/>
@@ -1041,6 +1060,9 @@
             </rpminfo_state>
             <rpminfo_state id="oval:org.open-scap.cpe.fedora:ste:30" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <version operation="pattern match">^30$</version>
+            </rpminfo_state>
+            <rpminfo_state id="oval:org.open-scap.cpe.fedora:ste:31" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+                  <version operation="pattern match">^31$</version>
             </rpminfo_state>
             <rpminfo_state id="oval:org.open-scap.cpe.sles:ste:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <name operation="pattern match">^sles-release</name>


### PR DESCRIPTION
Fedora 30 has been branched from Rawhide. Rawhide becomes future
Fedora 31. See https://fedoraproject.org/wiki/Releases/30/Schedule