### PR TITLE
Remove unused PROBE_OFFLINE_RPMDB mode

### DIFF
--- a/src/OVAL/probes/probe/probe.h
+++ b/src/OVAL/probes/probe/probe.h
@@ -88,7 +88,6 @@ struct probe_ctx {
 typedef enum {
 	PROBE_OFFLINE_NONE = 0x00,
 	PROBE_OFFLINE_CHROOT = 0x01,
-	PROBE_OFFLINE_RPMDB = 0x02,
 	PROBE_OFFLINE_OWN = 0x04,
 	PROBE_OFFLINE_ALL = 0x0f
 } probe_offline_flags;

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -1010,12 +1010,6 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 			probe->selected_offline_mode = PROBE_OFFLINE_CHROOT;
 		}
 	}
-
-	if (getenv("OSCAP_PROBE_RPMDB_PATH") != NULL) {
-		dI("Switching probe to PROBE_OFFLINE_RPMDB mode.");
-		probe->offline_mode = true;
-		probe->selected_offline_mode = PROBE_OFFLINE_RPMDB;
-	}
 #endif
 
 	SEXP_t *probe_in, *probe_out, *set;

--- a/src/OVAL/probes/unix/linux/rpminfo_probe.c
+++ b/src/OVAL/probes/unix/linux/rpminfo_probe.c
@@ -272,7 +272,7 @@ ret:
 
 int rpminfo_probe_offline_mode_supported()
 {
-	return PROBE_OFFLINE_CHROOT | PROBE_OFFLINE_RPMDB;
+	return PROBE_OFFLINE_CHROOT;
 }
 
 void *rpminfo_probe_init(void)
@@ -289,11 +289,6 @@ void *rpminfo_probe_init(void)
 
 	g_rpm->rpmts = rpmtsCreate();
 	pthread_mutex_init (&(g_rpm->mutex), NULL);
-
-	char *dbpath = getenv("OSCAP_PROBE_RPMDB_PATH");
-	if (dbpath) {
-		addMacro(NULL, "_dbpath", NULL, dbpath, 0);
-	}
 
 	return ((void *)g_rpm);
 }


### PR DESCRIPTION
The env variable OSCAP_PROBE_RPMDB_PATH isn't set anywhere,
therefore this mode isn't used anywhere.