### PR TITLE
Include additional headers in dkpginfo-helper for apt 1.9

### DIFF
--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
+++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
@@ -9,9 +9,12 @@
 
 #include <apt-pkg/init.h>
 #include <apt-pkg/error.h>
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/fileutl.h>
 #include <apt-pkg/mmap.h>
 #include <apt-pkg/pkgcache.h>
 #include <apt-pkg/pkgrecords.h>
+#include <apt-pkg/pkgsystem.h>
 
 #include "dpkginfo-helper.h"
 


### PR DESCRIPTION
apt 1.9 cleans up the header includes a bit, causing the build
to fail, so add the additional headers we are missing.