### PR TITLE
Add missing OVAL license

### DIFF
--- a/schemas/oval/terms-of-use.rst
+++ b/schemas/oval/terms-of-use.rst
@@ -1,0 +1,45 @@
+.. _terms-of-use:
+
+Terms of Use
+============
+
+Introduction
+------------
+OVAL is an open standard developed by the information security community as represented by the OVAL Board and the OVAL discussion lists, and maintained by the Center for Internet Security, Inc. under license from the United States Department of Homeland Security (U.S. DHS) on this public OVAL Website.
+
+The OVAL Language and any resulting OVAL content based upon the language that is stored in the OVAL Repository are free to use by any organization or individual for any research, development, and/or commercial purposes, per below.
+
+The United States Government has copyrighted the OVAL Language for the benefit of the community in order to ensure it remains a free and open standard, as well as to legally protect the ongoing use of it and any resulting content by government, vendors, and/or users. The United States Government has trademarked ® the OVAL acronym and the OVAL logo to protect its sole and ongoing use by the OVAL effort within the information security arena.
+
+Please contact oval@cisecurity.org if you require further clarification on this issue.
+
+Open Vulnerability and Assessment Language (OVAL®) License
+----------------------------------------------------------
+
+Your use of OVAL is conditioned upon acceptance of the following terms and conditions:
+
+OVAL is comprised of the OVAL Language, OVAL Content, and the OVAL Repository. Each is defined below:
+
+* The OVAL Language serves as the framework and vocabulary of OVAL. The Language covers the three steps of the assessment process: an OVAL System Characteristics schema for representing system information, an OVAL Definition schema for expressing a specific machine state, and an OVAL Results schema for reporting the results of an assessment.
+* OVAL Content is content written in the OVAL Language. All content written in the OVAL Language is considered OVAL Content.
+* The OVAL Repository is a collection of OVAL Content hosted by the Center for Internet Security, Inc. under license from the U.S. DHS. It is the central meeting place for the OVAL Community to discuss, analyze, store, and disseminate OVAL Definitions. Each definition in the OVAL Repository determines whether a specified software vulnerability, configuration issue, program, or patch is present on a system.
+
+The Center for Internet Security, Inc. (CIS) under license from U.S. DHS hereby grants you a non-exclusive, royalty-free, worldwide license to use OVAL for research, development, and commercial purposes. Any copy you make for such purposes is authorized provided that you reproduce the United States Government’s copyright designation and this license in any such copy.
+
+The OVAL Language is the copyrighted work of the United States Government. No ownership or other proprietary interest in the OVAL Language is granted to you other than what is granted in this license.
+
+The names and trademarks for OVAL may not be used in association with commercial products. Notwithstanding the foregoing, commercial products that are based upon or incorporate any portion of OVAL may use a word mark as part of a factual statement that references the commercial products' use of OVAL materials, but only in a manner that does not imply DHS’s endorsement of the commercial product.
+
+OVAL Content, whether already in the OVAL Repository hosted by CIS under license from the U.S. DHS or developed by you and sent to CIS via the discussion forums or any other means to be deposited into the OVAL Repository, is fully available for public use free of charge. In addition, to the extent that contributed OVAL Content involves pre-existing copyrighted works, you hereby grant to CIS and the United States Government an irrevocable, worldwide, royalty-free, non-exclusive, license, for the duration of the copyright, to do the following:
+
+* to reproduce such OVAL Content, either alone or as part of a collective work;
+* to translate, adapt, alter, transform, modify, or arrange such OVAL Content, thereby creating derivative works ("Derivative Works"); and
+* to distribute, display, or communicate copies of such OVAL Content to the public free of charge.
+
+ALL DOCUMENTS AND THE INFORMATION CONTAINED THEREIN ARE PROVIDED ON AN "AS IS" BASIS AND THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS OR IS SPONSORED BY (IF ANY), THE CENTER FOR INTERNET SECURITY, INC., ITS DIRECTORS, OFFICERS, EMPLOYEES CONTRACTORS, AND AGENTS, AND THE UNITED STATES GOVERNMENT DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION THEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+You understand that any export of the OVAL Language, OVAL Content, or OVAL Repository may require an export license and you assume full responsibility for obtaining such license.
+
+This License shall be construed, governed, interpreted and applied in accordance with the laws of the State of New York without regard to any conflict of law rules and you agree to submit to the exclusive jurisdiction of the State of New York courts.
+
+Copyright © 2010 United States Government. All Rights Reserved.


### PR DESCRIPTION
The new OVAL 5.11.2 schemas contain terms_of_use element which
says that it is required to include OVAL license header when distributing
copies of the OVAL Schema. To satisfy their requirement, we will
add a copy of the OVAL license obtained from:
https://github.com/OVAL-Community/OVAL/blob/master/terms-of-use.rst


See eg.:
https://github.com/OpenSCAP/openscap/blob/ef16b42e5327dea1e6708584326b3230a42a913c/schemas/oval/5.11.2/oval-definitions-schema.xsd#L39
