### PR TITLE
Fixed oscap-ssh failing to retrieve the result files when executing with --sudo

### DIFF
--- a/utils/oscap-ssh
+++ b/utils/oscap-ssh
@@ -280,7 +280,12 @@ echo "Starting the evaluation..."
 # changing directory because of --oval-results support. oval results files are
 # dumped into PWD, and we can't be sure by the file names - we need controlled
 # environment
-ssh_execute_with_command_and_options "cd $REMOTE_TEMP_DIR; $OSCAP_SUDO oscap $(command_array_to_string oscap_args)" "$SSH_TTY_ALLOCATION_OPTION"
+if [ -z "$OSCAP_SUDO" ]; then
+    ssh_execute_with_command_and_options "cd $REMOTE_TEMP_DIR; oscap $(command_array_to_string oscap_args)" "$SSH_TTY_ALLOCATION_OPTION"
+else
+    OSCAP_CMD="oscap $(command_array_to_string oscap_args); rc=\$?; chown \$SUDO_USER $REMOTE_TEMP_DIR/*; exit \$rc"
+    ssh_execute_with_command_and_options "cd $REMOTE_TEMP_DIR; $OSCAP_SUDO sh -c '$OSCAP_CMD'" "$SSH_TTY_ALLOCATION_OPTION"
+fi
 OSCAP_EXIT_CODE=$?
 echo "oscap exit code: $OSCAP_EXIT_CODE"
 


### PR DESCRIPTION
Depending on the umask configuration of the target system, "sudo oscap"
may create the result files in temporary directory with 600 permissions,
which makes retrieving the log (as the regular user that ssh'ed to the
system) impossible:

~~~
$ oscap-ssh --sudo user@system 22 xccdf eval ...
[...]
oscap exit code: 0
Copying back requested files...
scp: /tmp/tmp.0kfbPWEy6u/report.html: Permission denied
Failed to copy the HTML report back to local machine!
~~~

Scenario to reproduce the failure: set a default umask in /etc/sudoers:

~~~
Defaults	umask = 0077
~~~

The fix consists in changing the result files' ownership from "root" to
user's back, all while in the single sudo (using two sudo commands
wouldn't be nice since the user may get the password prompt twice,
depending on the sudo's configuration).

See also #1481