### PR TITLE
Add ability to run uninstalled oscap-docker

### DIFF
--- a/run.in
+++ b/run.in
@@ -53,7 +53,8 @@ fi
 
 # For SWIG bindings.
 export PERL5LIB=$b/swig/perl:$b/swig/perl${PERL5LIB:+:$PERL5LIB}
-export PYTHONPATH=$s/swig/python3:$b/swig/src:$b/swig/python3:$b/swig/python3${PYTHONPATH:+:$PYTHONPATH}
+export PYTHONPATH=$s/utils:$s/swig/python3:$b/swig/src:$b/swig/python3:$b/swig/python3${PYTHONPATH:+:$PYTHONPATH}
+export PYTHONDONTWRITEBYTECODE=Y
 
 # This is a cheap way to find some use-after-free and uninitialized
 # read problems when using glibc.

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -39,7 +39,12 @@ if(ENABLE_OSCAP_UTIL_CHROOT)
 	)
 endif()
 if(ENABLE_OSCAP_UTIL_DOCKER)
-	configure_file("oscap-docker.in" "oscap-docker" @ONLY)
+	configure_file("oscap-docker.in" "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/oscap-docker" @ONLY)
+	file(
+		COPY "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/oscap-docker"
+		DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+		FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+	)
 	execute_process(COMMAND
 		${OSCAP_DOCKER_PYTHON} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(False, False, prefix='${CMAKE_INSTALL_PREFIX}'))"
 		OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_INSTALL_DIR

--- a/utils/oscap-docker.in
+++ b/utils/oscap-docker.in
@@ -26,20 +26,6 @@ import sys
 from requests import exceptions
 
 
-def cve_scan(scan_target, other_scan_args):
-    ''' Wrapper function for container/image scanning '''
-    OS = OscapScan()
-    result = OS.scan_cve(scan_target, other_scan_args)
-    return result
-
-
-def scan(scan_target, other_scan_args):
-    ''' Wrapper function to scan with openscap'''
-    OS = OscapScan()
-    result = OS.scan(scan_target, other_scan_args)
-    return result
-
-
 def ping_docker():
     ''' Simple check if the docker daemon is running '''
     # Class docker.Client was renamed to docker.APIClient in
@@ -55,12 +41,13 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='oscap docker',
                                      epilog='See `man oscap` to learn \
                                      more about OSCAP-ARGUMENTS')
+    parser.add_argument('--oscap', dest='oscap_binary', default='', help='Set the oscap binary to use')
     subparser = parser.add_subparsers(help="commands")
 
     # Scan CVEs in image
     image_cve = subparser.add_parser('image-cve', help='Scan a docker image \
                                     for known vulnerabilities.')
-    image_cve.set_defaults(func=cve_scan)
+    image_cve.set_defaults(func=OscapScan.scan_cve)
     image_cve.add_argument('scan_target', help='Container or image to scan')
 
     # Scan an Image
@@ -68,20 +55,20 @@ if __name__ == '__main__':
     image.add_argument('scan_target',
                        help='Container or image to scan')
 
-    image.set_defaults(func=scan)
+    image.set_defaults(func=OscapScan.scan)
     # Scan a container
     container = subparser.add_parser('container', help='Scan a running docker\
                                       container of given name.')
     container.add_argument('scan_target',
                            help='Container or image to scan')
-    container.set_defaults(func=scan)
+    container.set_defaults(func=OscapScan.scan)
 
     # Scan CVEs in container
     container_cve = subparser.add_parser('container-cve', help='Scan a \
                                          running container for known \
                                          vulnerabilities.')
 
-    container_cve.set_defaults(func=cve_scan)
+    container_cve.set_defaults(func=OscapScan.scan_cve)
     container_cve.add_argument('scan_target',
                                help='Container or image to scan')
 
@@ -99,7 +86,8 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
-        rc = args.func(args.scan_target, leftover_args)
+        OS = OscapScan(oscap_binary=args.oscap_binary)
+        rc = args.func(OS, args.scan_target, leftover_args)
     except Exception as exc:
         sys.exit(255)
         raise exc

--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -79,8 +79,9 @@ class OscapHelpers(object):
     CPE = 'oval:org.open-scap.cpe.rhel:def:'
     DISTS = ["7", "6", "5"]
 
-    def __init__(self, cve_input_dir):
+    def __init__(self, cve_input_dir, oscap_binary):
         self.cve_input_dir = cve_input_dir
+        self.oscap_binary = oscap_binary or 'oscap'
 
     @staticmethod
     def _mk_tmp_dir(tmp_dir):
@@ -152,7 +153,7 @@ class OscapHelpers(object):
         os.environ["OSCAP_PROBE_OS_NAME"] = platform.system()
         os.environ["OSCAP_PROBE_OS_VERSION"] = platform.release()
         os.environ["OSCAP_EVALUATION_TARGET"] = self._get_target_name(target)
-        cmd = ['oscap'] + [x for x in oscap_args]
+        cmd = [self.oscap_binary] + [x for x in oscap_args]
         oscap_process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         oscap_stdout, oscap_stderr = oscap_process.communicate()
         return OscapResult(oscap_process.returncode,
@@ -207,9 +208,9 @@ def mount_image_filesystem():
 
 class OscapScan(object):
     def __init__(self, tmp_dir=tempfile.gettempdir(), mnt_dir=None,
-                 hours_old=2):
+                 hours_old=2, oscap_binary=''):
         self.tmp_dir = tmp_dir
-        self.helper = OscapHelpers(tmp_dir)
+        self.helper = OscapHelpers(tmp_dir, oscap_binary)
         self.mnt_dir = mnt_dir
         self.hours_old = hours_old
 


### PR DESCRIPTION
added option to choose `oscap` executable for `oscap-docker` invocation;
`oscap-docker` is now executable in build/utils;
extended PYTHONPATH with \<SRC\>/utils in `run`;
added PYTHONDONTWRITEBYTECODE to `run`.

This will allow execution of commands like:
`sudo ./run utils/oscap-docker --oscap=utils/oscap image registry.access.redhat.com/rhel7 oval eval probe_test_rpm.oval.xml`