### PR TITLE
Fix build warning

### DIFF
--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -33,6 +33,7 @@
 # include <pthread.h>
 #endif
 
+#include "oscap_helpers.h"
 #include "oval_probe.h"
 #include "oval_system_characteristics.h"
 #include "common/_error.h"


### PR DESCRIPTION
Addressing:
```
openscap/src/OVAL/oval_probe.c: In function ‘oval_probe_query_object’:
openscap/src/OVAL/oval_probe.c:145:15: warning: implicit declaration of function ‘oscap_sprintf’; did you mean ‘oscap_vsprintf’? [-Wimplicit-function-declaration]
   char *msg = oscap_sprintf("OVAL object '%s_object' is not supported.", type_name);
               ^~~~~~~~~~~~~
               oscap_vsprintf
openscap/src/OVAL/oval_probe.c:145:15: warning: initialization of ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
```