### PR TITLE
OVAL details in HTML report improvements

### DIFF
--- a/xsl/xccdf-report-oval-details.xsl
+++ b/xsl/xccdf-report-oval-details.xsl
@@ -50,7 +50,14 @@ Authors:
     </xsl:apply-templates>
 </xsl:template>
 
-<xsl:template mode='brief' match='ovalres:definition|ovalres:criteria|ovalres:criterion|ovalres:extend_definition'>
+<xsl:template mode='brief' match='ovalres:extend_definition'>
+    <xsl:param name='result'/>
+    <xsl:apply-templates select='key("oval-definition", @definition_ref)' mode='brief'>
+        <xsl:with-param name='result' select='$result'/>
+    </xsl:apply-templates>
+</xsl:template>
+
+<xsl:template mode='brief' match='ovalres:definition|ovalres:criteria|ovalres:criterion'>
     <xsl:param name='result'/>
     <xsl:apply-templates select='key("oval-test", @test_ref)' mode='brief'>
         <xsl:with-param name='title' select='key("oval-testdef", @test_ref)/@comment'/>

--- a/xsl/xccdf-report-oval-details.xsl
+++ b/xsl/xccdf-report-oval-details.xsl
@@ -123,7 +123,6 @@ Authors:
             <xsl:variable name='object_id' select='key("oval-testdef", @test_id)/*[local-name()="object"]/@object_ref'/>
             <xsl:variable name='object_info' select='key("oval-objectdef",$object_id)'/>
             <xsl:variable name='state_id' select='key("oval-testdef", @test_id)/*[local-name()="state"]/@state_ref'/>
-            <xsl:variable name='state_info' select='key("oval-statedef",$state_id)'/>
             <xsl:variable name='comment' select='$object_info[1]/@comment'/>
             <xsl:if test="$object_info">
                 <h4>
@@ -176,27 +175,6 @@ Authors:
                         </tr>
                     </tbody>
                 </table>
-                <xsl:if test="$state_info">
-                    <h5>State <strong><xsl:value-of select='$state_id'/></strong> of type
-                    <strong><xsl:value-of select='local-name($state_info)'/></strong></h5>
-                    <table class="table table-striped table-bordered">
-                        <thead>
-                            <xsl:apply-templates mode='item-head' select='$state_info[1]'/>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <xsl:variable name='variable_id' select='$state_info/*/@var_ref'/>
-                                <xsl:if test='$variable_id'>
-                                    <td>
-                                        <xsl:apply-templates mode='normal' select='ovalres:tested_variable'/>
-                                        <xsl:apply-templates mode='message' select='key("ovalsys-object",$object_id)'/>
-                                    </td>
-                                </xsl:if>
-                                <xsl:apply-templates mode='state' select='$state_info[1]'/>
-                            </tr>
-                       </tbody>
-                    </table>
-                </xsl:if>
             </xsl:if>
         </xsl:otherwise>
     </xsl:choose>

--- a/xsl/xccdf-report-oval-details.xsl
+++ b/xsl/xccdf-report-oval-details.xsl
@@ -44,35 +44,31 @@ Authors:
 
 <xsl:template mode='brief' match='ovalres:oval_results'>
     <xsl:param name='definition-id' />
-    <xsl:param name='result'/>
-    <xsl:apply-templates select='key("oval-definition", $definition-id)' mode='brief'>
-        <xsl:with-param name='result' select='$result'/>
-    </xsl:apply-templates>
+    <xsl:apply-templates select='key("oval-definition", $definition-id)' mode='brief' />
 </xsl:template>
 
 <xsl:template mode='brief' match='ovalres:extend_definition'>
-    <xsl:param name='result'/>
-    <xsl:apply-templates select='key("oval-definition", @definition_ref)' mode='brief'>
-        <xsl:with-param name='result' select='$result'/>
+    <xsl:apply-templates select='key("oval-definition", @definition_ref)' mode='brief' />
+</xsl:template>
+
+<xsl:template mode='brief' match='ovalres:criterion'>
+    <xsl:apply-templates select='key("oval-test", @test_ref)' mode='brief'>
+        <xsl:with-param name='title' select='key("oval-testdef", @test_ref)/@comment'/>
     </xsl:apply-templates>
 </xsl:template>
 
-<xsl:template mode='brief' match='ovalres:definition|ovalres:criteria|ovalres:criterion'>
-    <xsl:param name='result'/>
-    <xsl:apply-templates select='key("oval-test", @test_ref)' mode='brief'>
-        <xsl:with-param name='title' select='key("oval-testdef", @test_ref)/@comment'/>
-        <xsl:with-param name='result' select='$result'/>
-    </xsl:apply-templates>
+<xsl:template mode='brief' match='ovalres:criteria'>
     <!-- descend deeper into the logic formula -->
-    <xsl:apply-templates mode='brief'>
-        <xsl:with-param name='result' select='$result'/>
-    </xsl:apply-templates>
+    <xsl:apply-templates mode='brief' />
+</xsl:template>
+
+<xsl:template mode='brief' match='ovalres:definition'>
+    <xsl:apply-templates mode='brief' select="ovalres:criteria" />
 </xsl:template>
 
 <!-- OVAL items dump -->
 <xsl:template mode='brief' match='ovalres:test'>
     <xsl:param name='title'/>
-    <xsl:param name='result'/>
     <xsl:variable name='items' select='ovalres:tested_item'/>
     <xsl:choose>
         <!-- if there are items to display, go ahead -->
@@ -85,10 +81,19 @@ Authors:
                     </xsl:choose>
                 </span><!-- #160 is nbsp -->&#160;
                 <xsl:choose>
-                    <xsl:when test='$result="pass"'><span class="label label-success">passed</span> because of these items:</xsl:when>
-                    <xsl:otherwise><span class="label label-danger">failed</span> because of these items:</xsl:otherwise>
+                    <xsl:when test="@result='true'">
+                        <span class="label label-success">
+                            <xsl:value-of select="@result"/>
+                        </span>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <span class="label label-danger">
+                            <xsl:value-of select="@result"/>
+                        </span>
+                    </xsl:otherwise>
                 </xsl:choose>
             </h4>
+            <h5>Following items have been found on the system:</h5>
 
             <table class="table table-striped table-bordered">
                 <!-- table head (possibly item-type-specific) -->
@@ -124,10 +129,19 @@ Authors:
                 <h4>
                     <span class="label label-primary"><xsl:value-of select="$title"/></span><!-- #160 is nbsp -->&#160;
                     <xsl:choose>
-                        <xsl:when test='$result="pass"'><span class="label label-success">passed</span> because these items were not found:</xsl:when>
-                        <xsl:otherwise><span class="label label-danger">failed</span> because these items were missing:</xsl:otherwise>
+                        <xsl:when test="@result='true'">
+                            <span class="label label-success">
+                                <xsl:value-of select="@result"/>
+                            </span>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <span class="label label-danger">
+                                <xsl:value-of select="@result"/>
+                            </span>
+                        </xsl:otherwise>
                     </xsl:choose>
                 </h4>
+                <h5>No items have been found conforming to the following objects:</h5>
                 <h5>Object <strong><abbr>
                 <xsl:if test='$comment'>
                     <xsl:attribute name='title'>


### PR DESCRIPTION
The scope of this PR is smaller than #964 so hopefully it won't get stalled.

This PR adds the following XCCDF HTML report improvements:
* adds support for `extend_definition` element in  "OVAL details" section 
* Fixes misleading `pass` or `fail` in OVAL details section. Instead, it shows real OVAL results.
* Doesn't show OVAL state when no OVAL items were collected.

For more details and explanation, please read the commit messages of every commit.