### PR TITLE
Fix URL link mechanism for Red Hat Errata

### DIFF
--- a/xsl/oval-to-xccdf.xsl
+++ b/xsl/oval-to-xccdf.xsl
@@ -86,9 +86,9 @@ Authors:
     </xsl:template>
 
     <xsl:template match="oval-def:reference[@source='RHSA']">
-        <xsl:if test="starts-with(@ref_url, 'https://rhn.redhat.com/errata')">
-            <xccdf:ident system="https://rhn.redhat.com/errata">
-                <xsl:copy-of select="substring-before(substring-after(@ref_url, 'https://rhn.redhat.com/errata/'), '.html')"/>
+        <xsl:if test="starts-with(@ref_url, 'https://access.redhat.com/errata')">
+            <xccdf:ident system="https://access.redhat.com/errata">
+                <xsl:copy-of select="substring-after(@ref_url, 'https://access.redhat.com/errata/')"/>
             </xccdf:ident>
         </xsl:if>
     </xsl:template>

--- a/xsl/xccdf-share.xsl
+++ b/xsl/xccdf-share.xsl
@@ -55,8 +55,8 @@ Authors:
         <xsl:when test="starts-with(@system, 'http://cve.mitre.org')">
             <a href="{concat('https://cve.mitre.org/cgi-bin/cvename.cgi?name=', text())}"><abbr title="{concat(@system, concat(': ', text()))}"><xsl:value-of select="text()"/></abbr></a>
         </xsl:when>
-        <xsl:when test="starts-with(@system, 'https://rhn.redhat.com/errata')">
-            <a href="{concat('https://rhn.redhat.com/errata/', concat(text(), '.html'))}"><abbr title="{concat(@system, concat(': ', text()))}"><xsl:value-of select="text()"/></abbr></a>
+        <xsl:when test="starts-with(@system, 'https://access.redhat.com/errata')">
+            <a href="{concat('https://access.redhat.com/errata/', concat(text(), '.html'))}"><abbr title="{concat(@system, concat(': ', text()))}"><xsl:value-of select="text()"/></abbr></a>
         </xsl:when>
         <xsl:otherwise>
             <abbr title="{concat(@system, concat(': ', text()))}"><xsl:value-of select="text()"/></abbr>


### PR DESCRIPTION
Previously, public description of each erratum was available under

    https://rhn.redhat.com/errata/

at some point in time this has changed to

    https://access.redhat.com/errata/

and since not all links redirect properly from old to new, we have to fix
OpenSCAP end as well.

This enables people reviewing XCCDF policy guide or XCCDF result report to click
on RH[SBE]A-YYYY-ABCD acronym and be redirected to public description of the
given erratum.

# Before
![scrot-before-oscap-fix](https://user-images.githubusercontent.com/6666052/62127109-ca5bf580-b2c0-11e9-86c8-054fdad84c3f.jpg)

# After
![scrot-after-oscap-fix](https://user-images.githubusercontent.com/6666052/62127127-d5168a80-b2c0-11e9-97ae-334f00d20877.jpg)
