### PR TITLE
xccdf: Introduce 'urn:xccdf:fix:script:kubernetes' fix type

### DIFF
--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -873,10 +873,12 @@ int app_generate_fix(const struct oscap_action *action)
 			template = "urn:redhat:anaconda:pre";
 		} else if (strcmp(action->fix_type, "ignition") == 0) {
 			template = "urn:xccdf:fix:script:ignition";
+		} else if (strcmp(action->fix_type, "kubernetes") == 0) {
+			template = "urn:xccdf:fix:script:kubernetes";
 		} else {
 			fprintf(stderr,
 					"Unknown fix type '%s'.\n"
-					"Please provide one of: bash, ansible, puppet, anaconda, ignition.\n"
+					"Please provide one of: bash, ansible, puppet, anaconda, ignition, kubernetes.\n"
 					"Or provide a custom template using '--template' instead.\n",
 					action->fix_type);
 			return OSCAP_ERROR;

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -372,7 +372,7 @@ Result-oriented fixes are generated using result-id provided to select only the 
 Profile-oriented fixes are generated using all rules within the provided profile. If no result-id/profile are provided, (default) profile will be used to generate fixes.
 .TP
 \fB\-\-fix-type TYPE\fR
-Specify fix type. There are multiple programming languages in which the fix script can be generated. TYPE should be one of: bash, ansible, puppet, anaconda, ignition. Default is bash. This option is mutually exclusive with --template, because fix type already determines the template URN.
+Specify fix type. There are multiple programming languages in which the fix script can be generated. TYPE should be one of: bash, ansible, puppet, anaconda, ignition, kubernetes. Default is bash. This option is mutually exclusive with --template, because fix type already determines the template URN.
 .TP
 \fB\-\-output FILE\fR
 Write the report to this file instead of standard output.


### PR DESCRIPTION
This introduces the `urn:xccdf:fix:script:kubernetes` fix type which
will get added to the `system` entry in the `xccdf:fix` element. Similar
to the `urn:xccdf:fix:script:ignition`, this is initially meant for
OpenShift, however, the intent is to make these fixes more general and
applicable to other Kubernetes distributions.

This is a superset of the `urn:xccdf:fix:script:ignition` type, so it'll
eventually replace it.