### PR TITLE
Resolve parsing issues with OVAL 5.11.2 schemas

### DIFF
--- a/schemas/oval/5.11.2/oval-definitions-schema.xsd
+++ b/schemas/oval/5.11.2/oval-definitions-schema.xsd
@@ -1450,7 +1450,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-def:EntitySimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:hexBinary oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="binary"/>                                                
             </xsd:restriction>
@@ -1463,7 +1463,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-def:EntitySimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:boolean oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="boolean"/>                                                
             </xsd:restriction>
@@ -1476,7 +1476,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-def:EntitySimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:float oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="float"/>                                                
             </xsd:restriction>
@@ -1489,7 +1489,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-def:EntitySimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:integer oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="int"/>                                
             </xsd:restriction>
@@ -1656,7 +1656,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-def:EntityStateSimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:hexBinary oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="binary"/>                                
             </xsd:restriction>
@@ -1669,7 +1669,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-def:EntityStateSimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:boolean oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="boolean"/>                                
             </xsd:restriction>
@@ -1682,7 +1682,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-def:EntityStateSimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:float oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="float"/>                                                
             </xsd:restriction>
@@ -1695,7 +1695,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-def:EntityStateSimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:integer oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="int"/>                
             </xsd:restriction>

--- a/schemas/oval/5.11.2/oval-system-characteristics-schema.xsd
+++ b/schemas/oval/5.11.2/oval-system-characteristics-schema.xsd
@@ -493,7 +493,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-sc:EntityItemSimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:hexBinary oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="binary"/>                                                
             </xsd:restriction>
@@ -506,7 +506,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-sc:EntityItemSimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:boolean oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="boolean"/>                                                
             </xsd:restriction>
@@ -519,7 +519,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-sc:EntityItemSimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:float oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="float"/>
             </xsd:restriction>
@@ -532,7 +532,7 @@
         <xsd:simpleContent>
             <xsd:restriction base="oval-sc:EntityItemSimpleBaseType">
                 <xsd:simpleType>
-                    <xsd:union memberTypes="xsd:integer oval:EmptyStringType"/>
+                    <xsd:restriction base="xsd:string"/>
                 </xsd:simpleType>
                 <xsd:attribute name="datatype" type="oval:SimpleDatatypeEnumeration" use="required" fixed="int"/>
             </xsd:restriction>


### PR DESCRIPTION
Similar to 8ba623120fc9f479285f9d6032cb925db420011d but for OVAL 5.11.2.
The missing namespace imports have already been fixed in
32d4d9be295084f95bfbaec07ea84373b3b4aeb7. Addressing:
```
File '/root/openscap/schemas/oval/5.11.2/oval-definitions-schema.xsd'
line 1446: local union type: A type, derived by list or union, must have
the simple ur-type definition as base type, not
'{http://oval.mitre.org/XMLSchema/oval-definitions-5}(NULL)'.
File '/root/openscap/schemas/oval/5.11.2/oval-definitions-schema.xsd'
line 1459: local union type: A type, derived by list or union, must have
the simple ur-type definition as base type, not
'{http://oval.mitre.org/XMLSchema/oval-definitions-5}(NULL)'.
File '/root/openscap/schemas/oval/5.11.2/oval-definitions-schema.xsd'
line 1472: local union type: A type, derived by list or union, must have
the simple ur-type definition as base type, not
'{http://oval.mitre.org/XMLSchema/oval-definitions-5}(NULL)'.
File '/root/openscap/schemas/oval/5.11.2/oval-definitions-schema.xsd'
line 1485: local union type: A type, derived by list or union, must have
the simple ur-type definition as base type, not
'{http://oval.mitre.org/XMLSchema/oval-definitions-5}(NULL)'.
File '/root/openscap/schemas/oval/5.11.2/oval-definitions-schema.xsd'
line 1652: local union type: A type, derived by list or union, must have
the simple ur-type definition as base type, not
'{http://oval.mitre.org/XMLSchema/oval-definitions-5}(NULL)'.
File '/root/openscap/schemas/oval/5.11.2/oval-definitions-schema.xsd'
line 1665: local union type: A type, derived by list or union, must have
the simple ur-type definition as base type, not
'{http://oval.mitre.org/XMLSchema/oval-definitions-5}(NULL)'.
File '/root/openscap/schemas/oval/5.11.2/oval-definitions-schema.xsd'
line 1678: local union type: A type, derived by list or union, must have
the simple ur-type definition as base type, not
'{http://oval.mitre.org/XMLSchema/oval-definitions-5}(NULL)'.
File '/root/openscap/schemas/oval/5.11.2/oval-definitions-schema.xsd'
line 1691: local union type: A type, derived by list or union, must have
the simple ur-type definition as base type, not
'{http://oval.mitre.org/XMLSchema/oval-definitions-5}(NULL)'.
OpenSCAP Error: Could not parse XML schema [validate.c:113]
```

Blocks #1334.