### PR TITLE
Add a test to check --fix-type anaconda

### DIFF
--- a/tests/API/XCCDF/unittests/test_report_anaconda_fixes.sh
+++ b/tests/API/XCCDF/unittests/test_report_anaconda_fixes.sh
@@ -23,6 +23,16 @@ grep -v "$line1" $result | grep -v "$line2" | grep -v "$line3"
 [ "`grep -v "$line1" $result | grep -v "$line2" | sed 's/\W//g'`"x == x ]
 :> $result
 
+# use --fix-type instead of URN template to generate the same fix
+$OSCAP xccdf generate fix --fix-type anaconda \
+	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+grep "$line1" $result
+grep "$line2" $result
+grep -v "$line1" $result | grep -v "$line2" | grep -v "$line3"
+[ "`grep -v "$line1" $result | grep -v "$line2" | sed 's/\W//g'`"x == x ]
+:> $result
+
 $OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
 	--profile xccdf_moc.elpmaxe.www_profile_1 \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr


### PR DESCRIPTION
There should be 2 equal ways of generating Anaconda remediations:
"oscap xccdf generate fix --fix-type anaconda" and
"oscap xccdf generate fix --template urn:redhat:anaconda:pre"
Both commands should give the same output.
This tests a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1736850
introduced by b1448ec95a957a76eb8be6d439531c532d97ff3c