### PR TITLE
Small verbose mode improvements

### DIFF
--- a/src/OVAL/oval_affected.c
+++ b/src/OVAL/oval_affected.c
@@ -217,7 +217,7 @@ static int _oval_affected_parse_tag(xmlTextReaderPtr reader, struct oval_parser_
 			free(product);
 		}
 	} else {
-		dI("Skipping tag: %s", tagname);
+		dD("Skipping tag: %s", tagname);
 		return_code = oval_parser_skip_tag(reader, context);
 	}
 	free(tagname);

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -1175,7 +1175,7 @@ int oval_component_parse_tag(xmlTextReaderPtr reader,
 		component = oval_component_new(model, OVAL_FUNCTION_REGEX_CAPTURE);
 		return_code = _oval_component_parse_REGEX_CAPTURE_tag(reader, context, component);
 	} else {
-		dI("Tag <%s> not handled, line: %d.", tagname,
+		dD("Tag <%s> not handled, line: %d.", tagname,
                               xmlTextReaderGetParserLineNumber(reader));
 		return_code = oval_parser_skip_tag(reader, context);
 	}
@@ -1934,16 +1934,16 @@ static long unsigned int _parse_datetime(char *datetime, const char *fmt[], size
         size_t    i;
         char     *r;
 
-        dI("Parsing datetime string \"%s\"", datetime);
+        dD("Parsing datetime string \"%s\"", datetime);
 
         for (i = 0; i < fmtcnt; ++i) {
-                dI("%s", fmt[i]);
+                dD("%s", fmt[i]);
                 memset(&t, 0, sizeof t);
                 r = strptime(datetime, fmt[i], &t);
 
                 if (r != NULL) {
                         if (*r == '\0') {
-                                dI("Success!");
+                                dD("Success!");
                                 return _comp_sec(t.tm_year, t.tm_mon, t.tm_mday,
                                                  t.tm_hour, t.tm_min, t.tm_sec);
                         }

--- a/src/OVAL/oval_definition.c
+++ b/src/OVAL/oval_definition.c
@@ -422,7 +422,7 @@ static int _oval_definition_parse_tag(xmlTextReaderPtr reader, struct oval_parse
 	} else if ((strcmp(tagname, "criteria") == 0)) {
 		return_code = oval_criteria_parse_tag(reader, context, &_oval_definition_criteria_consumer, definition);
 	} else {
-		dI("Skipping tag: %s.", tagname);
+		dD("Skipping tag: %s.", tagname);
 		return_code = oval_parser_skip_tag(reader, context);
 	}
 	free(tagname);

--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -219,7 +219,7 @@ static SEXP_t *oval_probe_cmd_obj_eval(SEXP_t *sexp, void *arg)
 	obj    = oval_definition_model_get_object(defs, id_str);
 	ret    = SEXP_list_new (sexp, NULL);
 
-	dI("Get_object: %s.", id_str);
+	dD("Get_object: %s.", id_str);
 
 	if (obj == NULL) {
 		dE("Can't find obj: id=%s.", id_str);
@@ -448,7 +448,7 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
                                 }
 
 				if (++retry <= OVAL_PROBE_MAXRETRY) {
-					dI("Connect: retry %u/%u.", retry, OVAL_PROBE_MAXRETRY);
+					dD("Connect: retry %u/%u.", retry, OVAL_PROBE_MAXRETRY);
 					continue;
 				} else {
                                         char errbuf[__ERRBUF_SIZE];
@@ -523,7 +523,7 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 			pd->sd = -1;
 
 			if (++retry <= OVAL_PROBE_MAXRETRY) {
-				dI("Send: retry %u/%u.", retry, OVAL_PROBE_MAXRETRY);
+				dD("Send: retry %u/%u.", retry, OVAL_PROBE_MAXRETRY);
 				continue;
 			} else {
                                 char errbuf[__ERRBUF_SIZE];
@@ -555,11 +555,11 @@ static int oval_probe_comm(SEAP_CTX_t *ctx, oval_pd_t *pd, const SEXP_t *s_iobj,
 				SEAP_msg_free(s_omsg);
 			}
 			if (errno == ECONNABORTED) {
-				dI("Connection was aborted.");
+				dD("Connection was aborted.");
 				return (-2);
 			} else {
 				if (++retry <= OVAL_PROBE_MAXRETRY) {
-					dI("Recv: retry %u/%u.", retry, OVAL_PROBE_MAXRETRY);
+					dD("Recv: retry %u/%u.", retry, OVAL_PROBE_MAXRETRY);
 					continue;
 				} else {
 					protect_errno {
@@ -643,12 +643,12 @@ static int oval_probe_sys_eval(SEAP_CTX_t *ctx, oval_pd_t *pd, struct oval_sysch
                 val = probe_obj_getentval (obj, #name, 1);     \
                                                                         \
                 if (val == NULL) {                                      \
-                        dI("No entity or value: %s", #name); \
+                        dD("No entity or value: %s", #name); \
                         goto fail;                                      \
                 }                                                       \
                                                                         \
                 if (SEXP_string_cstr_r (val, buf, sizeof buf) >= sizeof buf) { \
-                        dI("Value too large: %s", #name);    \
+                        dD("Value too large: %s", #name);    \
                         SEXP_free (val);                                \
                         goto fail;                                      \
                 }                                                       \
@@ -679,12 +679,12 @@ static int oval_probe_sys_eval(SEAP_CTX_t *ctx, oval_pd_t *pd, struct oval_sysch
                                 val = probe_ent_getattrval (ent, #name); \
                                                                         \
                                 if (val == NULL) {                      \
-                                        dI("No value: %s", #name); \
+                                        dD("No value: %s", #name); \
                                         goto fail;                      \
                                 }                                       \
                                                                         \
                                 if (SEXP_string_cstr_r (val, buf, sizeof buf) >= sizeof buf) { \
-                                        dI("Value too large: %s", #name); \
+                                        dD("Value too large: %s", #name); \
                                         SEXP_free (val);                \
                                         goto fail;                      \
                                 }                                       \
@@ -983,7 +983,7 @@ int oval_probe_ext_eval(SEAP_CTX_t *ctx, oval_pd_t *pd, oval_pext_t *pext, struc
 	if (ret != 0) {
 		switch (errno) {
 		case ECONNABORTED:
-			dI("Closing sd=%d (pd=%p) after abort", pd->sd, pd);
+			dD("Closing sd=%d (pd=%p) after abort", pd->sd, pd);
 
 			SEAP_close(ctx, pd->sd);
 			pd->sd = -1;

--- a/src/OVAL/probes/SEAP/seap-command.c
+++ b/src/OVAL/probes/SEAP/seap-command.c
@@ -92,12 +92,12 @@ int SEAP_cmd_register (SEAP_CTX_t *ctx, SEAP_cmdcode_t code, uint32_t flags, SEA
                 /* rec is freed by SEAP_cmdtbl_add */
                 break;
         case SEAP_CMDTBL_ECOLL:
-                dI("Can't register command: code=%u, tbl=%p: already registered.",
+                dD("Can't register command: code=%u, tbl=%p: already registered.",
                    code, (void *)tbl);
                 SEAP_cmdrec_free (rec);
                 return (-1);
         case -1:
-                dI("Can't register command: code=%u, func=%p, tbl=%p, arg=%p: errno=%u, %s.",
+                dD("Can't register command: code=%u, func=%p, tbl=%p, arg=%p: errno=%u, %s.",
                    code, (void *)func, (void *)tbl, arg, errno, strerror (errno));
                 SEAP_cmdrec_free (rec);
                 return (-1);
@@ -140,7 +140,7 @@ SEAP_cmdtbl_t *SEAP_cmdtbl_new (void)
 
 #if defined(SEAP_THREAD_SAFE)
         if (pthread_rwlock_init (&t->lock, NULL) != 0) {
-                dI("Can't initialize rwlock: %u, %s.",
+                dD("Can't initialize rwlock: %u, %s.",
                    errno, strerror (errno));
 		free(t);
                 return (NULL);
@@ -335,13 +335,13 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                         case 0:
                                 break;
                         case SEAP_CMDTBL_ECOLL:
-                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: already registered.",
+                                dD("Can't register async command handler: id=%u, tbl=%p, sd=%u: already registered.",
                                    rec->code, (void *)dsc->cmd_w_table, sd);
                                 SEAP_cmdrec_free (rec);
 				SEAP_packet_free(packet);
                                 return (NULL);
                         case -1:
-                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: errno=%u, %s.",
+                                dD("Can't register async command handler: id=%u, tbl=%p, sd=%u: errno=%u, %s.",
                                    rec->code, (void *)dsc->cmd_w_table, sd, errno, strerror (errno));
                                 SEAP_cmdrec_free (rec);
 				SEAP_packet_free(packet);
@@ -355,7 +355,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
 
                         if (SEAP_packet_send (ctx, sd, packet) != 0) {
                                 protect_errno {
-                                        dI("FAIL: errno=%u, %s.", errno, strerror (errno));
+                                        dD("FAIL: errno=%u, %s.", errno, strerror (errno));
                                         SEAP_cmdtbl_del(dsc->cmd_w_table, rec);
                                         SEAP_packet_free(packet);
                                 }
@@ -381,7 +381,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                                         pthread_mutex_unlock(&h.mtx);
 
                                         if (SEAP_packet_recv(ctx, sd, &packet_rcv) != 0) {
-                                                dI("FAIL: ctx=%p, sd=%d, errno=%u, %s.", ctx, sd, errno, strerror(errno));
+                                                dD("FAIL: ctx=%p, sd=%d, errno=%u, %s.", ctx, sd, errno, strerror(errno));
 						SEAP_packet_free(packet);
                                                 return(NULL);
                                         }
@@ -457,13 +457,13 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
                         case 0:
                                 break;
                         case SEAP_CMDTBL_ECOLL:
-                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: already registered.",
+                                dD("Can't register async command handler: id=%u, tbl=%p, sd=%u: already registered.",
                                    rec->code, (void *)dsc->cmd_w_table, sd);
                                 SEAP_cmdrec_free (rec);
 				SEAP_packet_free(packet);
                                 return (NULL);
                         case -1:
-                                dI("Can't register async command handler: id=%u, tbl=%p, sd=%u: errno=%u, %s.",
+                                dD("Can't register async command handler: id=%u, tbl=%p, sd=%u: errno=%u, %s.",
                                    rec->code, (void *)dsc->cmd_w_table, sd, errno, strerror (errno));
                                 SEAP_cmdrec_free(rec);
 				SEAP_packet_free(packet);
@@ -477,7 +477,7 @@ SEXP_t *SEAP_cmd_exec (SEAP_CTX_t    *ctx,
 
                         if (SEAP_packet_send (ctx, sd, packet) != 0) {
                                 protect_errno {
-                                        dI("FAIL: errno=%u, %s.", errno, strerror (errno));
+                                        dD("FAIL: errno=%u, %s.", errno, strerror (errno));
                                         SEAP_cmdtbl_del(dsc->cmd_w_table, rec);
                                         SEAP_packet_free(packet);
                                 }

--- a/src/OVAL/probes/SEAP/seap-packet.c
+++ b/src/OVAL/probes/SEAP/seap-packet.c
@@ -113,7 +113,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
 
                 attr_name = SEXP_list_nth (sexp_msg, msg_n);
                 if (attr_name == NULL) {
-                        dI("Unexpected error: No S-exp (attr_name) at position %lu in the message (%p).",
+                        dD("Unexpected error: No S-exp (attr_name) at position %lu in the message (%p).",
                            msg_n, sexp_msg);
 
 		free(seap_msg->attrs);
@@ -126,7 +126,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
 
                                 attr_val = SEXP_list_nth (sexp_msg, msg_n + 1);
                                 if (attr_val == NULL) {
-                                        dI("Unexpected error: \"%s\": No attribute value at position %lu in the message (%p).",
+                                        dD("Unexpected error: \"%s\": No attribute value at position %lu in the message (%p).",
                                            "id", msg_n + 1, sexp_msg);
 
 					free(seap_msg->attrs);
@@ -145,7 +145,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
                                 {
                                         switch (errno) {
                                         case EDOM:
-                                                dI("id: invalid value or type: s_exp=%p, type=%s",
+                                                dD("id: invalid value or type: s_exp=%p, type=%s",
                                                    (void *)attr_val, SEXP_strtype (attr_val));
 
 						free(seap_msg->attrs);
@@ -154,7 +154,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
 
                                                 return (SEAP_EINVAL);
                                         case EFAULT:
-                                                dI("id: not found");
+                                                dD("id: not found");
 
 						free(seap_msg->attrs);
                                                 SEXP_free(attr_val);
@@ -170,7 +170,7 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
                                 seap_msg->attrs[attr_i].value = SEXP_list_nth (sexp_msg, msg_n + 1);
 
                                 if (seap_msg->attrs[attr_i].value == NULL) {
-                                        dI("Unexpected error: \"%s\": No attribute value at position %lu in the message (%p).",
+                                        dD("Unexpected error: \"%s\": No attribute value at position %lu in the message (%p).",
                                            seap_msg->attrs[attr_i].name, msg_n + 1, sexp_msg);
 
 					free(seap_msg->attrs[attr_i].name);
@@ -463,7 +463,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
                 switch (SEXP_typeof (member)) {
                 case SEXP_TYPE_STRING:
                         if (SEXP_string_nth (member, 1) != ':') {
-                                dI("Invalid string/attribute in packet");
+                                dD("Invalid string/attribute in packet");
                                 SEXP_free (member);
                                 errno = EINVAL;
                                 return (-1);
@@ -475,7 +475,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
                                 val = SEXP_list_nth (sexp_err, ++n);
 
                                 if (!SEXP_numberp (val)) {
-                                        dI("Invalid type of :orig_id value");
+                                        dD("Invalid type of :orig_id value");
                                         SEXP_free (val);
                                         SEXP_free (member);
                                         errno = EINVAL;
@@ -495,7 +495,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
 				seap_err->type = SEXP_number_getu_32(val);
 
 				if (!SEXP_numberp(val)) {
-                                        dI("Invalid type of the :type attribute");
+                                        dD("Invalid type of the :type attribute");
                                         SEXP_free (val);
                                         SEXP_free (member);
                                         errno = EINVAL;
@@ -504,7 +504,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
 
                                 if (!(seap_err->type == SEAP_ETYPE_INT ||
 				      seap_err->type == SEAP_ETYPE_USER)) {
-					dI("Invalid value of the :type attribute");
+					dD("Invalid value of the :type attribute");
 					SEXP_free(val);
 					SEXP_free(member);
 					errno = EINVAL;
@@ -513,7 +513,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
 
                                 SEXP_free (val);
                         } else {
-                                dI("Unknown packet attribute");
+                                dD("Unknown packet attribute");
                                 SEXP_free (member);
                                 errno = EINVAL;
                                 return (-1);
@@ -526,7 +526,7 @@ static int SEAP_packet_sexp2err (SEXP_t *sexp_err, SEAP_err_t *seap_err)
 
                         goto loop_exit;
                 default:
-                        dI("Unexpected type of packet member: list");
+                        dD("Unexpected type of packet member: list");
                         SEXP_free (member);
                         errno = EINVAL;
                         return (-1);
@@ -568,9 +568,9 @@ static SEXP_t *SEAP_packet_err2sexp (SEAP_err_t *err)
         if (err->data != NULL)
                 SEXP_list_add (sexp, err->data);
 
-	dI("ERR -> SEXP");
+	dD("ERR -> SEXP");
 	dO(OSCAP_DEBUGOBJ_SEXP, sexp);
-	dI("packet size: %zu", SEXP_sizeof(sexp));
+	dD("packet size: %zu", SEXP_sizeof(sexp));
 
         return (sexp);
 }
@@ -665,7 +665,7 @@ eloop_exit:
 
         while((sexp_packet = SEXP_list_pop (sexp_buffer)) != NULL) {
 		if (!SEXP_listp(sexp_packet)) {
-			dI("Invalid SEAP packet received: %s.", "not a list");
+			dD("Invalid SEAP packet received: %s.", "not a list");
 
 			SEXP_free (sexp_packet);
 			SEXP_free (sexp_buffer);
@@ -673,7 +673,7 @@ eloop_exit:
 			errno = EINVAL;
 			return (-1);
 		} else if (SEXP_list_length (sexp_packet) < 2) {
-			dI("Invalid SEAP packet received: %s.", "list length < 2");
+			dD("Invalid SEAP packet received: %s.", "list length < 2");
 
 			SEXP_free (sexp_packet);
 			SEXP_free (sexp_buffer);
@@ -685,7 +685,7 @@ eloop_exit:
 		psym_sexp = SEXP_list_first (sexp_packet);
 
 		if (!SEXP_stringp(psym_sexp)) {
-			dI("Invalid SEAP packet received: %s.", "first list item is not a string");
+			dD("Invalid SEAP packet received: %s.", "first list item is not a string");
 
 			SEXP_free (psym_sexp);
 			SEXP_free (sexp_packet);
@@ -694,7 +694,7 @@ eloop_exit:
 			errno = EINVAL;
 			return (-1);
 		} else if (SEXP_string_length (psym_sexp) != (strlen (SEAP_SYM_PREFIX) + 3)) {
-			dI("Invalid SEAP packet received: %s.", "invalid packet type symbol length");
+			dD("Invalid SEAP packet received: %s.", "invalid packet type symbol length");
 
 			SEXP_free (psym_sexp);
 			SEXP_free (sexp_packet);
@@ -703,7 +703,7 @@ eloop_exit:
 			errno = EINVAL;
 			return (-1);
 		} else if (SEXP_strncmp (psym_sexp, SEAP_SYM_PREFIX, strlen (SEAP_SYM_PREFIX)) != 0) {
-			dI("Invalid SEAP packet received: %s.", "invalid prefix");
+			dD("Invalid SEAP packet received: %s.", "invalid prefix");
 
 			SEXP_free (psym_sexp);
 			SEXP_free (sexp_packet);
@@ -727,7 +727,7 @@ eloop_exit:
 
 				if (SEAP_packet_sexp2msg (sexp_packet, &(_packet->data.msg)) != 0) {
 					/* error */
-					dI("Invalid SEAP packet received: %s.", "can't translate to msg struct");
+					dD("Invalid SEAP packet received: %s.", "can't translate to msg struct");
 
 					SEXP_free (sexp_packet);
 					SEAP_packet_free(_packet);
@@ -748,7 +748,7 @@ eloop_exit:
 
 				if (SEAP_packet_sexp2cmd (sexp_packet, &(_packet->data.cmd)) != 0) {
 					/* error */
-					dI("Invalid SEAP packet received: %s.", "can't translate to cmd struct");
+					dD("Invalid SEAP packet received: %s.", "can't translate to cmd struct");
 					SEXP_free (sexp_packet);
 					SEAP_packet_free(_packet);
 					SEXP_free (sexp_buffer);
@@ -768,7 +768,7 @@ eloop_exit:
 
 				if (SEAP_packet_sexp2err (sexp_packet, &(_packet->data.err)) != 0) {
 					/* error */
-					dI("Invalid SEAP packet received: %s.", "can't translate to err struct");
+					dD("Invalid SEAP packet received: %s.", "can't translate to err struct");
 					SEXP_free (sexp_packet);
 					SEAP_packet_free(_packet);
 					SEXP_free (sexp_buffer);
@@ -781,7 +781,7 @@ eloop_exit:
 			/* FALLTHROUGH */
 		default:
 		invalid:
-			dI("Invalid SEAP packet received: %s.", "invalid packet type symbol");
+			dD("Invalid SEAP packet received: %s.", "invalid packet type symbol");
 			SEXP_free (sexp_packet);
 			SEXP_free (sexp_buffer);
 			errno = EINVAL;
@@ -857,7 +857,7 @@ int SEAP_packet_send (SEAP_CTX_t *ctx, int sd, SEAP_packet_t *packet)
         packet_sexp = SEAP_packet2sexp (packet);
 
         if (packet_sexp == NULL) {
-                dI("Can't convert S-exp to packet");
+                dD("Can't convert S-exp to packet");
                 return (-1);
         }
 
@@ -868,7 +868,7 @@ int SEAP_packet_send (SEAP_CTX_t *ctx, int sd, SEAP_packet_t *packet)
                         ret = -1;
 
                         protect_errno {
-                                dI("FAIL: errno=%u, %s.", errno, strerror (errno));
+                                dD("FAIL: errno=%u, %s.", errno, strerror (errno));
                         }
                 }
 

--- a/src/OVAL/probes/SEAP/seap.c
+++ b/src/OVAL/probes/SEAP/seap.c
@@ -96,7 +96,7 @@ int SEAP_connect(SEAP_CTX_t *ctx)
 	sd = SEAP_desc_add(ctx->sd_table, SCH_QUEUE, NULL);
 
         if (sd < 0) {
-                dI("Can't create/add new SEAP descriptor");
+                dD("Can't create/add new SEAP descriptor");
                 return (-1);
         }
 
@@ -109,7 +109,7 @@ int SEAP_connect(SEAP_CTX_t *ctx)
 	dsc->subtype = ctx->subtype;
 
 	if (sch_queue_connect(dsc) != 0) {
-                dI("FAIL: errno=%u, %s.", errno, strerror (errno));
+                dD("FAIL: errno=%u, %s.", errno, strerror (errno));
                 SEAP_desc_del(ctx->sd_table, sd);
 
                 return (-1);
@@ -138,7 +138,7 @@ int SEAP_openfd2 (SEAP_CTX_t *ctx, int ifd, int ofd, uint32_t flags)
         sd = SEAP_desc_add(ctx->sd_table, SCH_QUEUE, NULL);
 
         if (sd < 0) {
-                dI("Can't create/add new SEAP descriptor");
+                dD("Can't create/add new SEAP descriptor");
                 return (-1);
         }
 
@@ -155,15 +155,15 @@ int SEAP_openfd2 (SEAP_CTX_t *ctx, int ifd, int ofd, uint32_t flags)
 int SEAP_add_probe (SEAP_CTX_t *ctx, sch_queuedata_t *data)
 {
 	int sd = SEAP_desc_add(ctx->sd_table, SCH_QUEUE, data);
-	dI("SEAP_add_probe");
+	dD("SEAP_add_probe");
 	if (sd < 0) {
-		dI("Can't create/add new SEAP descriptor");
+		dD("Can't create/add new SEAP descriptor");
 		return (-1);
 	}
 	SEAP_desc_t *dsc = SEAP_desc_get (ctx->sd_table, sd);
 
 	if (dsc == NULL) {
-		dI("dsc == NULL");
+		dD("dsc == NULL");
 	}
     return sd;
 }
@@ -211,7 +211,7 @@ static int __SEAP_cmdexec_reply (SEAP_CTX_t *ctx, int sd, SEAP_cmd_t *cmd)
 
         if (SEAP_packet_send (ctx, sd, packet) != 0) {
                 protect_errno {
-                        dI("FAIL: errno=%u, %s.", errno, strerror (errno));
+                        dD("FAIL: errno=%u, %s.", errno, strerror (errno));
                         SEAP_packet_free (packet);
                 }
                 return (-1);
@@ -278,7 +278,7 @@ int __SEAP_recvmsg_process_cmd (SEAP_CTX_t *ctx, int sd, SEAP_cmd_t *cmd)
                 if (pthread_create (&th, &th_attrs,
                                     &__SEAP_cmdexec_worker, (void *)job) != 0)
                 {
-                        dI("Can't create worker thread: %u, %s.", errno, strerror (errno));
+                        dD("Can't create worker thread: %u, %s.", errno, strerror (errno));
                         SEAP_cmdjob_free (job);
                         pthread_attr_destroy (&th_attrs);
 
@@ -354,7 +354,7 @@ int SEAP_recvmsg (SEAP_CTX_t *ctx, int sd, SEAP_msg_t **seap_msg)
         for (;;) {
                 if (SEAP_packet_recv (ctx, sd, &packet) != 0) {
 			protect_errno {
-				dI("FAIL: ctx=%p, sd=%d, errno=%u, %s.",
+				dD("FAIL: ctx=%p, sd=%d, errno=%u, %s.",
 				   ctx, sd, errno, strerror (errno));
 			}
                         return (-1);
@@ -498,7 +498,7 @@ static int __SEAP_senderr (SEAP_CTX_t *ctx, int sd, SEAP_err_t *err, unsigned in
 
         if (SEAP_packet_send (ctx, sd, packet) != 0) {
                 protect_errno {
-                        dI("FAIL: errno=%u, %s.", errno, strerror (errno));
+                        dD("FAIL: errno=%u, %s.", errno, strerror (errno));
                         SEAP_packet_free (packet);
                 }
 
@@ -609,7 +609,7 @@ int SEAP_close (SEAP_CTX_t *ctx, int sd)
         protect_errno {
                 if (SEAP_desc_del (ctx->sd_table, sd) != 0) {
                         /* something very bad happened */
-                        dI("SEAP_desc_del failed");
+                        dD("SEAP_desc_del failed");
                         return(-1);
                 }
         }

--- a/src/OVAL/probes/SEAP/sexp-manip.c
+++ b/src/OVAL/probes/SEAP/sexp-manip.c
@@ -2069,7 +2069,7 @@ void __SEXP_VALIDATE(const SEXP_t *s_exp, const char *file, uint32_t line, const
         SEXP_val_t v_dsc;
 
 #ifdef SEXP_VALIDATE_DEBUG
-        dI("VALIDATE: s_exp=%p (%s:%u:%s)", s_exp, file, line, func);
+        dD("VALIDATE: s_exp=%p (%s:%u:%s)", s_exp, file, line, func);
 #endif
 
 	if (sexp_validate_disabled)

--- a/src/OVAL/probes/SEAP/sexp-manip_r.c
+++ b/src/OVAL/probes/SEAP/sexp-manip_r.c
@@ -416,7 +416,7 @@ void __SEXP_free_r (SEXP_t *s_exp, const char *file, uint32_t line, const char *
 #endif
 {
 #if !defined(NDEBUG) && defined(SEAP_VERBOSE_DEBUG)
-        dI("s_exp=%p (%s:%u:%s)", s_exp, file, line, func);
+        dD("s_exp=%p (%s:%u:%s)", s_exp, file, line, func);
 #endif
         if (s_exp == NULL)
                 return;

--- a/src/OVAL/probes/independent/filehash58_probe.c
+++ b/src/OVAL/probes/independent/filehash58_probe.c
@@ -224,7 +224,7 @@ void *filehash58_probe_init(void)
 	case 0:
 		return ((void *)filehash58_probe_mutex);
 	default:
-		dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
+		dD("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
 		free(filehash58_probe_mutex);
 	}
 
@@ -282,7 +282,7 @@ int filehash58_probe_main(probe_ctx *ctx, void *arg)
 	case 0:
 		break;
 	default:
-		dI("Can't lock mutex(%p): %u, %s.", filehash58_probe_mutex, errno, strerror(errno));
+		dD("Can't lock mutex(%p): %u, %s.", filehash58_probe_mutex, errno, strerror(errno));
 
 		err = PROBE_EFATAL;
 		goto cleanup;
@@ -319,7 +319,7 @@ cleanup:
 	case 0:
 		break;
 	default:
-		dI("Can't unlock mutex(%p): %u, %s.", filehash58_probe_mutex, errno, strerror(errno));
+		dD("Can't unlock mutex(%p): %u, %s.", filehash58_probe_mutex, errno, strerror(errno));
 
 		err = PROBE_EFATAL;
 	}

--- a/src/OVAL/probes/independent/filehash_probe.c
+++ b/src/OVAL/probes/independent/filehash_probe.c
@@ -204,7 +204,7 @@ void *filehash_probe_init(void)
         case 0:
 		return ((void *)filehash_probe_mutex);
         default:
-                dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
+                dD("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
 		free(filehash_probe_mutex);
         }
 
@@ -259,7 +259,7 @@ int filehash_probe_main(probe_ctx *ctx, void *arg)
         case 0:
                 break;
         default:
-		dI("Can't lock mutex(%p): %u, %s.", filehash_probe_mutex, errno, strerror (errno));
+		dD("Can't lock mutex(%p): %u, %s.", filehash_probe_mutex, errno, strerror (errno));
 
 		SEXP_free (behaviors);
 		SEXP_free (path);
@@ -288,7 +288,7 @@ int filehash_probe_main(probe_ctx *ctx, void *arg)
         case 0:
                 break;
         default:
-	dI("Can't unlock mutex(%p): %u, %s.", filehash_probe_mutex, errno, strerror (errno));
+	dD("Can't unlock mutex(%p): %u, %s.", filehash_probe_mutex, errno, strerror (errno));
 
 		return (PROBE_EFATAL);
         }

--- a/src/OVAL/probes/independent/filemd5_probe.c
+++ b/src/OVAL/probes/independent/filemd5_probe.c
@@ -176,7 +176,7 @@ void *probe_init (void)
         case 0:
                 return ((void *)&__filemd5_probe_mutex);
         default:
-                dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
+                dD("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
         }
 
         return (NULL);
@@ -233,7 +233,7 @@ int probe_main (SEXP_t *probe_in, SEXP_t *probe_out, void *mutex, SEXP_t *filter
         case 0:
                 break;
         default:
-                dI("Can't lock mutex(%p): %u, %s.", &__filemd5_probe_mutex, errno, strerror (errno));
+                dD("Can't lock mutex(%p): %u, %s.", &__filemd5_probe_mutex, errno, strerror (errno));
 
 		SEXP_free (behaviors);
 		SEXP_free (path);
@@ -261,7 +261,7 @@ int probe_main (SEXP_t *probe_in, SEXP_t *probe_out, void *mutex, SEXP_t *filter
         case 0:
                 break;
         default:
-                dI("Can't unlock mutex(%p): %u, %s.", &__filemd5_probe_mutex, errno, strerror (errno));
+                dD("Can't unlock mutex(%p): %u, %s.", &__filemd5_probe_mutex, errno, strerror (errno));
 
 		return (PROBE_EFATAL);
         }

--- a/src/OVAL/probes/independent/ldap57_probe.c
+++ b/src/OVAL/probes/independent/ldap57_probe.c
@@ -261,7 +261,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
 
                                         switch(bertag & LBER_ENCODING_MASK) {
                                         case LBER_PRIMITIVE:
-                                                dI("Found primitive value, bertag = %u", bertag);
+                                                dD("Found primitive value, bertag = %u", bertag);
 						break;
                                         case LBER_CONSTRUCTED:
                                                 dW("Don't know how to handle LBER_CONSTRUCTED values");
@@ -336,7 +336,7 @@ int probe_main(probe_ctx *ctx, void *mutex)
                                         }       break;
                                         case LBER_NULL:
                                                 /* XXX: no equivalent LDAPTYPE_? or empty */
-                                                dI("LBER_NULL: skipped");
+                                                dD("LBER_NULL: skipped");
                                                 continue;
                                         case LBER_ENUMERATED:
                                                 /* XXX: no equivalent LDAPTYPE_? */

--- a/src/OVAL/probes/independent/sql57_probe.c
+++ b/src/OVAL/probes/independent/sql57_probe.c
@@ -202,7 +202,7 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 	tmp = NULL;
 
 	while ((tok = strsep (&copy, ";")) != NULL) {
-		dI("tok: '%s'.", tok);
+		dD("tok: '%s'.", tok);
 		switch (tolower(*tok)) {
 			matchitem1(tok, 's',
 				  "erver", info->host); break;
@@ -358,7 +358,7 @@ static int dbSQL_eval(const char *engine, const char *version,
                                                 col_type = OVAL_DATATYPE_UNKNOWN;
                                                 field    = NULL;
 
-						dI("Column type: %d.", odbx_column_type(sql_dbr, ci));
+						dD("Column type: %d.", odbx_column_type(sql_dbr, ci));
                                                 switch(odbx_column_type(sql_dbr, ci)) {
                                                 case ODBX_TYPE_BOOLEAN:
                                                         break;

--- a/src/OVAL/probes/independent/sql_probe.c
+++ b/src/OVAL/probes/independent/sql_probe.c
@@ -202,7 +202,7 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 	tmp = NULL;
 
 	while ((tok = strsep (&copy, ";")) != NULL) {
-		dI("tok: '%s'.", tok);
+		dD("tok: '%s'.", tok);
 		switch (tolower(*tok)) {
 			matchitem1(tok, 's',
 				  "erver", info->host); break;

--- a/src/OVAL/probes/independent/xmlfilecontent_probe.c
+++ b/src/OVAL/probes/independent/xmlfilecontent_probe.c
@@ -190,7 +190,7 @@ static int process_file(const char *prefix, const char *path, const char *filena
                                  "xpath",    OVAL_DATATYPE_STRING, pfd->xpath,
                                  NULL);
 
-	dI("xpath obj type: %d.", xpath_obj->type);
+	dD("xpath obj type: %d.", xpath_obj->type);
 	switch(xpath_obj->type) {
 	case XPATH_BOOLEAN:
 	{
@@ -239,7 +239,7 @@ static int process_file(const char *prefix, const char *path, const char *filena
 		}
 
 		node_cnt = nodes->nodeNr;
-		dI("node_cnt: %d.", node_cnt);
+		dD("node_cnt: %d.", node_cnt);
 		if (node_cnt == 0) {
 			probe_item_setstatus(item, SYSCHAR_STATUS_DOES_NOT_EXIST);
 			probe_item_ent_add(item, "value_of", NULL, NULL);
@@ -248,7 +248,7 @@ static int process_file(const char *prefix, const char *path, const char *filena
 			node_tab = nodes->nodeTab;
 			for (i = 0; i < node_cnt; ++i) {
 				cur_node = node_tab[i];
-				dI("node[%d] line: %d, name: '%s', type: %d.",
+				dD("node[%d] line: %d, name: '%s', type: %d.",
 				   i, cur_node->line, cur_node->name, cur_node->type);
 				if (cur_node->type == XML_ATTRIBUTE_NODE
 				    || cur_node->type == XML_TEXT_NODE) {

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -562,7 +562,7 @@ static int process_pattern_match(const char *path, pcre **regex_out)
 		   OVAL definitions that use ".*" as 'path' and then
 		   uncomment this.
 
-		dI("pcre_exec() returned PCRE_ERROR_PARTIAL for pattern '%s' "
+		dD("pcre_exec() returned PCRE_ERROR_PARTIAL for pattern '%s' "
 		   "and test path '%s'.\n", pattern, test_path1);
 		ret = pcre_exec(regex, NULL, test_path2, strlen(test_path2),
 			0, PCRE_PARTIAL, NULL, 0);
@@ -578,7 +578,7 @@ static int process_pattern_match(const char *path, pcre **regex_out)
 		*/
 		break;
 	case PCRE_ERROR_BADPARTIAL:
-		dI("pcre_exec() returned PCRE_ERROR_BADPARTIAL for pattern "
+		dD("pcre_exec() returned PCRE_ERROR_BADPARTIAL for pattern "
 		   "'%s' and a test path '%s'. Falling back to "
 		   "pcre_fullinfo().\n", pattern, test_path1);
 		pcre_free(regex);
@@ -643,9 +643,9 @@ static int process_pattern_match(const char *path, pcre **regex_out)
 	}
 
 	if (regex == NULL) {
-		dI("Disabling partial match optimization.");
+		dD("Disabling partial match optimization.");
 	} else {
-		dI("Enabling partial match optimization using "
+		dD("Enabling partial match optimization using "
 		   "pattern: '%s'.", pattern);
 		if (regex_out != NULL)
 			*regex_out = regex;
@@ -708,7 +708,7 @@ OVAL_FTS *oval_fts_open_prefixed(const char *prefix, SEXP_t *path, SEXP_t *filen
 		path_op = OVAL_OPERATION_EQUALS;
 	}
 #if defined(OSCAP_FTS_DEBUG)
-	dI("path_op: %u, '%s'.", path_op, oval_operation_get_text(path_op));
+	dD("path_op: %u, '%s'.", path_op, oval_operation_get_text(path_op));
 #endif
 	if (path) { /* filepath == NULL */
 		PROBE_ENT_STRVAL(path, cstr_path, sizeof cstr_path,
@@ -736,7 +736,7 @@ OVAL_FTS *oval_fts_open_prefixed(const char *prefix, SEXP_t *path, SEXP_t *filen
 		return (NULL);
 	}
 #if defined(OSCAP_FTS_DEBUG)
-	dI("bh.max_depth: %s => max_depth: %d", cstr_buff, max_depth);
+	dD("bh.max_depth: %s => max_depth: %d", cstr_buff, max_depth);
 #endif
 	SEXP_free(r0);
 
@@ -756,7 +756,7 @@ OVAL_FTS *oval_fts_open_prefixed(const char *prefix, SEXP_t *path, SEXP_t *filen
 		return (NULL);
 	}
 #if defined(OSCAP_FTS_DEBUG)
-	dI("bh.direction: %s => direction: %d", cstr_buff, direction);
+	dD("bh.direction: %s => direction: %d", cstr_buff, direction);
 #endif
 	SEXP_free(r0);
 
@@ -782,7 +782,7 @@ OVAL_FTS *oval_fts_open_prefixed(const char *prefix, SEXP_t *path, SEXP_t *filen
 		recurse = OVAL_RECURSE_SYMLINKS_AND_DIRS;
 	}
 #if defined(OSCAP_FTS_DEBUG)
-	dI("bh.recurse: %s => recurse: %d", cstr_buff, recurse);
+	dD("bh.recurse: %s => recurse: %d", cstr_buff, recurse);
 #endif
 	SEXP_free(r0);
 
@@ -808,7 +808,7 @@ OVAL_FTS *oval_fts_open_prefixed(const char *prefix, SEXP_t *path, SEXP_t *filen
 		filesystem = OVAL_RECURSE_FS_ALL;
 	}
 #if defined(OSCAP_FTS_DEBUG)
-	dI("bh.filesystem: %s => filesystem: %d", cstr_buff, filesystem);
+	dD("bh.filesystem: %s => filesystem: %d", cstr_buff, filesystem);
 #endif
 	SEXP_free(r0);
 
@@ -825,7 +825,7 @@ OVAL_FTS *oval_fts_open_prefixed(const char *prefix, SEXP_t *path, SEXP_t *filen
 		if (process_pattern_match(cstr_path, &regex) != 0)
 			return NULL;
 		paths[0] = extract_fixed_path_prefix(cstr_path);
-		dI("Extracted fixed path: '%s'.", paths[0]);
+		dD("Extracted fixed path: '%s'.", paths[0]);
 	} else {
 		paths[0] = strdup("/");
 	}
@@ -963,7 +963,7 @@ static FTSENT *oval_fts_read_match_path(OVAL_FTS *ofts)
 		}
 
 #if defined(OSCAP_FTS_DEBUG)
-		dI("fts_path: '%s' (l=%d)."
+		dD("fts_path: '%s' (l=%d)."
 		   "fts_name: '%s' (l=%d).\n"
 		   "fts_info: %u.\n", fts_ent->fts_path, fts_ent->fts_pathlen,
 		   fts_ent->fts_name, fts_ent->fts_namelen, fts_ent->fts_info);
@@ -971,7 +971,7 @@ static FTSENT *oval_fts_read_match_path(OVAL_FTS *ofts)
 
 		if (fts_ent->fts_info == FTS_SL) {
 #if defined(OSCAP_FTS_DEBUG)
-			dI("Only the target of a symlink gets reported, skipping '%s'.", fts_ent->fts_path, fts_ent->fts_name);
+			dD("Only the target of a symlink gets reported, skipping '%s'.", fts_ent->fts_path, fts_ent->fts_name);
 #endif
 			fts_set(ofts->ofts_match_path_fts, fts_ent, FTS_FOLLOW);
 			continue;
@@ -1071,7 +1071,7 @@ static FTSENT *oval_fts_read_recurse_path(OVAL_FTS *ofts)
 			char * const paths[2] = { ofts->ofts_match_path_fts_ent->fts_path, NULL };
 
 #if defined(OSCAP_FTS_DEBUG)
-			dI("fts_open args: path: \"%s\", options: %d.",
+			dD("fts_open args: path: \"%s\", options: %d.",
 				paths[0], ofts->ofts_recurse_path_fts_opts);
 #endif
 			/* reset errno as fts_open() doesn't do it itself. */
@@ -1118,7 +1118,7 @@ static FTSENT *oval_fts_read_recurse_path(OVAL_FTS *ofts)
 			}
 
 #if defined(OSCAP_FTS_DEBUG)
-			dI("fts_path: '%s' (l=%d)."
+			dD("fts_path: '%s' (l=%d)."
 			   "fts_name: '%s' (l=%d).\n"
 			   "fts_info: %u.\n", fts_ent->fts_path, fts_ent->fts_pathlen,
 			   fts_ent->fts_name, fts_ent->fts_namelen, fts_ent->fts_info);
@@ -1206,7 +1206,7 @@ static FTSENT *oval_fts_read_recurse_path(OVAL_FTS *ofts)
 				char * const paths[2] = { ofts->ofts_recurse_path_curpth, NULL };
 
 #if defined(OSCAP_FTS_DEBUG)
-				dI("fts_open args: path: \"%s\", options: %d.",
+				dD("fts_open args: path: \"%s\", options: %d.",
 					paths[0], ofts->ofts_recurse_path_fts_opts);
 #endif
 				/* reset errno as fts_open() doesn't do it itself. */
@@ -1319,7 +1319,7 @@ OVAL_FTSENT *oval_fts_read(OVAL_FTS *ofts)
 	FTSENT *fts_ent;
 
 #if defined(OSCAP_FTS_DEBUG)
-	dI("ofts: %p.", ofts);
+	dD("ofts: %p.", ofts);
 #endif
 
 	if (ofts == NULL)

--- a/src/OVAL/probes/probe-api.c
+++ b/src/OVAL/probes/probe-api.c
@@ -437,7 +437,7 @@ SEXP_t *probe_obj_getent(const SEXP_t * obj, const char *name, uint32_t n)
 #if !defined(NDEBUG) && defined(SEAP_VERBOSE_DEBUG)
 			char buf[128];
 			SEXP_string_cstr_r(ent_name, buf, sizeof buf);
-			dI("1=\"%s\", 2=\"%s\", n=%u", buf, name, n);
+			dD("1=\"%s\", 2=\"%s\", n=%u", buf, name, n);
 #endif
 
 			if (SEXP_strcmp(ent_name, name) == 0 && (--n == 0)) {

--- a/src/OVAL/probes/probe/entcmp.c
+++ b/src/OVAL/probes/probe/entcmp.c
@@ -434,7 +434,7 @@ oval_result_t probe_entobj_cmp(SEXP_t * ent_obj, SEXP_t * val)
 	valcnt = probe_ent_getvals(ent_obj, &r0);
 	SEXP_free(r0);
 	if (valcnt == 0) {
-		dI("valcnt == 0.");
+		dD("valcnt == 0.");
 		return OVAL_RESULT_FALSE;
 	}
 

--- a/src/OVAL/probes/probe/icache.c
+++ b/src/OVAL/probes/probe/icache.c
@@ -99,7 +99,7 @@ static int icache_lookup(rbt_t *tree, int64_t item_id, probe_iqpair_t *pair) {
 	/*
 	* Maybe a cache HIT
 	*/
-	dI("cache HIT #1");
+	dD("cache HIT #1");
 
 	register uint16_t i;
 	for (i = 0; i < cached->count; ++i) {
@@ -123,7 +123,7 @@ static int icache_lookup(rbt_t *tree, int64_t item_id, probe_iqpair_t *pair) {
 		/*
 		* Cache MISS
 		*/
-		dI("cache MISS");
+		dD("cache MISS");
 
 		cached->item = realloc(cached->item, sizeof(SEXP_t *) * ++cached->count);
 		cached->item[cached->count - 1] = pair->p.item;
@@ -134,7 +134,7 @@ static int icache_lookup(rbt_t *tree, int64_t item_id, probe_iqpair_t *pair) {
 		/*
 		* Cache HIT
 		*/
-		dI("cache HIT #2 -> real HIT");
+		dD("cache HIT #2 -> real HIT");
 		SEXP_free(pair->p.item);
 		pair->p.item = cached->item[i];
 	}
@@ -206,7 +206,7 @@ static void *probe_icache_worker(void *arg)
 				return NULL;
 			}
         do {
-                dI("Extracting item from the cache queue: cnt=%"PRIu16", beg=%"PRIu16"", cache->queue_cnt, cache->queue_beg);
+                dD("Extracting item from the cache queue: cnt=%"PRIu16", beg=%"PRIu16"", cache->queue_cnt, cache->queue_beg);
                 /*
                  * Extract an item from the queue and update queue beg, end & cnt
                  */
@@ -274,7 +274,7 @@ static void *probe_icache_worker(void *arg)
                                 /*
                                  * Cache MISS
                                  */
-                                dI("cache MISS");
+                                dD("cache MISS");
                                 icache_add_to_tree(cache->tree, item_ID, pair);
                         }
 

--- a/src/OVAL/probes/probe/probe_main.c
+++ b/src/OVAL/probes/probe/probe_main.c
@@ -199,7 +199,7 @@ void *probe_common_main(void *arg)
 # endif
 #endif
 
-	dI("probe_common_main started");
+	dD("probe_common_main started");
 
 	const unsigned thread_count = 2; // input and icache threads
 	if ((errno = pthread_barrier_init(&OSCAP_GSYM(th_barrier), NULL, thread_count)) != 0) {

--- a/src/OVAL/probes/unix/file_probe.c
+++ b/src/OVAL/probes/unix/file_probe.c
@@ -327,7 +327,7 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr, 
 
 	char *st_path_with_prefix = oscap_path_join(prefix, st_path);
 	if (lstat(st_path_with_prefix, &st) == -1) {
-                dI("lstat failed when processing %s: errno=%u, %s.", st_path, errno, strerror (errno));
+                dD("lstat failed when processing %s: errno=%u, %s.", st_path, errno, strerror (errno));
 		/*
 		 * Whatever the reason of this lstat error (for example the file may
 		 * have disappeared) we don't want it to stop the whole file tree walk;
@@ -432,7 +432,7 @@ void *file_probe_init(void)
 		return ((void *)file_probe_mutex);
         default:
 		free(file_probe_mutex);
-                dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
+                dD("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
         }
 #if 0
 	probe_setoption(PROBEOPT_VARREF_HANDLING, false, "path");
@@ -486,7 +486,7 @@ int file_probe_main(probe_ctx *ctx, void *mutex)
         case 0:
                 break;
         default:
-                dI("Can't lock mutex(%p): %u, %s.", mutex, errno, strerror (errno));
+                dD("Can't lock mutex(%p): %u, %s.", mutex, errno, strerror (errno));
 
 		SEXP_free(path);
 		SEXP_free(filename);
@@ -532,7 +532,7 @@ int file_probe_main(probe_ctx *ctx, void *mutex)
         case 0:
                 break;
         default:
-                dI("Can't unlock mutex(%p): %u, %s.", mutex, errno, strerror (errno));
+                dD("Can't unlock mutex(%p): %u, %s.", mutex, errno, strerror (errno));
 
                 return PROBE_EFATAL;
         }

--- a/src/OVAL/probes/unix/fileextendedattribute_probe.c
+++ b/src/OVAL/probes/unix/fileextendedattribute_probe.c
@@ -113,7 +113,7 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr, 
 
 		if (xattr_count < 0) {
 			free(st_path_with_prefix);
-				dI("FAIL: llistxattr(%s, %p, %zu): errno=%u, %s.", errno, strerror(errno));
+				dD("FAIL: llistxattr(%s, %p, %zu): errno=%u, %s.", errno, strerror(errno));
 				return 0;
 		}
 
@@ -128,7 +128,7 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr, 
 	} while (errno == ERANGE);
 
         if (xattr_count < 0) {
-                dI("FAIL: llistxattr(%s, %p, %zu): errno=%u, %s.", errno, strerror(errno));
+                dD("FAIL: llistxattr(%s, %p, %zu): errno=%u, %s.", errno, strerror(errno));
                 free(xattr_buf);
         }
 
@@ -182,7 +182,7 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr, 
 
                                 free(xattr_val);
                         } else {
-                                dI("FAIL: lgetxattr(%s, %s, NULL, 0): errno=%u, %s.", errno, strerror(errno));
+                                dD("FAIL: lgetxattr(%s, %s, NULL, 0): errno=%u, %s.", errno, strerror(errno));
 
                                 item = probe_item_create(OVAL_UNIX_FILEEXTENDEDATTRIBUTE, NULL, NULL);
                                 probe_item_setstatus(item, SYSCHAR_STATUS_ERROR);
@@ -222,7 +222,7 @@ void *fileextendedattribute_probe_init(void)
         case 0:
 		return ((void *)mutex);
         default:
-                dI("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
+                dD("Can't initialize mutex: errno=%u, %s.", errno, strerror (errno));
         }
 #if 0
 	probe_setoption(PROBEOPT_VARREF_HANDLING, false, "path");
@@ -280,7 +280,7 @@ int fileextendedattribute_probe_main(probe_ctx *ctx, void *mutex)
         case 0:
                 break;
         default:
-		dI("Can't lock mutex(%p): %u, %s.", mutex, errno, strerror(errno));
+		dD("Can't lock mutex(%p): %u, %s.", mutex, errno, strerror(errno));
 
 		SEXP_free(path);
 		SEXP_free(filename);
@@ -320,7 +320,7 @@ int fileextendedattribute_probe_main(probe_ctx *ctx, void *mutex)
         case 0:
                 break;
         default:
-		dI("Can't unlock mutex(%p): %u, %s.", mutex, errno, strerror(errno));
+		dD("Can't unlock mutex(%p): %u, %s.", mutex, errno, strerror(errno));
 
                 return PROBE_EFATAL;
         }

--- a/src/OVAL/probes/unix/linux/dpkginfo_probe.c
+++ b/src/OVAL/probes/unix/linux/dpkginfo_probe.c
@@ -119,7 +119,7 @@ int dpkginfo_probe_main (probe_ctx *ctx, void *arg)
         val = probe_ent_getval (ent);
 
         if (val == NULL) {
-                dI("%s: no value", "name");
+                dD("%s: no value", "name");
                 SEXP_free (ent);
                 return (PROBE_ENOVAL);
         }
@@ -130,11 +130,11 @@ int dpkginfo_probe_main (probe_ctx *ctx, void *arg)
         if (request_st == NULL) {
                 switch (errno) {
                 case EINVAL:
-                        dI("%s: invalid value type", "name");
+                        dD("%s: invalid value type", "name");
 			return PROBE_EINVAL;
                         break;
                 case EFAULT:
-                        dI("%s: element not found", "name");
+                        dD("%s: element not found", "name");
 			return PROBE_ENOELM;
                         break;
 		default:
@@ -151,12 +151,12 @@ int dpkginfo_probe_main (probe_ctx *ctx, void *arg)
                 switch (errflag) {
 		case 0: /* Not found */
 		{
-			dI("Package \"%s\" not found.", request_st);
+			dD("Package \"%s\" not found.", request_st);
 			break;
 		}
 		case -1: /* Error */
 		{
-			dI("dpkginfo_get_by_name failed.");
+			dD("dpkginfo_get_by_name failed.");
 			item = probe_item_create(OVAL_LINUX_DPKG_INFO, NULL,
 					"name", OVAL_DATATYPE_STRING, request_st,
 					NULL);
@@ -177,7 +177,7 @@ int dpkginfo_probe_main (probe_ctx *ctx, void *arg)
 		}
 
                 for (i = 0; i < num_items; ++i) {
-                        dI("%s: element found version %s", dpkginfo_reply->name, dpkginfo_reply->evr);
+                        dD("%s: element found version %s", dpkginfo_reply->name, dpkginfo_reply->evr);
                         item = probe_item_create (OVAL_LINUX_DPKG_INFO, NULL,
                                         "name", OVAL_DATATYPE_STRING, dpkginfo_reply->name,
                                         "arch", OVAL_DATATYPE_STRING, dpkginfo_reply->arch,

--- a/src/OVAL/probes/unix/linux/partition_probe.c
+++ b/src/OVAL/probes/unix/linux/partition_probe.c
@@ -198,7 +198,7 @@ static int collect_item(probe_ctx *ctx, oval_schema_version_t over, struct mnten
             add_mnt_opt(&mnt_opts, ++mnt_ocnt, "move");
         }
 
-        dI("mnt_ocnt = %d, mnt_opts[mnt_ocnt]=%p", mnt_ocnt, mnt_opts[mnt_ocnt]);
+        dD("mnt_ocnt = %d, mnt_opts[mnt_ocnt]=%p", mnt_ocnt, mnt_opts[mnt_ocnt]);
 
 	/*
 	 * "Correct" the type (this won't be (hopefully) needed in a later version

--- a/src/OVAL/probes/unix/linux/rpminfo_probe.c
+++ b/src/OVAL/probes/unix/linux/rpminfo_probe.c
@@ -282,7 +282,7 @@ void *rpminfo_probe_init(void)
 #endif
 	struct rpm_probe_global *g_rpm = malloc(sizeof(struct rpm_probe_global));
 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
-		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
+		dD("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
 		g_rpm->rpmts = NULL;
 		return ((void *)g_rpm);
         }
@@ -427,7 +427,7 @@ int rpminfo_probe_main(probe_ctx *ctx, void *arg)
         val = probe_ent_getval (ent);
 
         if (val == NULL) {
-                dI("%s: no value", "name");
+                dD("%s: no value", "name");
                 SEXP_free (ent);
                 return (PROBE_ENOVAL);
         }
@@ -461,11 +461,11 @@ int rpminfo_probe_main(probe_ctx *ctx, void *arg)
 		SEXP_free (ent);
                 switch (errno) {
                 case EINVAL:
-                        dI("%s: invalid value type", "name");
+                        dD("%s: invalid value type", "name");
 			return PROBE_EINVAL;
                         break;
                 case EFAULT:
-                        dI("%s: element not found", "name");
+                        dD("%s: element not found", "name");
 			return PROBE_ENOELM;
                         break;
 		default:
@@ -481,7 +481,7 @@ int rpminfo_probe_main(probe_ctx *ctx, void *arg)
                 dI("Package \"%s\" not found.", request_st.name);
                 break;
         case -1: /* Error */
-                dI("get_rpminfo failed");
+                dD("get_rpminfo failed");
 
                 item = probe_item_create(OVAL_LINUX_RPM_INFO, NULL,
                                          "name", OVAL_DATATYPE_STRING, request_st.name,

--- a/src/OVAL/probes/unix/linux/rpmverify_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverify_probe.c
@@ -231,7 +231,7 @@ void *rpmverify_probe_init(void)
 	rpmlogSetCallback(rpmErrorCb, NULL);
 #endif
         if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
-                dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
+                dD("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
                 return (NULL);
         }
 	struct rpm_probe_global *g_rpm = malloc(sizeof(struct rpm_probe_global));
@@ -383,7 +383,7 @@ int rpmverify_probe_main(probe_ctx *ctx, void *arg)
 
                         if (aval != NULL) {
                                 if (SEXP_strcmp(aval, "true") == 0) {
-                                        dI("omit verify attr: %s", rpmverify_bhmap[i].a_name);
+                                        dD("omit verify attr: %s", rpmverify_bhmap[i].a_name);
                                         collect_flags |= rpmverify_bhmap[i].a_flag;
                                 }
 

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -338,7 +338,7 @@ void *rpmverifyfile_probe_init(void)
 	rpmlogSetCallback(rpmErrorCb, NULL);
 #endif
 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
-		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
+		dD("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
 		return (NULL);
 	}
 
@@ -537,7 +537,7 @@ int rpmverifyfile_probe_main(probe_ctx *ctx, void *arg)
 		SEXP_free(bh_ent);
 	}
 
-	dI("Collecting rpmverifyfile data, query: f=\"%s\" (%d)",
+	dD("Collecting rpmverifyfile data, query: f=\"%s\" (%d)",
 	   file, file_op);
 
 	if (rpmverify_collect(ctx,

--- a/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
@@ -339,7 +339,7 @@ void *rpmverifypackage_probe_init(void)
 	}
 
 	if (rpmReadConfigFiles (NULL, (const char *)NULL) != 0) {
-		dI("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
+		dD("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
 		g_rpm->rpm.rpmts = NULL;
 		return ((void *)g_rpm);
 	}
@@ -401,13 +401,13 @@ static int rpmverifypackage_additem(probe_ctx *ctx, struct rpmverify_res *res)
 				 NULL);
 
 	if (res->vflags & VERIFY_DEPS) {
-		dI("VERIFY_DEPS %lu", res->vresults & VERIFY_DEPS);
+		dD("VERIFY_DEPS %lu", res->vresults & VERIFY_DEPS);
 		value = probe_entval_from_cstr(OVAL_DATATYPE_BOOLEAN, (res->vresults & VERIFY_DEPS ? "1" : "0"), 1);
 		probe_item_ent_add(item, "dependency_check_passed", NULL, value);
 		SEXP_free(value);
 	}
 	if (res->vflags & VERIFY_SCRIPT) {
-		dI("VERIFY_SCRIPT %d", res->vresults & VERIFY_SCRIPT);
+		dD("VERIFY_SCRIPT %d", res->vresults & VERIFY_SCRIPT);
 		value = probe_entval_from_cstr(OVAL_DATATYPE_BOOLEAN, (res->vresults & VERIFY_SCRIPT ? "1" : "0"), 1);
 		probe_item_ent_add(item, "verification_script_successful", NULL, value);
 		SEXP_free(value);
@@ -458,7 +458,7 @@ int rpmverifypackage_probe_main(probe_ctx *ctx, void *arg)
 
 			if (aval != NULL) {
 				if (SEXP_strcmp(aval, "true") == 0) {
-					dI("omit verify attr: %s", rpmverifypackage_bhmap[i].a_name);
+					dD("omit verify attr: %s", rpmverifypackage_bhmap[i].a_name);
 					collect_flags |= rpmverifypackage_bhmap[i].a_flag;
 				}
 

--- a/src/OVAL/probes/unix/linux/systemdshared.h
+++ b/src/OVAL/probes/unix/linux/systemdshared.h
@@ -84,7 +84,7 @@ static char *get_path_by_unit(DBusConnection *conn, const char *unit)
 		"LoadUnit"
 	);
 	if (msg == NULL) {
-		dI("Failed to create dbus_message via dbus_message_new_method_call!");
+		dD("Failed to create dbus_message via dbus_message_new_method_call!");
 		goto cleanup;
 	}
 
@@ -92,16 +92,16 @@ static char *get_path_by_unit(DBusConnection *conn, const char *unit)
 
 	dbus_message_iter_init_append(msg, &args);
 	if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &unit)) {
-		dI("Failed to append unit '%s' string parameter to dbus message!", unit);
+		dD("Failed to append unit '%s' string parameter to dbus message!", unit);
 		goto cleanup;
 	}
 
 	if (!dbus_connection_send_with_reply(conn, msg, &pending, -1)) {
-		dI("Failed to send message via dbus!");
+		dD("Failed to send message via dbus!");
 		goto cleanup;
 	}
 	if (pending == NULL) {
-		dI("Invalid dbus pending call!");
+		dD("Invalid dbus pending call!");
 		goto cleanup;
 	}
 
@@ -111,18 +111,18 @@ static char *get_path_by_unit(DBusConnection *conn, const char *unit)
 	dbus_pending_call_block(pending);
 	msg = dbus_pending_call_steal_reply(pending);
 	if (msg == NULL) {
-		dI("Failed to steal dbus pending call reply.");
+		dD("Failed to steal dbus pending call reply.");
 		goto cleanup;
 	}
 	dbus_pending_call_unref(pending); pending = NULL;
 
 	if (!dbus_message_iter_init(msg, &args)) {
-		dI("Failed to initialize iterator over received dbus message.");
+		dD("Failed to initialize iterator over received dbus message.");
 		goto cleanup;
 	}
 
 	if (dbus_message_iter_get_arg_type(&args) != DBUS_TYPE_OBJECT_PATH) {
-		dI("Expected string argument in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
+		dD("Expected string argument in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
 		goto cleanup;
 	}
 
@@ -153,7 +153,7 @@ static int get_all_systemd_units(DBusConnection* conn, int(*callback)(const char
 		"ListUnits"
 	);
 	if (msg == NULL) {
-		dI("Failed to create dbus_message via dbus_message_new_method_call!");
+		dD("Failed to create dbus_message via dbus_message_new_method_call!");
 		goto cleanup;
 	}
 
@@ -163,11 +163,11 @@ static int get_all_systemd_units(DBusConnection* conn, int(*callback)(const char
 	dbus_message_iter_init_append(msg, &args);
 
 	if (!dbus_connection_send_with_reply(conn, msg, &pending, -1)) {
-		dI("Failed to send message via dbus!");
+		dD("Failed to send message via dbus!");
 		goto cleanup;
 	}
 	if (pending == NULL) {
-		dI("Invalid dbus pending call!");
+		dD("Invalid dbus pending call!");
 		goto cleanup;
 	}
 
@@ -177,25 +177,25 @@ static int get_all_systemd_units(DBusConnection* conn, int(*callback)(const char
 	dbus_pending_call_block(pending);
 	msg = dbus_pending_call_steal_reply(pending);
 	if (msg == NULL) {
-		dI("Failed to steal dbus pending call reply.");
+		dD("Failed to steal dbus pending call reply.");
 		goto cleanup;
 	}
 	dbus_pending_call_unref(pending); pending = NULL;
 
 	if (!dbus_message_iter_init(msg, &args)) {
-		dI("Failed to initialize iterator over received dbus message.");
+		dD("Failed to initialize iterator over received dbus message.");
 		goto cleanup;
 	}
 
 	if (dbus_message_iter_get_arg_type(&args) != DBUS_TYPE_ARRAY) {
-		dI("Expected array of structs in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
+		dD("Expected array of structs in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
 		goto cleanup;
 	}
 
 	dbus_message_iter_recurse(&args, &unit_iter);
 	do {
 		if (dbus_message_iter_get_arg_type(&unit_iter) != DBUS_TYPE_STRUCT) {
-			dI("Expected unit struct as elements in returned array. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&unit_iter)));
+			dD("Expected unit struct as elements in returned array. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&unit_iter)));
 			goto cleanup;
 		}
 
@@ -203,7 +203,7 @@ static int get_all_systemd_units(DBusConnection* conn, int(*callback)(const char
 		dbus_message_iter_recurse(&unit_iter, &unit_name);
 
 		if (dbus_message_iter_get_arg_type(&unit_name) != DBUS_TYPE_STRING) {
-			dI("Expected string as the first element in the unit struct. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&unit_name)));
+			dD("Expected string as the first element in the unit struct. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&unit_name)));
 			goto cleanup;
 		}
 
@@ -285,7 +285,7 @@ static char *dbus_value_to_string(DBusMessageIter *iter)
 			//	return oscap_sprintf("%i", value.fd);
 
 			default:
-				dI("Encountered unknown dbus basic type!");
+				dD("Encountered unknown dbus basic type!");
 				return oscap_strdup("error, unknown basic type!");
 		}
 	}
@@ -331,17 +331,17 @@ static DBusConnection *connect_dbus()
 
 	conn = dbus_bus_get(DBUS_BUS_SYSTEM, &err);
 	if (dbus_error_is_set(&err)) {
-		dI("Failed to get DBUS_BUS_SYSTEM connection - %s", err.message);
+		dD("Failed to get DBUS_BUS_SYSTEM connection - %s", err.message);
 		goto cleanup;
 	}
 	if (conn == NULL) {
-		dI("DBusConnection == NULL!");
+		dD("DBusConnection == NULL!");
 		goto cleanup;
 	}
 
 	dbus_bus_register(conn, &err);
 	if (dbus_error_is_set(&err)) {
-		dI("Failed to register on dbus - %s", err.message);
+		dD("Failed to register on dbus - %s", err.message);
 		goto cleanup;
 	}
 

--- a/src/OVAL/probes/unix/linux/systemdunitdependency_probe.c
+++ b/src/OVAL/probes/unix/linux/systemdunitdependency_probe.c
@@ -50,7 +50,7 @@ static char *get_property_by_unit_path(DBusConnection *conn, const char *unit_pa
 		"Get"
 	);
 	if (msg == NULL) {
-		dI("Failed to create dbus_message via dbus_message_new_method_call!");
+		dD("Failed to create dbus_message via dbus_message_new_method_call!");
 		goto cleanup;
 	}
 
@@ -60,20 +60,20 @@ static char *get_property_by_unit_path(DBusConnection *conn, const char *unit_pa
 
 	dbus_message_iter_init_append(msg, &args);
 	if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &interface)) {
-		dI("Failed to append interface '%s' string parameter to dbus message!", interface);
+		dD("Failed to append interface '%s' string parameter to dbus message!", interface);
 		goto cleanup;
 	}
 	if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &property)) {
-		dI("Failed to append property '%s' string parameter to dbus message!", property);
+		dD("Failed to append property '%s' string parameter to dbus message!", property);
 		goto cleanup;
 	}
 
 	if (!dbus_connection_send_with_reply(conn, msg, &pending, -1)) {
-		dI("Failed to send message via dbus!");
+		dD("Failed to send message via dbus!");
 		goto cleanup;
 	}
 	if (pending == NULL) {
-		dI("Invalid dbus pending call!");
+		dD("Invalid dbus pending call!");
 		goto cleanup;
 	}
 
@@ -83,19 +83,19 @@ static char *get_property_by_unit_path(DBusConnection *conn, const char *unit_pa
 	dbus_pending_call_block(pending);
 	msg = dbus_pending_call_steal_reply(pending);
 	if (msg == NULL) {
-		dI("Failed to steal dbus pending call reply.");
+		dD("Failed to steal dbus pending call reply.");
 		goto cleanup;
 	}
 	dbus_pending_call_unref(pending); pending = NULL;
 
 	if (!dbus_message_iter_init(msg, &args)) {
-		dI("Failed to initialize iterator over received dbus message.");
+		dD("Failed to initialize iterator over received dbus message.");
 		goto cleanup;
 	}
 
 	if (dbus_message_iter_get_arg_type(&args) != DBUS_TYPE_VARIANT)
 	{
-		dI("Expected variant argument in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
+		dD("Expected variant argument in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
 		goto cleanup;
 	}
 

--- a/src/OVAL/probes/unix/linux/systemdunitproperty_probe.c
+++ b/src/OVAL/probes/unix/linux/systemdunitproperty_probe.c
@@ -49,7 +49,7 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 		"GetAll"
 	);
 	if (msg == NULL) {
-		dI("Failed to create dbus_message via dbus_message_new_method_call!");
+		dD("Failed to create dbus_message via dbus_message_new_method_call!");
 		goto cleanup;
 	}
 
@@ -59,16 +59,16 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 
 	dbus_message_iter_init_append(msg, &args);
 	if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &interface)) {
-		dI("Failed to append interface '%s' string parameter to dbus message!", interface);
+		dD("Failed to append interface '%s' string parameter to dbus message!", interface);
 		goto cleanup;
 	}
 
 	if (!dbus_connection_send_with_reply(conn, msg, &pending, -1)) {
-		dI("Failed to send message via dbus!");
+		dD("Failed to send message via dbus!");
 		goto cleanup;
 	}
 	if (pending == NULL) {
-		dI("Invalid dbus pending call!");
+		dD("Invalid dbus pending call!");
 		goto cleanup;
 	}
 
@@ -78,18 +78,18 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 	dbus_pending_call_block(pending);
 	msg = dbus_pending_call_steal_reply(pending);
 	if (msg == NULL) {
-		dI("Failed to steal dbus pending call reply.");
+		dD("Failed to steal dbus pending call reply.");
 		goto cleanup;
 	}
 	dbus_pending_call_unref(pending); pending = NULL;
 
 	if (!dbus_message_iter_init(msg, &args)) {
-		dI("Failed to initialize iterator over received dbus message.");
+		dD("Failed to initialize iterator over received dbus message.");
 		goto cleanup;
 	}
 
 	if (dbus_message_iter_get_arg_type(&args) != DBUS_TYPE_ARRAY && dbus_message_iter_get_element_type(&args) != DBUS_TYPE_DICT_ENTRY) {
-		dI("Expected array of dict_entry argument in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
+		dD("Expected array of dict_entry argument in reply. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&args)));
 		goto cleanup;
 	}
 
@@ -99,7 +99,7 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 		dbus_message_iter_recurse(&property_iter, &dict_entry);
 
 		if (dbus_message_iter_get_arg_type(&dict_entry) != DBUS_TYPE_STRING) {
-			dI("Expected string as key in dict_entry. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&dict_entry)));
+			dD("Expected string as key in dict_entry. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&dict_entry)));
 			goto cleanup;
 		}
 
@@ -114,7 +114,7 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 		}
 
 		if (dbus_message_iter_get_arg_type(&dict_entry) != DBUS_TYPE_VARIANT) {
-			dI("Expected variant as value in dict_entry. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&dict_entry)));
+			dD("Expected variant as value in dict_entry. Instead received: %s.", dbus_message_type_to_string(dbus_message_iter_get_arg_type(&dict_entry)));
 			free(property_name);
 			goto cleanup;
 		}

--- a/src/OVAL/probes/unix/routingtable_probe.c
+++ b/src/OVAL/probes/unix/routingtable_probe.c
@@ -205,7 +205,7 @@ static int process_line_ip4(char *line, struct route_info *rt)
 #define TOK_flags  token[3]
 #define TOK_ifname token[0]
 
-    dI("name=%s, dst=%s, gw=%s, flags=%s", TOK_ifname, TOK_dst, TOK_gw, TOK_flags);
+    dD("name=%s, dst=%s, gw=%s, flags=%s", TOK_ifname, TOK_dst, TOK_gw, TOK_flags);
 
     if (proc_ip4_to_string(TOK_dst, strlen(TOK_dst), rt->ip_dst, sizeof rt->ip_dst) != 0 ||
         proc_ip4_to_string(TOK_gw, strlen(TOK_gw), rt->ip_gw, sizeof rt->ip_gw) != 0)
@@ -270,7 +270,7 @@ static int process_line_ip6(char *line, struct route_info *rt)
 #define TOK_flags  token[8]
 #define TOK_ifname token[9]
 
-    dI("name=%s, dst=%s, gw=%s, flags=%s", TOK_ifname, TOK_dst, TOK_gw, TOK_flags);
+    dD("name=%s, dst=%s, gw=%s, flags=%s", TOK_ifname, TOK_dst, TOK_gw, TOK_flags);
 
     if (proc_ip6_to_string(TOK_dst, strlen(TOK_dst), rt->ip_dst, sizeof rt->ip_dst) != 0 ||
         proc_ip6_to_string(TOK_gw, strlen(TOK_gw), rt->ip_gw, sizeof rt->ip_gw) != 0)

--- a/src/OVAL/probes/unix/runlevel_probe.c
+++ b/src/OVAL/probes/unix/runlevel_probe.c
@@ -105,12 +105,12 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 
 	orig_dir = opendir(".");
 	if (orig_dir == NULL) {
-		dI("Can't open directory \".\": errno=%d, %s.", errno, strerror(errno));
+		dD("Can't open directory \".\": errno=%d, %s.", errno, strerror(errno));
 		return -1;
 	}
 	init_dir = opendir(init_path);
 	if (init_dir == NULL) {
-		dI("Can't open directory \"%s\": errno=%d, %s.",
+		dD("Can't open directory \"%s\": errno=%d, %s.",
 		   init_path, errno, strerror (errno));
 		closedir(orig_dir);
 		return (-1);
@@ -124,7 +124,7 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 		// Ensure that we are in the expected directory before
 		// touching relative paths
 		if (fchdir(dirfd(init_dir)) != 0) {
-			dI("Can't fchdir to \"%s\": errno=%d, %s.",
+			dD("Can't fchdir to \"%s\": errno=%d, %s.",
 			   init_path, errno, strerror (errno));
 			closedir(init_dir);
 			closedir(orig_dir);
@@ -132,7 +132,7 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 		}
 
 		if (stat(init_dp->d_name, &init_st) != 0) {
-			dI("Can't stat file %s/%s: errno=%d, %s.",
+			dD("Can't stat file %s/%s: errno=%d, %s.",
 			   init_path, init_dp->d_name, errno, strerror(errno));
 			continue;
 		}
@@ -160,12 +160,12 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 			snprintf(pathbuf, sizeof (pathbuf), rc_path, runlevel_list[i]);
 			rc_dir = opendir(pathbuf);
 			if (rc_dir == NULL) {
-				dI("Can't open directory \"%s\": errno=%d, %s.",
+				dD("Can't open directory \"%s\": errno=%d, %s.",
 				   rc_path, errno, strerror (errno));
 				continue;
 			}
 			if (chdir(pathbuf) != 0) {
-				dI("Can't fchdir to \"%s\": errno=%d, %s.",
+				dD("Can't fchdir to \"%s\": errno=%d, %s.",
 				   rc_path, errno, strerror (errno));
 				closedir(rc_dir);
 				continue;
@@ -183,7 +183,7 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 
 			while ((rc_dp = readdir(rc_dir)) != NULL) {
 				if (stat(rc_dp->d_name, &rc_st) != 0) {
-					dI("Can't stat file %s/%s: errno=%d, %s.",
+					dD("Can't stat file %s/%s: errno=%d, %s.",
 					   rc_path, rc_dp->d_name, errno, strerror(errno));
 					continue;
 				}
@@ -207,7 +207,7 @@ static int get_runlevel_sysv (struct runlevel_req *req, struct runlevel_rep **re
 							kill = true;
 							break;
 						} else {
-							dI("Unexpected character in filename: %c, %s/%s.",
+							dD("Unexpected character in filename: %c, %s/%s.",
 							   rc_dp->d_name[0], pathbuf, rc_dp->d_name);
 						}
 					}
@@ -482,7 +482,7 @@ int runlevel_probe_main(probe_ctx *ctx, void *arg)
 
 	request_st.service_name_ent = probe_obj_getent(object, "service_name", 1);
 	if (request_st.service_name_ent == NULL) {
-		dI("%s: element not found", "service_name");
+		dD("%s: element not found", "service_name");
 
 		return PROBE_ENOELM;
 	}
@@ -490,7 +490,7 @@ int runlevel_probe_main(probe_ctx *ctx, void *arg)
 	request_st.runlevel_ent = probe_obj_getent(object, "runlevel", 1);
 	if (request_st.runlevel_ent == NULL) {
 		SEXP_free(request_st.service_name_ent);
-		dI("%s: element not found", "runlevel");
+		dD("%s: element not found", "runlevel");
 
 		return PROBE_ENOELM;
 	}
@@ -507,7 +507,7 @@ int runlevel_probe_main(probe_ctx *ctx, void *arg)
 		SEXP_t *item;
 
 		while (reply_st != NULL) {
-			dI("get_runlevel: [0]=\"%s\", [1]=\"%s\", [2]=\"%d\", [3]=\"%d\"",
+			dD("get_runlevel: [0]=\"%s\", [1]=\"%s\", [2]=\"%d\", [3]=\"%d\"",
 			   reply_st->service_name, reply_st->runlevel, reply_st->start, reply_st->kill);
 
                         item = probe_item_create(OVAL_UNIX_RUNLEVEL, NULL,

--- a/src/OVAL/probes/unix/solaris/isainfo_probe.c
+++ b/src/OVAL/probes/unix/solaris/isainfo_probe.c
@@ -72,7 +72,7 @@ static void report_finding(struct result_info *res, probe_ctx *ctx)
 }
 
 int read_sysinfo(probe_ctx *ctx) {
-	dI("In read_sysinfo for isainfo probe");
+	dD("In read_sysinfo for isainfo probe");
 
 	int err = 1;
 	int ret = 0;

--- a/src/OVAL/probes/unix/sysctl_probe.c
+++ b/src/OVAL/probes/unix/sysctl_probe.c
@@ -134,7 +134,7 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
 		}
 		/* the sysctl utility uses same condition in sysctl.c in ReadSetting() */
 		if ((file_stat.st_mode & S_IRUSR) == 0) {
-			dI("Skipping write-only file %s", mibpath);
+			dD("Skipping write-only file %s", mibpath);
 			oval_ftsent_free(ofts_ent);
 			continue;
 		}
@@ -148,7 +148,7 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
                         --miblen;
                 }
 
-                dI("MIB: %s", mib);
+                dD("MIB: %s", mib);
                 se_mib = SEXP_string_new(mib, strlen(mib));
                 free(mib);
 
@@ -160,7 +160,7 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
                         long i, l;
                         size_t s;
 
-                        dI("MIB match");
+                        dD("MIB match");
 
                         /*
                          * read sysctl value
@@ -182,7 +182,7 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
 				 */
 				if (strncmp(ofts_ent->path, ipv6_conf_path, ipv6_conf_path_len) == 0 &&
 						strcmp(ofts_ent->file, "stable_secret") == 0) {
-					dI("Skipping file %s", mibpath);
+					dD("Skipping file %s", mibpath);
 					oval_ftsent_free(ofts_ent);
 					SEXP_free(se_mib);
 					fclose(fp);
@@ -200,7 +200,7 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
 			 * See https://bugzilla.redhat.com/show_bug.cgi?id=1473207
 			 */
 			if (l == 0) {
-				dI("Skipping file '%s' because it has no value.", mibpath);
+				dD("Skipping file '%s' because it has no value.", mibpath);
 				oval_ftsent_free(ofts_ent);
 				SEXP_free(se_mib);
 				continue;

--- a/src/OVAL/probes/unix/xinetd_probe.c
+++ b/src/OVAL/probes/unix/xinetd_probe.c
@@ -552,7 +552,7 @@ static int xiconf_add_cfile(xiconf_t *xiconf, const char *path, int depth)
 		return (-1);
 	}
 
-	dI("Reading included file: %s", path);
+	dD("Reading included file: %s", path);
 	xifile = xiconf_read (path, 0);
 
 	if (xifile == NULL) {
@@ -564,7 +564,7 @@ static int xiconf_add_cfile(xiconf_t *xiconf, const char *path, int depth)
 	xiconf->cfile = realloc(xiconf->cfile, sizeof(xiconf_file_t *) * ++xiconf->count);
 	xiconf->cfile[xiconf->count - 1] = xifile;
 
-	dI("Added new file to the cfile queue: %s; fi=%zu", path, xiconf->count - 1);
+	dD("Added new file to the cfile queue: %s; fi=%zu", path, xiconf->count - 1);
 
 	return (0);
 }
@@ -729,7 +729,7 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 
 				switch (inctype) {
 				case XICONF_INCTYPE_FILE:
-					dI("includefile: %s", pathbuf);
+					dD("includefile: %s", pathbuf);
 
 					if (xiconf_add_cfile (xiconf, pathbuf, xifile->depth + 1) != 0) {
 						tmpbuf_free(buffer);
@@ -742,7 +742,7 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 					DIR           *dirfp;
 					struct dirent  dent, *dentp = NULL;
 
-					dI("includedir open: %s", inclarg);
+					dD("includedir open: %s", inclarg);
 					dirfp = opendir (inclarg);
 
 					if (dirfp == NULL) {
@@ -777,7 +777,7 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 						if (fnmatch ("*~",  dent.d_name, FNM_PATHNAME) == 0 ||
 						    fnmatch ("*.*", dent.d_name, FNM_PATHNAME) == 0)
 						{
-							dI("Skipping: %s", dent.d_name);
+							dD("Skipping: %s", dent.d_name);
 							continue;
 						}
 
@@ -787,7 +787,7 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 							continue;
 					}
 
-					dI("includedir close: %s", inclarg);
+					dD("includedir close: %s", inclarg);
 					closedir(dirfp);
 					break;
 				}}
@@ -810,7 +810,7 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 
 int xiconf_update(xiconf_t *xiconf)
 {
-	dI("Not implemented yet.");
+	dD("Not implemented yet.");
 	return (0);
 }
 
@@ -971,11 +971,11 @@ int xiconf_parse_section(xiconf_t *xiconf, xiconf_file_t *xifile, int type, char
 			switch (xiattr->pass_arg) {
 			case XIATTR_OPARG_LOCAL:
 				opvar = (void *)xiattr_ptr(snew, xiattr->offset);
-				dI("local opvar");
+				dD("local opvar");
 				break;
 			case XIATTR_OPARG_GLOBAL:
 				opvar = (void *)xiconf;
-				dI("global opvar");
+				dD("global opvar");
 				break;
 			default:
 				abort ();
@@ -985,21 +985,21 @@ int xiconf_parse_section(xiconf_t *xiconf, xiconf_file_t *xifile, int type, char
 				opfun = xiattr->op_assign;
 				opval = op + 1;
 
-				dI("assign(%p): var=%s (at %p+%zu = %p), val=%s",
+				dD("assign(%p): var=%s (at %p+%zu = %p), val=%s",
 				   opfun, xiattr->name, snew, xiattr->offset, opvar, opval);
 
 			} else if (*op == '+' && *(op+1) == '=') {
 				opfun = xiattr->op_insert;
 				opval = op + 2;
 
-				dI("insert(%p): var=%s (at %p+%zu = %p), val=%s",
+				dD("insert(%p): var=%s (at %p+%zu = %p), val=%s",
 				   opfun, xiattr->name, snew, xiattr->offset, opvar, opval);
 
 			} else if (*op == '-' && *(op+1) == '=') {
 				opfun = xiattr->op_remove;
 				opval = op + 2;
 
-				dI("remove(%p): var=%s (at %p+%zu = %p), val=%s",
+				dD("remove(%p): var=%s (at %p+%zu = %p), val=%s",
 				   opfun, xiattr->name, snew, xiattr->offset, opvar, opval);
 			} else
 				goto fail;
@@ -1077,21 +1077,21 @@ finish_section:
 			// If we still don't know the protocol, then get the default from /etc/services
 			if (scur->protocol == NULL) {
 				struct servent *service = getservbyname(scur->name, NULL);
-				dI("protocol is empty, trying to guess from /etc/services for %s", scur->name);
+				dD("protocol is empty, trying to guess from /etc/services for %s", scur->name);
 				if (service != NULL) {
 					scur->protocol = strdup(service->s_proto);
-					dI("service %s has default protocol=%s", scur->name, scur->protocol);
+					dD("service %s has default protocol=%s", scur->name, scur->protocol);
 				}
 				endservent();
 			}
 		}
 		if (scur->port == 0) {
 			struct servent *service = getservbyname(scur->name, scur->protocol);
-			dI("port not set, trying to guess from /etc/services for %s", scur->name);
+			dD("port not set, trying to guess from /etc/services for %s", scur->name);
 			if (service != NULL) {
 				if (service->s_port > 0 && service->s_port < 65536) {
 					scur->port = ntohs((uint16_t)service->s_port);
-					dI("service %s has default port=%hu/%s",
+					dD("service %s has default port=%hu/%s",
 					   scur->name, scur->port, scur->protocol);
 				}
 			}
@@ -1127,7 +1127,7 @@ finish_section:
 		rbt_str_get(xiconf->ttree, st_key, (void *)&st);
 
 		if (st == NULL) {
-			dI("new strans record: k=%s", st_key);
+			dD("new strans record: k=%s", st_key);
 
 			st = malloc(sizeof(xiconf_strans_t));
 			st->cnt = 1;
@@ -1140,7 +1140,7 @@ finish_section:
 				return (-1);
 			}
 		} else {
-			dI("adding new strans record to an exiting one: k=%s, cnt=%u+1",
+			dD("adding new strans record to an exiting one: k=%s, cnt=%u+1",
 			   st_key, st->cnt);
 
 			st->srv = realloc(st->srv, sizeof (xiconf_service_t *) * ++(st->cnt));
@@ -1361,7 +1361,7 @@ int op_assign_strl(void *var, char *val)
 		if (*tok == '\0') {
 			continue;
 		}
-		dI("Adding new member to string array: %s", tok);
+		dD("Adding new member to string array: %s", tok);
 		string_array = realloc(string_array, sizeof(char *) * (++string_array_size + 1));
 		string_array[string_array_size-1] = strdup(tok);
 		string_array[string_array_size] = NULL;
@@ -1382,7 +1382,7 @@ int op_insert_strl(void *var, char *val)
 		while(string_array[string_array_size]) {
 			++string_array_size;
 		}
-		dI("String array has %zu members", string_array_size);
+		dD("String array has %zu members", string_array_size);
 	}
 	str = val;
 	while ((tok = strsep(&str, " ")) != NULL) {
@@ -1392,7 +1392,7 @@ int op_insert_strl(void *var, char *val)
 		if (*tok == '\0') {
 			continue;
 		}
-		dI("Adding new member to string array: %s", tok);
+		dD("Adding new member to string array: %s", tok);
 		string_array = realloc(string_array, sizeof(char *) * (++string_array_size + 1));
 		string_array[string_array_size-1] = strdup(tok);
 		string_array[string_array_size] = NULL;
@@ -1416,7 +1416,7 @@ int op_remove_strl(void *var, char *val)
 		while(string_array[string_array_size]) {
 			++string_array_size;
 		}
-		dI("String array has %zu members", string_array_size);
+		dD("String array has %zu members", string_array_size);
 	}
 
 	if (string_array_size < 1) {
@@ -1438,7 +1438,7 @@ int op_remove_strl(void *var, char *val)
 		if (*tok == '\0') {
 			continue;
 		}
-		dI("Adding new member to string array: %s", tok);
+		dD("Adding new member to string array: %s", tok);
 		valstr_array = realloc(valstr_array, sizeof(char *) * (++valstr_array_size + 1));
 		valstr_array[valstr_array_size-1] = tok;
 		valstr_array[valstr_array_size] = NULL;
@@ -1451,10 +1451,10 @@ int op_remove_strl(void *var, char *val)
 
 		for (valstr_array_pos = 0; valstr_array[valstr_array_pos]; ++valstr_array_pos) {
 			char *delete_val = valstr_array[valstr_array_pos];
-			dI("Removing: %s", delete_val);
+			dD("Removing: %s", delete_val);
 			// Destroy the string if it matches a string from the value string array
 			// Otherwise move it to the new string array
-			dI("cmp: %s ?= %s", string_array_val, delete_val);
+			dD("cmp: %s ?= %s", string_array_val, delete_val);
 			if (strcmp(string_array_val, delete_val) == 0) {
 				free(string_array_val);
 				string_array_val = NULL;
@@ -1500,7 +1500,7 @@ int op_assign_disabled(void *var, char *val)
 			srv->id = strdup (tok);
 			srv->def_disabled = 1;
 
-			dI("new: def_disabled: = 1: %s", srv->id);
+			dD("new: def_disabled: = 1: %s", srv->id);
 
 			if (rbt_str_add (xiconf->stree, srv->id, srv) != 0) {
 				dE("Can't add service (%s) into the service tree (%p)",
@@ -1510,7 +1510,7 @@ int op_assign_disabled(void *var, char *val)
 				return (-1);
 			}
 		} else {
-			dI("mod: def_disabled: %u -> 1: %s", srv->def_disabled, srv->id);
+			dD("mod: def_disabled: %u -> 1: %s", srv->def_disabled, srv->id);
 			srv->def_disabled = 1;
 		}
 	}
@@ -1541,7 +1541,7 @@ int op_assign_enabled(void *var, char *val)
 			srv->id = strdup (tok);
 			srv->def_enabled = 1;
 
-			dI("new: def_enabled: = 1: %s", srv->id);
+			dD("new: def_enabled: = 1: %s", srv->id);
 
 			if (rbt_str_add (xiconf->stree, srv->id, srv) != 0) {
 				dE("Can't add service (%s) into the service tree (%p)",
@@ -1551,7 +1551,7 @@ int op_assign_enabled(void *var, char *val)
 				return (-1);
 			}
 		} else {
-			dI("mod: def_enabled: %u -> 1: %s", srv->def_disabled, srv->id);
+			dD("mod: def_enabled: %u -> 1: %s", srv->def_disabled, srv->id);
 			srv->def_enabled = 1;
 		}
 	}
@@ -1675,7 +1675,7 @@ int xinetd_probe_main(probe_ctx *ctx, void *arg)
 
 	SEXP_free (eval);
 
-	dI("Updating xinetd configuration cache");
+	dD("Updating xinetd configuration cache");
 
 	if (xiconf_update(arg) != 0) {
 		err = PROBE_EUNKNOWN;

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -986,7 +986,6 @@ _xccdf_policy_rule_evaluate(struct xccdf_policy * policy, const struct xccdf_rul
 	 * evaluated is not equal to the selected rule, do not evaluate it and
 	 * mark it as notselected. */
 	if (policy->rule != NULL) {
-		dI("Policy selects only 1 rule");
 		if (strcmp(policy->rule, rule_id) != 0) {
 			return _xccdf_policy_report_rule_result(policy, result, rule, NULL, XCCDF_RESULT_NOT_SELECTED, NULL);
 		}
@@ -1001,9 +1000,9 @@ _xccdf_policy_rule_evaluate(struct xccdf_policy * policy, const struct xccdf_rul
 	xccdf_role_t role = xccdf_get_final_role(rule, r_rule);
 
 	if (!is_selected) {
-		dI("Rule '%s' is not selected.", rule_id);
 		return _xccdf_policy_report_rule_result(policy, result, rule, NULL, XCCDF_RESULT_NOT_SELECTED, NULL);
 	}
+	dI("Evaluating XCCDF rule '%s'.", rule_id);
 
 	if (role == XCCDF_ROLE_UNCHECKED)
 		return _xccdf_policy_report_rule_result(policy, result, rule, NULL, XCCDF_RESULT_NOT_CHECKED, NULL);
@@ -1131,14 +1130,10 @@ static int xccdf_policy_item_evaluate(struct xccdf_policy * policy, struct xccdf
 
     switch (itype) {
         case XCCDF_RULE:{
-			const char *rule_id = xccdf_rule_get_id((const struct xccdf_rule *)item);
-			dI("Evaluating XCCDF rule '%s'.", rule_id);
 			return _xccdf_policy_rule_evaluate(policy, (struct xccdf_rule *) item, result);
         } break;
 
         case XCCDF_GROUP:{
-			const char *group_id = xccdf_group_get_id((const struct xccdf_group *)item);
-			dI("Evaluating XCCDF group '%s'.", group_id);
 			child_it = xccdf_group_get_content((const struct xccdf_group *)item);
 			while (xccdf_item_iterator_has_more(child_it)) {
 				child = xccdf_item_iterator_next(child_it);

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -986,6 +986,7 @@ _xccdf_policy_rule_evaluate(struct xccdf_policy * policy, const struct xccdf_rul
 	 * evaluated is not equal to the selected rule, do not evaluate it and
 	 * mark it as notselected. */
 	if (policy->rule != NULL) {
+		dI("Policy selects only 1 rule");
 		if (strcmp(policy->rule, rule_id) != 0) {
 			return _xccdf_policy_report_rule_result(policy, result, rule, NULL, XCCDF_RESULT_NOT_SELECTED, NULL);
 		}

--- a/src/common/memusage.c
+++ b/src/common/memusage.c
@@ -117,7 +117,7 @@ static int read_status(const char *source, void *base, struct stat_parser *spt, 
 			sp = oscap_bfind(spt, spt_size, sizeof(struct stat_parser),
 			                 linebuf, (int(*)(void *, void *))&cmpkey);
 
-			dI("spt: %s", linebuf);
+			dD("spt: %s", linebuf);
 
 			if (sp == NULL) {
 				/* drop end of unread line */

--- a/src/common/xml_iterate.c
+++ b/src/common/xml_iterate.c
@@ -84,7 +84,7 @@ int xml_iterate_dfs(const char *input_text, char **output_text, xml_iterate_call
 				dE("xmlNodeDump failed!");
 			}
 			else if (size == 0) {
-				dI("xmlNodeDump returned zero.");
+				dD("xmlNodeDump returned zero.");
 			}
 
 			child = child->next;


### PR DESCRIPTION
I have wished to do this for a long time, I finally decided to do a small refresh of verbose mode.

I have changed the category of many messages from INFO to DEVEL. These are mostly the messages that remained in the code from the legacy system. However, in the legacy system the messages were printed only if complied with debug symbols, and therefore they had a different purpose. I believe the purpose of INFO level is to provide description of the evaluation process on a logical level, and not to overwhelm users by implementation details.

I also stopped showing messages about evaluation of rules and groups when they aren't evaluated. From the scanner point of view, the XCCDF group doesn't affect rule evaluation. We don't need to report them, because it makes the verbose output longer. And, the rules that are not selected by the profile don't need to be reported in the verbose output as well.

I believe this can also improve the user experience of SSGTS if SSGTS decides to switch to INFO level logs.