### PR TITLE
Make is_local_fs static again

### DIFF
--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -79,7 +79,7 @@ static int fsdev_cmp(const void *a, const void *b)
 #define DEVID_ARRAY_ADD  8
 
 #if defined(__linux__)
-int is_local_fs(struct mntent *ment)
+static int is_local_fs(struct mntent *ment)
 {
 // todo: would it be usefull to provide the choice during build-time?
 #if 1
@@ -129,7 +129,7 @@ int is_local_fs(struct mntent *ment)
 }
 
 #elif defined(_AIX)
-int is_local_fs(struct mntent *ment)
+static int is_local_fs(struct mntent *ment)
 {
 	int i;
 	struct vfs_ent *e;

--- a/src/OVAL/probes/public/fsdev.h
+++ b/src/OVAL/probes/public/fsdev.h
@@ -86,15 +86,5 @@ int fsdev_path(fsdev_t * lfs, const char *path);
  */
 int fsdev_fd(fsdev_t * lfs, int fd);
 
-#if defined(__linux__) || defined(_AIX)
-/**
- * Detemines whether a given mtab entry is a local file system.
- * @param ment Structure returned by getmntent (see `man 3 getmntent`).
- * @retval 1 if local
- * @retval 0 otherwise
- */
-int is_local_fs(struct mntent *ment);
-#endif
-
 #endif				/* FSDEV_H */
 /// @}

--- a/tests/API/probes/Makefile.am
+++ b/tests/API/probes/Makefile.am
@@ -5,8 +5,9 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/CPE/public \
 	-I$(top_srcdir)/src/CVE/public \
 	-I${top_srcdir}/src/CVSS/public \
-	-I$(top_srcdir)/src/OVAL/probes/SEAP/public \
+	-I$(top_srcdir)/src/OVAL/probes \
 	-I$(top_srcdir)/src/OVAL/probes/public \
+	-I$(top_srcdir)/src/OVAL/probes/SEAP/public \
 	-I$(top_srcdir)/src/OVAL/public \
 	-I$(top_srcdir)/src/XCCDF/public \
 	-I$(top_srcdir)/src/common/public \

--- a/tests/API/probes/test_fsdev_is_local_fs.c
+++ b/tests/API/probes/test_fsdev_is_local_fs.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <mntent.h>
 #include "fsdev.h"
+#include "fsdev.c"
 
 static int test_single_call()
 {


### PR DESCRIPTION
It isn't necessary to expose this function in public API.
The function has been accidentaly introduced to public API
in fff58197d9747a08d0fc23914a31fefbe44f07ea which hasn't
been released yet, so it can be safe to remove it.