### PR TITLE
Move the chroot call to probe_worker

### DIFF
--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -124,7 +124,7 @@ void *probe_input_handler(void *arg)
 			SEXP_VALIDATE(oid);
 
 			if (probe->offline_mode && probe->supported_offline_mode == PROBE_OFFLINE_NONE) {
-				dW("Requested offline mode is not supported by %s.", probe->name);
+				dW("Requested offline mode is not supported by %s probe.", oval_subtype_get_text(probe->subtype));
 				/* Return a dummy. */
 				probe_out = probe_cobj_new(SYSCHAR_FLAG_NOT_APPLICABLE, NULL, NULL, NULL);
 				probe_ret = 0;

--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -128,7 +128,7 @@ void *probe_input_handler(void *arg)
 				SEXP_t *skip_flag, *obj_mask;
 
 				skip_flag = probe_obj_getattrval(probe_in, "skip_eval");
-								obj_mask  = probe_obj_getmask(probe_in);
+				obj_mask = probe_obj_getmask(probe_in);
 				SEXP_free(probe_in);
 				probe_in = NULL;
 
@@ -145,8 +145,8 @@ void *probe_input_handler(void *arg)
 
 					probe_ret = 0;
 					SEXP_free(oid);
-										SEXP_free(skip_flag);
-										SEXP_free(obj_mask);
+					SEXP_free(skip_flag);
+					SEXP_free(obj_mask);
 				} else {
 
 					SEXP_free(oid);
@@ -155,7 +155,7 @@ void *probe_input_handler(void *arg)
 
 					probe_pwpair_t *pair = malloc(sizeof(probe_pwpair_t));
 					pair->probe = probe;
-					pair->pth   = probe_worker_new();
+					pair->pth = probe_worker_new();
 					pair->pth->sid = SEAP_msg_id(seap_request);
 					pair->pth->msg = seap_request;
 					pair->pth->msg_handler = &probe_worker;

--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -122,99 +122,86 @@ void *probe_input_handler(void *arg)
 
 		if (oid != NULL) {
 			SEXP_VALIDATE(oid);
+			probe_out = probe_rcache_sexp_get(probe->rcache, oid);
 
-			if (probe->offline_mode && probe->supported_offline_mode == PROBE_OFFLINE_NONE) {
-				dW("Requested offline mode is not supported by %s probe.", oval_subtype_get_text(probe->subtype));
-				/* Return a dummy. */
-				probe_out = probe_cobj_new(SYSCHAR_FLAG_NOT_APPLICABLE, NULL, NULL, NULL);
-				probe_ret = 0;
-				SEXP_free(oid);
+			if (probe_out == NULL) { /* cache miss */
+				SEXP_t *skip_flag, *obj_mask;
+
+				skip_flag = probe_obj_getattrval(probe_in, "skip_eval");
+								obj_mask  = probe_obj_getmask(probe_in);
 				SEXP_free(probe_in);
-				oid = NULL;
 				probe_in = NULL;
-			}
-			else {
-				probe_out = probe_rcache_sexp_get(probe->rcache, oid);
 
-				if (probe_out == NULL) { /* cache miss */
-					SEXP_t *skip_flag, *obj_mask;
+				if (skip_flag != NULL) {
+					oval_syschar_collection_flag_t cobj_flag;
 
-					skip_flag = probe_obj_getattrval(probe_in, "skip_eval");
-	                                obj_mask  = probe_obj_getmask(probe_in);
-					SEXP_free(probe_in);
-					probe_in = NULL;
+					cobj_flag = SEXP_number_geti_32(skip_flag);
+					probe_out = probe_cobj_new(cobj_flag, NULL, NULL, obj_mask);
 
-					if (skip_flag != NULL) {
-						oval_syschar_collection_flag_t cobj_flag;
+					if (probe_rcache_sexp_add(probe->rcache, oid, probe_out) != 0) {
+						/* TODO */
+						abort();
+					}
 
-						cobj_flag = SEXP_number_geti_32(skip_flag);
-						probe_out = probe_cobj_new(cobj_flag, NULL, NULL, obj_mask);
+					probe_ret = 0;
+					SEXP_free(oid);
+										SEXP_free(skip_flag);
+										SEXP_free(obj_mask);
+				} else {
 
-						if (probe_rcache_sexp_add(probe->rcache, oid, probe_out) != 0) {
-							/* TODO */
-							abort();
-						}
+					SEXP_free(oid);
+					SEXP_free(skip_flag);
+					SEXP_free(obj_mask);
 
-						probe_ret = 0;
-						SEXP_free(oid);
-	                                        SEXP_free(skip_flag);
-	                                        SEXP_free(obj_mask);
+					probe_pwpair_t *pair = malloc(sizeof(probe_pwpair_t));
+					pair->probe = probe;
+					pair->pth   = probe_worker_new();
+					pair->pth->sid = SEAP_msg_id(seap_request);
+					pair->pth->msg = seap_request;
+					pair->pth->msg_handler = &probe_worker;
+
+					if (rbt_i32_add(probe->workers, pair->pth->sid, pair->pth, NULL) != 0) {
+						/*
+							* Getting here means that there is already a
+							* thread handling the message with the given
+							* ID.
+							*/
+						dW("Attempt to evaluate an object "
+							"(ID=%u) " // TODO: 64b IDs
+							"which is already being evaluated by an other thread.", pair->pth->sid);
+
+						free(pair->pth);
+						free(pair);
+						SEAP_msg_free(seap_request);
 					} else {
+						/* OK */
 
-						SEXP_free(oid);
-						SEXP_free(skip_flag);
-						SEXP_free(obj_mask);
+						if (pthread_create(&pair->pth->tid, &pth_attr, &probe_worker_runfn, pair))
+						{
+							dE("Cannot start a new worker thread: %d, %s.", errno, strerror(errno));
 
-						probe_pwpair_t *pair = malloc(sizeof(probe_pwpair_t));
-						pair->probe = probe;
-						pair->pth   = probe_worker_new();
-						pair->pth->sid = SEAP_msg_id(seap_request);
-						pair->pth->msg = seap_request;
-						pair->pth->msg_handler = &probe_worker;
+							if (rbt_i32_del(probe->workers, pair->pth->sid, NULL) != 0)
+								dE("rbt_i32_del: failed to remove worker thread (ID=%u)", pair->pth->sid);
 
-						if (rbt_i32_add(probe->workers, pair->pth->sid, pair->pth, NULL) != 0) {
-							/*
-							 * Getting here means that there is already a
-							 * thread handling the message with the given
-							 * ID.
-							 */
-							dW("Attempt to evaluate an object "
-							   "(ID=%u) " // TODO: 64b IDs
-							   "which is already being evaluated by an other thread.", pair->pth->sid);
-
+							SEAP_msg_free(pair->pth->msg);
 							free(pair->pth);
 							free(pair);
-							SEAP_msg_free(seap_request);
-						} else {
-							/* OK */
 
-							if (pthread_create(&pair->pth->tid, &pth_attr, &probe_worker_runfn, pair))
-							{
-								dE("Cannot start a new worker thread: %d, %s.", errno, strerror(errno));
+							probe_ret = PROBE_EUNKNOWN;
+							probe_out = NULL;
 
-								if (rbt_i32_del(probe->workers, pair->pth->sid, NULL) != 0)
-									dE("rbt_i32_del: failed to remove worker thread (ID=%u)", pair->pth->sid);
-
-								SEAP_msg_free(pair->pth->msg);
-								free(pair->pth);
-								free(pair);
-
-								probe_ret = PROBE_EUNKNOWN;
-								probe_out = NULL;
-
-								goto __error_reply;
-							}
+							goto __error_reply;
 						}
-
-						seap_request = NULL;
-						continue;
 					}
-				} else {
-					/* cache hit */
-					SEXP_free(oid);
-					SEXP_free(probe_in);
-					probe_ret = 0;
+
+					seap_request = NULL;
+					continue;
 				}
+			} else {
+				/* cache hit */
+				SEXP_free(oid);
+				SEXP_free(probe_in);
+				probe_ret = 0;
 			}
 		} else {
                         /* the `id' was not found in the input object */

--- a/src/OVAL/probes/probe/probe.h
+++ b/src/OVAL/probes/probe/probe.h
@@ -47,7 +47,6 @@ typedef struct {
 	pthread_rwlock_t rwlock;
 	uint32_t         flags;
 
-	char       *name;
 	pid_t       pid;
 
         void       *probe_arg;

--- a/src/OVAL/probes/probe/probe_main.c
+++ b/src/OVAL/probes/probe/probe_main.c
@@ -158,7 +158,6 @@ static void probe_common_main_cleanup(void *arg)
 	rbt_i32_free(probe->workers);
 	SEAP_CTX_free(probe->SEAP_ctx);
 	free(probe->option);
-	free(probe->name);
 
 	dD("probe_common_main_cleanup finished");
 }
@@ -193,7 +192,6 @@ void *probe_common_main(void *arg)
 	probe.selected_offline_mode = PROBE_OFFLINE_NONE;
 	probe.flags = 0;
 	probe.pid   = getpid();
-	probe.name = (char *) arg;
         probe.probe_exitcode = 0;
 
 	/*

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -25,6 +25,8 @@
 #endif
 
 #include "_seap.h"
+#include <stdio.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
@@ -40,6 +42,29 @@
 
 extern bool  OSCAP_GSYM(varref_handling);
 extern void *OSCAP_GSYM(probe_arg);
+
+
+static int fail(int err, const char *who, int line)
+{
+	fprintf(stderr, "FAIL: %d:%s: %d, %s\n", line, who, err, strerror(err));
+	exit(err);
+}
+
+// Dummy pthread routine
+static void *dummy_routine(void *dummy_param)
+{
+	return NULL;
+}
+
+static void preload_libraries_before_chroot()
+{
+	// Force to load dynamic libraries used by pthread_cancel
+	pthread_t t;
+	if (pthread_create(&t, NULL, dummy_routine, NULL))
+		fail(errno, "pthread_create(probe_preload)", __LINE__ - 1);
+	pthread_cancel(t);
+	pthread_join(t, NULL);
+}
 
 void *probe_worker_runfn(void *arg)
 {
@@ -945,6 +970,54 @@ static SEXP_t *probe_set_eval(probe_t *probe, SEXP_t *set, size_t depth)
  */
 SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 {
+#ifndef OS_WINDOWS
+	char *rootdir = NULL;
+	probe_offline_mode_function_t offline_mode_function = probe_table_get_offline_mode_function(probe->subtype);
+	if (offline_mode_function != NULL) {
+		probe->supported_offline_mode = offline_mode_function();
+	}
+
+	/*
+	 * Setup offline mode(s)
+	 */
+	rootdir = getenv("OSCAP_PROBE_ROOT");
+	if ((rootdir != NULL) && (strlen(rootdir) > 0)) {
+		probe->offline_mode = true;
+
+		preload_libraries_before_chroot(); // todo - maybe useless for own mode
+
+		if (probe->supported_offline_mode & PROBE_OFFLINE_OWN) {
+			dI("Switching probe to PROBE_OFFLINE_OWN mode.");
+			probe->selected_offline_mode = PROBE_OFFLINE_OWN;
+
+		} else if (probe->supported_offline_mode & PROBE_OFFLINE_CHROOT) {
+			probe->real_root_fd = open("/", O_RDONLY);
+			probe->real_cwd_fd = open(".", O_RDONLY);
+			if (chdir(rootdir) != 0) {
+				fail(errno, "chdir", __LINE__ -1);
+			}
+
+			if (chroot(rootdir) != 0) {
+				fail(errno, "chroot", __LINE__ - 1);
+			}
+			/* NOTE: We're running in a different root directory.
+			 * Unless /proc, /sys are somehow emulated for the new
+			 * environment, they are not relevant and so are other
+			 * runtime only things (e.g. getenv, uname, ...).
+			 * Switch to offline mode. We may add a separate
+			 * mechanism to control this behaviour in the future.
+			 */
+			dI("Switching probe to PROBE_OFFLINE_CHROOT mode.");
+			probe->selected_offline_mode = PROBE_OFFLINE_CHROOT;
+		}
+	}
+
+	if (getenv("OSCAP_PROBE_RPMDB_PATH") != NULL) {
+		dI("Switching probe to PROBE_OFFLINE_RPMDB mode.");
+		probe->selected_offline_mode = PROBE_OFFLINE_RPMDB;
+	}
+#endif
+
 	SEXP_t *probe_in, *probe_out, *set;
 
 	if (msg_in == NULL) {

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -982,12 +982,16 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 	 */
 	rootdir = getenv("OSCAP_PROBE_ROOT");
 	if ((rootdir != NULL) && (strlen(rootdir) > 0)) {
-		probe->offline_mode = true;
-
 		preload_libraries_before_chroot(); // todo - maybe useless for own mode
 
-		if (probe->supported_offline_mode & PROBE_OFFLINE_OWN) {
+		if (probe->supported_offline_mode == PROBE_OFFLINE_NONE) {
+			dW("Requested offline mode is not supported by %s probe.", oval_subtype_get_text(probe->subtype));
+			*ret = 0;
+			return probe_cobj_new(SYSCHAR_FLAG_NOT_APPLICABLE, NULL, NULL, NULL);
+
+		} else if (probe->supported_offline_mode & PROBE_OFFLINE_OWN) {
 			dI("Switching probe to PROBE_OFFLINE_OWN mode.");
+			probe->offline_mode = true;
 			probe->selected_offline_mode = PROBE_OFFLINE_OWN;
 
 		} else if (probe->supported_offline_mode & PROBE_OFFLINE_CHROOT) {
@@ -1008,12 +1012,14 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 			 * mechanism to control this behaviour in the future.
 			 */
 			dI("Switching probe to PROBE_OFFLINE_CHROOT mode.");
+			probe->offline_mode = true;
 			probe->selected_offline_mode = PROBE_OFFLINE_CHROOT;
 		}
 	}
 
 	if (getenv("OSCAP_PROBE_RPMDB_PATH") != NULL) {
 		dI("Switching probe to PROBE_OFFLINE_RPMDB mode.");
+		probe->offline_mode = true;
 		probe->selected_offline_mode = PROBE_OFFLINE_RPMDB;
 	}
 #endif

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -43,13 +43,6 @@
 extern bool  OSCAP_GSYM(varref_handling);
 extern void *OSCAP_GSYM(probe_arg);
 
-
-static int fail(int err, const char *who, int line)
-{
-	fprintf(stderr, "FAIL: %d:%s: %d, %s\n", line, who, err, strerror(err));
-	exit(err);
-}
-
 // Dummy pthread routine
 static void *dummy_routine(void *dummy_param)
 {
@@ -60,8 +53,9 @@ static void preload_libraries_before_chroot()
 {
 	// Force to load dynamic libraries used by pthread_cancel
 	pthread_t t;
-	if (pthread_create(&t, NULL, dummy_routine, NULL))
-		fail(errno, "pthread_create(probe_preload)", __LINE__ - 1);
+	if (pthread_create(&t, NULL, dummy_routine, NULL)) {
+		dE("pthread_create failed: %s", strerror(errno));
+	}
 	pthread_cancel(t);
 	pthread_join(t, NULL);
 }
@@ -998,11 +992,11 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 			probe->real_root_fd = open("/", O_RDONLY);
 			probe->real_cwd_fd = open(".", O_RDONLY);
 			if (chdir(rootdir) != 0) {
-				fail(errno, "chdir", __LINE__ -1);
+				dE("chdir failed: %s", strerror(errno));
 			}
 
 			if (chroot(rootdir) != 0) {
-				fail(errno, "chroot", __LINE__ - 1);
+				dE("chroot failed: %s", strerror(errno));
 			}
 			/* NOTE: We're running in a different root directory.
 			 * Unless /proc, /sys are somehow emulated for the new


### PR DESCRIPTION
We have discovered a problem when testing offline mode in the symlink
probe. When the probe main function needs to be executed multiple times,
function `probe_common_main`, where the chroot is entered, is called
only once, but function `probe_worker`, which leaves the chroot, is called
many times. This leads to a situation that the first OVAL test is
evaluated in chroot, but all further tests have retrieved data from the
host. Therefore the collected data were wrong. We try to address this
problem by moving the code.

EDIT:
* I have checked that the symlink probe test proposed without that #1428 fails without my patch and passes with the patch applied. Actually it's vice-versa due to  `PROPERTIES WILL_FAIL true` in CMakeLists.txt
* tests of RPM probes from #1430 started to pass when I merged this PR in.
