### PR TITLE
Remove --graphviz from TRAVIS CI for MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       before_install:
         - brew update
         - brew upgrade python
-        - brew install doxygen --with-graphviz
+        - brew install doxygen
         - brew install opendbx
         - brew install popt
         - brew install swig


### PR DESCRIPTION
- The --graphviz brew install option seems to be broken for doxygen.
  This removes the option from the Travis configuration.