### PR TITLE
Remove unused environment variables

### DIFF
--- a/utils/oscap-chroot
+++ b/utils/oscap-chroot
@@ -91,11 +91,6 @@ fi
 # Learn more at https://www.redhat.com/archives/open-scap-list/2013-July/msg00000.html
 export OSCAP_PROBE_ROOT
 OSCAP_PROBE_ROOT="$(cd "$1"; pwd)"
-export OSCAP_PROBE_OS_NAME="Linux" # TODO: This may be wrong!
-export OSCAP_PROBE_OS_VERSION
-OSCAP_PROBE_OS_VERSION="$(uname --kernel-release)" # TODO
-export OSCAP_PROBE_ARCHITECTURE
-OSCAP_PROBE_ARCHITECTURE="$(uname --hardware-platform)" # TODO
 export OSCAP_EVALUATION_TARGET="chroot://$OSCAP_PROBE_ROOT"
 shift 1
 

--- a/utils/oscap-podman
+++ b/utils/oscap-podman
@@ -84,9 +84,6 @@ for VAR in `podman inspect $ID --format '{{join .Config.Env " "}}'`; do
 done
 
 export OSCAP_PROBE_ROOT="$(cd "$DIR"; pwd)"
-export OSCAP_PROBE_OS_NAME="Linux"
-export OSCAP_PROBE_OS_VERSION="$(uname --kernel-release)"
-export OSCAP_PROBE_ARCHITECTURE="$(uname --hardware-platform)"
 export OSCAP_EVALUATION_TARGET="$TARGET"
 shift 1
 

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -129,11 +129,6 @@ fi
 # Learn more at https://www.redhat.com/archives/open-scap-list/2013-July/msg00000.html
 export OSCAP_PROBE_ROOT
 OSCAP_PROBE_ROOT="$(cd "$MOUNTPOINT"; pwd)"
-export OSCAP_PROBE_OS_NAME="Linux" # TODO: This may be wrong!
-export OSCAP_PROBE_OS_VERSION
-OSCAP_PROBE_OS_VERSION="$(uname --kernel-release)" # TODO
-export OSCAP_PROBE_ARCHITECTURE
-OSCAP_PROBE_ARCHITECTURE="$(uname --hardware-platform)" # TODO
 export OSCAP_EVALUATION_TARGET="oscap-vm $1 $2"
 shift 2
 

--- a/utils/oscap_docker_python/oscap_docker_common.py
+++ b/utils/oscap_docker_python/oscap_docker_common.py
@@ -33,11 +33,7 @@ def oscap_chroot(chroot_path, oscap_binary, oscap_args, target_name, local_env=[
         '''
         Wrapper running oscap_chroot on an OscapDockerScan OscapAtomicScan object
         '''
-        os.environ["OSCAP_PROBE_ARCHITECTURE"] = platform.processor()
         os.environ["OSCAP_PROBE_ROOT"] = os.path.join(chroot_path)
-        os.environ["OSCAP_PROBE_OS_NAME"] = platform.system()
-        os.environ["OSCAP_PROBE_OS_VERSION"] = platform.release()
-
         os.environ["OSCAP_EVALUATION_TARGET"] = target_name
 
         for var in local_env:


### PR DESCRIPTION
Removes these environment variables: OSCAP_PROBE_OS_NAME,
OSCAP_PROBE_OS_VERSION, OSCAP_PROBE_ARCHITECTURE. They are not
read anywhere since 1c18a7b22ef50d0687e52cadb547e05eb29d5159,
so we don't have to set them.
Fixes #1427.