### PR TITLE
Check local filesystems when using 'filepath' element

### DIFF
--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -1346,6 +1346,12 @@ OVAL_FTSENT *oval_fts_read(OVAL_FTS *ofts)
 		if (ofts->ofts_sfilepath) {
 			fts_ent = ofts->ofts_match_path_fts_ent;
 			ofts->ofts_match_path_fts_ent = NULL;
+			if (ofts->filesystem == OVAL_RECURSE_FS_LOCAL
+				&& (!OVAL_FTS_localp(ofts, fts_ent->fts_path,
+					(fts_ent->fts_statp != NULL) ?
+					&fts_ent->fts_statp->st_dev : NULL))) {
+				continue;
+			}
 			break;
 		} else {
 			fts_ent = oval_fts_read_recurse_path(ofts);


### PR DESCRIPTION
The recurse_file_system="local" doesn’t work with file_object and
textfilecontent54_object where <filepath> element is used to define the
file path and operation=”equals” is used on filepath.  As of OVAL
specification of FileBehaviors element:
https://oval.mitre.org/language/version5.10/ovaldefinition/documentation/unix-definitions-schema.html#FileBehaviors
"'recurse_file_system' defines the file system limitation of any
searching and applies to all operations as specified on the path or
filepath entity." Notice the words “any searching” and notice the words
“all operations”. We can solve this bug by performing a similar check
as we do in oval_fts_read_recurse_path.