### PR TITLE
oscap-podman: add podman init to every scanned image/container.

### DIFF
--- a/utils/oscap-podman
+++ b/utils/oscap-podman
@@ -77,7 +77,16 @@ else
     ID=$1
     TARGET="podman-container://$1"
 fi
+
+# podman init creates required files such as: /run/.containerenv - we don't care about output and exit code
+podman init $ID &> /dev/null || true
+
 DIR=$(podman mount $ID) || die
+
+if [ ! -f "$DIR/run/.containerenv" ]; then
+    # ubi8-init image does not create .containerenv when running podman init, but we need to make sure that the file is there
+    touch "$DIR/run/.containerenv"
+fi
 
 for VAR in `podman inspect $ID --format '{{join .Config.Env " "}}'`; do
     eval "export OSCAP_OFFLINE_$VAR"


### PR DESCRIPTION
It makes sure that /run/.containerenv gets created.

Tested with ubi8-init from redhat and the output is:

```
$ oscap-podman registry.access.redhat.com/ubi8-init oval eval --id oval:ssg-installed_env_is_a_container:def:1 --oval-id scap_org.open-scap_cref_ssg-rhel8-oval.xml /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml 
Definition oval:ssg-installed_env_is_a_container:def:1: true
Evaluation done.
```