### PR TITLE
Prevent broken output in "--progress" mode

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -592,10 +592,10 @@ _xccdf_policy_rule_get_applicable_check(struct xccdf_policy *policy, struct xccd
 
 		// Only print a warning if we didn't select a check but could've otherwise.
 		if (print_oval_warning) {
-			printf("WARNING: Skipping rule that uses OVAL but is possibly malformed; "
+			dW("Skipping rule that uses OVAL but is possibly malformed; "
 			       "an incorrect content reference prevents this check from being evaluated.\n");
 		} else if (print_general_warning && result == NULL) {
-			printf("WARNING: Skipping rule that requires an unregistered check system "
+			dW("Skipping rule that requires an unregistered check system "
 			       "or incorrect content reference to evaluate. "
 			       "Please consider providing a valid SCAP/OVAL instead of %s\n",
 				warning_check_system);

--- a/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_empty.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_empty.sh
@@ -12,7 +12,7 @@ $OSCAP xccdf eval --profile xccdf_moc.elpmaxe.www_profile_1 --results $result $s
 
 echo "Stderr file = $stderr"
 echo "Result file = $result"
-[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+rm $stderr
 
 $OSCAP xccdf validate-xml $result
 

--- a/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_empty.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_empty.sh
@@ -12,6 +12,7 @@ $OSCAP xccdf eval --profile xccdf_moc.elpmaxe.www_profile_1 --results $result $s
 
 echo "Stderr file = $stderr"
 echo "Result file = $result"
+grep "Skipping rule that requires an unregistered check system or incorrect content reference to evaluate." $stderr
 rm $stderr
 
 $OSCAP xccdf validate-xml $result

--- a/tests/API/XCCDF/unittests/test_xccdf_check_unsupported_check_system.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_unsupported_check_system.sh
@@ -8,6 +8,7 @@ stderr=`mktemp`
 
 $OSCAP xccdf eval --results $result $srcdir/test_xccdf_check_unsupported_check_system.xml 2> $stderr
 echo "Stderr file = $stderr"
+grep "Skipping rule that requires an unregistered check system or incorrect content reference to evaluate." $stderr
 rm $stderr
 
 $OSCAP xccdf validate-xml $result

--- a/tests/API/XCCDF/unittests/test_xccdf_check_unsupported_check_system.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_unsupported_check_system.sh
@@ -8,7 +8,7 @@ stderr=`mktemp`
 
 $OSCAP xccdf eval --results $result $srcdir/test_xccdf_check_unsupported_check_system.xml 2> $stderr
 echo "Stderr file = $stderr"
-[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+rm $stderr
 
 $OSCAP xccdf validate-xml $result
 

--- a/tests/API/XCCDF/unittests/test_xccdf_check_without_content_refs.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_without_content_refs.sh
@@ -11,6 +11,7 @@ $OSCAP xccdf eval --results $result $srcdir/test_xccdf_check_without_content_ref
 echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]
+grep "Skipping rule that uses OVAL but is possibly malformed; an incorrect content reference prevents this check from being evaluated." $stderr
 rm $stderr
 
 $OSCAP xccdf validate-xml $result

--- a/tests/API/XCCDF/unittests/test_xccdf_check_without_content_refs.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_without_content_refs.sh
@@ -10,7 +10,8 @@ $OSCAP xccdf eval --results $result $srcdir/test_xccdf_check_without_content_ref
 
 echo "Stderr file = $stderr"
 echo "Result file = $result"
-[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+[ -f $stderr ]
+rm $stderr
 
 $OSCAP xccdf validate-xml $result
 

--- a/tests/API/XCCDF/unittests/test_xccdf_multiple_testresults.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_multiple_testresults.sh
@@ -16,7 +16,7 @@ tmpdir=$(dirname $result)
 for i in {1..5}; do
 	$OSCAP xccdf eval --results $result $result 2> $stderr
 	[ -f $stderr ]
-	[ "`cat $stderr`" == "WARNING: Skipping $tmpdir/non_existent.oval.xml file which is referenced from XCCDF content" ]
+	grep "Skipping $tmpdir/non_existent\.oval\.xml file which is referenced from XCCDF content" $stderr
 	:> $stderr
 
 	$OSCAP xccdf validate-xml $result

--- a/tests/API/XCCDF/unittests/test_xccdf_notchecked_has_check.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_notchecked_has_check.sh
@@ -13,7 +13,7 @@ $OSCAP xccdf eval --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]
-[ "WARNING: Skipping $srcdir/_non_existent_.oval.xml file which is referenced from XCCDF content" == "`cat $stderr`" ]
+grep "Skipping $srcdir/_non_existent_\.oval\.xml file which is referenced from XCCDF content" $stderr
 rm $stderr
 
 $OSCAP xccdf validate-xml $result

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -374,21 +374,6 @@ static int callback_scr_result(struct xccdf_rule_result *rule_result, void *arg)
 	return 0;
 }
 
-static int callback_scr_rule_progress(struct xccdf_rule *rule, void *arg)
-{
-	const char * rule_id = xccdf_rule_get_id(rule);
-
-	/* is rule selected? we print only selected rules */
-	const bool selected = xccdf_policy_is_item_selected((struct xccdf_policy *) arg, rule_id);
-	if (!selected)
-		return 0;
-
-	printf("%s:", rule_id);
-	fflush(stdout);
-
-	return 0;
-}
-
 static int callback_scr_result_progress(struct xccdf_rule_result *rule_result, void *arg)
 {
 	xccdf_test_result_type_t result = xccdf_rule_result_get_result(rule_result);
@@ -398,9 +383,10 @@ static int callback_scr_result_progress(struct xccdf_rule_result *rule_result, v
 		return 0;
 
 	/* print result */
-	const char * result_str = xccdf_test_result_type_get_text(result);
+	const char *rule_id = xccdf_rule_result_get_idref(rule_result);
+	const char *result_str = xccdf_test_result_type_get_text(result);
 
-	printf("%s\n", result_str);
+	printf("%s:%s\n", rule_id, result_str);
 	fflush(stdout);
 
 	return 0;
@@ -442,8 +428,6 @@ static void _register_progress_callback(struct xccdf_session *session, bool prog
 {
 	struct xccdf_policy_model *policy_model = xccdf_session_get_policy_model(session);
 	if (progress) {
-		xccdf_policy_model_register_start_callback(policy_model, callback_scr_rule_progress,
-				(void *) xccdf_session_get_xccdf_policy(session));
 		xccdf_policy_model_register_output_callback(policy_model, callback_scr_result_progress, NULL);
 	}
 	else {


### PR DESCRIPTION
In "--progress" mode we print out the rule id and ': ' before the rule
evaluation starts and the rest of the line after the rule evaluation
finishes. If any warning occurs during the evaluation, it's printed in
the middle, which looks ugly. We can fix this by printing the
whole line at the same moment, after the rule evaluation finishes.
Also, the warnings should use dW macros in order to be able to turn them
on/off using `--verbose` option.
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1640889