### PR TITLE
Add XCCDF results into user manual

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -450,34 +450,43 @@ This table lists the possible results of a single rule:
 
 .XCCDF results
 |===
-|Result |Description
+|Result |Description |Example Situation
 
 |pass
 |The target system or system component satisfied all the conditions of the rule.
+|
 
 |fail
 |The target system or system component did not satisfy all the conditions of the rule.
+|
 
 |error
-|The checking engine could not complete the evaluation, therefore the status of the target’s compliance with the rule is not certain. This could happen, for example, if a testing tool was run with insufficient privileges and could not gather all of the necessary information.
+|The checking engine could not complete the evaluation, therefore the status of the target’s compliance with the rule is not certain.
+|OpenSCAP was run with insufficient privileges and could not gather all of the necessary information.
 
 |unknown
-|The testing tool encountered some problem and the result is unknown. For example, a result of ‘unknown’ might be given if the testing tool was unable to interpret the output of the checking engine (the output has no meaning to the testing tool)
+|The testing tool encountered some problem and the result is unknown.
+|OpenSCAP was unable to interpret the output of the checking engine (the output has no meaning to OpenSCAP).
 
 |notapplicable
-|The rule was not applicable to the target of the test. For example, the rule might have been specific to a different version of the target OS, or it might have been a test against a platform feature that was not installed.
+|The rule was not applicable to the target of the test.
+|The rule might have been specific to a different version of the target OS, or it might have been a test against a platform feature that was not installed.
 
 |notchecked
-|The rule was not evaluated by the checking engine. This status is designed for rules that have no <xccdf:check> elements or that correspond to an unsupported checking system. It may also correspond to a status returned by a checking engine if the checking engine does not support the indicated check code. For example, the rule does not reference any OVAL check.
+|The rule was not evaluated by the checking engine. This status is designed for rules that have no <xccdf:check> elements or that correspond to an unsupported checking system. It may also correspond to a status returned by a checking engine if the checking engine does not support the indicated check code.
+|The rule does not reference any OVAL check.
 
 |notselected
 |The rule was not selected in the benchmark. OpenSCAP does not display rules that were not selected.
+|The rule exists in the benchmark, but is not a part of selected profile.
 
 |informational
 |The rule was checked, but the output from the checking engine is simply information for auditors or administrators; it is not a compliance category. This status value is designed for rules whose main purpose is to extract information from the target rather than test the target.
+|
 
 |fixed
 |The rule had failed, but was then fixed by automated remediation.
+|
 |===
 
 The CPE dictionary is used to determine whether the content is

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -445,6 +445,41 @@ Ident   CCE-3967-7
 Result  pass
 ----
 
+The meaning of results is defined by https://csrc.nist.gov/CSRC/media/Publications/nistir/7275/rev-4/final/documents/nistir-7275r4_updated-march-2012_clean.pdf[XCCDF Specification].
+This table lists the possible results of a single rule:
+
+.XCCDF results
+|===
+|Result |Description
+
+|pass
+|The target system or system component satisfied all the conditions of the rule.
+
+|fail
+|The target system or system component did not satisfy all the conditions of the rule.
+
+|error
+|The checking engine could not complete the evaluation, therefore the status of the target’s compliance with the rule is not certain. This could happen, for example, if a testing tool was run with insufficient privileges and could not gather all of the necessary information.
+
+|unknown
+|The testing tool encountered some problem and the result is unknown. For example, a result of ‘unknown’ might be given if the testing tool was unable to interpret the output of the checking engine (the output has no meaning to the testing tool)
+
+|notapplicable
+|The rule was not applicable to the target of the test. For example, the rule might have been specific to a different version of the target OS, or it might have been a test against a platform feature that was not installed.
+
+|notchecked
+|The rule was not evaluated by the checking engine. This status is designed for rules that have no <xccdf:check> elements or that correspond to an unsupported checking system. It may also correspond to a status returned by a checking engine if the checking engine does not support the indicated check code. For example, the rule does not reference any OVAL check.
+
+|notselected
+|The rule was not selected in the benchmark. OpenSCAP does not display rules that were not selected.
+
+|informational
+|The rule was checked, but the output from the checking engine is simply information for auditors or administrators; it is not a compliance category. This status value is designed for rules whose main purpose is to extract information from the target rather than test the target.
+
+|fixed
+|The rule had failed, but was then fixed by automated remediation.
+|===
+
 The CPE dictionary is used to determine whether the content is
 applicable on the target platform or not. Any content that is not
 applicable will result in each relevant XCCDF rule being evaluated to


### PR DESCRIPTION
Users don't know what the results of rule evaluation mean. Although
it's specified in XCCDF specification, it's easier to find it
described in user's manual. I have mostly copied the table 26 from
https://csrc.nist.gov/CSRC/media/Publications/nistir/7275/rev-4/final/documents/nistir-7275r4_updated-march-2012_clean.pdf
and have added some OpenSCAP specific examples.