### PR TITLE
Modified test suite to make use of setcap-blessed oscap binary.

### DIFF
--- a/docs/developer/developer.adoc
+++ b/docs/developer/developer.adoc
@@ -169,7 +169,21 @@ It's also possible to use `ctest` to test any other oscap binary present in the 
 $ export CUSTOM_OSCAP=/usr/bin/oscap; ctest
 ----
 
-Not every check tests the oscap tool, however, when the CUSTOM_OSCAP variable is set, only the checks which do are executed.
+Some tests that use the so-called offline mode of probes need to chroot during the test execution.
+Some of those probes use the chroot syscall, which an unprivileged process is not allowed to do.
+This is not a problem during the scanning itself, as oscap is usually scanning as root.
+However, we don't want to run oscap as root during tests, as the whole test suite would have to use root privileges to clean up.
+
+Instead, build the `oscap-chrootable` target as superuser.
+This target creates the chroot-enabled binary that the test suite will use for some of those offline tests.
+Internally, the binary is stored under `OSCAP_CHROOTABLE_EXEC` variable, and the invocation suitable for tests can be done using by unquoted expansion of the `OSCAP_CHROOTABLE` variable.
+Therefore, it is recommended to run
+
+----
+$ sudo make oscap-chrootable
+----
+
+Not every check tests the oscap tool, however, when the `CUSTOM_OSCAP` variable is set, only the checks which do are executed.
 
 To enable the MITRE tests, use the `ENABLE_MITRE` flag:
 

--- a/docs/developer/developer.adoc
+++ b/docs/developer/developer.adoc
@@ -174,9 +174,9 @@ Some of those probes use the chroot syscall, which an unprivileged process is no
 This is not a problem during the scanning itself, as oscap is usually scanning as root.
 However, we don't want to run oscap as root during tests, as the whole test suite would have to use root privileges to clean up.
 
-Instead, build the `oscap-chrootable` target as superuser.
-This target creates the chroot-enabled binary that the test suite will use for some of those offline tests.
-Internally, the binary is stored under `OSCAP_CHROOTABLE_EXEC` variable, and the invocation suitable for tests can be done using by unquoted expansion of the `OSCAP_CHROOTABLE` variable.
+Instead, build the `oscap-chrootable` target as superuser, or build `oscap-chrootable-nocap` first and then grant the capability manually.
+This target creates the binary that the test suite will use for some of those offline tests.
+In offline tests, use the `set_offline_test_mode [chroot directory]` and `unset_offline_test_mode` functions from the common test module - those will set variables in such way that the unquoted `$OSCAP` invocation will use the chroot-capable binary, or it will exit with an error code, aborting the test.
 Therefore, it is recommended to run
 
 ----

--- a/tests/probes/symlink/CMakeLists.txt
+++ b/tests/probes/symlink/CMakeLists.txt
@@ -1,5 +1,4 @@
 if(ENABLE_PROBES_UNIX)
 	add_oscap_test("all.sh")
 	add_oscap_test("test_offline_mode_symlink.sh")
-	set_tests_properties("probes/symlink/test_offline_mode_symlink.sh" PROPERTIES WILL_FAIL true)
 endif()

--- a/tests/probes/symlink/test_offline_mode_symlink.sh
+++ b/tests/probes/symlink/test_offline_mode_symlink.sh
@@ -45,7 +45,12 @@ function test_offline_mode_symlink {
 
     bash ${srcdir}/test_offline_mode_symlink.xml.sh "" > "$DF"
     export OSCAP_PROBE_ROOT="$tmpdir"
-    $OSCAP oval eval --results $RF $DF
+    if test -x "$OSCAP_CHROOTABLE_EXEC"; then
+	    $OSCAP_CHROOTABLE oval eval --results $RF $DF
+    else
+	    echo "Skipping test '${FUNCNAME[0]}' as '$OSCAP_CHROOTABLE_EXEC' oscap with chroot capability doesn't exist."
+	    return
+    fi
 
     result=$RF
 

--- a/tests/probes/symlink/test_offline_mode_symlink.sh
+++ b/tests/probes/symlink/test_offline_mode_symlink.sh
@@ -44,13 +44,12 @@ function test_offline_mode_symlink {
 
 
     bash ${srcdir}/test_offline_mode_symlink.xml.sh "" > "$DF"
-    export OSCAP_PROBE_ROOT="$tmpdir"
-    if test -x "$OSCAP_CHROOTABLE_EXEC"; then
-	    $OSCAP_CHROOTABLE oval eval --results $RF $DF
-    else
-	    echo "Skipping test '${FUNCNAME[0]}' as '$OSCAP_CHROOTABLE_EXEC' oscap with chroot capability doesn't exist."
-	    return
-    fi
+
+    set_chroot_offline_test_mode "$tmpdir"
+
+    $OSCAP oval eval --results $RF $DF
+
+    unset_chroot_offline_test_mode
 
     result=$RF
 

--- a/tests/test_common.sh.in
+++ b/tests/test_common.sh.in
@@ -29,6 +29,8 @@ if [ -z ${CUSTOM_OSCAP+x} ] ; then
     else
         [ -z "@CMAKE_BINARY_DIR@" ] || export OSCAP="bash @CMAKE_BINARY_DIR@/run @CMAKE_BINARY_DIR@/utils/oscap"
     fi
+    [ -z "@CMAKE_BINARY_DIR@" ] || export OSCAP_CHROOTABLE_EXEC="@CMAKE_BINARY_DIR@/utils/oscap-chrootable"
+    [ -z "@CMAKE_BINARY_DIR@" ] || export OSCAP_CHROOTABLE="bash @CMAKE_BINARY_DIR@/run $OSCAP_CHROOTABLE_EXEC"
 else
     export OSCAP=${CUSTOM_OSCAP}
 fi

--- a/tests/test_common.sh.in
+++ b/tests/test_common.sh.in
@@ -184,4 +184,45 @@ assert_exists() {
                 return 1
         fi
 }
+
+# $1: The chroot directory
+set_chroot_offline_test_mode() {
+	if test -n "$_OSCAP_BEFORE"; then
+		echo "Already in offline test mode!" >&2
+		return
+	fi
+	if test -x "$OSCAP_CHROOTABLE_EXEC"; then
+		if ! getcap "$OSCAP_CHROOTABLE_EXEC" | grep -q 'cap_sys_chroot+ep'; then
+			echo "Skipping test '${FUNCNAME[1]}' as '$OSCAP_CHROOTABLE_EXEC' doesn't have the chroot capability." >&2
+			return 255
+		fi
+	else
+		echo "Skipping test '${FUNCNAME[1]}' as '$OSCAP_CHROOTABLE_EXEC' oscap which is supposed to have chroot capability doesn't exist." >&2
+		return 255
+	fi
+	_OSCAP_BEFORE="$OSCAP"
+	OSCAP="$OSCAP_CHROOTABLE"
+	set_offline_chroot_dir "$1"
+	return 0
+}
+
+# $1: The chroot directory. If empty, unset the OSCAP_PROBE_ROOT variable
+set_offline_chroot_dir() {
+	if test -n "$1"; then
+		export OSCAP_PROBE_ROOT="$1"
+	else
+		unset OSCAP_PROBE_ROOT
+	fi
+}
+
+unset_chroot_offline_test_mode() {
+	if ! test -n "$_OSCAP_BEFORE"; then
+		echo "Not in the offline test mode!" >&2
+		return
+	fi
+	OSCAP="$_OSCAP_BEFORE"
+	set_offline_chroot_dir ""
+	_OSCAP_BEFORE=
+}
+
 export -f assert_exists

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -33,6 +33,18 @@ if(ENABLE_OSCAP_UTIL)
 			DESTINATION "${CMAKE_INSTALL_MANDIR}/man8"
 		)
 	endif()
+
+	add_custom_target(oscap-chrootable-nocap
+		COMMAND cp oscap oscap-chrootable
+		COMMENT "Copying oscap binary to a buddy binary that awaits chroot blessing by setcap"
+		DEPENDS oscap
+	)
+
+	add_custom_target(oscap-chrootable
+		COMMAND setcap cap_sys_chroot+ep oscap-chrootable
+		COMMENT "Generating chroot-capable oscap buddy"
+		DEPENDS oscap-chrootable
+	)
 endif()
 if(ENABLE_OSCAP_UTIL_CHROOT)
 	install(PROGRAMS "oscap-chroot"
@@ -49,7 +61,7 @@ if(ENABLE_OSCAP_UTIL_DOCKER)
 		DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
 		FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 	)
-	
+
 	if(NOT PYTHON_SITE_PACKAGES_INSTALL_DIR)
 	execute_process(COMMAND
 		${OSCAP_DOCKER_PYTHON} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(False, False, prefix='${CMAKE_INSTALL_PREFIX}'))"
@@ -57,7 +69,7 @@ if(ENABLE_OSCAP_UTIL_DOCKER)
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)
 	endif()
-	
+
 	install(DIRECTORY oscap_docker_python
 		DESTINATION ${PYTHON_SITE_PACKAGES_INSTALL_DIR}
 	)


### PR DESCRIPTION
Some offline-mode tests require chroot syscalls during execution.

The build system and test suite are now aware of this and support build/usage of oscap "buddy binary" that is oscap with setcap chroot blessing.
The person who builds may either decide to run `sudo make oscap-chrootable`, or `make oscap-chrootable-nocap` followed by manual `setcap` call.