### PR TITLE
Reset chroot file descriptor after closed

### DIFF
--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -1083,24 +1083,30 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 			dE("fchdir failed: %s", strerror(errno));
 			close(probe->real_root_fd);
 			close(probe->real_cwd_fd);
+			probe->real_root_fd = -1;
+			probe->real_cwd_fd = -1;
 			SEXP_free(probe_out);
 			return NULL;
 		}
 		close(probe->real_root_fd);
+		probe->real_root_fd = -1;
 		dI("Leaving chroot mode");
 		if (chroot(".") == -1) {
 			dE("chroot(\".\") failed: %s", strerror(errno));
 			close(probe->real_cwd_fd);
+			probe->real_cwd_fd = -1;
 			SEXP_free(probe_out);
 			return NULL;
 		}
 		if (fchdir(probe->real_cwd_fd) != 0) {
 			dE("fchdir failed: %s", strerror(errno));
 			close(probe->real_cwd_fd);
+			probe->real_cwd_fd = -1;
 			SEXP_free(probe_out);
 			return NULL;
 		}
 		close(probe->real_cwd_fd);
+		probe->real_cwd_fd = -1;
 	}
 #endif
 


### PR DESCRIPTION
In chroot mode, sometimes we'll get `fchdir failed: Bad file descriptor` error and the oscap will be aborted. 
This PR is to reset the file descriptor variables when the descriptors are already closed. so it won't go to the `if` condition again and try to do `fchdir` with invalid descriptor parameter.