### PR TITLE
Do not use C++ keyword operator as a function parameter name

### DIFF
--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -1669,7 +1669,7 @@ OSCAP_API void oval_variable_possible_value_iterator_free(struct oval_variable_p
  * @param hint A short description of what the value means or represents.
  * @memberof oval_variable_possible_restriction
  */
-OSCAP_API struct oval_variable_possible_restriction *oval_variable_possible_restriction_new(oval_operator_t operator, const char *hint);
+OSCAP_API struct oval_variable_possible_restriction *oval_variable_possible_restriction_new(oval_operator_t, const char *);
 
 
 /**


### PR DESCRIPTION
This fixes SCAP Workbench build.

Addressing:
```
[ 37%] Building CXX object CMakeFiles/scap-workbench.dir/scap-workbench_autogen/mocs_compilation.cpp.o
In file included from /usr/local/include/openscap/xccdf_policy.h:39,
                 from /home/jcerny/work/git/scap-workbench/include/TailoringDockWidgets.h:31,
                 from /home/jcerny/work/git/scap-workbench/build/scap-workbench_autogen/6YEA5652QU/moc_TailoringDockWidgets.cpp:10,
                 from /home/jcerny/work/git/scap-workbench/build/scap-workbench_autogen/mocs_compilation.cpp:18:
/usr/local/include/openscap/oval_definitions.h:1676:117: error: declaration of ‘operator,’ as parameter
 1676 | restriction *oval_variable_possible_restriction_new(oval_operator_t operator, const char *hint);
      |                                                                             ^
```
Fixes: #1462