### PR TITLE
Fix duplicate global variables

### DIFF
--- a/src/OVAL/probes/unix/process58_probe.c
+++ b/src/OVAL/probes/unix/process58_probe.c
@@ -152,7 +152,7 @@ static void report_finding(struct result_info *res, probe_ctx *ctx)
 
 #if defined(OS_LINUX)
 
-unsigned long ticks, boot;
+static unsigned long ticks, boot;
 
 static void get_boot_time(void)
 {

--- a/src/OVAL/probes/unix/process_probe.c
+++ b/src/OVAL/probes/unix/process_probe.c
@@ -58,7 +58,7 @@
 #include "process_probe.h"
 #include "oscap_helpers.h"
 
-oval_schema_version_t over;
+static oval_schema_version_t over;
 
 /* Convenience structure for the results being reported */
 struct result_info {
@@ -106,7 +106,7 @@ static void report_finding(struct result_info *res, probe_ctx *ctx)
 
 #if defined(OS_LINUX)
 
-unsigned long ticks, boot;
+static unsigned long ticks, boot;
 
 static void get_boot_time(void)
 {

--- a/src/OVAL/probes/unix/shadow_probe.c
+++ b/src/OVAL/probes/unix/shadow_probe.c
@@ -61,7 +61,7 @@
 #include <probe/option.h>
 #include "shadow_probe.h"
 
-oval_schema_version_t over;
+static oval_schema_version_t over;
 
 #ifndef HAVE_SHADOW_H
 int shadow_probe_main(probe_ctx *ctx, void *arg)


### PR DESCRIPTION
This should fix failed builds with GCC 10 on Rawhide.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1793914