### PR TITLE
Fixes for Evaluation Characteristics

### DIFF
--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -354,6 +354,11 @@ static xmlNodePtr ds_rds_add_ai_from_xccdf_results(xmlDocPtr doc, xmlNodePtr ass
 		}
 	}
 
+	if (xmlGetLastChild(connections) == NULL) {
+		xmlUnlinkNode(connections);
+		xmlFreeNode(connections);
+	}
+
 	return asset;
 }
 

--- a/src/OVAL/probes/independent/system_info_probe.c
+++ b/src/OVAL/probes/independent/system_info_probe.c
@@ -472,25 +472,12 @@ static ssize_t __sysinfo_saneval(const char *s)
 }
 
 #ifndef OS_WINDOWS
-static FILE *_fopen_with_prefix(const char *prefix, const char *path)
-{
-	FILE *fp;
-	if (prefix != NULL) {
-		char *path_with_prefix = oscap_sprintf("%s%s", prefix, path);
-		fp = fopen(path_with_prefix, "r");
-		free(path_with_prefix);
-	} else {
-		fp = fopen(path, "r");
-	}
-	return fp;
-}
-
 static char *_get_os_release(const char *oscap_probe_root)
 {
 	char os_release_data[MAX_BUFFER_SIZE+1];
 	char *ret = NULL;
 
-	FILE *fp = _fopen_with_prefix(oscap_probe_root, "/etc/os-release");
+	FILE *fp = oscap_fopen_with_prefix(oscap_probe_root, "/etc/os-release");
 	if (fp == NULL)
 		goto fail;
 
@@ -544,7 +531,7 @@ static char *_offline_get_hname(const char *oscap_probe_root)
 	char *ret = NULL;
 	int rc;
 
-	fp = _fopen_with_prefix(oscap_probe_root, "/etc/hostname");
+	fp = oscap_fopen_with_prefix(oscap_probe_root, "/etc/hostname");
 
 	if (fp == NULL)
 		goto fail;

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -426,6 +426,21 @@ int oscap_get_substrings(char *str, int *ofs, pcre *re, int want_substrs, char *
 	return ret;
 }
 
+#ifndef OS_WINDOWS
+FILE *oscap_fopen_with_prefix(const char *prefix, const char *path)
+{
+	FILE *fp;
+	if (prefix != NULL) {
+		char *path_with_prefix = oscap_sprintf("%s%s", prefix, path);
+		fp = fopen(path_with_prefix, "r");
+		free(path_with_prefix);
+	} else {
+		fp = fopen(path, "r");
+	}
+	return fp;
+}
+#endif
+
 #ifdef OS_WINDOWS
 char *oscap_windows_wstr_to_str(const wchar_t *wstr)
 {

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -26,6 +26,7 @@
 
 #include "oscap_platforms.h"
 #include <stdlib.h>
+#include <stdio.h>
 #include <stdbool.h>
 #include <assert.h>
 #include "public/oscap.h"
@@ -480,6 +481,19 @@ char *oscap_strerror_r(int errnum, char *buf, size_t buflen);
  * negative value on failure
  */
 int oscap_get_substrings(char *str, int *ofs, pcre *re, int want_substrs, char ***substrings);
+
+
+#ifndef OS_WINDOWS
+/**
+ * Open file for reading with prefix added to its name.
+ * Caller is responsible for closing the handle.
+ * @param prefix the prefix, might be NULL or empty
+ * @param path the file name with the path
+ * @return FILE* handle of opened file
+ * NULL on failure
+ */
+FILE *oscap_fopen_with_prefix(const char *prefix, const char *path);
+#endif
 
 #ifdef OS_WINDOWS
 /**

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -82,6 +82,12 @@ Authors:
                             <xsl:value-of select="$testresult/cdf:target/text()"/>
                         </td>
                     </tr>
+                    <xsl:if test="$testresult/cdf:target-facts/cdf:fact[@name = 'urn:xccdf:fact:identifier']">
+                        <tr>
+                            <th>Target ID</th>
+                            <td><xsl:value-of select="$testresult/cdf:target-facts/cdf:fact[@name = 'urn:xccdf:fact:identifier']/text()"/></td>
+                        </tr>
+                    </xsl:if>
                     <xsl:if test="$testresult/cdf:benchmark">
                         <tr>
                             <th>Benchmark URL</th>


### PR DESCRIPTION
OSCAP_EVALUATION_TARGET is now stored in `target-facts` as `xccdf:fact:identifier` and `target` is always a hostname (with offline support).

ARF result is always valid.

Network entities are not collected in offline mode.

Identity entities are not collected in offline mode.