### PR TITLE
Allow oscap to generate machineconfig fix

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -650,6 +650,7 @@ static int _write_fix_missing_warning_to_fd(const char *sys, int output_fd, stru
 	}
 }
 
+
 static inline int _parse_ansible_fix(const char *fix_text, struct oscap_list *variables, struct oscap_list *tasks)
 {
 	// TODO: Tolerate different indentation styles in this regex
@@ -785,7 +786,6 @@ static int _xccdf_policy_rule_generate_fix(struct xccdf_policy *policy, struct x
 	ret = _write_fix_footer_to_fd(template, output_fd, rule);
 	return ret;
 }
-
 
 static int _xccdf_policy_rule_generate_ansible_fix(struct xccdf_policy *policy, struct xccdf_rule *rule, const char *template, struct oscap_list *variables, struct oscap_list *tasks)
 {

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -864,10 +864,12 @@ int app_generate_fix(const struct oscap_action *action)
 			template = "urn:xccdf:fix:script:puppet";
 		} else if (strcmp(action->fix_type, "anaconda") == 0) {
 			template = "urn:redhat:anaconda:pre";
+		} else if (strcmp(action->fix_type, "ignition") == 0) {
+			template = "urn:xccdf:fix:script:ignition";
 		} else {
 			fprintf(stderr,
 					"Unknown fix type '%s'.\n"
-					"Please provide one of: bash, ansible, puppet, anaconda.\n"
+					"Please provide one of: bash, ansible, puppet, anaconda, ignition.\n"
 					"Or provide a custom template using '--template' instead.\n",
 					action->fix_type);
 			return OSCAP_ERROR;

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -363,7 +363,7 @@ Result-oriented fixes are generated using result-id provided to select only the 
 Profile-oriented fixes are generated using all rules within the provided profile. If no result-id/profile are provided, (default) profile will be used to generate fixes.
 .TP
 \fB\-\-fix-type TYPE\fR
-Specify fix type. There are multiple programming languages in which the fix script can be generated. TYPE should be one of: bash, ansible, puppet, anaconda. Default is bash. This option is mutually exclusive with --template, because fix type already determines the template URN.
+Specify fix type. There are multiple programming languages in which the fix script can be generated. TYPE should be one of: bash, ansible, puppet, anaconda, ignition. Default is bash. This option is mutually exclusive with --template, because fix type already determines the template URN.
 .TP
 \fB\-\-output FILE\fR
 Write the report to this file instead of standard output.


### PR DESCRIPTION
#### Description

Given a DS has Rules `<fix>` elements with `@system=urn:xccdf:fix:script:machineconfig`, allow `oscap` to generate `machineconfig` for a Profile, or based on scan results.
Example usage:
- Profile:
  `oscap xccdf generate fix --profile hipaa --fix-type machineconfig --output machineconfig_hipaa.yml jhorozek-ssg-rhel8-ds.xml`
- When `resuts.xml` is available: 
  `oscap xccdf generate fix --result-id xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_hipaa --fix-type machineconfig --output machineconfig_hipaa.yml ../results.xml`

This is a very simple MVP implementation. It will simply take any remediation text in element 
`<xccdf:fix id="*" system="urn:xccdf:fix:script:ignition">` and concatenate them in the output.
At this moment it is not known if any kind of processing will be necessary. It will mostly depend on any extra content in the `machineconfig` remediation besides the `spec:`.

#### Obtaining testing content
To have a DS for testing:
- Take DS built from https://github.com/jhrozek/content/tree/remediation_demo;
  - replace `urn:xccdf:script:fix:bash` with `urn:xccdf:fix:script:ignition`, in rules:
    - `no_empty_passwords`
    - `no_direct_root_logins`

#### fix template
I'm not sure in which fix category a `machineconfiguration` fits in. Although it is not a script, it seems to be the best fit, like ansible.

| URI | Content of the <xccdf:fix> Element |
| ----- | ---------------------------------------------- |
| urn:xccdf:fix:commands | A list of target system commands; executed in order, the commands should bring the target system into compliance with the rule. |
| urn:xccdf:fix:urls | A list of one or more URLs. The resources identified by the URLs should be applied to bring the system into compliance with the rule. |
| urn:xccdf:fix:script:language | A script written in the given language. Executing the script should bring the target system into compliance with the rule. The following languages are pre-defined: sh – Bourne shell csh – C Shell perl – Perl batch – Windows batch script python – Python and all Python-based  scripting languages vbscript – Visual Basic Script (VBS) javascript – Javascript (ECMAScript, Jscript) tcl – Tcl and all Tcl-based scripting languages |
| urn:xccdf:fix:patch:vendor | A patch identifier, in proprietary format as defined by the vendor. The vendor string should be the DNS domain name of the vendor. For example, for Microsoft Corporation, the DNS domain is “Microsoft.com”. |

Table 17: Predefined Values for system Attribute of <xccdf:fix> Element
 
