### PR TITLE
Extend unit test for is_local_fs from fsdev.h

### DIFF
--- a/tests/API/probes/Makefile.am
+++ b/tests/API/probes/Makefile.am
@@ -1,4 +1,5 @@
 AM_CPPFLAGS = \
+	-DDATADIR=\"$(srcdir)/\" \
 	-I$(top_srcdir)/src \
 	-I$(top_srcdir)/src/CCE/public \
 	-I$(top_srcdir)/src/CPE/public \
@@ -35,6 +36,7 @@ test_fsdev_is_local_fs_SOURCES = test_fsdev_is_local_fs.c
 
 EXTRA_DIST += \
 	all.sh \
+	fake_mtab \
 	fts.sh \
 	gentree.sh \
 	test_api_probes_smoke.c \

--- a/tests/API/probes/fake_mtab
+++ b/tests/API/probes/fake_mtab
@@ -1,3 +1,7 @@
 /dev/mapper/fedora-root / ext4 rw,seclabel,relatime 0 0
+tmpfs /tmp tmpfs rw,seclabel,nosuid,nodev 0 0
 /etc/mount.map /nfs/test autofs rw,relatime,fd=17,pgrp=11111,timeout=5,minproto=5,maxproto=5,direct,pipe_ino=1246883 0 0
 192.168.122.231:/test /nfs/test nfs4 rw,relatime,vers=4.2,rsize=262144,wsize=262144,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.1,local_lock=none,addr=192.168.122.231 0 0
+/dev/mapper/fedora-home /home ext4 rw,seclabel,relatime 0 0
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+//192.168.0.5/storage /media/movies cifs guest,uid=myuser,iocharset=utf8,file_mode=0777,dir_mode=0777,noperm 0 0

--- a/tests/API/probes/fake_mtab
+++ b/tests/API/probes/fake_mtab
@@ -1,0 +1,3 @@
+/dev/mapper/fedora-root / ext4 rw,seclabel,relatime 0 0
+/etc/mount.map /nfs/test autofs rw,relatime,fd=17,pgrp=11111,timeout=5,minproto=5,maxproto=5,direct,pipe_ino=1246883 0 0
+192.168.122.231:/test /nfs/test nfs4 rw,relatime,vers=4.2,rsize=262144,wsize=262144,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.1,local_lock=none,addr=192.168.122.231 0 0

--- a/tests/API/probes/test_fsdev_is_local_fs.c
+++ b/tests/API/probes/test_fsdev_is_local_fs.c
@@ -40,7 +40,10 @@ static int test_single_call()
 
 static int test_multiple_calls()
 {
-	/* fake mtab contains only 1 local filesystem */
+	/*
+	 * fake mtab contains only 4 local filesystems:
+	 * /, /tmp, /home and /proc
+	 */
 	FILE *f = setmntent(DATADIR "fake_mtab", "r");
 	if (f == NULL) {
 		fprintf(stderr, "fake_mtab could not be open\n");
@@ -54,7 +57,7 @@ static int test_multiple_calls()
 		}
 	}
 	endmntent(f);
-	return (locals == 1);
+	return (locals == 4);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
The test uses a fake `mtab` file which contains 4 entries for a local filesystem, 1 entry for a direct autofs map, 1 entry for a NFS system mounted using autofs and 1 entry for a mounted cifs system. By parsing the `mtab` file only 4 local filesystems should be found. It will help us to test https://github.com/OpenSCAP/openscap/pull/1329