### PR TITLE
Generate HTML guide using tailoring file

### DIFF
--- a/src/XCCDF/benchmark.c
+++ b/src/XCCDF/benchmark.c
@@ -866,6 +866,19 @@ xccdf_benchmark_find_target_htable(const struct xccdf_benchmark *benchmark, xccd
 	return XITEM(benchmark)->sub.benchmark.items_dict;
 }
 
+int xccdf_benchmark_include_tailored_profiles(struct xccdf_benchmark *benchmark)
+{
+	struct oscap_list *profiles = XITEM(benchmark)->sub.benchmark.profiles;
+	struct oscap_htable_iterator *it = oscap_htable_iterator_new(XITEM(benchmark)->sub.benchmark.profiles_dict);
+	while(oscap_htable_iterator_has_more(it)) {
+		struct xccdf_profile *profile = oscap_htable_iterator_next_value(it);
+		if (xccdf_profile_get_tailoring(profile)) {
+			oscap_list_add(profiles, xccdf_profile_clone(profile));
+		}
+	}
+	oscap_htable_iterator_free(it);
+	return 0;
+}
 
 struct xccdf_plain_text *xccdf_plain_text_new(void)
 {

--- a/src/XCCDF/item.h
+++ b/src/XCCDF/item.h
@@ -437,6 +437,7 @@ void xccdf_item_dump(struct xccdf_item *item, int depth);
 struct xccdf_item* xccdf_item_get_benchmark_internal(struct xccdf_item* item);
 bool xccdf_benchmark_parse(struct xccdf_item *benchmark, xmlTextReaderPtr reader);
 void xccdf_benchmark_dump(struct xccdf_benchmark *benchmark);
+int xccdf_benchmark_include_tailored_profiles(struct xccdf_benchmark *benchmark);
 struct oscap_htable_iterator *xccdf_benchmark_get_cluster_items(struct xccdf_benchmark *benchmark, const char *cluster_id);
 bool xccdf_benchmark_register_item(struct xccdf_benchmark *benchmark, struct xccdf_item *item);
 bool xccdf_benchmark_unregister_item(struct xccdf_item *item);

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -558,6 +558,14 @@ OSCAP_API int xccdf_session_build_policy_from_testresult(struct xccdf_session *s
  */
 OSCAP_API int xccdf_session_add_report_from_source(struct xccdf_session *session, struct oscap_source *report_source);
 
+/**
+ * Generate HTML guide form a loaded XCCDF session
+ * @param session XCCDF Session
+ * @param outfile path to the output file
+ * @returns zero on success
+ */
+OSCAP_API int xccdf_session_generate_guide(struct xccdf_session *session, const char *outfile);
+
 /// @}
 /// @}
 #endif

--- a/tests/API/XCCDF/tailoring/all.sh
+++ b/tests/API/XCCDF/tailoring/all.sh
@@ -134,6 +134,21 @@ function test_api_xccdf_tailoring_profile_generate_fix {
     rm -f $tailoring_result $fix_result
 }
 
+function test_api_xccdf_tailoring_profile_generate_guide {
+    local INPUT=$srcdir/$1
+    local TAILORING=$srcdir/$2
+
+    guide=`mktemp`
+    # tailoring profile only with "always fail" rule and generate HTML guide
+    $OSCAP xccdf generate guide --tailoring-file $TAILORING --profile "xccdf_com.example.www_profile_customized" --output $guide $INPUT
+
+    grep -q "Baseline Testing Profile 1 \[CUSTOMIZED\]" $guide
+    # profile 'customized' selects first rule and deselects the second
+    grep -q "xccdf_com.example.www_rule_first" $guide
+    grep -v "xccdf_com.example.www_rule_second" $guide
+    rm -f $guide
+}
+
 # Testing.
 
 test_init "test_api_xccdf_tailoring.log"
@@ -154,6 +169,7 @@ test_run "test_api_xccdf_tailoring_autonegotiation" test_api_xccdf_tailoring_aut
 test_run "test_api_xccdf_tailoring_simple_include_in_arf" test_api_xccdf_tailoring_simple_include_in_arf simple-xccdf.xml simple-tailoring.xml
 test_run "test_api_xccdf_tailoring_profile_include_in_arf" test_api_xccdf_tailoring_profile_include_in_arf baseline.xccdf.xml baseline.tailoring.xml
 test_run "test_api_xccdf_tailoring_profile_generate_fix" test_api_xccdf_tailoring_profile_generate_fix baseline.xccdf.xml baseline.tailoring.xml
+test_run "test_api_xccdf_tailoring_profile_generate_guide" test_api_xccdf_tailoring_profile_generate_guide baseline.xccdf.xml baseline.tailoring.xml
 
 
 test_exit

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -331,7 +331,7 @@ Generate a HTML document containing a security guide from an XCCDF Benchmark. Un
 Write the guide to this file instead of standard output.
 .TP
 \fB\-\-hide-profile-info\fR
-Information on chosen profile (e.g. rules selected by the profile) will be excluded from the document.
+This option has no effect and is kept only for backward compatibility purposes.
 .TP
 \fB\-\-benchmark-id ID\fR
 Selects a component ref from any datastream that references a component with XCCDF Benchmark such that its @id attribute matches given string exactly.

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -335,6 +335,15 @@ Information on chosen profile (e.g. rules selected by the profile) will be exclu
 .TP
 \fB\-\-benchmark-id ID\fR
 Selects a component ref from any datastream that references a component with XCCDF Benchmark such that its @id attribute matches given string exactly.
+.TP
+\fB\-\-xccdf-id ID\fR
+Takes component ref with given ID from checklists. This allows to select a particular XCCDF component even in cases where there are 2 XCCDFs in one datastream. If none is given, the first component from the checklists element is used.
+.TP
+\fB\-\-tailoring-file TAILORING_FILE\fR
+Use given file for XCCDF tailoring. Select profile from tailoring file to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
+.TP
+\fB\-\-tailoring-id COMPONENT_REF_ID\fR
+Use tailoring component in input source datastream for XCCDF tailoring. The tailoring component must be specified by its Ref-ID (value of component-ref/@id attribute in input source datastream). Select profile from tailoring component to apply using --profile. If both --tailoring-file and --tailoring-id are specified, --tailoring-file takes priority.
 .RE
 .TP
 .B \fBreport\fR  [\fIoptions\fR] xccdf-file


### PR DESCRIPTION
If we use a tailoring file we can't apply XSLT directly to source
datastream file or to source XCCDF file, because we need to
resolve tailoring and add the custom profile.

The way that I propose is to load the XCCDF session first, similar
way as we do in `xccdf generate fix module`. That will resolve
resolve the tailoring automatically. Then export XCCDF benchmark
into DOM and apply XSLT on the generated tree in-memory.

The problem is that the current design doesn't add the tailoring
profiles to xccdf_benchmark profiles, but there is a separate hash
table. It would require more refactoring.

I have discovered that --hide-profile-info option doesn't do anything
because the functionality was removed 6 years ago, so I changed
documentation for it.

Resolves: RHBZ#1743835