### PR TITLE
Change creating of zombie process and waiting for processes at process58 test

### DIFF
--- a/tests/probes/process58/command_line.sh
+++ b/tests/probes/process58/command_line.sh
@@ -90,7 +90,7 @@ echo "stderr file: $stderr"
 	CMDLINE_REGEX='/(\w+/)+bash.*stopped_process\.sh param1 param2 param3$'
 
 	# Run zombie process (without full cmdline)
-	( SHELL_PID=$BASHPID && ( kill -STOP $SHELL_PID ) ) &
+	( SHELL_PID=$BASHPID && ( kill -STOP $SHELL_PID && sleep 1 ) ) &
 	ZOMBIE_PPID=$!
 	ZOMBIE_PID=$(get_zombie_pid_from_ppid ${ZOMBIE_PPID})
 	[ -n "${ZOMBIE_PPID}" ]


### PR DESCRIPTION
The old creating zombie process did not work properly (seems like there were some changes in planning/stopping processes) and it caused problems with running tests (it was randomly passing/failing/waiting because of the test).

The commit also changes waiting for process, because the name of created zombie process isn't `stopped_process.sh`, but `command_line.sh` (line [98](https://github.com/mildas/openscap/blob/a923e01a29df6e051d9b8a0dfa2336084adb1829/tests/probes/process58/command_line.sh#L98)), so it was waiting 30 seconds for `stopped_process.sh` zombie, but it never appears.