### PR TITLE
Use rule severity refinement

### DIFF
--- a/xsl/xccdf-guide-impl.xsl
+++ b/xsl/xccdf-guide-impl.xsl
@@ -245,6 +245,7 @@ Authors:
                         <tr><td><span class="label label-warning">Severity:</span>&#160;</td><td><div class="severity">
                             <xsl:call-template name="item-severity">
                                 <xsl:with-param name="item" select="$item" />
+                                <xsl:with-param name="profile" select="$profile"/>
                             </xsl:call-template>
                         </div></td></tr>
 

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -384,6 +384,7 @@ Authors:
         <td class="rule-severity" style="text-align: center">
             <xsl:call-template name="item-severity">
                 <xsl:with-param name="item" select="." />
+                <xsl:with-param name="profile" select="$profile" />
             </xsl:call-template>
         </td>
         <td class="rule-result rule-result-{$result}">
@@ -784,7 +785,15 @@ Authors:
                 </tr>
             </xsl:if>
             <tr><td>Time</td><td><xsl:value-of select="@time"/></td></tr>
-            <tr><td>Severity</td><td><xsl:call-template name="item-severity"><xsl:with-param name="item" select="." /></xsl:call-template></td></tr>
+            <tr>
+                <td>Severity</td>
+                <td>
+                    <xsl:call-template name="item-severity">
+                        <xsl:with-param name="item" select="." />
+                        <xsl:with-param name="profile" select="$profile" />
+                    </xsl:call-template>
+                </td>
+            </tr>
             <tr><td>Identifiers and References</td><td class="identifiers">
                 <!-- XCCDF 1.2 spec says that idents in rule-result should be copied from
                     the Rule itself. That means that we can just use the same code as guide

--- a/xsl/xccdf-share.xsl
+++ b/xsl/xccdf-share.xsl
@@ -128,7 +128,21 @@ Authors:
 <!-- works for both XCCDF Rule elements and rule-result elements -->
 <xsl:template name="item-severity">
     <xsl:param name="item"/>
-    <xsl:choose><xsl:when test="$item/@severity"><xsl:value-of select="$item/@severity"/></xsl:when><xsl:otherwise>unknown</xsl:otherwise></xsl:choose>
+    <xsl:param name="profile"/>
+    <xsl:variable name="refine-rule" select="$profile/cdf:refine-rule[@idref=$item/@id]" />
+    <xsl:choose>
+        <xsl:when test="$refine-rule/@severity">
+            <xsl:value-of select="$refine-rule/@severity"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:choose>
+                <xsl:when test="$item/@severity">
+                    <xsl:value-of select="$item/@severity"/>
+                </xsl:when>
+                <xsl:otherwise>unknown</xsl:otherwise>
+            </xsl:choose>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- substitution for testresults, used in HTML report -->


### PR DESCRIPTION
This patch will ensure that rule severity changed by refine-rule element
will be correctly displayed in HTML guide and HTML report.  Before this
patch, the refine-rule element was ignored and severity defined in the
Rule element has been shown instead.

This patch still doesn't support refine-rule from parent profile if the
given profile extends another profile. But, the whole XSLT doesn't
support extended profiles and requires fully resolved benchmark as an
input. Therefore I think it doesn't make sense to implement it only
for this particular value.

Fixes: #1512