### PR TITLE
Do not drop empty lines from Ansible remediations

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -139,11 +139,10 @@ static int _write_remediation_to_fd_and_free(int output_fd, const char* template
 					free(text);
 					return 1;
 				}
-
-				if (_write_text_to_fd(output_fd, "\n") != 0) {
-					free(text);
-					return 1;
-				}
+			}
+			if (_write_text_to_fd(output_fd, "\n") != 0) {
+				free(text);
+				return 1;
 			}
 
 			if (next_delim != NULL) {

--- a/tests/API/XCCDF/unittests/CMakeLists.txt
+++ b/tests/API/XCCDF/unittests/CMakeLists.txt
@@ -18,6 +18,7 @@ if(PYTHONINTERP_FOUND)
 	add_oscap_test("all_python.sh")
 endif()
 
+add_oscap_test("test_ansible_yaml_block_scalar.sh")
 add_oscap_test("test_xccdf_shall_pass1.sh")
 add_oscap_test("test_xccdf_shall_pass2.sh")
 add_oscap_test("test_xccdf_shall_pass3.sh")

--- a/tests/API/XCCDF/unittests/test_ansible_yaml_block_scalar.playbook.yml
+++ b/tests/API/XCCDF/unittests/test_ansible_yaml_block_scalar.playbook.yml
@@ -1,0 +1,37 @@
+---
+
+
+- hosts: all
+  vars:
+  tasks:
+    - name: Make sure contents of /etc/audit/rules.d/10-base-config.rules are as expected
+      copy:
+        dest: /etc/audit/rules.d/10-base-config.rules
+        content: |+
+          ## First rule - delete all
+          -D
+
+          ## Increase the buffers to survive stress events.
+          ## Make this bigger for busy systems
+          -b 8192
+
+          ## This determine how long to wait in burst of events
+          --backlog_wait_time 60000
+
+          ## Set failure mode to syslog
+          -f 1
+
+
+        force: true
+      when: ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
+      tags:
+        - audit_basic_configuration
+        - medium_severity
+        - restrict_strategy
+        - low_complexity
+        - low_disruption
+        - no_reboot_needed
+        - CCE-82462-3
+        - NIST-800-53-AU-2(a)
+
+

--- a/tests/API/XCCDF/unittests/test_ansible_yaml_block_scalar.sh
+++ b/tests/API/XCCDF/unittests/test_ansible_yaml_block_scalar.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+. $builddir/tests/test_common.sh
+
+set -e
+set -o pipefail
+
+profile="xccdf_moc.elpmaxe.www_profile_standard"
+
+name=$(basename $0 .sh)
+stderr=$(mktemp -t ${name}.err.XXXXXX)
+playbook=$(mktemp -t ${name}.yml.XXXXXX)
+playbook_without_header=$(mktemp -t ${name}.yml.XXXXXX)
+
+# Generate an Ansible playbook from a profile in SDS file
+$OSCAP xccdf generate fix --profile $profile --fix-type ansible "$srcdir/$name.xccdf.xml"  >$playbook 2>$stderr
+sed '/^#/d' $playbook > $playbook_without_header
+diff -u $playbook_without_header $srcdir/$name.playbook.yml
+[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
+
+rm $playbook
+rm $playbook_without_header

--- a/tests/API/XCCDF/unittests/test_ansible_yaml_block_scalar.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_ansible_yaml_block_scalar.xccdf.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+  <status>incomplete</status>
+  <title>Security Benchmark</title>
+  <description xml:lang="en-US">A sample benchmark</description>
+  <version>1.0</version>
+  <Profile id="xccdf_moc.elpmaxe.www_profile_standard">
+    <title xml:lang="en-US">Standard System Security Profile</title>
+    <description xml:lang="en-US">This profile contains rules to ensure standard security baseline of your system.</description>
+    <select idref="xccdf_moc.elpmaxe.www_rule_1" selected="true"/>
+  </Profile>
+  <Rule selected="false" id="xccdf_moc.elpmaxe.www_rule_1">
+    <title>Passing rule</title>
+    <fix id="ansible_fix_for_passing_rule" system="urn:xccdf:fix:script:ansible">- name: Make sure contents of /etc/audit/rules.d/10-base-config.rules are as expected
+  copy:
+    dest: /etc/audit/rules.d/10-base-config.rules
+    content: |+
+      ## First rule - delete all
+      -D
+
+      ## Increase the buffers to survive stress events.
+      ## Make this bigger for busy systems
+      -b 8192
+
+      ## This determine how long to wait in burst of events
+      --backlog_wait_time 60000
+
+      ## Set failure mode to syslog
+      -f 1
+
+
+    force: true
+  when: ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
+  tags:
+    - audit_basic_configuration
+    - medium_severity
+    - restrict_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed
+    - CCE-82462-3
+    - NIST-800-53-AU-2(a)
+</fix>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref href="oval/pass/oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
+    </check>
+  </Rule>
+</Benchmark>


### PR DESCRIPTION
We are removing empty lines from generated Ansible Playbook.  It looks
nice, but there is a catch.

Ansible tasks are a YAML snippets. So they contain YAML block scalars,
indicated by a pipe (|). Within these block scalars, the newlines should
be preserved.  By removing the empty lines from the scalars we are
actually changing the meaning of the scalars.

Unfortunately, OpenSCAP doesn't understand YAML, but only reads the
Ansible fix line-by-line as s string. That means it doesn't know when it
reads a block scalar. Therefore we need to stop removing the empty lines
anywhere.

This commit also adds a small test.

Resolves: RHBZ#1795563