### PR TITLE
SWIG Python : bug fixes related to the internal object type

### DIFF
--- a/swig/openscap_api.py
+++ b/swig/openscap_api.py
@@ -56,6 +56,7 @@ del version_info
 
 import os
 
+
 def extract_type_from_obj(obj):
     # Extract the name of structure from the representation of the object
     # "<Swig Object of type 'struct xccdf_result_iterator *' at 0x7f8f65fc1390>"
@@ -324,7 +325,8 @@ class OSCAP_Object(object):
         return obj[0](OSCAP_Object("xccdf_rule", rule), obj[1])
 
     def __output_callback(self, result, obj):
-        # the returned object can be a rule_result or an oval_definition_result, so I extract the right name from the object repr.
+        # the returned object can be a rule_result or an oval_definition_result,
+        # so I extract the right name from the object repr.
         return obj[0](OSCAP_Object(extract_type_from_obj(result), result), obj[1])
 
     def register_start_callback(self, cb, usr):

--- a/swig/openscap_api.py
+++ b/swig/openscap_api.py
@@ -321,8 +321,10 @@ class OSCAP_Object(object):
     def __start_callback(self, rule, obj):
         return obj[0](OSCAP_Object("xccdf_rule", rule), obj[1])
 
-    def __output_callback(self, rule_result, obj):
-        return obj[0](OSCAP_Object("xccdf_rule_result", rule_result), obj[1])
+    def __output_callback(self, result, obj):
+		# the returned object can be a rule_result or an oval_definition_result, so I extract the right name from the object repr.
+        structure = re.findall(r"type '(struct )?(\b\S*\b)", result.__repr__())[0][1]
+        return obj[0](OSCAP_Object(structure, rule_result), obj[1])
 
     def register_start_callback(self, cb, usr):
         if self.object != "xccdf_policy_model":

--- a/swig/openscap_api.py
+++ b/swig/openscap_api.py
@@ -138,7 +138,8 @@ class OSCAP_Object(object):
         if type(retobj).__name__ in ('SwigPyObject', 'PySwigObject'):
             # Extract the name of structure from the representation of the object
             # "<Swig Object of type 'struct xccdf_result_iterator *' at 0x7f8f65fc1390>"
-            structure = re.findall(r"type 'struct (\b\S*\b)", retobj.__repr__())[0]
+            # or "<Swig Object of type 'oval_agent_session_t *' at 0x7f9aa2cdf360>"
+            structure = re.findall(r"type '(struct )?(\b\S*\b)", retobj.__repr__())[0][1]
             return OSCAP_Object(structure, retobj)
         else:
             return retobj


### PR DESCRIPTION
When running for instance this : sess = oscap.oval.agent_new_session(oval_def, "...."), the returned object representation is like this : <Swig Object of type 'oval_agent_session_t *' at 0x7f9aa2cdf360> 
However, the regex modified some days ago is [commit 149785d](https://github.com/DominiqueDevinci/openscap/commit/149785de3ec374c3eb395fa14a1c68add9ac6f8e) always expects a struct object (which isn't the case of oval_agent_session_t);
It produce something like this:

`Traceback (most recent call last):
  File "test.py", line 48, in <module>
    sess = oscap.oval.agent_new_session(oval_def, "oval_is_quadcore");
  File "/usr/local/lib/python3.6/dist-packages/openscap_api.py", line 203, in __getter_wrapper
    return OSCAP_Object.new(retobj)
  File "/usr/local/lib/python3.6/dist-packages/openscap_api.py", line 142, in new
    structure = re.findall(r"type 'struct (\b\S*\b)", retobj.__repr__())[0]
IndexError: list index out of range`

I've modified the regex to handle the current issue (and potential similar issues).
Tested with python2.7 and python3.6