### PR TITLE
probes/environmentvariable58: Fix regression in container variables

### DIFF
--- a/tests/probes/environmentvariable58/test_probes_environmentvariable58_offline_mode.sh
+++ b/tests/probes/environmentvariable58/test_probes_environmentvariable58_offline_mode.sh
@@ -17,6 +17,7 @@ function test_probes_environmentvariable58_offline_mode {
     [ -f $RF ] && rm -f $RF
 
     tmpdir=$(mktemp -t -d "test_offline_mode_environmentvariable58.XXXXXX")
+    mkdir -p "$tmpdir/proc/1"
 
     set_chroot_offline_test_mode "$tmpdir"
 


### PR DESCRIPTION
Force the scanner to account only for variables passed via
OSCAP_CONTAINER_VARIABLES (only if it is not empty).