### PR TITLE
Remove useless warnings

### DIFF
--- a/src/OVAL/probes/public/probe-api.h
+++ b/src/OVAL/probes/public/probe-api.h
@@ -488,11 +488,9 @@ OSCAP_API SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t 
 		SEXP_t *___r;					\
 								\
 		if ((___r = probe_ent_getval(ent)) == NULL) {	\
-			dW("Entity has no value!");		\
 			invalid_exp				\
 		} else {					\
 			if (!SEXP_stringp(___r)) {		\
-				dE("Invalid type");		\
 				SEXP_free(___r);		\
 				invalid_exp			\
 			}					\
@@ -511,11 +509,9 @@ OSCAP_API SEXP_t *probe_item_create(oval_subtype_t item_subtype, probe_elmatr_t 
 		SEXP_t *___r;					\
 								\
 		if ((___r = probe_ent_getval(ent)) == NULL) {	\
-			dW("Entity has no value!");		\
 			nil_exp;				\
 		} else {					\
 			if (!SEXP_numberp(___r)) {		\
-				dE("Invalid type");		\
 				SEXP_free(___r);		\
 				invalid_exp;			\
 			} else {				\


### PR DESCRIPTION
These warnings give zero value to the user, because they don't specify
what went wrong. Moreover, the severity of the message depends on the
parameters of the macro. For example, in environemntvariable58 probe the
macro is used in a way that "Entity has no value" is a valid and
expected situation, because if the pid element is set to xsi:nil the PID
should be set to the PID of the calling process.

Resolves: RHBZ#1764139