### PR TITLE
Fix Free Software Foundation address

### DIFF
--- a/compat/compat.h
+++ b/compat/compat.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/compat/oscap_platforms.h
+++ b/compat/oscap_platforms.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/compat/strsep.c
+++ b/compat/strsep.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/schemas/sce/1.0/sce-result-schema.xsd
+++ b/schemas/sce/1.0/sce-result-schema.xsd
@@ -18,7 +18,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * 2) MIT
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/schemas/sce/1.0/sce-xccdf-extended-component.xsd
+++ b/schemas/sce/1.0/sce-xccdf-extended-component.xsd
@@ -18,7 +18,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * 2) MIT
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/src/CPE/cpe_ctx_priv.c
+++ b/src/CPE/cpe_ctx_priv.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *	Šimon Lukašík

--- a/src/CPE/cpe_ctx_priv.h
+++ b/src/CPE/cpe_ctx_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *	Šimon Lukašík

--- a/src/CPE/cpe_session.c
+++ b/src/CPE/cpe_session.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Author:
  *     Šimon Lukašík

--- a/src/CPE/cpe_session_priv.h
+++ b/src/CPE/cpe_session_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/src/CPE/cpedict.c
+++ b/src/CPE/cpedict.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/CPE/cpedict_ext_priv.c
+++ b/src/CPE/cpedict_ext_priv.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Šimon Lukašík

--- a/src/CPE/cpedict_ext_priv.h
+++ b/src/CPE/cpedict_ext_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  * 	Šimon Lukašík

--- a/src/CPE/cpedict_priv.c
+++ b/src/CPE/cpedict_priv.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/CPE/cpedict_priv.h
+++ b/src/CPE/cpedict_priv.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/CPE/cpelang.c
+++ b/src/CPE/cpelang.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/CPE/cpelang_priv.c
+++ b/src/CPE/cpelang_priv.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/CPE/cpelang_priv.h
+++ b/src/CPE/cpelang_priv.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/CPE/cpename.c
+++ b/src/CPE/cpename.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Brandon Dixon  <brandon.dixon@g2-inc.com>

--- a/src/CPE/public/cpe_dict.h
+++ b/src/CPE/public/cpe_dict.h
@@ -26,7 +26,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/CPE/public/cpe_lang.h
+++ b/src/CPE/public/cpe_lang.h
@@ -26,7 +26,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/CPE/public/cpe_name.h
+++ b/src/CPE/public/cpe_name.h
@@ -28,7 +28,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/CVE/cve.c
+++ b/src/CVE/cve.c
@@ -23,7 +23,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas  <mbarabas@redhat.com>

--- a/src/CVE/cve_priv.c
+++ b/src/CVE/cve_priv.c
@@ -23,7 +23,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/CVE/cve_priv.h
+++ b/src/CVE/cve_priv.h
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/CVE/public/cve_nvd.h
+++ b/src/CVE/public/cve_nvd.h
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas  <mbarabas@redhat.com>

--- a/src/CVRF/cvrf.c
+++ b/src/CVRF/cvrf.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  * 		Katarina Jankov <kj226@cornell.edu>

--- a/src/CVRF/cvrf_enumeration.c
+++ b/src/CVRF/cvrf_enumeration.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  * 		Katarina Jankov <kj226@cornell.edu>

--- a/src/CVRF/cvrf_eval.c
+++ b/src/CVRF/cvrf_eval.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  * 		Katarina Jankov <kj226@cornell.edu>

--- a/src/CVRF/cvrf_priv.c
+++ b/src/CVRF/cvrf_priv.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * * Authors:
  * 		Katarina Jankov <kj226@cornell.edu>

--- a/src/CVRF/cvrf_priv.h
+++ b/src/CVRF/cvrf_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  * 		Katarina Jankov <kj226@cornell.edu>

--- a/src/CVRF/public/cvrf.h
+++ b/src/CVRF/public/cvrf.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  * 		Katarina Jankov <kj226@cornell.edu>

--- a/src/CVSS/cvss.c
+++ b/src/CVSS/cvss.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Tomas Heinrich <theinric@redhat.com>

--- a/src/CVSS/cvss_priv.h
+++ b/src/CVSS/cvss_priv.h
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/CVSS/public/cvss_score.h
+++ b/src/CVSS/public/cvss_score.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Tomas Heinrich <theinric@redhat.com>

--- a/src/DS/ds_common.c
+++ b/src/DS/ds_common.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/DS/ds_common.h
+++ b/src/DS/ds_common.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/DS/ds_rds_session.c
+++ b/src/DS/ds_rds_session.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Author:
  *     Šimon Lukašík

--- a/src/DS/ds_rds_session_priv.h
+++ b/src/DS/ds_rds_session_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Šimon Lukašík

--- a/src/DS/ds_sds_session.c
+++ b/src/DS/ds_sds_session.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Author:
  *     Šimon Lukašík

--- a/src/DS/ds_sds_session_priv.h
+++ b/src/DS/ds_sds_session_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/src/DS/public/ds_rds_session.h
+++ b/src/DS/public/ds_rds_session.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Author:
  *     Šimon Lukašík

--- a/src/DS/public/ds_sds_session.h
+++ b/src/DS/public/ds_sds_session.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Author:
  *     Šimon Lukašík

--- a/src/DS/public/scap_ds.h
+++ b/src/DS/public/scap_ds.h
@@ -23,7 +23,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/DS/rds_asset_index.c
+++ b/src/DS/rds_asset_index.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/DS/rds_index.c
+++ b/src/DS/rds_index.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/DS/rds_index_priv.h
+++ b/src/DS/rds_index_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/src/DS/rds_priv.h
+++ b/src/DS/rds_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/src/DS/rds_report_index.c
+++ b/src/DS/rds_report_index.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/DS/rds_report_request_index.c
+++ b/src/DS/rds_report_request_index.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/DS/sds_index.c
+++ b/src/DS/sds_index.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/DS/sds_index_priv.h
+++ b/src/DS/sds_index_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/src/DS/sds_priv.h
+++ b/src/DS/sds_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/src/OVAL/_oval_probe_handler.h
+++ b/src/OVAL/_oval_probe_handler.h
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/_oval_probe_session.h
+++ b/src/OVAL/_oval_probe_session.h
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/adt/oval_collection.c
+++ b/src/OVAL/adt/oval_collection.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/adt/oval_collection_impl.h
+++ b/src/OVAL/adt/oval_collection_impl.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/adt/oval_smc.c
+++ b/src/OVAL/adt/oval_smc.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Šimon Lukašík

--- a/src/OVAL/adt/oval_smc_impl.h
+++ b/src/OVAL/adt/oval_smc_impl.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Šimon Lukašík

--- a/src/OVAL/adt/oval_smc_iterator.c
+++ b/src/OVAL/adt/oval_smc_iterator.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Šimon Lukašík

--- a/src/OVAL/adt/oval_smc_iterator_impl.h
+++ b/src/OVAL/adt/oval_smc_iterator_impl.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Šimon Lukašík

--- a/src/OVAL/adt/oval_string_map.c
+++ b/src/OVAL/adt/oval_string_map.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/adt/oval_string_map_impl.h
+++ b/src/OVAL/adt/oval_string_map_impl.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/collectVarRefs.c
+++ b/src/OVAL/collectVarRefs.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Tomas Heinrich" <theinric@redhat.com>

--- a/src/OVAL/collectVarRefs_impl.h
+++ b/src/OVAL/collectVarRefs_impl.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Tomas Heinrich" <theinric@redhat.com>

--- a/src/OVAL/oval_affected.c
+++ b/src/OVAL/oval_affected.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Peter Vrabec" <pvrabec@redhat.com>

--- a/src/OVAL/oval_agent_api_impl.h
+++ b/src/OVAL/oval_agent_api_impl.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_behavior.c
+++ b/src/OVAL/oval_behavior.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_component.c
+++ b/src/OVAL/oval_component.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_criteriaNode.c
+++ b/src/OVAL/oval_criteriaNode.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_defModel.c
+++ b/src/OVAL/oval_defModel.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_definition.c
+++ b/src/OVAL/oval_definition.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_definitions_impl.h
+++ b/src/OVAL/oval_definitions_impl.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_directives.c
+++ b/src/OVAL/oval_directives.c
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Peter Vrabec" <pvrabec@redhat.com>

--- a/src/OVAL/oval_directives_impl.h
+++ b/src/OVAL/oval_directives_impl.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Peter Vrabec" <pvrabec@redhat.com>

--- a/src/OVAL/oval_entity.c
+++ b/src/OVAL/oval_entity.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_enumerations.c
+++ b/src/OVAL/oval_enumerations.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_filter.c
+++ b/src/OVAL/oval_filter.c
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Tomas Heinrich" <theinric@redhat.com>

--- a/src/OVAL/oval_generator.c
+++ b/src/OVAL/oval_generator.c
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Tomas Heinrich" <theinric@redhat.com>

--- a/src/OVAL/oval_glob_to_regex.c
+++ b/src/OVAL/oval_glob_to_regex.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/src/OVAL/oval_glob_to_regex.h
+++ b/src/OVAL/oval_glob_to_regex.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/oval_message.c
+++ b/src/OVAL/oval_message.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_object.c
+++ b/src/OVAL/oval_object.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_objectContent.c
+++ b/src/OVAL/oval_objectContent.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_parser.c
+++ b/src/OVAL/oval_parser.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_parser_impl.h
+++ b/src/OVAL/oval_parser_impl.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_probe.c
+++ b/src/OVAL/oval_probe.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/oval_probe_ext.h
+++ b/src/OVAL/oval_probe_ext.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/oval_probe_handler.c
+++ b/src/OVAL/oval_probe_handler.c
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/oval_probe_hint.c
+++ b/src/OVAL/oval_probe_hint.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Šimon Lukašík

--- a/src/OVAL/oval_probe_impl.h
+++ b/src/OVAL/oval_probe_impl.h
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/oval_probe_session.c
+++ b/src/OVAL/oval_probe_session.c
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/oval_recordField.c
+++ b/src/OVAL/oval_recordField.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Tomas Heinrich <theinric@redhat.com>

--- a/src/OVAL/oval_reference.c
+++ b/src/OVAL/oval_reference.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_schema_version.c
+++ b/src/OVAL/oval_schema_version.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/src/OVAL/oval_session.c
+++ b/src/OVAL/oval_session.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Author:
  * 		Michal Šrubař <msrubar@redhat.com>

--- a/src/OVAL/oval_set.c
+++ b/src/OVAL/oval_set.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_sexp.c
+++ b/src/OVAL/oval_sexp.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/oval_sexp.h
+++ b/src/OVAL/oval_sexp.h
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/oval_state.c
+++ b/src/OVAL/oval_state.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_stateContent.c
+++ b/src/OVAL/oval_stateContent.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_sysEnt.c
+++ b/src/OVAL/oval_sysEnt.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_sysInfo.c
+++ b/src/OVAL/oval_sysInfo.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_sysInterface.c
+++ b/src/OVAL/oval_sysInterface.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_sysItem.c
+++ b/src/OVAL/oval_sysItem.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_sysModel.c
+++ b/src/OVAL/oval_sysModel.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_sys_parser.c
+++ b/src/OVAL/oval_sys_parser.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Peter Vrabec" <pvrabec@redhat.com

--- a/src/OVAL/oval_syschar.c
+++ b/src/OVAL/oval_syschar.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_syscharIterator.c
+++ b/src/OVAL/oval_syscharIterator.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Šimon Lukašík

--- a/src/OVAL/oval_system_characteristics_impl.h
+++ b/src/OVAL/oval_system_characteristics_impl.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_test.c
+++ b/src/OVAL/oval_test.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_value.c
+++ b/src/OVAL/oval_value.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_varModel.c
+++ b/src/OVAL/oval_varModel.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_vardefMapping.c
+++ b/src/OVAL/oval_vardefMapping.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Šimon Lukašík

--- a/src/OVAL/oval_variable.c
+++ b/src/OVAL/oval_variable.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/oval_variableBinding.c
+++ b/src/OVAL/oval_variableBinding.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/probes/SEAP/_seap-command.h
+++ b/src/OVAL/probes/SEAP/_seap-command.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_seap-error.h
+++ b/src/OVAL/probes/SEAP/_seap-error.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_seap-message.h
+++ b/src/OVAL/probes/SEAP/_seap-message.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_seap-packet.h
+++ b/src/OVAL/probes/SEAP/_seap-packet.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_seap-types.h
+++ b/src/OVAL/probes/SEAP/_seap-types.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_seap.h
+++ b/src/OVAL/probes/SEAP/_seap.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_sexp-ID.h
+++ b/src/OVAL/probes/SEAP/_sexp-ID.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_sexp-atomic.h
+++ b/src/OVAL/probes/SEAP/_sexp-atomic.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_sexp-datatype.h
+++ b/src/OVAL/probes/SEAP/_sexp-datatype.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_sexp-manip.h
+++ b/src/OVAL/probes/SEAP/_sexp-manip.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_sexp-output.h
+++ b/src/OVAL/probes/SEAP/_sexp-output.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_sexp-types.h
+++ b/src/OVAL/probes/SEAP/_sexp-types.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/_sexp-value.h
+++ b/src/OVAL/probes/SEAP/_sexp-value.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/bfind.c
+++ b/src/OVAL/probes/SEAP/generic/bfind.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/bfind.h
+++ b/src/OVAL/probes/SEAP/generic/bfind.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/bitmap.c
+++ b/src/OVAL/probes/SEAP/generic/bitmap.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/bitmap.h
+++ b/src/OVAL/probes/SEAP/generic/bitmap.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/common.c
+++ b/src/OVAL/probes/SEAP/generic/common.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/common.h
+++ b/src/OVAL/probes/SEAP/generic/common.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/rbt/rbt.h
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/rbt/rbt_common.c
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt_common.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/rbt/rbt_common.h
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt_common.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/rbt/rbt_i32.c
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt_i32.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/rbt/rbt_i32.h
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt_i32.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/rbt/rbt_i64.c
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt_i64.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/rbt/rbt_i64.h
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt_i64.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/rbt/rbt_str.c
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt_str.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/rbt/rbt_str.h
+++ b/src/OVAL/probes/SEAP/generic/rbt/rbt_str.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/redblack.h
+++ b/src/OVAL/probes/SEAP/generic/redblack.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/spb.c
+++ b/src/OVAL/probes/SEAP/generic/spb.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/spb.h
+++ b/src/OVAL/probes/SEAP/generic/spb.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/strbuf.c
+++ b/src/OVAL/probes/SEAP/generic/strbuf.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/strbuf.h
+++ b/src/OVAL/probes/SEAP/generic/strbuf.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/strto.c
+++ b/src/OVAL/probes/SEAP/generic/strto.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/strto.h
+++ b/src/OVAL/probes/SEAP/generic/strto.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/xbase64.c
+++ b/src/OVAL/probes/SEAP/generic/xbase64.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/generic/xbase64.h
+++ b/src/OVAL/probes/SEAP/generic/xbase64.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/public/sexp-datatype.h
+++ b/src/OVAL/probes/SEAP/public/sexp-datatype.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/public/sexp-manip.h
+++ b/src/OVAL/probes/SEAP/public/sexp-manip.h
@@ -26,7 +26,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/public/sexp-manip_r.h
+++ b/src/OVAL/probes/SEAP/public/sexp-manip_r.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/public/sexp-output.h
+++ b/src/OVAL/probes/SEAP/public/sexp-output.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/public/sexp-types.h
+++ b/src/OVAL/probes/SEAP/public/sexp-types.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/public/sexp.h
+++ b/src/OVAL/probes/SEAP/public/sexp.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/sch_queue.c
+++ b/src/OVAL/probes/SEAP/sch_queue.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/src/OVAL/probes/SEAP/sch_queue.h
+++ b/src/OVAL/probes/SEAP/sch_queue.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/src/OVAL/probes/SEAP/seap-command-backendT.c
+++ b/src/OVAL/probes/SEAP/seap-command-backendT.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/seap-command-backendT.h
+++ b/src/OVAL/probes/SEAP/seap-command-backendT.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/seap-command.c
+++ b/src/OVAL/probes/SEAP/seap-command.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/seap-descriptor.c
+++ b/src/OVAL/probes/SEAP/seap-descriptor.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/seap-descriptor.h
+++ b/src/OVAL/probes/SEAP/seap-descriptor.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/seap-error.c
+++ b/src/OVAL/probes/SEAP/seap-error.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/seap-message.c
+++ b/src/OVAL/probes/SEAP/seap-message.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/seap-packet.c
+++ b/src/OVAL/probes/SEAP/seap-packet.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/seap.c
+++ b/src/OVAL/probes/SEAP/seap.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/sexp-ID.c
+++ b/src/OVAL/probes/SEAP/sexp-ID.c
@@ -23,7 +23,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/sexp-atomic.c
+++ b/src/OVAL/probes/SEAP/sexp-atomic.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/sexp-datatype.c
+++ b/src/OVAL/probes/SEAP/sexp-datatype.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/sexp-manip.c
+++ b/src/OVAL/probes/SEAP/sexp-manip.c
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/sexp-manip_r.c
+++ b/src/OVAL/probes/SEAP/sexp-manip_r.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/sexp-output.c
+++ b/src/OVAL/probes/SEAP/sexp-output.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/SEAP/sexp-value.c
+++ b/src/OVAL/probes/SEAP/sexp-value.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/_probe-api.h
+++ b/src/OVAL/probes/_probe-api.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/crapi.c
+++ b/src/OVAL/probes/crapi/crapi.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/crapi.h
+++ b/src/OVAL/probes/crapi/crapi.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/digest.c
+++ b/src/OVAL/probes/crapi/digest.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/digest.h
+++ b/src/OVAL/probes/crapi/digest.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/md5.c
+++ b/src/OVAL/probes/crapi/md5.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/md5.h
+++ b/src/OVAL/probes/crapi/md5.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/rmd160.c
+++ b/src/OVAL/probes/crapi/rmd160.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/rmd160.h
+++ b/src/OVAL/probes/crapi/rmd160.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/sha1.c
+++ b/src/OVAL/probes/crapi/sha1.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/sha1.h
+++ b/src/OVAL/probes/crapi/sha1.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/sha2.c
+++ b/src/OVAL/probes/crapi/sha2.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/crapi/sha2.h
+++ b/src/OVAL/probes/crapi/sha2.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/fsdev.h
+++ b/src/OVAL/probes/fsdev.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/independent/environmentvariable58_probe.c
+++ b/src/OVAL/probes/independent/environmentvariable58_probe.c
@@ -23,7 +23,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Petr Lautrbach <plautrba@redhat.com>

--- a/src/OVAL/probes/independent/environmentvariable58_probe.h
+++ b/src/OVAL/probes/independent/environmentvariable58_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/independent/environmentvariable_probe.c
+++ b/src/OVAL/probes/independent/environmentvariable_probe.c
@@ -23,7 +23,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Petr Lautrbach <plautrba@redhat.com>

--- a/src/OVAL/probes/independent/environmentvariable_probe.h
+++ b/src/OVAL/probes/independent/environmentvariable_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/independent/family_probe.c
+++ b/src/OVAL/probes/independent/family_probe.c
@@ -25,7 +25,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Tomas Heinrich" <theinric@redhat.com>

--- a/src/OVAL/probes/independent/family_probe.h
+++ b/src/OVAL/probes/independent/family_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/independent/filehash58_probe.c
+++ b/src/OVAL/probes/independent/filehash58_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/independent/filehash58_probe.h
+++ b/src/OVAL/probes/independent/filehash58_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/independent/filehash_probe.c
+++ b/src/OVAL/probes/independent/filehash_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/independent/filehash_probe.h
+++ b/src/OVAL/probes/independent/filehash_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/independent/filemd5_probe.c
+++ b/src/OVAL/probes/independent/filemd5_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/independent/ldap57_probe.c
+++ b/src/OVAL/probes/independent/ldap57_probe.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/independent/sql57_probe.c
+++ b/src/OVAL/probes/independent/sql57_probe.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/independent/sql57_probe.h
+++ b/src/OVAL/probes/independent/sql57_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/independent/sql_probe.c
+++ b/src/OVAL/probes/independent/sql_probe.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/independent/sql_probe.h
+++ b/src/OVAL/probes/independent/sql_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/independent/system_info_probe.c
+++ b/src/OVAL/probes/independent/system_info_probe.c
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Tomas Heinrich" <theinric@redhat.com>

--- a/src/OVAL/probes/independent/system_info_probe.h
+++ b/src/OVAL/probes/independent/system_info_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/independent/textfilecontent54_probe.c
+++ b/src/OVAL/probes/independent/textfilecontent54_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Tomas Heinrich" <theinric@redhat.com>

--- a/src/OVAL/probes/independent/textfilecontent54_probe.h
+++ b/src/OVAL/probes/independent/textfilecontent54_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/independent/textfilecontent_probe.c
+++ b/src/OVAL/probes/independent/textfilecontent_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Tomas Heinrich" <theinric@redhat.com>

--- a/src/OVAL/probes/independent/textfilecontent_probe.h
+++ b/src/OVAL/probes/independent/textfilecontent_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/independent/variable_probe.c
+++ b/src/OVAL/probes/independent/variable_probe.c
@@ -23,7 +23,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Tomas Heinrich" <theinric@redhat.com>

--- a/src/OVAL/probes/independent/variable_probe.h
+++ b/src/OVAL/probes/independent/variable_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/independent/xmlfilecontent_probe.c
+++ b/src/OVAL/probes/independent/xmlfilecontent_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Tomas Heinrich" <theinric@redhat.com>

--- a/src/OVAL/probes/independent/xmlfilecontent_probe.h
+++ b/src/OVAL/probes/independent/xmlfilecontent_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/oval_fts.h
+++ b/src/OVAL/probes/oval_fts.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe-api.c
+++ b/src/OVAL/probes/probe-api.c
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe-table.c
+++ b/src/OVAL/probes/probe-table.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/src/OVAL/probes/probe/entcmp.c
+++ b/src/OVAL/probes/probe/entcmp.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Tomas Heinrich <theinric@redhat.com>

--- a/src/OVAL/probes/probe/entcmp.h
+++ b/src/OVAL/probes/probe/entcmp.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Tomas Heinrich <theinric@redhat.com>

--- a/src/OVAL/probes/probe/icache.c
+++ b/src/OVAL/probes/probe/icache.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/icache.h
+++ b/src/OVAL/probes/probe/icache.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/input_handler.h
+++ b/src/OVAL/probes/probe/input_handler.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/ncache.c
+++ b/src/OVAL/probes/probe/ncache.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/ncache.h
+++ b/src/OVAL/probes/probe/ncache.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/probe.c
+++ b/src/OVAL/probes/probe/probe.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/probe.h
+++ b/src/OVAL/probes/probe/probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/probe_main.c
+++ b/src/OVAL/probes/probe/probe_main.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/probe_main.h
+++ b/src/OVAL/probes/probe/probe_main.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/src/OVAL/probes/probe/rcache.c
+++ b/src/OVAL/probes/probe/rcache.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/rcache.h
+++ b/src/OVAL/probes/probe/rcache.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/probe/worker.h
+++ b/src/OVAL/probes/probe/worker.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/public/probe-api.h
+++ b/src/OVAL/probes/public/probe-api.h
@@ -48,7 +48,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/public/probe-table.h
+++ b/src/OVAL/probes/public/probe-table.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/dnscache_probe.h
+++ b/src/OVAL/probes/unix/dnscache_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/file_probe.c
+++ b/src/OVAL/probes/unix/file_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/file_probe.h
+++ b/src/OVAL/probes/unix/file_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/fileextendedattribute_probe.c
+++ b/src/OVAL/probes/unix/fileextendedattribute_probe.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/fileextendedattribute_probe.h
+++ b/src/OVAL/probes/unix/fileextendedattribute_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/gconf_probe.c
+++ b/src/OVAL/probes/unix/gconf_probe.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/gconf_probe.h
+++ b/src/OVAL/probes/unix/gconf_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/interface_probe.c
+++ b/src/OVAL/probes/unix/interface_probe.c
@@ -25,7 +25,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Tomas Heinrich" <theinric@redhat.com>

--- a/src/OVAL/probes/unix/interface_probe.h
+++ b/src/OVAL/probes/unix/interface_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.h
+++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *	"Pierre Chifflier <chifflier@edenwall.com>"

--- a/src/OVAL/probes/unix/linux/dpkginfo_probe.c
+++ b/src/OVAL/probes/unix/linux/dpkginfo_probe.c
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Pierre Chifflier <chifflier@wzdftpd.net>"

--- a/src/OVAL/probes/unix/linux/dpkginfo_probe.h
+++ b/src/OVAL/probes/unix/linux/dpkginfo_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/iflisteners_probe.c
+++ b/src/OVAL/probes/unix/linux/iflisteners_probe.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Steve Grubb <sgrubb@redhat.com>

--- a/src/OVAL/probes/unix/linux/iflisteners_probe.h
+++ b/src/OVAL/probes/unix/linux/iflisteners_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/inetlisteningservers_probe.c
+++ b/src/OVAL/probes/unix/linux/inetlisteningservers_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Steve Grubb <sgrubb@redhat.com>

--- a/src/OVAL/probes/unix/linux/inetlisteningservers_probe.h
+++ b/src/OVAL/probes/unix/linux/inetlisteningservers_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/partition_probe.c
+++ b/src/OVAL/probes/unix/linux/partition_probe.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/linux/partition_probe.h
+++ b/src/OVAL/probes/unix/linux/partition_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/probe-chroot.c
+++ b/src/OVAL/probes/unix/linux/probe-chroot.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/OVAL/probes/unix/linux/probe-chroot.h
+++ b/src/OVAL/probes/unix/linux/probe-chroot.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 #ifndef __PROBE_CHROOT__

--- a/src/OVAL/probes/unix/linux/rpm-helper.c
+++ b/src/OVAL/probes/unix/linux/rpm-helper.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 #ifndef __RPM_HELPER__

--- a/src/OVAL/probes/unix/linux/rpminfo_probe.c
+++ b/src/OVAL/probes/unix/linux/rpminfo_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/linux/rpminfo_probe.h
+++ b/src/OVAL/probes/unix/linux/rpminfo_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/rpmverify_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverify_probe.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/linux/rpmverify_probe.h
+++ b/src/OVAL/probes/unix/linux/rpmverify_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.h
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/linux/rpmverifypackage_probe.h
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/selinuxboolean_probe.c
+++ b/src/OVAL/probes/unix/linux/selinuxboolean_probe.c
@@ -23,7 +23,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Petr Lautrbach <plautrba@redhat.com>

--- a/src/OVAL/probes/unix/linux/selinuxboolean_probe.h
+++ b/src/OVAL/probes/unix/linux/selinuxboolean_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c
+++ b/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Petr Lautrbach" <plautrba@redhat.com>

--- a/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.h
+++ b/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/systemdshared.h
+++ b/src/OVAL/probes/unix/linux/systemdshared.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *

--- a/src/OVAL/probes/unix/linux/systemdunitdependency_probe.c
+++ b/src/OVAL/probes/unix/linux/systemdunitdependency_probe.c
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *

--- a/src/OVAL/probes/unix/linux/systemdunitdependency_probe.h
+++ b/src/OVAL/probes/unix/linux/systemdunitdependency_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/linux/systemdunitproperty_probe.c
+++ b/src/OVAL/probes/unix/linux/systemdunitproperty_probe.c
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *

--- a/src/OVAL/probes/unix/linux/systemdunitproperty_probe.h
+++ b/src/OVAL/probes/unix/linux/systemdunitproperty_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/password_probe.c
+++ b/src/OVAL/probes/unix/password_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Steve Grubb <sgrubb@redhat.com>

--- a/src/OVAL/probes/unix/password_probe.h
+++ b/src/OVAL/probes/unix/password_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/process58_probe.c
+++ b/src/OVAL/probes/unix/process58_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Steve Grubb <sgrubb@redhat.com>

--- a/src/OVAL/probes/unix/process58_probe.h
+++ b/src/OVAL/probes/unix/process58_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/process_probe.c
+++ b/src/OVAL/probes/unix/process_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Steve Grubb <sgrubb@redhat.com>

--- a/src/OVAL/probes/unix/process_probe.h
+++ b/src/OVAL/probes/unix/process_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/routingtable_probe.c
+++ b/src/OVAL/probes/unix/routingtable_probe.c
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/routingtable_probe.h
+++ b/src/OVAL/probes/unix/routingtable_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/runlevel_probe.c
+++ b/src/OVAL/probes/unix/runlevel_probe.c
@@ -25,7 +25,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/runlevel_probe.h
+++ b/src/OVAL/probes/unix/runlevel_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/shadow_probe.c
+++ b/src/OVAL/probes/unix/shadow_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Steve Grubb <sgrubb@redhat.com>

--- a/src/OVAL/probes/unix/shadow_probe.h
+++ b/src/OVAL/probes/unix/shadow_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/solaris/isainfo_probe.c
+++ b/src/OVAL/probes/unix/solaris/isainfo_probe.c
@@ -27,7 +27,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
 #ifdef HAVE_CONFIG_H

--- a/src/OVAL/probes/unix/solaris/isainfo_probe.h
+++ b/src/OVAL/probes/unix/solaris/isainfo_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/symlink_probe.c
+++ b/src/OVAL/probes/unix/symlink_probe.c
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/symlink_probe.h
+++ b/src/OVAL/probes/unix/symlink_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/sysctl_probe.c
+++ b/src/OVAL/probes/unix/sysctl_probe.c
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/sysctl_probe.h
+++ b/src/OVAL/probes/unix/sysctl_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/uname_probe.c
+++ b/src/OVAL/probes/unix/uname_probe.c
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Steve Grubb <sgrubb@redhat.com>

--- a/src/OVAL/probes/unix/uname_probe.h
+++ b/src/OVAL/probes/unix/uname_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/unix/xinetd_probe.c
+++ b/src/OVAL/probes/unix/xinetd_probe.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Daniel Kopecek <dkopecek@redhat.com>

--- a/src/OVAL/probes/unix/xinetd_probe.h
+++ b/src/OVAL/probes/unix/xinetd_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/windows/accesstoken_probe.c
+++ b/src/OVAL/probes/windows/accesstoken_probe.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/windows/accesstoken_probe.h
+++ b/src/OVAL/probes/windows/accesstoken_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/windows/registry_probe.c
+++ b/src/OVAL/probes/windows/registry_probe.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/windows/registry_probe.h
+++ b/src/OVAL/probes/windows/registry_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/windows/wmi57_probe.c
+++ b/src/OVAL/probes/windows/wmi57_probe.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/probes/windows/wmi57_probe.h
+++ b/src/OVAL/probes/windows/wmi57_probe.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/OVAL/public/oval_adt.h
+++ b/src/OVAL/public/oval_adt.h
@@ -29,7 +29,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/public/oval_agent_api.h
+++ b/src/OVAL/public/oval_agent_api.h
@@ -29,7 +29,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/OVAL/public/oval_agent_xccdf_api.h
+++ b/src/OVAL/public/oval_agent_xccdf_api.h
@@ -28,7 +28,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/OVAL/public/oval_definitions.h
+++ b/src/OVAL/public/oval_definitions.h
@@ -29,7 +29,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/public/oval_directives.h
+++ b/src/OVAL/public/oval_directives.h
@@ -28,7 +28,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/public/oval_probe.h
+++ b/src/OVAL/public/oval_probe.h
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/public/oval_probe_session.h
+++ b/src/OVAL/public/oval_probe_session.h
@@ -22,7 +22,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/src/OVAL/public/oval_results.h
+++ b/src/OVAL/public/oval_results.h
@@ -32,7 +32,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/public/oval_schema_version.h
+++ b/src/OVAL/public/oval_schema_version.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/src/OVAL/public/oval_session.h
+++ b/src/OVAL/public/oval_session.h
@@ -28,7 +28,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Author:
  * 		Michal Šrubař <msrubar@redhat.com>

--- a/src/OVAL/public/oval_system_characteristics.h
+++ b/src/OVAL/public/oval_system_characteristics.h
@@ -29,7 +29,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/public/oval_types.h
+++ b/src/OVAL/public/oval_types.h
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/public/oval_variables.h
+++ b/src/OVAL/public/oval_variables.h
@@ -27,7 +27,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/results/oval_cmp.c
+++ b/src/OVAL/results/oval_cmp.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *     David Niemoller <David.Niemoller@g2-inc.com>

--- a/src/OVAL/results/oval_cmp_basic.c
+++ b/src/OVAL/results/oval_cmp_basic.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *     Tomas Heinrich <theinric@redhat.com>

--- a/src/OVAL/results/oval_cmp_basic_impl.h
+++ b/src/OVAL/results/oval_cmp_basic_impl.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *     Šimon Lukašík

--- a/src/OVAL/results/oval_cmp_evr_string.c
+++ b/src/OVAL/results/oval_cmp_evr_string.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Peter Vrabec" <pvrabec@redhat.com>

--- a/src/OVAL/results/oval_cmp_evr_string_impl.h
+++ b/src/OVAL/results/oval_cmp_evr_string_impl.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *     Šimon Lukašík

--- a/src/OVAL/results/oval_cmp_impl.h
+++ b/src/OVAL/results/oval_cmp_impl.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *     Šimon Lukašík

--- a/src/OVAL/results/oval_cmp_ip_address.c
+++ b/src/OVAL/results/oval_cmp_ip_address.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *     Tomas Heinrich <theinric@redhat.com>

--- a/src/OVAL/results/oval_cmp_ip_address_impl.h
+++ b/src/OVAL/results/oval_cmp_ip_address_impl.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *     Tomas Heinrich <theinric@redhat.com>

--- a/src/OVAL/results/oval_resModel.c
+++ b/src/OVAL/results/oval_resModel.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/results/oval_resultCriteriaNode.c
+++ b/src/OVAL/results/oval_resultCriteriaNode.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/results/oval_resultDefinition.c
+++ b/src/OVAL/results/oval_resultDefinition.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/results/oval_resultDefinitionIterator.c
+++ b/src/OVAL/results/oval_resultDefinitionIterator.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Šimon Lukašík

--- a/src/OVAL/results/oval_resultItem.c
+++ b/src/OVAL/results/oval_resultItem.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/results/oval_resultSystem.c
+++ b/src/OVAL/results/oval_resultSystem.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/results/oval_resultTest.c
+++ b/src/OVAL/results/oval_resultTest.c
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/results/oval_resultTestIterator.c
+++ b/src/OVAL/results/oval_resultTestIterator.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Šimon Lukašík

--- a/src/OVAL/results/oval_results_impl.h
+++ b/src/OVAL/results/oval_results_impl.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/OVAL/results/oval_status_counter.c
+++ b/src/OVAL/results/oval_status_counter.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/src/OVAL/results/oval_status_counter.h
+++ b/src/OVAL/results/oval_status_counter.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/src/SCE/module_entry.c
+++ b/src/SCE/module_entry.c
@@ -19,7 +19,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Martin Preisler" <mpreisle@redhat.com>

--- a/src/SCE/public/sce_engine_api.h
+++ b/src/SCE/public/sce_engine_api.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Martin Preisler" <mpreisle@redhat.com>

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -19,7 +19,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Martin Preisler" <mpreisle@redhat.com>

--- a/src/XCCDF/benchmark.c
+++ b/src/XCCDF/benchmark.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/elements.c
+++ b/src/XCCDF/elements.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/elements.h
+++ b/src/XCCDF/elements.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/helpers.h
+++ b/src/XCCDF/helpers.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/item.c
+++ b/src/XCCDF/item.c
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/item.h
+++ b/src/XCCDF/item.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/profile.c
+++ b/src/XCCDF/profile.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/public/xccdf_benchmark.h
+++ b/src/XCCDF/public/xccdf_benchmark.h
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -25,7 +25,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/XCCDF/resolve.c
+++ b/src/XCCDF/resolve.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/result.c
+++ b/src/XCCDF/result.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/result_scoring.c
+++ b/src/XCCDF/result_scoring.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/XCCDF/result_scoring_priv.h
+++ b/src/XCCDF/result_scoring_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 #ifndef OSCAP_XCCDF_RESULT_SCORING_H

--- a/src/XCCDF/rule.c
+++ b/src/XCCDF/rule.c
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/tailoring.c
+++ b/src/XCCDF/tailoring.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/XCCDF/unused.h
+++ b/src/XCCDF/unused.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/value.c
+++ b/src/XCCDF/value.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/XCCDF/xccdf_impl.h
+++ b/src/XCCDF/xccdf_impl.h
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Josh Adams <jadams@tresys.com>

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 #include <string.h>

--- a/src/XCCDF_POLICY/check_engine_plugin.c
+++ b/src/XCCDF_POLICY/check_engine_plugin.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Author: Martin Preisler <mpreisle@redhat.com>
  */

--- a/src/XCCDF_POLICY/public/check_engine_plugin.h
+++ b/src/XCCDF_POLICY/public/check_engine_plugin.h
@@ -24,7 +24,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/XCCDF_POLICY/public/xccdf_policy.h
+++ b/src/XCCDF_POLICY/public/xccdf_policy.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/XCCDF_POLICY/reporter.c
+++ b/src/XCCDF_POLICY/reporter.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *    Šimon Lukašík

--- a/src/XCCDF_POLICY/reporter_priv.h
+++ b/src/XCCDF_POLICY/reporter_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Simon Lukasik <slukasik@redhat.com>

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -16,7 +16,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *  Created on: Dec 16, 2009
  *      Author: David Niemoller

--- a/src/XCCDF_POLICY/xccdf_policy_engine.c
+++ b/src/XCCDF_POLICY/xccdf_policy_engine.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *    Šimon Lukašík

--- a/src/XCCDF_POLICY/xccdf_policy_engine_priv.h
+++ b/src/XCCDF_POLICY/xccdf_policy_engine_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Simon Lukasik <slukasik@redhat.com>

--- a/src/XCCDF_POLICY/xccdf_policy_model.c
+++ b/src/XCCDF_POLICY/xccdf_policy_model.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *    Šimon Lukašík

--- a/src/XCCDF_POLICY/xccdf_policy_model_priv.h
+++ b/src/XCCDF_POLICY/xccdf_policy_model_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Simon Lukasik <slukasik@redhat.com>

--- a/src/XCCDF_POLICY/xccdf_policy_priv.h
+++ b/src/XCCDF_POLICY/xccdf_policy_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Simon Lukasik <slukasik@redhat.com>

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 #ifdef HAVE_CONFIG_H

--- a/src/XCCDF_POLICY/xccdf_policy_resolve.c
+++ b/src/XCCDF_POLICY/xccdf_policy_resolve.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/XCCDF_POLICY/xccdf_policy_resolve.h
+++ b/src/XCCDF_POLICY/xccdf_policy_resolve.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/XCCDF_POLICY/xccdf_policy_substitute.c
+++ b/src/XCCDF_POLICY/xccdf_policy_substitute.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 #ifdef HAVE_CONFIG_H

--- a/src/common/_error.h
+++ b/src/common/_error.h
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/bfind.c
+++ b/src/common/bfind.c
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/bfind.h
+++ b/src/common/bfind.h
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Daniel Kopecek <dkopecek@redhat.com>

--- a/src/common/compat_pthread_barrier.c
+++ b/src/common/compat_pthread_barrier.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Martin Preisler <mpreisle@redhat.com>

--- a/src/common/compat_pthread_barrier.h
+++ b/src/common/compat_pthread_barrier.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/debug_priv.h
+++ b/src/common/debug_priv.h
@@ -18,7 +18,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Daniel Kopecek <dkopecek@redhat.com>

--- a/src/common/elements.c
+++ b/src/common/elements.c
@@ -18,7 +18,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/common/elements.h
+++ b/src/common/elements.h
@@ -18,7 +18,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/common/err_queue.c
+++ b/src/common/err_queue.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/common/err_queue.h
+++ b/src/common/err_queue.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/common/error.c
+++ b/src/common/error.c
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/list.c
+++ b/src/common/list.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/list.h
+++ b/src/common/list.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/memusage.c
+++ b/src/common/memusage.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Daniel Kopecek <dkopecek@redhat.com>

--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/common/oscap_acquire.h
+++ b/src/common/oscap_acquire.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/common/oscap_buffer.c
+++ b/src/common/oscap_buffer.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/common/oscap_buffer.h
+++ b/src/common/oscap_buffer.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/common/oscap_queue.c
+++ b/src/common/oscap_queue.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/common/oscap_queue.h
+++ b/src/common/oscap_queue.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/common/oscap_string.c
+++ b/src/common/oscap_string.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/common/oscap_string.h
+++ b/src/common/oscap_string.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/common/oscapxml.c
+++ b/src/common/oscapxml.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/oscapxml.h
+++ b/src/common/oscapxml.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/common/public/oscap.h
+++ b/src/common/public/oscap.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/public/oscap_debug.h
+++ b/src/common/public/oscap_debug.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Jan Černý <jcerny@redhat.com>

--- a/src/common/public/oscap_download_cb.h
+++ b/src/common/public/oscap_download_cb.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/common/public/oscap_error.h
+++ b/src/common/public/oscap_error.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 /**

--- a/src/common/public/oscap_export.h
+++ b/src/common/public/oscap_export.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *    Jan Černý <jcerny@redhat.com>

--- a/src/common/public/oscap_helpers.h
+++ b/src/common/public/oscap_helpers.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/src/common/public/oscap_reference.h
+++ b/src/common/public/oscap_reference.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/public/oscap_text.h
+++ b/src/common/public/oscap_text.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/common/reference.c
+++ b/src/common/reference.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/reference_priv.h
+++ b/src/common/reference_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/text.c
+++ b/src/common/text.c
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *       Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/text_priv.h
+++ b/src/common/text_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "David Niemoller" <David.Niemoller@g2-inc.com>

--- a/src/common/tsort.c
+++ b/src/common/tsort.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/tsort.h
+++ b/src/common/tsort.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/src/common/xml_iterate.c
+++ b/src/common/xml_iterate.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 #ifdef HAVE_CONFIG_H

--- a/src/common/xml_iterate.h
+++ b/src/common/xml_iterate.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Simon Lukasik <slukasik@redhat.com>

--- a/src/common/xmlns_priv.h
+++ b/src/common/xmlns_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *   Simon Lukasik <slukasik@redhat.com>

--- a/src/common/xmltext_priv.c
+++ b/src/common/xmltext_priv.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *	Šimon Lukašík

--- a/src/common/xmltext_priv.h
+++ b/src/common/xmltext_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *	Šimon Lukašík

--- a/src/source/bz2.c
+++ b/src/source/bz2.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *     Šimon Lukašík

--- a/src/source/bz2_priv.h
+++ b/src/source/bz2_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/src/source/doc_type.c
+++ b/src/source/doc_type.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/src/source/doc_type_priv.h
+++ b/src/source/doc_type_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Author:
  *     Šimon Lukašík

--- a/src/source/oscap_source_priv.h
+++ b/src/source/oscap_source_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Author:
  *     Šimon Lukašík

--- a/src/source/public/oscap_source.h
+++ b/src/source/public/oscap_source.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Author:
  *     Šimon Lukašík

--- a/src/source/schematron.c
+++ b/src/source/schematron.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/source/schematron_priv.h
+++ b/src/source/schematron_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/src/source/validate.c
+++ b/src/source/validate.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/source/validate_priv.h
+++ b/src/source/validate_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/src/source/xslt.c
+++ b/src/source/xslt.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/src/source/xslt_priv.h
+++ b/src/source/xslt_priv.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  *
  */

--- a/swig/openscap.i
+++ b/swig/openscap.i
@@ -19,7 +19,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas   <mbarabas@redhat.com>

--- a/swig/openscap_api.py
+++ b/swig/openscap_api.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
 # Authors:
 #      Maros Barabas  <mbarabas@redhat.com>

--- a/tests/API/CPE/inbuilt/all.sh
+++ b/tests/API/CPE/inbuilt/all.sh
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 set -e -o pipefail
 

--- a/tests/API/CVRF/test_api_cvrf.c
+++ b/tests/API/CVRF/test_api_cvrf.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 

--- a/tests/API/OVAL/schema_version/test_schema_version.c
+++ b/tests/API/OVAL/schema_version/test_schema_version.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/tests/API/SEAP/test_api_seap_concurency.c
+++ b/tests/API/SEAP/test_api_seap_concurency.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/tests/API/XCCDF/parser/test_api_xccdf.c
+++ b/tests/API/XCCDF/parser/test_api_xccdf.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/tests/API/XCCDF/unittests/test_oscap_common.c
+++ b/tests/API/XCCDF/unittests/test_oscap_common.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *	Simon Lukasik <slukasik@redhat.com>

--- a/tests/API/XCCDF/unittests/test_xccdf_overrides.c
+++ b/tests/API/XCCDF/unittests/test_xccdf_overrides.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *	Simon Lukasik <slukasik@redhat.com>

--- a/tests/API/XCCDF/unittests/test_xccdf_shall_pass.c
+++ b/tests/API/XCCDF/unittests/test_xccdf_shall_pass.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *	Simon Lukasik <slukasik@redhat.com>

--- a/tests/API/XCCDF/unittests/unit_helper.c
+++ b/tests/API/XCCDF/unittests/unit_helper.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *	Simon Lukasik <slukasik@redhat.com>

--- a/tests/API/XCCDF/unittests/unit_helper.h
+++ b/tests/API/XCCDF/unittests/unit_helper.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *	Simon Lukasik <slukasik@redhat.com>

--- a/tests/API/XCCDF/variable_instance/all.sh
+++ b/tests/API/XCCDF/variable_instance/all.sh
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 set -e -o pipefail
 

--- a/tests/API/crypt/test_crapi_digest.c
+++ b/tests/API/crypt/test_crapi_digest.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/tests/API/crypt/test_crapi_mdigest.c
+++ b/tests/API/crypt/test_crapi_mdigest.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Daniel Kopecek" <dkopecek@redhat.com>

--- a/tests/API/probes/test_fsdev_is_local_fs.c
+++ b/tests/API/probes/test_fsdev_is_local_fs.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      "Jan Černý" <jcerny@redhat.com>

--- a/tests/bz2/test_bz2_memory_source.c
+++ b/tests/bz2/test_bz2_memory_source.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *	Simon Lukasik <slukasik@redhat.com>

--- a/tests/oscap_assert.h
+++ b/tests/oscap_assert.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/tests/oscap_string/test_oscap_string.c
+++ b/tests/oscap_string/test_oscap_string.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Jan Černý <jcerny@redhat.com>

--- a/tests/sce/script_tester.py
+++ b/tests/sce/script_tester.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
 # Authors:
 #      "Martin Preisler" <mpreisle@redhat.com>

--- a/utils/oscap-cpe.c
+++ b/utils/oscap-cpe.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Peter Vrabec  <pvrabec@redhat.com>

--- a/utils/oscap-cve.c
+++ b/utils/oscap-cve.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Peter Vrabec  <pvrabec@redhat.com>

--- a/utils/oscap-cvrf.c
+++ b/utils/oscap-cvrf.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  */
 #ifdef HAVE_CONFIG_H

--- a/utils/oscap-cvss.c
+++ b/utils/oscap-cvss.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas  <mbarabas@redhat.com>

--- a/utils/oscap-docker.in
+++ b/utils/oscap-docker.in
@@ -15,8 +15,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
 
 ''' oscap docker command '''
 

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Martin Preisler <mpreisle@redhat.com>

--- a/utils/oscap-info.c
+++ b/utils/oscap-info.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Peter Vrabec  <pvrabec@redhat.com>

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/utils/oscap-tool.h
+++ b/utils/oscap-tool.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software 
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas <mbarabas@redhat.com>

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Peter Vrabec   <pvrabec@redhat.com>

--- a/utils/oscap.c
+++ b/utils/oscap.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * Authors:
  *      Maros Barabas  <mbarabas@redhat.com>

--- a/utils/oscap_docker_python/__init__.py
+++ b/utils/oscap_docker_python/__init__.py
@@ -12,5 +12,5 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA

--- a/utils/oscap_docker_python/get_cve_input.py
+++ b/utils/oscap_docker_python/get_cve_input.py
@@ -12,8 +12,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
 
 import urllib.parse
 import urllib.request

--- a/utils/oscap_docker_python/oscap_docker_common.py
+++ b/utils/oscap_docker_python/oscap_docker_common.py
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
 
 import subprocess
 import platform

--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
 
 ''' Utilities for oscap-docker '''
 

--- a/utils/oscap_docker_python/oscap_docker_util_noatomic.py
+++ b/utils/oscap_docker_python/oscap_docker_util_noatomic.py
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
 
 from __future__ import print_function
 

--- a/utils/scap-as-rpm
+++ b/utils/scap-as-rpm
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
 # Authors:
 #      Martin Preisler <mpreisle@redhat.com>

--- a/xsl/legacy-fix.xsl
+++ b/xsl/legacy-fix.xsl
@@ -20,7 +20,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/xsl/legacy-fixtpl-bash.xml
+++ b/xsl/legacy-fixtpl-bash.xml
@@ -15,7 +15,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/xsl/legacy-xccdf-share.xsl
+++ b/xsl/legacy-xccdf-share.xsl
@@ -15,7 +15,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
      Lukas Kuklinek <lkuklinek@redhat.com>

--- a/xsl/oval-to-xccdf.xsl
+++ b/xsl/oval-to-xccdf.xsl
@@ -11,8 +11,8 @@ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
 for more details.
 
 You should have received a copy of the GNU Lesser General Public License along
-with this library; if not, write to the Free Software Foundation, Inc., 59
-Temple Place, Suite 330, Boston, MA  02111-1307 USA
+with this library; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
      Šimon Lukašík <slukasik@redhat.com>

--- a/xsl/xccdf-branding.xsl
+++ b/xsl/xccdf-branding.xsl
@@ -16,7 +16,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
      Martin Preisler <mpreisle@redhat.com>

--- a/xsl/xccdf-guide-impl.xsl
+++ b/xsl/xccdf-guide-impl.xsl
@@ -15,7 +15,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
     Martin Preisler <mpreisle@redhat.com>

--- a/xsl/xccdf-guide.xsl
+++ b/xsl/xccdf-guide.xsl
@@ -15,7 +15,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
     Martin Preisler <mpreisle@redhat.com>

--- a/xsl/xccdf-references.xsl
+++ b/xsl/xccdf-references.xsl
@@ -16,7 +16,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
      Martin Preisler <mpreisle@redhat.com>

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -16,7 +16,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
      Martin Preisler <mpreisle@redhat.com>

--- a/xsl/xccdf-report-oval-details.xsl
+++ b/xsl/xccdf-report-oval-details.xsl
@@ -16,7 +16,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
     Lukas Kuklinek <lkuklinek@redhat.com>

--- a/xsl/xccdf-report.xsl
+++ b/xsl/xccdf-report.xsl
@@ -16,7 +16,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
      Martin Preisler <mpreisle@redhat.com>

--- a/xsl/xccdf-share.xsl
+++ b/xsl/xccdf-share.xsl
@@ -16,7 +16,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
      Martin Preisler <mpreisle@redhat.com>

--- a/xsl/xccdf_1.1_remove_dangling_sub.xsl
+++ b/xsl/xccdf_1.1_remove_dangling_sub.xsl
@@ -16,7 +16,7 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Authors:
       Šimon Lukašík

--- a/xsl/xccdf_1.1_to_1.2.xsl
+++ b/xsl/xccdf_1.1_to_1.2.xsl
@@ -16,7 +16,7 @@ Lesser General Public License for more details.
  
 You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  
 Authors:
       Martin Preisler <mpreisle@redhat.com>


### PR DESCRIPTION
We should use correct address as in the License:
https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt
rpmlint complains about the incorrect address:
https://fedoraproject.org/wiki/Common_Rpmlint_issues#incorrect-fsf-address