### PR TITLE
Suppress SWIG-related warnings

### DIFF
--- a/swig/perl/CMakeLists.txt
+++ b/swig/perl/CMakeLists.txt
@@ -1,9 +1,6 @@
 include(UseSWIG)
 
 set(CMAKE_SWIG_FLAGS "-module" "openscap_pm")
-if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
-	set_property(SOURCE openscapPERL5_wrap.c PROPERTY COMPILE_OPTIONS "-w")
-endif()
 if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
 	swig_add_module(openscap_pm perl5 ../openscap.i)
 else()
@@ -11,6 +8,9 @@ else()
 endif()
 swig_link_libraries(openscap_pm openscap ${PERL_LIBRARY})
 target_include_directories(openscap_pm PUBLIC ${PERL_INCLUDE_PATH})
+if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+	target_compile_options(${SWIG_MODULE_openscap_pm_REAL_NAME} PUBLIC "-w")
+endif()
 
 install(TARGETS ${SWIG_MODULE_openscap_pm_REAL_NAME}
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/perl5/vendor_perl)

--- a/swig/python3/CMakeLists.txt
+++ b/swig/python3/CMakeLists.txt
@@ -6,15 +6,15 @@ include_directories(${PYTHON_INCLUDE_PATH})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set(CMAKE_SWIG_FLAGS "-module" "openscap_py" "-py3")
-if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
-	set_property(SOURCE openscapPYTHON_wrap.c PROPERTY COMPILE_OPTIONS "-w")
-endif()
 if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
 	swig_add_module(openscap_py python ../openscap.i)
 else()
 	swig_add_library(openscap_py LANGUAGE python SOURCES ../openscap.i)
 endif()
 swig_link_libraries(openscap_py openscap ${PYTHON_LIBRARIES} ${LIBXML2_LIBRARIES} ${LIBXSLT_LIBRARIES} ${LIBXSLT_EXSLT_LIBRARIES} ${PCRE_LIBRARIES} ${CURL_LIBRARIES} ${BZIP2_LIBRARIES} ${RPM_LIBRARIES})
+if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+	target_compile_options(${SWIG_MODULE_openscap_py_REAL_NAME} PUBLIC "-w")
+endif()
 
 add_custom_command(OUTPUT ${PYTHON_COMPILED_FILES}
 	COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/../openscap_api.py ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
The suppression is already there, but it is not really effective for all of the warnings