### PR TITLE
Adjusting unittests for building on Debian10

### DIFF
--- a/tests/API/OVAL/unittests/test_object_component_type.oval.xml
+++ b/tests/API/OVAL/unittests/test_object_component_type.oval.xml
@@ -30,7 +30,7 @@
             <ind:object object_ref="oval:oscap:obj:2" />
             <ind:state state_ref="oval:oscap:ste:1" />
         </ind:variable_test>
-        <ind:variable_test id="oval:oscap:tst:3" check="all" comment="The value of PASS_MIN_LEN should be set appropriately in /etc/login.defs" version="1">
+        <ind:variable_test id="oval:oscap:tst:3" check="all" comment="The value of PASS_MIN_DAYS should be set appropriately in /etc/login.defs" version="1">
             <ind:object object_ref="oval:oscap:obj:3" />
             <ind:state state_ref="oval:oscap:ste:1" />
         </ind:variable_test>
@@ -47,11 +47,11 @@
             <ind:var_ref>oval:oscap:var:3</ind:var_ref>
         </ind:variable_object>
         <ind:textfilecontent54_object id="oval:oscap:obj:10" version="1">
-            <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_MIN_LEN directive occurrence -->
+            <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_MIN_DAYS directive occurrence -->
             <ind:behaviors singleline="true" />
             <ind:filepath>/etc/login.defs</ind:filepath>
-            <!-- Retrieve last (uncommented) occurrence of PASS_MIN_LEN directive -->
-            <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MIN_LEN\s+\d+)\s*\n</ind:pattern>
+            <!-- Retrieve last (uncommented) occurrence of PASS_MIN_DAYS directive -->
+            <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MIN_DAYS\s+\d+)\s*\n</ind:pattern>
             <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
         </ind:textfilecontent54_object>
     </objects>
@@ -64,20 +64,20 @@
 
     <variables>
         <!-- variable with a meaningfully specified object_component/@item_field attribute -->
-        <local_variable id="oval:oscap:var:1" datatype="int" comment="The value of last PASS_MIN_LEN directive in /etc/login.defs" version="1">
-            <regex_capture pattern="PASS_MIN_LEN\s+(\d+)">
+        <local_variable id="oval:oscap:var:1" datatype="int" comment="The value of last PASS_MIN_DAYS directive in /etc/login.defs" version="1">
+            <regex_capture pattern="PASS_MIN_DAYS\s+(\d+)">
                <object_component item_field="subexpression" object_ref="oval:oscap:obj:10" />
             </regex_capture>
         </local_variable>
         <!-- variable with a nonsense in the object_component/@item_field attribute -->
         <local_variable id="oval:oscap:var:2" datatype="int" comment="Reference to not existing entity within textfilecontent_item. Should report an error when evaluating." version="1">
-            <regex_capture pattern="PASS_MIN_LEN\s+(\d+)">
+            <regex_capture pattern="PASS_MIN_DAYS\s+(\d+)">
                <object_component item_field="something_bogus" object_ref="oval:oscap:obj:10" />
             </regex_capture>
         </local_variable>
         <!-- variable that requires a record data type in OVAL Item -->
         <local_variable id="oval:oscap:var:3" datatype="int" comment="Record_field attribute suggest than an record data type is expected, but actually string data type will be provided. Should report an error when evaluating." version="1">
-            <regex_capture pattern="PASS_MIN_LEN\s+(\d+)">
+            <regex_capture pattern="PASS_MIN_DAYS\s+(\d+)">
                <object_component item_field="subexpression" record_field="some_record_field_name" object_ref="oval:oscap:obj:10" />
             </regex_capture>
         </local_variable>

--- a/tests/DS/test_ds_misc.sh
+++ b/tests/DS/test_ds_misc.sh
@@ -76,6 +76,7 @@ sds_add_multiple_twice(){
 }
 
 function test_eval {
+    probecheck "rpminfo" || return 255
     local stderr=$(mktemp -t ${name}.out.XXXXXX)
     $OSCAP xccdf eval "${srcdir}/$1" 2> $stderr
     diff /dev/null $stderr; rm $stderr
@@ -164,15 +165,6 @@ function test_eval_complex()
 	rm $arf
 }
 
-function test_eval_depends {
-    # only run test if dependency file exists
-    if [ -f "$2" ]; then
-        return test_eval $1
-    else
-        return 255
-    fi
-}
-
 function test_oval_eval {
 
     $OSCAP oval eval "${srcdir}/$1"
@@ -251,6 +243,7 @@ test_run "sds_external_xccdf" test_sds_external_xccdf sds_external_xccdf sds_ext
 test_run "sds_tailoring" test_sds_tailoring sds_tailoring sds_tailoring/sds.ds.xml scap_com.example_datastream_with_tailoring xccdf_com.example_cref_tailoring_01 xccdf_com.example_profile_tailoring
 
 test_run "eval_simple" test_eval eval_simple/sds.xml
+test_run "cpe_in_ds" test_eval cpe_in_ds/sds.xml
 test_run "eval_invalid" test_invalid_eval eval_invalid/sds.xml
 test_run "eval_invalid_oval" test_invalid_oval_eval eval_invalid/sds-oval.xml
 test_run "eval_xccdf_id1" test_eval_id eval_xccdf_id/sds.xml scap_org.open-scap_datastream_tst scap_org.open-scap_cref_first-xccdf.xml first
@@ -267,7 +260,6 @@ test_run "test_eval_complex" test_eval_complex
 test_run "sds_add_multiple_oval_twice_in_row" sds_add_multiple_twice
 test_run "test_ds_1_2_continue_without_remote_resources" test_ds_continue_without_remote_resources ds_continue_without_remote_resources/remote_content_1.2.ds.xml xccdf_com.example.www_profile_test_remote_res
 test_run "test_ds_1_3_continue_without_remote_resources" test_ds_continue_without_remote_resources ds_continue_without_remote_resources/remote_content_1.3.ds.xml xccdf_com.example.www_profile_test_remote_res
-test_run "cpe_in_ds" test_eval_depends cpe_in_ds/sds.xml /etc/sysconfig/prelink
 
 test_exit
 

--- a/tests/DS/test_ds_misc.sh
+++ b/tests/DS/test_ds_misc.sh
@@ -164,6 +164,15 @@ function test_eval_complex()
 	rm $arf
 }
 
+function test_eval_depends {
+    # only run test if dependency file exists
+    if [ -f "$2" ]; then
+        return test_eval $1
+    else
+        return 255
+    fi
+}
+
 function test_oval_eval {
 
     $OSCAP oval eval "${srcdir}/$1"
@@ -242,7 +251,6 @@ test_run "sds_external_xccdf" test_sds_external_xccdf sds_external_xccdf sds_ext
 test_run "sds_tailoring" test_sds_tailoring sds_tailoring sds_tailoring/sds.ds.xml scap_com.example_datastream_with_tailoring xccdf_com.example_cref_tailoring_01 xccdf_com.example_profile_tailoring
 
 test_run "eval_simple" test_eval eval_simple/sds.xml
-test_run "cpe_in_ds" test_eval cpe_in_ds/sds.xml
 test_run "eval_invalid" test_invalid_eval eval_invalid/sds.xml
 test_run "eval_invalid_oval" test_invalid_oval_eval eval_invalid/sds-oval.xml
 test_run "eval_xccdf_id1" test_eval_id eval_xccdf_id/sds.xml scap_org.open-scap_datastream_tst scap_org.open-scap_cref_first-xccdf.xml first
@@ -259,6 +267,7 @@ test_run "test_eval_complex" test_eval_complex
 test_run "sds_add_multiple_oval_twice_in_row" sds_add_multiple_twice
 test_run "test_ds_1_2_continue_without_remote_resources" test_ds_continue_without_remote_resources ds_continue_without_remote_resources/remote_content_1.2.ds.xml xccdf_com.example.www_profile_test_remote_res
 test_run "test_ds_1_3_continue_without_remote_resources" test_ds_continue_without_remote_resources ds_continue_without_remote_resources/remote_content_1.3.ds.xml xccdf_com.example.www_profile_test_remote_res
+test_run "cpe_in_ds" test_eval_depends cpe_in_ds/sds.xml /etc/sysconfig/prelink
 
 test_exit
 

--- a/tests/DS/test_sds_eval.sh
+++ b/tests/DS/test_sds_eval.sh
@@ -99,6 +99,15 @@ function test_eval_complex()
 	rm $arf
 }
 
+function test_eval_depends {
+    # only run test if dependency file exists
+    if [ -f "$2" ]; then
+        return test_eval $1
+    else
+        return 255
+    fi
+}
+
 function test_oval_eval {
 
     $OSCAP oval eval "${srcdir}/$1"
@@ -162,7 +171,6 @@ test_run "sds_external_xccdf" test_sds_external_xccdf sds_external_xccdf sds_ext
 test_run "sds_tailoring" test_sds_tailoring sds_tailoring sds_tailoring/sds.ds.xml scap_com.example_datastream_with_tailoring xccdf_com.example_cref_tailoring_01 xccdf_com.example_profile_tailoring
 
 test_run "eval_simple" test_eval eval_simple/sds.xml
-test_run "cpe_in_ds" test_eval cpe_in_ds/sds.xml
 test_run "eval_invalid" test_invalid_eval eval_invalid/sds.xml
 test_run "eval_invalid_oval" test_invalid_oval_eval eval_invalid/sds-oval.xml
 test_run "eval_xccdf_id1" test_eval_id eval_xccdf_id/sds.xml scap_org.open-scap_datastream_tst scap_org.open-scap_cref_first-xccdf.xml first
@@ -176,5 +184,6 @@ test_run "eval_oval_id2" test_oval_eval_id eval_oval_id/sds.xml scap_org.open-sc
 test_run "eval_cpe" test_eval_cpe eval_cpe/sds.xml
 
 test_run "test_eval_complex" test_eval_complex
+test_run "cpe_in_ds" test_eval_depends cpe_in_ds/sds.xml /etc/sysconfig/prelink
 
 test_exit

--- a/tests/DS/test_sds_eval.sh
+++ b/tests/DS/test_sds_eval.sh
@@ -11,6 +11,7 @@ set -e -o pipefail
 # Test Cases.
 
 function test_eval {
+    probecheck "rpminfo" || return 255
     local stderr=$(mktemp -t ${name}.out.XXXXXX)
     $OSCAP xccdf eval "${srcdir}/$1" 2> $stderr
     diff /dev/null $stderr; rm $stderr
@@ -99,15 +100,6 @@ function test_eval_complex()
 	rm $arf
 }
 
-function test_eval_depends {
-    # only run test if dependency file exists
-    if [ -f "$2" ]; then
-        return test_eval $1
-    else
-        return 255
-    fi
-}
-
 function test_oval_eval {
 
     $OSCAP oval eval "${srcdir}/$1"
@@ -171,6 +163,7 @@ test_run "sds_external_xccdf" test_sds_external_xccdf sds_external_xccdf sds_ext
 test_run "sds_tailoring" test_sds_tailoring sds_tailoring sds_tailoring/sds.ds.xml scap_com.example_datastream_with_tailoring xccdf_com.example_cref_tailoring_01 xccdf_com.example_profile_tailoring
 
 test_run "eval_simple" test_eval eval_simple/sds.xml
+test_run "cpe_in_ds" test_eval cpe_in_ds/sds.xml
 test_run "eval_invalid" test_invalid_eval eval_invalid/sds.xml
 test_run "eval_invalid_oval" test_invalid_oval_eval eval_invalid/sds-oval.xml
 test_run "eval_xccdf_id1" test_eval_id eval_xccdf_id/sds.xml scap_org.open-scap_datastream_tst scap_org.open-scap_cref_first-xccdf.xml first
@@ -184,6 +177,5 @@ test_run "eval_oval_id2" test_oval_eval_id eval_oval_id/sds.xml scap_org.open-sc
 test_run "eval_cpe" test_eval_cpe eval_cpe/sds.xml
 
 test_run "test_eval_complex" test_eval_complex
-test_run "cpe_in_ds" test_eval_depends cpe_in_ds/sds.xml /etc/sysconfig/prelink
 
 test_exit

--- a/tests/probes/rpm/rpmverifyfile/test_probes_rpmverifyfile.sh
+++ b/tests/probes/rpm/rpmverifyfile/test_probes_rpmverifyfile.sh
@@ -11,6 +11,7 @@ set -e -o pipefail
 
 function test_probes_rpmverifyfile {
     probecheck "rpmverifyfile" || return 255
+    require "rpm" || return 255
 
     DF="$srcdir/test_probes_rpmverifyfile.xml"
     RF="results.xml"

--- a/tests/probes/rpm/rpmverifyfile/test_probes_rpmverifyfile_older.sh
+++ b/tests/probes/rpm/rpmverifyfile/test_probes_rpmverifyfile_older.sh
@@ -11,6 +11,7 @@ set -e -o pipefail
 
 function test_probes_rpmverifyfile {
     probecheck "rpmverifyfile" || return 255
+    require "rpm" || return 255
 
     DF="$srcdir/test_probes_rpmverifyfile_older.xml"
     RF="results.xml"

--- a/tests/probes/runlevel/test_probes_runlevel.sh
+++ b/tests/probes/runlevel/test_probes_runlevel.sh
@@ -82,6 +82,7 @@ function test_probes_runlevel_A {
 function test_probes_runlevel_B {
 
     probecheck "runlevel" || return 255
+    require "chkconfig" || return 255
 
     local ret_val=0;
     local DF="test_probes_runlevel_B.xml"
@@ -109,6 +110,7 @@ function test_probes_runlevel_B {
 
 function test_probes_runlevel_C {
     probecheck "runlevel" || return 255
+    require "chkconfig" || return 255
 
     local ret_val=0;
     local definition="test_probes_runlevel_C.xml"

--- a/tests/probes/sysctl/test_sysctl_probe_all.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_all.sh
@@ -58,7 +58,8 @@ grep unix-sys:name "$result" | grep -v $SYSCTL_BLACKLIST_REGEX | sed -E 's;.*>(.
 # If procps_ver > 3.3.12 we need to filter *stable_secret and vm.stat_refresh
 # options from the sysctl output, for more details see
 # https://github.com/OpenSCAP/openscap/issues/1152.
-procps_ver=$(rpm -q procps-ng --qf="%{version}")
+procps_ver="$(package_version procps-ng procps)"
+
 lowest_ver=$(echo -e "3.3.12\n$procps_ver" | sort -V | head -n1)
 if [ "$procps_ver" != "$lowest_ver" ]; then
 	sed -i '/net.ipv6.conf.*stable_secret$/d' "$sysctlNames"

--- a/tests/probes/uname/test_probes_uname.xml.sh
+++ b/tests/probes/uname/test_probes_uname.xml.sh
@@ -846,7 +846,6 @@ cat <<EOF
       <os_name>`uname -s`</os_name>
       <os_release>`uname -r`</os_release>
       <os_version>`uname -v`</os_version>
-      <processor_type>`uname -p`</processor_type>
     </uname_state>
 
     <!-- FULLY FALSE STATE -->
@@ -856,7 +855,6 @@ cat <<EOF
       <os_name>X`uname -s`</os_name>
       <os_release>X`uname -r`</os_release>
       <os_version>X`uname -v`</os_version>
-      <processor_type>X`uname -p`</processor_type>
     </uname_state>
 
     <!-- MIXED STATE :-) -->
@@ -866,7 +864,6 @@ cat <<EOF
       <os_name>`uname -s`</os_name>
       <os_release>`uname -r`</os_release>
       <os_version>`uname -v`</os_version>
-      <processor_type>X`uname -p`</processor_type>
     </uname_state>
 
   </states>

--- a/tests/probes/uname/test_probes_uname.xml.sh
+++ b/tests/probes/uname/test_probes_uname.xml.sh
@@ -846,6 +846,7 @@ cat <<EOF
       <os_name>`uname -s`</os_name>
       <os_release>`uname -r`</os_release>
       <os_version>`uname -v`</os_version>
+      <processor_type>`uname -m`</processor_type>
     </uname_state>
 
     <!-- FULLY FALSE STATE -->
@@ -855,6 +856,7 @@ cat <<EOF
       <os_name>X`uname -s`</os_name>
       <os_release>X`uname -r`</os_release>
       <os_version>X`uname -v`</os_version>
+      <processor_type>X`uname -m`</processor_type>
     </uname_state>
 
     <!-- MIXED STATE :-) -->
@@ -864,6 +866,7 @@ cat <<EOF
       <os_name>`uname -s`</os_name>
       <os_release>`uname -r`</os_release>
       <os_version>`uname -v`</os_version>
+      <processor_type>X`uname -m`</processor_type>
     </uname_state>
 
   </states>

--- a/tests/test_common.sh.in
+++ b/tests/test_common.sh.in
@@ -131,6 +131,42 @@ function probecheck {
     return 0
 }
 
+# Check for package names and return a version number
+function package_version {
+    # loop through multiple potential package names
+    # return first version number found
+    for package in $@; do
+        ver=""
+
+        # check rpm for package version first
+        if [ -f "/usr/bin/rpm" ]; then
+            ver=$(rpm -q $package --qf="%{version}" 2> /dev/null)
+
+            # rpm returns error messages on stdout, check return code
+            if [ ! "$?" -eq "0" ]; then
+                ver=""
+            fi
+        fi
+
+        # fall back to dpkg for debian systems
+        if [ "${ver}" == "" ] && [ -f "/usr/bin/dpkg-query" ]; then
+            # for Debian-based systems, return the upstream version
+            ver="$(dpkg-query -f '${source:Upstream-Version}' -W $package 2> /dev/null)"
+        fi
+
+        # return the first match found
+        if [ "${ver}" != "" ]; then
+            echo "${ver}"
+            return 0
+        fi
+    done
+
+    # package not found
+    if [ "${ver}" == "" ]; then
+        return 255
+    fi
+}
+
 function verify_results {
 
     require "grep" || return 255


### PR DESCRIPTION
Added minimal patches to handle skip tests that depend specifically on rpm or chkconfig, or to use dpkg-query as an alternative when possible.  I don't know if this is the best solution but I can get past most of `make test` with these changes, except for one outstanding test related to `uname`.