### PR TITLE
update docker image to fedora 31

### DIFF
--- a/Dockerfiles/mitre_tests
+++ b/Dockerfiles/mitre_tests
@@ -1,4 +1,4 @@
-FROM fedora:28
+FROM fedora:31
 
 ENV OSCAP_USERNAME oscap
 ENV OSCAP_DIR openscap


### PR DESCRIPTION
update docker image to fedora 31 as current 29 is EOL as of 30th November 2019