### PR TITLE
Fix --fix-type anaconda

### DIFF
--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -835,7 +835,7 @@ int app_generate_fix(const struct oscap_action *action)
 		} else if (strcmp(action->fix_type, "puppet") == 0) {
 			template = "urn:xccdf:fix:script:puppet";
 		} else if (strcmp(action->fix_type, "anaconda") == 0) {
-			template = "urn:xccdf:fix:script:anaconda";
+			template = "urn:redhat:anaconda:pre";
 		} else {
 			fprintf(stderr,
 					"Unknown fix type '%s'.\n"


### PR DESCRIPTION
`oscap xccdf generate fix --fix-type anaconda` was failing, because of wrong template associated with the fix type.