### PR TITLE
Fix invalid OVAL in test ds_continue_without_remote_resources

### DIFF
--- a/tests/DS/ds_continue_without_remote_resources/remote_content_1.2.ds.xml
+++ b/tests/DS/ds_continue_without_remote_resources/remote_content_1.2.ds.xml
@@ -43,6 +43,13 @@
       <var_ref>oval:x:var:1</var_ref>
     </variable_object>
     </objects>
+
+    <variables>
+      <constant_variable id="oval:x:var:1" version="1" comment="x" datatype="int">
+        <value>100</value>
+      </constant_variable>
+    </variables>
+
 </oval_definitions>
 </ds:component>
 

--- a/tests/DS/ds_continue_without_remote_resources/remote_content_1.3.ds.xml
+++ b/tests/DS/ds_continue_without_remote_resources/remote_content_1.3.ds.xml
@@ -45,6 +45,13 @@
       <var_ref>oval:x:var:1</var_ref>
     </variable_object>
     </objects>
+
+    <variables>
+      <constant_variable id="oval:x:var:1" version="1" comment="x" datatype="int">
+        <value>100</value>
+      </constant_variable>
+    </variables>
+
 </oval_definitions>
 </ds:component>
 


### PR DESCRIPTION
Addressing:
```
$ oscap ds sds-split remote_content_1.2.ds.xml /tmp/xxx
$ oscap oval validate --schematron /tmp/xxx/test_single_rule.oval.xml
<?xml version="1.0"?>
oval:x:obj:1 - referenced variable oval:x:var:1 not found. The var_ref entity must hold a variable id that exists in the document.
```