### PR TITLE
Fix case where CMake couldn't find libacl or xattr.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ cmake_dependent_option(OPENSCAP_PROBE_INDEPENDENT_XMLFILECONTENT "Independent xm
 # UNIX PROBES
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_DNSCACHE "Unix dnscache probe" ON "ENABLE_PROBES_UNIX" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_FILE "Unix file probe" ON "ENABLE_PROBES_UNIX" OFF)
-cmake_dependent_option(OPENSCAP_PROBE_UNIX_FILEEXTENDEDATTRIBUTE "Unix fileextendedattribute probe" ON "ENABLE_PROBES_UNIX; (HAVE_SYS_XATTR_H OR HAVE_ATTR_XATTR_H)" OFF)
+cmake_dependent_option(OPENSCAP_PROBE_UNIX_FILEEXTENDEDATTRIBUTE "Unix fileextendedattribute probe" ON "ENABLE_PROBES_UNIX; HAVE_SYS_XATTR_H OR HAVE_ATTR_XATTR_H" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_GCONF "Unix gconf probe" ON "ENABLE_PROBES_UNIX; GCONF_FOUND" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_INTERFACE "Unix interface probe" ON "ENABLE_PROBES_UNIX" OFF)
 cmake_dependent_option(OPENSCAP_PROBE_UNIX_PASSWORD "Unix password probe" ON "ENABLE_PROBES_UNIX" OFF)

--- a/cmake/FindACL.cmake
+++ b/cmake/FindACL.cmake
@@ -8,17 +8,17 @@
 include(LibFindMacros)
 
 # Use pkg-config to get hints about paths
-libfind_pkg_check_modules(ACL_PKGCONF acl)
+libfind_pkg_check_modules(ACL_PKGCONF libacl)
 
 # Include dir
 find_path(ACL_INCLUDE_DIR
-	NAMES acl/libacl.h
+	NAMES "acl/libacl.h sys/libacl.h"
 	PATHS ${ACL_PKGCONF_INCLUDE_DIRS}
 )
 
 # Finally the library itself
 find_library(ACL_LIBRARY
-	NAMES acl
+	NAMES libacl
 	PATHS ${ACL_PKGCONF_LIBRARY_DIRS}
 )
 


### PR DESCRIPTION
This might be a Fedora 31ism or a later version of CMake but found some issues where CMake wasn't finding some of the installed libraries.