### PR TITLE
Fix (null) string when XCCDF value not set

### DIFF
--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -425,6 +425,9 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 		if (value == NULL)
 		{
 			value = xccdf_value_binding_get_value(binding);
+			if (value == NULL) {
+				value = "";
+			}
 		}
 		xccdf_operator_t operator = xccdf_value_binding_get_operator(binding);
 


### PR DESCRIPTION
Similar to 793475c2dfddf4d122722f097b99b5e0d0ca48ce assign an
emtpy string to XCCDF value if xccdf_value_binding_get_value
returns NULL.