### PR TITLE
Improved UX of executing oscap right after compilation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,7 +494,13 @@ add_subdirectory("schemas")
 add_subdirectory("xsl")
 add_subdirectory("cpe")
 add_subdirectory("swig")
-configure_file("run.in" "run" @ONLY)
+configure_file("run.in" ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/run @ONLY)
+configure_file("oscap_wrapper.in" ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/oscap_wrapper @ONLY)
+file(
+	COPY "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/run" "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/oscap_wrapper"
+	DESTINATION ${CMAKE_BINARY_DIR}
+	FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)
 
 if(NOT WIN32)
 	# pkgconfig file

--- a/oscap_wrapper.in
+++ b/oscap_wrapper.in
@@ -1,0 +1,34 @@
+#!/bin/bash -
+# openscap 'run' programs locally script
+# Copyright (C) 2011-2013 Red Hat Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#----------------------------------------------------------------------
+
+# With this script you can run oscap without needing to
+# install the utility first.  You just have to do for example:
+#
+#   ./oscap_wrapper [oscap args ...]
+#
+# This works for any C program or test that uses the openscap
+# libraries.
+
+#----------------------------------------------------------------------
+
+# Build directory
+b=@CMAKE_BINARY_DIR@
+
+"$b/run" "$b/utils/oscap" "$@"

--- a/oscap_wrapper.in
+++ b/oscap_wrapper.in
@@ -1,6 +1,6 @@
 #!/bin/bash -
 # openscap 'run' programs locally script
-# Copyright (C) 2011-2013 Red Hat Inc.
+# Copyright (C) 2011-2019 Red Hat Inc.
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -22,9 +22,6 @@
 # install the utility first.  You just have to do for example:
 #
 #   ./oscap_wrapper [oscap args ...]
-#
-# This works for any C program or test that uses the openscap
-# libraries.
 
 #----------------------------------------------------------------------
 

--- a/run.in
+++ b/run.in
@@ -18,10 +18,10 @@
 
 #----------------------------------------------------------------------
 
-# With this script you can run oscap without needing to
+# With this script you can run oscap (or valgrind, gdb, ...) without needing to
 # install the utility first.  You just have to do for example:
 #
-#   ./run ./utils/oscap [args ...]
+#   ./run program [program args ...]
 #
 # This works for any C program or test that uses the openscap
 # libraries.


### PR DESCRIPTION
* ~Renamed run to oscap_wrapper.~
* ~Make the compiled oscap invocation part of the scipt.~
* Introduced the oscap_wrapper script that contains the compiled oscap invocation.
* Improved comments of the run script, to make it's usage more explicit.

Making this 1.3-only as this heavily depends on the build system.