### PR TITLE
Fix #1173, RHBZ#1603347: Double chdir/chroot in probe rpmverifypackage

### DIFF
--- a/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
@@ -314,8 +314,7 @@ ret:
 
 int rpmverifypackage_probe_offline_mode_supported()
 {
-	// TODO: Switch this to OFFLINE_MODE_OWN once rpmtsSetRootDir is fully supported by librpm
-	return PROBE_OFFLINE_CHROOT;
+	return PROBE_OFFLINE_OWN;
 }
 
 void *rpmverifypackage_probe_init(void)


### PR DESCRIPTION
The probe is using chroot in the init function, where all the packages
information is being collected. So, the comment is actually misleading
everybody and the probe should be switched to the custom offline mode
right away.

This will fix #1173, [RHBZ#1603347](https://bugzilla.redhat.com/show_bug.cgi?id=1603347).

I used the content attached to the RHBZ ticket to check this patch. I ran all the test from this file (not just 6, as in example) and all where successful (except for 8, but that is expected I suppose).