### PR TITLE
Do not run probes if they don't support offline mode

### DIFF
--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -969,6 +969,8 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 	probe_offline_mode_function_t offline_mode_function = probe_table_get_offline_mode_function(probe->subtype);
 	if (offline_mode_function != NULL) {
 		probe->supported_offline_mode = offline_mode_function();
+	} else {
+		probe->supported_offline_mode = PROBE_OFFLINE_NONE;
 	}
 
 	/*


### PR DESCRIPTION
When the probe doesn't implement offline mode function it means
the probe doesn't support offline mode, therefore it should
set the supported_offline_mode flag to PROBE_OFFLINE_NONE.
This omission caused that the probe was run and scanned the host.