### PR TITLE
Remove python upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ matrix:
     - os: osx
       before_install:
         - brew update
-        - brew upgrade python
         - brew install doxygen
         - brew install opendbx
         - brew install popt


### PR DESCRIPTION
I think this will fix the broken Travis build on OSX. Python is present there in asuitable version, see the CMake output:

```
-- Found PythonInterp: /usr/local/bin/python3 (found suitable version "3.7.5", minimum required is "3") 

-- Found PythonLibs: /usr/local/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7m.dylib (found suitable version "3.7.5", minimum required is "3")
```

So it looks that we don't have to upgrade Python.