### PR TITLE
Update blacklist of kernel params with net.core.bpf_jit_limit

### DIFF
--- a/tests/probes/sysctl/test_sysctl_probe_all.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_all.sh
@@ -20,6 +20,7 @@ SYSCTL_BLACKLIST='
 	kernel.usermodehelper.inheritable
 	net.core.bpf_jit_harden
 	net.core.bpf_jit_kallsyms
+	net.core.bpf_jit_limit
 	net.ipv4.tcp_fastopen_key
 	stable_secret
 	vm.mmap_rnd_bits


### PR DESCRIPTION
The `net.core.bpf_jit_limit` kernel parameter cannot be set by
non root users and so add it to blacklist in the test.