### PR TITLE
SWIG openscap_api: Use __repr__() to get consistent string output

### DIFF
--- a/swig/openscap_api.py
+++ b/swig/openscap_api.py
@@ -27,6 +27,7 @@ __author__ = 'Maros Barabas'
 __version__ = '1.0'
 
 import logging                  # Logger for debug/info/error messages
+import re
 logger = logging.getLogger("openscap")
 
 from sys import version_info
@@ -135,8 +136,9 @@ class OSCAP_Object(object):
     @staticmethod
     def new(retobj):
         if type(retobj).__name__ in ('SwigPyObject', 'PySwigObject'):
-            # Extract the name of structure from "<num>_p_<name>"
-            structure = retobj.__str__()[retobj.__str__().find("_p_")+3:]
+            # Extract the name of structure from the representation of the object
+            # "<Swig Object of type 'struct xccdf_result_iterator *' at 0x7f8f65fc1390>"
+            structure = re.findall(r"type 'struct (\b\S*\b)", retobj.__repr__())[0]
             return OSCAP_Object(structure, retobj)
         else:
             return retobj


### PR DESCRIPTION
Lets use `__repr__()` to infer object structure, instead of `__str__()`.

`__str__()` returns different strings on different python versions

On python2, it returns something like
`'_e016160100000000_p_xccdf_result_iterator'`
On python3, it returns something like
`'<Swig Object of type 'struct xccdf_result_iterator *' at 0x7fc81474adb0>'`

`__repr__()` returns the second format on both python versions.

Fixes traceback where it tried to use a strange function:
```
Traceback (most recent call last):
  File "get_results.py", line 17, in <module>
    results = benchmark.get_results()
  File "/usr/lib64/python3.6/site-packages/openscap_api.py", line 196, in __getter_wrapper
    list.generate(OSCAP_Object.new(retobj))
  File "/usr/lib64/python3.6/site-packages/openscap_api.py", line 89, in generate
    while iterator.has_more():
  File "/usr/lib64/python3.6/site-packages/openscap_api.py", line 277, in __call__
    raise NameError("name '"+self.object+"' is not defined")
NameError: name 'wig Object of type 'struct xccdf_result_iterator *' at 0x7f7f7dc20090>_has_more' is not defined
Exception ignored in: <bound method OSCAP_List.__del__ of []>
Traceback (most recent call last):
  File "/usr/lib64/python3.6/site-packages/openscap_api.py", line 81, in __del__
    self.iterator.free()
  File "/usr/lib64/python3.6/site-packages/openscap_api.py", line 314, in free
    raise Exception("Can't free %s" % (self.object,))
Exception: Can't free wig Object of type 'struct xccdf_result_iterator *' at 0x7f7f7dc20090>
```