### PR TITLE
Cleanup some warnings reported by Coverity and cppcheck.

### DIFF
--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -904,6 +904,9 @@ static int ds_sds_compose_add_component_dependencies(xmlDocPtr doc, xmlNodePtr d
 				if (ret < 0) {
 					// oscap_seterr has already been called
 					oscap_htable_free0(exported);
+					xmlXPathFreeObject(xpathObj);
+					xmlXPathFreeContext(xpathCtx);
+					free(filepath_cpy);
 					free(dir);
 					return -1;
 				}

--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -94,7 +94,7 @@ oval_agent_session_t * oval_agent_new_session(struct oval_definition_model *mode
 	struct oval_generator *generator;
 	int ret;
 
-	dI("Started new OVAL agent.", name);
+	dI("Started new OVAL agent %s.", name);
 
 	/* Optimalization */
 	oval_definition_model_optimize_by_filter_propagation(model);

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1950,7 +1950,7 @@ static long unsigned int _parse_datetime(char *datetime, const char *fmt[], size
                 }
         }
 
-        dE("Unable to interpret \"%s\" as a datetime string");
+        dE("Unable to interpret \"%s\" as a datetime string", datetime);
 
         return (0);
 }

--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -365,7 +365,7 @@ static inline int _handle_SEAP_receive_failure(SEAP_CTX_t *ctx, oval_pd_t *pd, S
 		case  0:
 			break;
 		case  1: /* no error found */
-			dE("Internal error: An error was signaled on sd=%d but the error queue is empty.");
+			dE("Internal error: An error was signaled on sd=%d but the error queue is empty.", pd->sd);
 			oscap_seterr(OSCAP_EFAMILY_OVAL, "SEAP_recverr_byid: internal error: empty error queue.");
 			return (-1);
 		case -1: /* internal error */

--- a/src/OVAL/probes/SEAP/seap-packet.c
+++ b/src/OVAL/probes/SEAP/seap-packet.c
@@ -113,7 +113,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
 
                 attr_name = SEXP_list_nth (sexp_msg, msg_n);
                 if (attr_name == NULL) {
-                        dI("Unexpected error: No S-exp (attr_name) at position %u in the message (%p).",
+                        dI("Unexpected error: No S-exp (attr_name) at position %lu in the message (%p).",
                            msg_n, sexp_msg);
 
 		free(seap_msg->attrs);
@@ -126,7 +126,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
 
                                 attr_val = SEXP_list_nth (sexp_msg, msg_n + 1);
                                 if (attr_val == NULL) {
-                                        dI("Unexpected error: \"%s\": No attribute value at position %u in the message (%p).",
+                                        dI("Unexpected error: \"%s\": No attribute value at position %lu in the message (%p).",
                                            "id", msg_n + 1, sexp_msg);
 
 					free(seap_msg->attrs);
@@ -170,7 +170,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
                                 seap_msg->attrs[attr_i].value = SEXP_list_nth (sexp_msg, msg_n + 1);
 
                                 if (seap_msg->attrs[attr_i].value == NULL) {
-                                        dI("Unexpected error: \"%s\": No attribute value at position %u in the message (%p).",
+                                        dI("Unexpected error: \"%s\": No attribute value at position %lu in the message (%p).",
                                            seap_msg->attrs[attr_i].name, msg_n + 1, sexp_msg);
 
 					free(seap_msg->attrs[attr_i].name);

--- a/src/OVAL/probes/SEAP/sexp-manip_r.c
+++ b/src/OVAL/probes/SEAP/sexp-manip_r.c
@@ -266,11 +266,6 @@ SEXP_t *SEXP_string_newf_rv(SEXP_t *sexp_mem, const char *format, va_list ap)
 		return NULL;
 	}
 
-        if (v_strlen < 0) {
-                /* TODO: handle this */
-                return (NULL);
-        }
-
         if (SEXP_val_new (&v_dsc, sizeof (char) * v_strlen,
                           SEXP_VALTYPE_STRING) != 0)
         {

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -389,7 +389,7 @@ static int badpartial_check_slash(const char *pattern)
 	if (regex == NULL) {
 		dE("Failed to validate the pattern: pcre_compile(): "
 		   "error: '%s', error offset: %d, pattern: '%s'.\n",
-		   errofs, errptr, pattern);
+		   errptr, errofs, pattern);
 		return -1;
 	}
 	ret = pcre_fullinfo(regex, NULL, PCRE_INFO_FIRSTBYTE, &fb);

--- a/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
@@ -369,12 +369,12 @@ void rpmverifypackage_probe_fini(void *ptr)
 	rpmFreeMacros(NULL);
 	rpmlogClose();
 
-	// This will be always set by probe_init(), lets free it
-	probe_chroot_free(&r->chr);
-
 	// If r is null, probe_init() failed during chroot
 	if (r == NULL)
 		return;
+
+	// This will be always set by probe_init(), lets free it
+	probe_chroot_free(&r->chr);
 
 	// If r->rpm.rpmts was not initialized the mutex was not as well
 	if (r->rpm.rpmts == NULL)
@@ -401,7 +401,7 @@ static int rpmverifypackage_additem(probe_ctx *ctx, struct rpmverify_res *res)
 				 NULL);
 
 	if (res->vflags & VERIFY_DEPS) {
-		dI("VERIFY_DEPS %d", res->vresults & VERIFY_DEPS);
+		dI("VERIFY_DEPS %lu", res->vresults & VERIFY_DEPS);
 		value = probe_entval_from_cstr(OVAL_DATATYPE_BOOLEAN, (res->vresults & VERIFY_DEPS ? "1" : "0"), 1);
 		probe_item_ent_add(item, "dependency_check_passed", NULL, value);
 		SEXP_free(value);

--- a/src/OVAL/probes/unix/process_probe.c
+++ b/src/OVAL/probes/unix/process_probe.c
@@ -421,7 +421,7 @@ static int read_process(SEXP_t *cmd_ent, probe_ctx *ctx)
 			int fixfmt_year;
 
 			r.scheduling_class = malloc(PRCLSZ);
-			strncpy(r.scheduling_class, (psinfo->pr_lwp).pr_clname, sizeof(r.scheduling_class));
+			strncpy(r.scheduling_class, (psinfo->pr_lwp).pr_clname, PRCLSZ);
 
 			// Get the start time
 			s_time = time(NULL);

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -270,7 +270,7 @@ xmlDoc *oscap_source_get_xmlDoc(struct oscap_source *source)
 				source->xml.doc = xmlReadMemory(source->origin.memory, source->origin.memory_size, NULL, NULL, 0);
 				if (source->xml.doc == NULL) {
 					if (memory_file_is_executable(source->origin.memory, source->origin.memory_size)) {
-						dI("oscap-source in memory was detected as executable file. Skipped XML parsing", oscap_source_readable_origin(source));
+						dI("oscap-source in memory was detected as executable file '%s'. Skipped XML parsing", oscap_source_readable_origin(source));
 						oscap_string_clear(xml_error_string);
 					} else {
 						oscap_setxmlerr(xmlGetLastError());
@@ -299,7 +299,7 @@ xmlDoc *oscap_source_get_xmlDoc(struct oscap_source *source)
 					source->xml.doc = xmlReadFd(fd, NULL, NULL, 0);
 					if (source->xml.doc == NULL) {
 						if (fd_file_is_executable(fd)) {
-							dI("oscap-source file was detected as executable file. Skipped XML parsing", oscap_source_readable_origin(source));
+							dI("oscap-source file was detected as executable file '%s'. Skipped XML parsing", oscap_source_readable_origin(source));
 							oscap_string_clear(xml_error_string);
 						} else {
 							oscap_setxmlerr(xmlGetLastError());


### PR DESCRIPTION
This fixes some memory leaks in sds.c, printf format string mistakes, and
a possible NULL ptr dereference.