### PR TITLE
Add "offline" mode test for the password OVAL probe

### DIFF
--- a/tests/probes/password/CMakeLists.txt
+++ b/tests/probes/password/CMakeLists.txt
@@ -1,3 +1,4 @@
 if(ENABLE_PROBES_UNIX)
 	add_oscap_test("test_probes_password.sh")
+	add_oscap_test("test_probes_password_offline.sh")
 endif()

--- a/tests/probes/password/test_probes_password_offline.sh
+++ b/tests/probes/password/test_probes_password_offline.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright 2009 Red Hat Inc., Durham, North Carolina.
+# All Rights Reserved.
+#
+# OpenScap Probes Test Suite.
+#
+# Created on: Nov 30, 2009
+#
+# Authors:
+#      Peter Vrabec, <pvrabec@redhat.com>
+#      David Niemoller
+#      Ondrej Moris, <omoris@redhat.com>
+#      Evgenii Kolesnikov, <ekolesni@redhat.com>
+
+. $builddir/tests/test_common.sh
+
+# Test Cases.
+
+function test_probes_password {
+
+    probecheck "password" || return 255
+
+    local ret_val=0;
+    local DF="${srcdir}/test_probes_password_offline.xml"
+    local RF="results.xml"
+
+    [ -f $RF ] && rm -f $RF
+
+    tmpdir=$(mktemp -t -d "test_password.XXXXXX")
+    set_chroot_offline_test_mode "$tmpdir"
+
+    $OSCAP oval eval --results $RF $DF
+
+    unset_chroot_offline_test_mode
+    rm -rf $tempdir
+
+    if [ -f $RF ]; then
+        result=$RF
+        assert_exists 1 'oval_results/results/system/tests/test[@test_id="oval:1:tst:1"][@result="not applicable"]'
+        ret_val=$?
+    else
+        ret_val=1
+    fi
+
+    return $ret_val
+}
+
+# Testing.
+
+test_init
+
+test_run "test_probes_password_offline" test_probes_password
+
+test_exit

--- a/tests/probes/password/test_probes_password_offline.xml
+++ b/tests/probes/password/test_probes_password_offline.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<oval_definitions xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
+      <generator>
+            <oval:product_name>password</oval:product_name>
+            <oval:product_version>1.0</oval:product_version>
+            <oval:schema_version>5.4</oval:schema_version>
+            <oval:timestamp>2008-03-31T00:00:00-00:00</oval:timestamp>
+      </generator>
+  <definitions>
+    <definition class="compliance" version="1" id="oval:1:def:1">  <!-- comment="true" -->
+      <metadata>
+        <title></title>
+        <description></description>
+      </metadata>
+      <criteria>
+        <criteria operator="AND">
+          <criterion test_ref="oval:1:tst:1"/>
+        </criteria>
+      </criteria>
+    </definition>
+  </definitions>
+
+  <tests>
+    <password_test version="1" id="oval:1:tst:1" check="all" comment="true" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+      <object object_ref="oval:1:obj:1"/>
+      <state state_ref="oval:1:ste:1"/>
+    </password_test>
+  </tests>
+
+  <objects>
+    <password_object version="1" id="oval:1:obj:1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+      <username>root</username>
+    </password_object>
+  </objects>
+
+  <states>
+    <password_state version="1" id="oval:1:ste:1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix">
+      <username>root</username>
+      <password>x</password>
+      <user_id datatype="int">0</user_id>
+      <group_id datatype="int">0</group_id>
+      <gcos>root</gcos>
+      <home_dir>/root</home_dir>
+      <login_shell>/bin/bash</login_shell>
+    </password_state>
+  </states>
+
+</oval_definitions>


### PR DESCRIPTION
The probe does not support any of offline modes,
thus it should return "not applicable" response.