### PR TITLE
Fix FindACL.cmake

### DIFF
--- a/cmake/FindACL.cmake
+++ b/cmake/FindACL.cmake
@@ -12,13 +12,13 @@ libfind_pkg_check_modules(ACL_PKGCONF libacl)
 
 # Include dir
 find_path(ACL_INCLUDE_DIR
-	NAMES "acl/libacl.h sys/libacl.h"
+	NAMES "acl/libacl.h" "sys/libacl.h"
 	PATHS ${ACL_PKGCONF_INCLUDE_DIRS}
 )
 
 # Finally the library itself
 find_library(ACL_LIBRARY
-	NAMES libacl
+	NAMES acl
 	PATHS ${ACL_PKGCONF_LIBRARY_DIRS}
 )
 


### PR DESCRIPTION
find_path parameter `NAMES` values should be separated. According to
https://cmake.org/cmake/help/latest/command/find_path.html it should be:
`NAMES name1 [name2 ...]`

find_library parameter `NAMES` either should not contain `lib` or should
contain both `lib` and `.so.` The documentation at
https://cmake.org/cmake/help/latest/command/find_library.html says: Each
library name given to the `NAMES` option is first considered as a
library file name and then considered with platform-specific prefixes
(e.g. `lib`) and suffixes (e.g. `.so`).

This bug caused that even if cmake reported that libacl was found, the
library wasn't linked to the built `libopenscap.so`. Also,
`HAVE_ACL_EXTENDED_FILE`, `HAVE_ACL_LIBACL_H` and `HAVE_SYS_ACL_H` were
undefined in `config.h`, which caused some guarded pieces of code to not
compile, which means features missing.