### PR TITLE
Allow DS session to continue without remote resources

### DIFF
--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -412,6 +412,7 @@ static int ds_sds_dump_component_by_href(struct ds_sds_session *session, char* x
 			}
 
 			ds_sds_session_remote_resources_progress(session)(true, "WARNING: Skipping '%s' file which is referenced from datastream\n", url);
+			// -2 means that remote resources were not downloaded
 			return -2;
 		}
 
@@ -444,8 +445,12 @@ int ds_sds_dump_component_ref_as(const xmlNodePtr component_ref, struct ds_sds_s
 	xmlFree(xlink_href);
 	xmlFree(cref_id);
 
-	if (ret != 0) {
-
+	if (ret == -2) {
+		// A remote component was not dumped
+		// It should be ok to continue without it
+		free(target_filename_dirname);
+		return 0;
+	} else if (ret != 0) {
 		free(target_filename_dirname);
 		return -1;
 	}


### PR DESCRIPTION
When loading a DS session, there can remote components.
If `--fetch-remote-resources` option is not provided, the resources pointed by the components won't be downloaded.

```shell
$ oscap xccdf eval --profile pci-dss ~/git/scap-security-guide/build/ssg-fedora-ds.xml 
WARNING: Datastream component 'scap_org.open-scap_cref_security-data-oval-com.redhat.rhsa-RHEL7.xml.bz2' points out to the remote 'https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2'. Use '--fetch-remote-resources' option to download it.
WARNING: Skipping 'https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2' file which is referenced from datastream
OpenSCAP Error: Could not extract scap_org.open-scap_cref_ssg-fedora-xccdf-1.2.xml with all dependencies from datastream. [/builddir/build/BUILD/openscap-1.3.0/src/DS/ds_sds_session.c:210]


```
Related to: https://github.com/ComplianceAsCode/content/pull/4302#issuecomment-487639000

This patch allows the scan to continue without remote components.
Result of rules which reference the missing remote resource will be 'notchecked'.