### PR TITLE
Fix #528 - Eval SCE script when /tmp is in mode noexec

### DIFF
--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -384,7 +384,7 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 	{
 		// use the sce wrapper if it's not possible to acquire +x rights
 		use_sce_wrapper = true;
-		dI("%s isn't executable, oscap-run-sce-script will be use.", tmp_href);
+		dI("%s isn't executable, oscap-run-sce-script will be used.", tmp_href);
 	}
 
 	// all the result codes are shifted by 100, because otherwise syntax errors in scripts
@@ -515,7 +515,6 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 
 		if (fork_result == 0)
 		{
-
 			// we won't read from the pipes, so close the reading fd
 			close(stdout_pipefd[0]);
 			close(stderr_pipefd[0]);
@@ -544,7 +543,7 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 			if(use_sce_wrapper)
 				execvpe("oscap-run-sce-script", argvp, env_values);
 			else
-                execve(tmp_href, argvp, env_values);
+				execve(tmp_href, argvp, env_values);
 
 			free_env_values(env_values, index_of_first_env_value_not_compiled_in, env_value_count);
 

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -491,7 +491,7 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 		env_values[env_value_count] = env_operator_entry;
 		env_value_count++;
 	}
-    
+
 	env_values = realloc(env_values, (env_value_count + 1) * sizeof(char*));
 	env_values[env_value_count] = NULL;
 
@@ -507,7 +507,7 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 
 	// FIXME: We definitely want to impose security restrictions in the forked child process in the future.
 	//        This would prevent scripts from writing to files or deleting them.
-	
+
 	int fork_result = fork();
 	if (fork_result >= 0)
 	{
@@ -519,7 +519,7 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 			// we won't read from the pipes, so close the reading fd
 			close(stdout_pipefd[0]);
 			close(stderr_pipefd[0]);
-            
+
 			// forward stdout and stderr to our custom opened pipes
 			dup2(stdout_pipefd[1], fileno(stdout));
 			dup2(stderr_pipefd[1], fileno(stderr));
@@ -547,7 +547,7 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 			} else {
                 execve(tmp_href, argvp, env_values);
             }
-            
+
 			free_env_values(env_values, index_of_first_env_value_not_compiled_in, env_value_count);
 
 			// no need to check the return value of execve, if it returned at all we are in trouble

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -541,12 +541,10 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 
 			// we are the child process
 
-			if(use_sce_wrapper) {
-                dI("Eval sce script using oscap-run-sce-script because %s isn't +x", tmp_href);
+			if(use_sce_wrapper)
 				execvpe("oscap-run-sce-script", argvp, env_values);
-			} else {
+			else
                 execve(tmp_href, argvp, env_values);
-            }
 
 			free_env_values(env_values, index_of_first_env_value_not_compiled_in, env_value_count);
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,3 +1,7 @@
+install(PROGRAMS "oscap-run-sce-script"
+	DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
 if(ENABLE_OSCAP_UTIL)
 	file(GLOB UTILS_SOURCES "*.c")
 	if(HAVE_GETOPT_H)

--- a/utils/oscap-run-sce-script
+++ b/utils/oscap-run-sce-script
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Authors:
+#      Dominique Blaze <contact@d0m.tech>
+#
+# use by oscap for evaluate a SCE file when +x rights are missing
+
+if [ ! -z $1 ] && [ -f $1 ] 
+then
+	# file exists. first check if shebang is here 
+	
+	firstline=$(head -n1 $1)
+	if [ ${firstline:0:2} = "#!" ]
+	then  # it's a shebang
+		cmd=${firstline:2}  # remove the begin (#!)
+		cmd=${cmd##*( )}  # trim whitespaces
+		eval $cmd $1 > /dev/stdout
+	else  # no shebang, trying bash by default ...
+		/usr/bin/env bash $1 > /dev/stdout
+	fi
+	
+else
+	echo "Script file not found: $1" > /dev/stderr
+fi


### PR DESCRIPTION
Hello,
I experienced recently an error already signalled in issue #528 . As suggested by Martin Presiler, i've used a wrapper (so it's easy to fix a problem linked to the wrapper for everyone). My wrapper parse the shebang (or use bash by default if there is no shebang).

I use the wrapper only if there is no posssibility to acquire +x rights on the extracted .sh file, so the legacy code is not affected (and the wrapper is less reliable than a direct execution, so it's better to only use in when needed).

Result:
With a /tmp partition with noexec mode: 
```oscap xccdf eval --verbose INFO test_sce_in_ds.xml
I: oscap: Identified document type: data-stream-collection
I: oscap: Created a new XCCDF session from a SCAP Source Datastream 'test_sce_in_ds.xml'.
I: oscap: Identified document type: Benchmark
I: oscap: Evaluating a XCCDF policy with selected 'default-profile' profile.
I: oscap: Evaluating XCCDF rule 'xccdf_org.open-scap.sce-community-content_rule_services_obsolete-disable_nfs_exports'.
Title
Rule    xccdf_org.open-scap.sce-community-content_rule_services_obsolete-disable_nfs_exports
I: oscap: /tmp/oscap.UmezuG/services/obsolete/disable_nfs_exports.sh isn't executable, oscap-run-sce-script will be use.
Result  pass
```
This test was not passing before this fix.