### PR TITLE
Update Fedora CPE OVAL

### DIFF
--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -911,7 +911,7 @@
                   <lin-def:name>redhat-release</lin-def:name>
             </lin-def:rpminfo_object>
             <lin-def:rpminfo_object id="oval:org.open-scap.cpe.fedora-release:obj:2" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-                  <lin-def:name>fedora-release</lin-def:name>
+                  <lin-def:name operation="pattern match">^fedora-release.*</lin-def:name>
             </lin-def:rpminfo_object>
             <lin-def:rpmverifyfile_object id="oval:org.open-scap.cpe.redhat-release:obj:3" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <!-- Sadly, OVAL cannot do the right query (rpm -q -whatprovides system-release). Let's check the filename instead. -->


### PR DESCRIPTION
Since Fedora 30 there is no more a single fedora-release RPM
package. There is fedora-release-common and then the specific
package for the type of realease, for example
fedora-release-workstation. Similar to:
https://github.com/ComplianceAsCode/content/pull/4372