### PR TITLE
Update versions.sh in maint-1.2

### DIFF
--- a/release_tools/versions.sh
+++ b/release_tools/versions.sh
@@ -1,6 +1,6 @@
-version=1.2.17
-previous_version=1.2.16
-latest_fedora=29
-latest_rhel=7
+version=1.2.18
+previous_version=1.2.17
+latest_fedora=31
+latest_rhel=8
 
 version_major_minor="${version%.*}"


### PR DESCRIPTION
Future version of OpenSCAP is 1.2.18. Latest released version is 1.2.17.
Latest supported Fedora is 31 (current Rawhide). Latest RHEL is 8.