### PR TITLE
OVAL/selinuxsecuritycontext: Remove the is_selinux_enabled check.

### DIFF
--- a/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c
+++ b/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c
@@ -330,11 +330,6 @@ int selinuxsecuritycontext_probe_main(probe_ctx *ctx, void *arg)
 	OVAL_FTS    *ofts;
 	OVAL_FTSENT *ofts_ent;
 
-	if ( ! is_selinux_enabled()) {
-		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
-		return 0;
-	}
-
 	probe_in  = probe_ctx_getobject(ctx);
 
 	behaviors = probe_obj_getent (probe_in, "behaviors", 1);


### PR DESCRIPTION
The probe is supposed to check security context (extended attrs.)
of objects in question. The fact that SELinux is enabled or
disabled is irrelevant to this check.

Fixes #1332