### PR TITLE
[WIP] Compose SCAP 1.3 DataStreams

### DIFF
--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -58,8 +58,8 @@
 typedef enum oscap_source_type {
 	OSCAP_SRC_FROM_USER_XML_FILE = 1,               ///< The source originated from XML file supplied by user
 	OSCAP_SRC_FROM_USER_MEMORY,                     ///< The source originated from memory supplied by user
-	OSCAP_SRC_FROM_XML_DOM,                         ///< The source originated from XML DOM (most often from DataStream).
-	// TODO: downloaded from an http address (XCCDF can refer to remote sources)
+	OSCAP_SRC_FROM_XML_DOM,                         ///< The source originated from XML DOM (most often from DataStream.
+	OSCAP_SRC_FROM_URL,                             ///< The source originated from a URL.
 } oscap_source_type_t;
 
 struct oscap_source {
@@ -75,6 +75,14 @@ struct oscap_source {
 		xmlDoc *doc;                            /// DOM
 	} xml;
 };
+
+struct oscap_source *oscap_source_new_from_url(const char *url)
+{
+	struct oscap_source *source = (struct oscap_source *) calloc(1, sizeof(struct oscap_source));
+	source->origin.filepath = oscap_strdup(url);
+	source->origin.type = OSCAP_SRC_FROM_URL;
+	return source;
+}
 
 struct oscap_source *oscap_source_new_from_file(const char *filepath)
 {


### PR DESCRIPTION
This is a very early and rough patch to update openscap to compose SCAP 1.3 compliant Data Streams.

What this PR does for now:
- When a `check-content-ref`'s `href` attribute is a supported URL (i.e.: `http://` or `https://`)
  - Add a `uri` entry in the `Benchmark`s component-ref catalog, but don't include its contents in DS
  - Add a `component-ref` to datastream's `<ds:checks>`

What it needs to do:
- Get the path from the URL and generate the  component `name` and `uri`.
- `oscap_source_new_from_url` not sure if makes sense to implement it.

Related to https://github.com/ComplianceAsCode/content/pull/4302