### PR TITLE
Add test for DS session and SCAP 1.3 remote resources

### DIFF
--- a/tests/DS/Makefile.am
+++ b/tests/DS/Makefile.am
@@ -11,6 +11,8 @@ TESTS_ENVIRONMENT= \
 TESTS = test_ds.sh
 
 EXTRA_DIST = test_ds.sh \
+		ds_continue_without_remote_resources/remote_content_1.2.ds.xml \
+		ds_continue_without_remote_resources/remote_content_1.3.ds.xml \
 		eval_invalid/sds.xml \
 		eval_invalid/sds-oval.xml \
 		eval_simple/sds.xml \

--- a/tests/DS/ds_continue_without_remote_resources/remote_content_1.2.ds.xml
+++ b/tests/DS/ds_continue_without_remote_resources/remote_content_1.2.ds.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ds:data-stream-collection xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" id="scap_org.open-scap_collection_from_xccdf_test_single_rule.xccdf.xml" schematron-version="1.2">
+<ds:data-stream id="scap_org.open-scap_datastream_from_xccdf_test_single_rule.xccdf.xml" scap-version="1.2" use-case="OTHER">
+  <ds:checklists>
+    <ds:component-ref id="scap_org.open-scap_cref_test_single_rule.xccdf.xml" xlink:href="#scap_org.open-scap_comp_test_single_rule.xccdf.xml">
+      <cat:catalog>
+        <cat:uri name="test_single_rule.oval.xml" uri="#scap_org.open-scap_cref_test_single_rule.oval.xml"/>
+      </cat:catalog>
+    </ds:component-ref>
+  </ds:checklists>
+  <ds:checks>
+    <ds:component-ref id="scap_org.open-scap_cref_test_single_rule.oval.xml" xlink:href="#scap_org.open-scap_comp_test_single_rule.oval.xml"/>
+  </ds:checks>
+</ds:data-stream>
+
+<ds:component id="scap_org.open-scap_comp_test_single_rule.oval.xml" timestamp="2017-06-09T07:07:38">
+<oval_definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:win-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd    http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#windows windows-definitions-schema.xsd">
+  <generator>
+    <oval:schema_version>5.10</oval:schema_version>
+    <oval:timestamp>2009-01-12T10:41:00-05:00</oval:timestamp>
+  </generator>
+
+  <definitions>
+    <definition class="compliance" id="oval:test-pass:def:1" version="1">
+      <metadata>
+        <title>PASS</title>
+	<description>pass</description>
+      </metadata>
+      <criteria>
+        <criterion comment="PASS test" test_ref="oval:x:tst:1"/>
+      </criteria>
+    </definition>
+  </definitions>
+
+    <tests>
+    <variable_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:tst:1" check="all" comment="always pass" version="1">
+      <object object_ref="oval:x:obj:1"/>
+    </variable_test>
+    </tests>
+
+    <objects>
+    <variable_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:obj:1" version="1" comment="x">
+      <var_ref>oval:x:var:1</var_ref>
+    </variable_object>
+    </objects>
+</oval_definitions>
+</ds:component>
+
+<ds:component id="scap_org.open-scap_comp_test_single_rule.xccdf.xml" timestamp="2017-06-09T09:15:45">
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_com.example.www_benchmark_dummy" xml:lang="en-US">
+  <status>accepted</status>
+  <version>1.0</version>
+
+  <Profile id="xccdf_com.example.www_profile_test_remote_res">
+    <title>xccdf_test_profile</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_test-pass" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_test-remote_res" selected="true"/>
+  </Profile>
+
+  <Value id="xccdf_com.example.www_value_val1" type="number" operator="equals" interactive="0">
+    <title>test value</title>
+    <description>foo</description>
+    <value selector="bar_1">50</value>
+    <value selector="bar_2">100</value>
+  </Value>
+  <Rule selected="true" id="xccdf_com.example.www_rule_test-pass">
+    <title>This rule always pass</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_single_rule.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+  <Rule selected="true" id="xccdf_com.example.www_rule_test-remote_res">
+      <title>This rule checks remote resource</title>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+          <check-content-ref href="https://www.example.com/security/data/oval/oval.xml.bz2"/>
+      </check>
+  </Rule>
+  <Rule selected="true" id="xccdf_com.example.www_rule_test-pass2">
+    <title>This rule always pass</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_single_rule.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+</Benchmark>
+</ds:component>
+</ds:data-stream-collection>

--- a/tests/DS/ds_continue_without_remote_resources/remote_content_1.3.ds.xml
+++ b/tests/DS/ds_continue_without_remote_resources/remote_content_1.3.ds.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ds:data-stream-collection xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" id="scap_org.open-scap_collection_from_xccdf_test_single_rule.xccdf.xml" schematron-version="1.3">
+<ds:data-stream id="scap_org.open-scap_datastream_from_xccdf_test_single_rule.xccdf.xml" scap-version="1.3" use-case="OTHER">
+  <ds:checklists>
+    <ds:component-ref id="scap_org.open-scap_cref_test_single_rule.xccdf.xml" xlink:href="#scap_org.open-scap_comp_test_single_rule.xccdf.xml">
+      <cat:catalog>
+        <cat:uri name="test_single_rule.oval.xml" uri="#scap_org.open-scap_cref_test_single_rule.oval.xml"/>
+        <cat:uri name="security-data-oval.xml.bz2" uri="#scap_org.open-scap_cref_security-data-oval.xml.bz2"/>
+      </cat:catalog>
+    </ds:component-ref>
+  </ds:checklists>
+  <ds:checks>
+    <ds:component-ref id="scap_org.open-scap_cref_test_single_rule.oval.xml" xlink:href="#scap_org.open-scap_comp_test_single_rule.oval.xml"/>
+    <ds:component-ref id="scap_org.open-scap_cref_security-data-oval.xml.bz2" xlink:href="https://www.example.com/security/data/oval/oval.xml.bz2"/>
+  </ds:checks>
+</ds:data-stream>
+
+<ds:component id="scap_org.open-scap_comp_test_single_rule.oval.xml" timestamp="2017-06-09T07:07:38">
+<oval_definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:win-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd    http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd   http://oval.mitre.org/XMLSchema/oval-definitions-5#windows windows-definitions-schema.xsd">
+  <generator>
+    <oval:schema_version>5.11</oval:schema_version>
+    <oval:timestamp>2009-01-12T10:41:00-05:00</oval:timestamp>
+  </generator>
+
+  <definitions>
+    <definition class="compliance" id="oval:test-pass:def:1" version="1">
+      <metadata>
+        <title>PASS</title>
+	<description>pass</description>
+      </metadata>
+      <criteria>
+        <criterion comment="PASS test" test_ref="oval:x:tst:1"/>
+      </criteria>
+    </definition>
+  </definitions>
+
+    <tests>
+    <variable_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:tst:1" check="all" comment="always pass" version="1">
+      <object object_ref="oval:x:obj:1"/>
+    </variable_test>
+    </tests>
+
+    <objects>
+    <variable_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:obj:1" version="1" comment="x">
+      <var_ref>oval:x:var:1</var_ref>
+    </variable_object>
+    </objects>
+</oval_definitions>
+</ds:component>
+
+<ds:component id="scap_org.open-scap_comp_test_single_rule.xccdf.xml" timestamp="2017-06-09T09:15:45">
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_com.example.www_benchmark_dummy" xml:lang="en-US">
+  <status>accepted</status>
+  <version>1.0</version>
+
+  <Profile id="xccdf_com.example.www_profile_test_remote_res">
+    <title>xccdf_test_profile</title>
+    <description>This profile is for testing.</description>
+    <select idref="xccdf_com.example.www_rule_test-pass" selected="true"/>
+    <select idref="xccdf_com.example.www_rule_test-remote_res" selected="true"/>
+  </Profile>
+
+  <Value id="xccdf_com.example.www_value_val1" type="number" operator="equals" interactive="0">
+    <title>test value</title>
+    <description>foo</description>
+    <value selector="bar_1">50</value>
+    <value selector="bar_2">100</value>
+  </Value>
+  <Rule selected="true" id="xccdf_com.example.www_rule_test-pass">
+    <title>This rule always pass</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_single_rule.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+  <Rule selected="true" id="xccdf_com.example.www_rule_test-remote_res">
+    <title>This rule checks remote resource</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" multi-check="true">
+      <check-content-ref href="security-data-oval.xml.bz2"/>
+    </check>
+  </Rule>
+  <Rule selected="true" id="xccdf_com.example.www_rule_test-pass2">
+    <title>This rule always pass</title>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_single_rule.oval.xml" name="oval:test-pass:def:1"/>
+    </check>
+  </Rule>
+</Benchmark>
+</ds:component>
+</ds:data-stream-collection>

--- a/tests/DS/test_ds.sh
+++ b/tests/DS/test_ds.sh
@@ -414,6 +414,21 @@ function test_sds_tailoring {
 	rm -f "$result"
 }
 
+function test_ds_continue_without_remote_resources() {
+	local DS="${srcdir}/$1"
+	local PROFILE="$2"
+	local result=$(mktemp)
+
+	$OSCAP xccdf eval --profile "$PROFILE" --results "$result" "$DS"
+
+	assert_exists 1 '//rule-result[@idref="xccdf_com.example.www_rule_test-pass"]/result[text()="pass"]'
+	assert_exists 1 '//rule-result[@idref="xccdf_com.example.www_rule_test-remote_res"]/result[text()="notchecked"]'
+	assert_exists 1 '//rule-result[@idref="xccdf_com.example.www_rule_test-pass2"]/result[text()="pass"]'
+
+	rm -f "$result"
+}
+
+
 # Testing.
 test_init "test_ds.log"
 
@@ -454,6 +469,8 @@ test_run "rds_split_simple" test_rds_split rds_split_simple report-request.xml r
 
 test_run "test_eval_complex" test_eval_complex
 test_run "sds_add_multiple_oval_twice_in_row" sds_add_multiple_twice
+test_run "test_ds_1_2_continue_without_remote_resources" test_ds_continue_without_remote_resources ds_continue_without_remote_resources/remote_content_1.2.ds.xml xccdf_com.example.www_profile_test_remote_res
+test_run "test_ds_1_3_continue_without_remote_resources" test_ds_continue_without_remote_resources ds_continue_without_remote_resources/remote_content_1.3.ds.xml xccdf_com.example.www_profile_test_remote_res
 
 test_exit
 


### PR DESCRIPTION
* Test for PR #1324 which verifies that DS session does not quit
   when SCAP 1.3 content contains remote component but
   `--fetch-remote-resources` option is not provided. The test is
   also extended to verify that scans utilizing SCAP 1.2 and 1.3
   datastreams produce the same results.