### PR TITLE
Use the latest 5.11.3 OVAL when validating the 1.3 datastreams

### DIFF
--- a/schemas/sds/1.3/scap-source-data-stream_1.3.xsd
+++ b/schemas/sds/1.3/scap-source-data-stream_1.3.xsd
@@ -16,7 +16,7 @@
   <xs:import namespace="http://checklists.nist.gov/xccdf/1.2"
     schemaLocation="../../xccdf/1.2/xccdf_1.2.xsd"/>
   <xs:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-    schemaLocation="../../oval/5.11.2/oval-definitions-schema.xsd"/>
+    schemaLocation="../../oval/5.11.3/oval-definitions-schema.xsd"/>
   <xs:import namespace="http://cpe.mitre.org/dictionary/2.0"
     schemaLocation="../../cpe/2.3/cpe-dictionary_2.3.xsd"/>
   <xs:import namespace="http://scap.nist.gov/schema/ocil/2.0"


### PR DESCRIPTION
This PR changes how oscap validates 1.3 datastreams - now it will use the `5.11.3` development OVAL schemas further expanded by us to include the `yamlfilecontent` family.

Related to: https://github.com/OpenSCAP/openscap/pull/1482