### PR TITLE
Prevent infinite recursion in systemdunitdependency probe

### DIFF
--- a/src/OVAL/probes/unix/linux/systemdunitdependency_probe.c
+++ b/src/OVAL/probes/unix/linux/systemdunitdependency_probe.c
@@ -162,11 +162,6 @@ static void get_all_dependencies_by_unit(DBusConnection *conn, const char *unit,
 
 			if (add_unit_dependency(requires[i], item) == 0) {
 				get_all_dependencies_by_unit(conn, requires[i], item);
-			} else {
-				free(requires);
-				free(requires_s);
-				free(path);
-				return;
 			}
 		}
 		free(requires);
@@ -183,11 +178,6 @@ static void get_all_dependencies_by_unit(DBusConnection *conn, const char *unit,
 
 			if (add_unit_dependency(wants[i], item) == 0) {
 				get_all_dependencies_by_unit(conn, wants[i], item);
-			} else {
-				free(wants);
-				free(wants_s);
-				free(path);
-				return;
 			}
 		}
 		free(wants);

--- a/src/OVAL/probes/unix/linux/systemdunitdependency_probe.c
+++ b/src/OVAL/probes/unix/linux/systemdunitdependency_probe.c
@@ -155,8 +155,9 @@ static void process_unit_property(const char *property, DBusConnection *conn, co
 	if (values_s) {
 		char **values = oscap_split(values_s, ", ");
 		for (int i = 0; values[i] != NULL; ++i) {
-			if (oscap_strcmp(values[i], "") == 0)
+			if (oscap_strcmp(values[i], "") == 0) {
 				continue;
+			}
 
 			if (add_unit_dependency(values[i], item, visited_units) == 0) {
 				get_all_dependencies_by_unit(conn, values[i], item, visited_units);


### PR DESCRIPTION
Systemd units trees can contain cycles in them, which causes infinite recursion in our probe.

We will save processed units in a hash table and if we meet an unit that is already processed we won't process it again.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1478285
See comment 11 in this BZ for a reproducer.

This PR also contains some refactoring to make the bug fix easier. For more details about specific changes please read the commit messages of respective commits.