### PR TITLE
Remove OSCAP_EVALUATION_TARGET override

### DIFF
--- a/src/XCCDF/result.c
+++ b/src/XCCDF/result.c
@@ -224,14 +224,8 @@ void xccdf_result_fill_sysinfo(struct xccdf_result *result)
 
 	_xccdf_result_clear_metadata(XITEM(result));
 
-	/* override target name by environment variable */
-	const char *target_hostname = getenv("OSCAP_EVALUATION_TARGET");
-	if (target_hostname == NULL) {
-		target_hostname = sname.nodename;
-	}
-
 	/* store target name */
-	xccdf_result_add_target(result, target_hostname);
+	xccdf_result_add_target(result, sname.nodename);
 #elif defined(OS_WINDOWS)
 	TCHAR computer_name[MAX_COMPUTERNAME_LENGTH + 1];
 	DWORD computer_name_size = MAX_COMPUTERNAME_LENGTH + 1;

--- a/utils/oscap-chroot
+++ b/utils/oscap-chroot
@@ -94,7 +94,6 @@ fi
 # Learn more at https://www.redhat.com/archives/open-scap-list/2013-July/msg00000.html
 export OSCAP_PROBE_ROOT
 OSCAP_PROBE_ROOT="$(cd "$1" && pwd)" || die "Invalid CHROOT_PATH argument."
-export OSCAP_EVALUATION_TARGET="chroot://$OSCAP_PROBE_ROOT"
 shift 1
 
 oscap "$@"

--- a/utils/oscap-podman
+++ b/utils/oscap-podman
@@ -104,7 +104,6 @@ OSCAP_CONTAINER_VARS=`podman inspect $ID --format '{{join .Config.Env "\n"}}'`
 
 export OSCAP_PROBE_ROOT
 OSCAP_PROBE_ROOT="$(cd "$DIR" && pwd)" || die "Unable to change current directory to OSCAP_PROBE_ROOT (DIR)."
-export OSCAP_EVALUATION_TARGET="$TARGET"
 shift 1
 
 $OSCAP_BINARY "$@"

--- a/utils/oscap-vm
+++ b/utils/oscap-vm
@@ -132,7 +132,6 @@ fi
 # Learn more at https://www.redhat.com/archives/open-scap-list/2013-July/msg00000.html
 export OSCAP_PROBE_ROOT
 OSCAP_PROBE_ROOT="$(cd "$MOUNTPOINT" && pwd)" || die "Unable to change current directory to OSCAP_PROBE_ROOT (MOUNTPOINT)."
-export OSCAP_EVALUATION_TARGET="oscap-vm $1 $2"
 shift 2
 
 $OSCAP_BINARY "$@"

--- a/utils/oscap_docker_python/oscap_docker_common.py
+++ b/utils/oscap_docker_python/oscap_docker_common.py
@@ -34,7 +34,6 @@ def oscap_chroot(chroot_path, oscap_binary, oscap_args, target_name, local_env=[
         Wrapper running oscap_chroot on an OscapDockerScan OscapAtomicScan object
         '''
         os.environ["OSCAP_PROBE_ROOT"] = os.path.join(chroot_path)
-        os.environ["OSCAP_EVALUATION_TARGET"] = target_name
         os.environ["OSCAP_CONTAINER_VARS"] = '\n'.join(local_env)
 
         cmd = [oscap_binary] + [x for x in oscap_args]


### PR DESCRIPTION
As the system_info probe now properly support offline mode and it is able to return correct host name of the target system, there is no need in this override.