### PR TITLE
Fix warnings

### DIFF
--- a/src/OVAL/probes/SEAP/MurmurHash3.c
+++ b/src/OVAL/probes/SEAP/MurmurHash3.c
@@ -30,7 +30,7 @@
 
 #else	// defined(_MSC_VER)
 
-#define	FORCE_INLINE __attribute__((always_inline))
+#define	FORCE_INLINE __attribute__((always_inline)) inline
 
 static inline uint32_t rotl32 ( uint32_t x, int8_t r )
 {

--- a/tests/API/SEAP/test_api_seap_spb.c
+++ b/tests/API/SEAP/test_api_seap_spb.c
@@ -203,6 +203,7 @@ int main (int argc, char *argv[])
         {
                 uint8_t b;
                 spb_iterate (spb, 0, b, abort ());
+                (void) b; // It is technically unused, we know
         }
         spb_free (spb, 0);
         //////////////////////////////////////////////////////////////////////////        

--- a/tests/API/probes/test_fsdev_is_local_fs.c
+++ b/tests/API/probes/test_fsdev_is_local_fs.c
@@ -32,7 +32,7 @@
 
 static int test_single_call()
 {
-	struct mntent ment;
+	struct mntent ment = {0};
 	ment.mnt_type = "autofs";
 	int ret = is_local_fs(&ment);
 	/* autofs entry is never considered local */


### PR DESCRIPTION
test_api_seap_spb.c:204:25: warning: variable ‘b’ set but not used [-Wunused-but-set-variable]
test_fsdev_is_local_fs.c:37:12: warning: ‘ment’ is used uninitialized in this function [-Wuninitialized]
MurmurHash3.c:82:30: warning: always_inline function might not be inlinable [-Wattributes] (x4)