### PR TITLE
Fix typo in manpage and add missing option help usage documentation.

### DIFF
--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -112,7 +112,8 @@ static struct oscap_module OVAL_EVAL = {
 	"   --datastream-id <id>          - ID of the datastream in the collection to use.\n"
 	"                                   (only applicable for source datastreams)\n"
 	"   --oval-id <id>                - ID of the OVAL component ref in the datastream to use.\n"
-	"                                   (only applicable for source datastreams)\n",
+	"                                   (only applicable for source datastreams)\n"
+	"   --fetch-remote-resources      - Download remote content referenced by OVAL Definitions.\n",
     .opt_parser = getopt_oval_eval,
     .func = app_evaluate_oval
 };

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -569,7 +569,7 @@ Do not validate input/output files.
 .TP
 .B \fBsds-add\fR [\fIoptions\fR] NEW_COMPONENT EXISTING_SDS
 .RS
-Adds given NEW_COMPONENT file to the existing source datastream (EXISTING_SDS). Component file might be OVAL, XCCDF or CPE Dictionary file. Dependencies like OVAL files are automatically detected  an bundled in target source datastream.
+Adds given NEW_COMPONENT file to the existing source datastream (EXISTING_SDS). Component file might be OVAL, XCCDF or CPE Dictionary file. Dependencies like OVAL files are automatically detected and bundled in target source datastream.
 .TP
 \fB\-\-datastream-id DATASTREAM_ID\fR
 Uses a datastream with that particular ID from the given datastream collection. If not given the first datastream is used.


### PR DESCRIPTION
- Fix typo in oscap manpage.
- Add missing option from oval eval help usage documentation (--fetch-remote-resources)