### PR TITLE
Dpkg info offline mode, fixes

### DIFF
--- a/src/OVAL/probes/probe-table.c
+++ b/src/OVAL/probes/probe-table.c
@@ -246,7 +246,7 @@ static const probe_table_entry_t probe_table[] = {
 	{OVAL_INDEPENDENT_XML_FILE_CONTENT, xmlfilecontent_probe_init, xmlfilecontent_probe_main, xmlfilecontent_probe_fini, xmlfilecontent_probe_offline_mode_supported},
 #endif
 #ifdef OPENSCAP_PROBE_LINUX_DPKGINFO
-	{OVAL_LINUX_DPKG_INFO, dpkginfo_probe_init, dpkginfo_probe_main, NULL, NULL},
+	{OVAL_LINUX_DPKG_INFO, dpkginfo_probe_init, dpkginfo_probe_main, dpkginfo_probe_fini, dpkginfo_probe_offline_mode_supported},
 #endif
 #ifdef OPENSCAP_PROBE_LINUX_IFLISTENERS
 	{OVAL_LINUX_IFLISTENERS, NULL, iflisteners_probe_main, NULL, NULL},

--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
+++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
@@ -112,7 +112,7 @@ struct dpkginfo_reply_t * dpkginfo_get_by_name(const char *name, int *err)
         return reply;
 }
 
-void * dpkginfo_free_reply(struct dpkginfo_reply_t *reply)
+void dpkginfo_free_reply(struct dpkginfo_reply_t *reply)
 {
         if (reply) {
                 free(reply->name);

--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
+++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
@@ -28,7 +28,10 @@ static int opencache (void) {
         if (pkgInitConfig (*_config) == false) return 0;
         if (pkgInitSystem (*_config, _system) == false) return 0;
 
-        FileFd *fd = new FileFd (_config->FindFile ("Dir::Cache::pkgcache"),
+        const char* root = getenv("OSCAP_PROBE_ROOT");
+        string pkgCacheRoot(root != NULL ? root : "");
+
+        FileFd *fd = new FileFd (pkgCacheRoot + _config->FindFile ("Dir::Cache::pkgcache"),
                         FileFd::ReadOnly);
 
         dpkg_mmap = new MMap (*fd, MMap::Public|MMap::ReadOnly);

--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.h
+++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.h
@@ -40,7 +40,7 @@ int dpkginfo_fini();
 
 struct dpkginfo_reply_t * dpkginfo_get_by_name(const char *name, int *err);
 
-void * dpkginfo_free_reply(struct dpkginfo_reply_t *reply);
+void dpkginfo_free_reply(struct dpkginfo_reply_t *reply);
 
 #ifdef __cplusplus
 }

--- a/src/OVAL/probes/unix/linux/dpkginfo_probe.c
+++ b/src/OVAL/probes/unix/linux/dpkginfo_probe.c
@@ -57,6 +57,8 @@
 #include "common/debug_priv.h"
 #include "public/oval_schema_version.h"
 
+#include <probe/probe.h>
+
 #include "dpkginfo-helper.h"
 
 #include "dpkginfo_probe.h"
@@ -70,6 +72,9 @@ static struct dpkginfo_global g_dpkg = {
         .init_done = -1,
 };
 
+int dpkginfo_probe_offline_mode_supported(void) {
+        return PROBE_OFFLINE_OWN;
+}
 
 void *dpkginfo_probe_init(void)
 {

--- a/src/OVAL/probes/unix/linux/dpkginfo_probe.h
+++ b/src/OVAL/probes/unix/linux/dpkginfo_probe.h
@@ -25,6 +25,7 @@
 
 #include "probe-api.h"
 
+int dpkginfo_probe_offline_mode_supported(void);
 void *dpkginfo_probe_init(void);
 int dpkginfo_probe_main(probe_ctx *ctx, void *arg);
 void dpkginfo_probe_fini(void *arg);


### PR DESCRIPTION
Adding PROBE_OFFLINE_OWN support was very easy. But still there is a problem here: I'm unable to check any pkgcache.bin, be it a mounted file from VM or local file without any chroot shenanigans. The `new pkgCache (dpkg_mmap);` call always returns error 'The package cache file is corrupted'.

I'll just leave it here in case someone could shed some light on the matters.

This PR will also fix #1367 