### PR TITLE
make links showing remediation snippets in guides accessible

### DIFF
--- a/xsl/xccdf-share.xsl
+++ b/xsl/xccdf-share.xsl
@@ -284,7 +284,7 @@ Authors:
         </xsl:choose>
     </xsl:variable>
 
-    <span class="label label-success">Remediation <xsl:value-of select="$fix_type"/>:</span>&#160;&#160;&#160;<a data-toggle="collapse" data-target="#{generate-id($fix)}">(show)</a><br />
+    <span class="label label-success">Remediation <xsl:value-of select="$fix_type"/>:</span>&#160;&#160;&#160;<a data-toggle="collapse" data-target="#{generate-id($fix)}" tabindex="0" role="link" aria-expanded="false" href="#!">(show)</a><br />
     <div class="panel-collapse collapse" id="{generate-id($fix)}">
         <xsl:if test="$fix/@complexity or $fix/@disruption or $fix/@reboot or $fix/@strategy">
             <table class="table table-striped table-bordered table-condensed">

--- a/xsl/xccdf-share.xsl
+++ b/xsl/xccdf-share.xsl
@@ -284,7 +284,7 @@ Authors:
         </xsl:choose>
     </xsl:variable>
 
-    <span class="label label-success">Remediation <xsl:value-of select="$fix_type"/>:</span>&#160;&#160;&#160;<a data-toggle="collapse" data-target="#{generate-id($fix)}" tabindex="0" role="link" aria-expanded="false" href="#!">(show)</a><br />
+    <a class="btn btn-success" data-toggle="collapse" data-target="#{generate-id($fix)}" tabindex="0" role="button" aria-expanded="false" title="Activate to reveal" href="#!">Remediation <xsl:value-of select="$fix_type"/> &#8690;</a><br />
     <div class="panel-collapse collapse" id="{generate-id($fix)}">
         <xsl:if test="$fix/@complexity or $fix/@disruption or $fix/@reboot or $fix/@strategy">
             <table class="table table-striped table-bordered table-condensed">


### PR DESCRIPTION
Links showing and hiding remediation snippets in HTML guides generated by Openscap were not accessible to screenreader users. This is now fixed by adding appropriate parameters to the <a> tag in the XSLT template.