### PR TITLE
Mention bzip2 dependency for tests in documentation

### DIFF
--- a/docs/developer/developer.adoc
+++ b/docs/developer/developer.adoc
@@ -111,7 +111,7 @@ After building the library you might want to run library self-checks. To do
 that you need to have these additional packages installed:
 
 ----
-wget lua which procps-ng initscripts chkconfig sendmail
+wget lua which procps-ng initscripts chkconfig sendmail bzip2
 ----
 
 and it is also required to have `sendmail` service running on the system:


### PR DESCRIPTION
[tests/bz2/test_bz2_datastream.sh](https://github.com/OpenSCAP/openscap/blob/maint-1.3/tests/bz2/test_bz2_datastream.sh) uses `bzip2`. This tool is in `bzip2` package (not in `bzip2-devel` mentioned in build dependencies).