### PR TITLE
Fix missing filepaths in rpminfo items

### DIFF
--- a/src/OVAL/probes/unix/linux/rpminfo.c
+++ b/src/OVAL/probes/unix/linux/rpminfo.c
@@ -339,7 +339,8 @@ static int collect_rpm_files(SEXP_t *item, const struct rpminfo_rep *rep) {
 		ret = -1;
 		goto cleanup;
 	}
-	if (rpmdbSetIteratorRE(ts, RPMTAG_EPOCH, RPMMIRE_STRCMP, rep->epoch) != 0) {
+	char *epoch_override = oscap_streq(rep->epoch, "(none)") ? "0" : rep->epoch;
+	if (rpmdbSetIteratorRE(ts, RPMTAG_EPOCH, RPMMIRE_STRCMP, epoch_override) != 0) {
 		ret = -1;
 		goto cleanup;
 	}


### PR DESCRIPTION
When the queried RPM package has null epoch (or "(none)" as returned by "rpm -q --qf '%{EPOCH}\n'" command), the rpminfo_item produced by the probe didn't contain any filepath element. To use the null epoch as a parameter of rpmdbSetIteratorRE, the "(none)" string should be replaced by "0".

I have a reproducer on Fedora 30: [rpminfo_reproducer.zip](https://github.com/OpenSCAP/openscap/files/3421607/rpminfo_reproducer.zip) The rpminfo_item in OVAL results doesn't contain any filepath.
