### PR TITLE
Partial fix for systemdunitproperty probe

### DIFF
--- a/src/OVAL/probes/unix/linux/systemdshared.h
+++ b/src/OVAL/probes/unix/linux/systemdshared.h
@@ -312,7 +312,7 @@ static char *dbus_value_to_string(DBusMessageIter *iter)
 			if (old_ret == NULL)
 				ret = oscap_sprintf("%s", element);
 			else
-				ret = oscap_sprintf("%s, %s", old_ret, element);
+				ret = oscap_sprintf("%s ; %s", old_ret, element);
 
 			free(old_ret);
 			free(element);

--- a/src/OVAL/probes/unix/linux/systemdshared.h
+++ b/src/OVAL/probes/unix/linux/systemdshared.h
@@ -247,7 +247,7 @@ static char *dbus_value_to_string(DBusMessageIter *iter)
 				return oscap_sprintf("0x%x", value.byt);
 
 			case DBUS_TYPE_BOOLEAN:
-				return oscap_strdup(value.bool_val ? "true" : "false");
+				return oscap_strdup(value.bool_val ? "yes" : "no");
 
 			case DBUS_TYPE_INT16:
 				return oscap_sprintf("%i", value.i16);

--- a/src/OVAL/probes/unix/linux/systemdshared.h
+++ b/src/OVAL/probes/unix/linux/systemdshared.h
@@ -244,7 +244,7 @@ static char *dbus_value_to_string(DBusMessageIter *iter)
 		switch (arg_type)
 		{
 			case DBUS_TYPE_BYTE:
-				return oscap_sprintf("%c", value.byt);
+				return oscap_sprintf("0x%x", value.byt);
 
 			case DBUS_TYPE_BOOLEAN:
 				return oscap_strdup(value.bool_val ? "true" : "false");

--- a/src/OVAL/probes/unix/linux/systemdshared.h
+++ b/src/OVAL/probes/unix/linux/systemdshared.h
@@ -327,12 +327,7 @@ static char *dbus_value_to_string(DBusMessageIter *iter)
 		while (dbus_message_iter_next(&array));
 
 		return ret;
-	}/*
-	else if (arg_type == DBUS_TYPE_VARIANT) {
-		DBusMessageIter inner;
-		dbus_message_iter_recurse(iter, &inner);
-		return dbus_value_to_string(&inner);
-	}*/
+	}
 
 	return NULL;
 }

--- a/src/OVAL/probes/unix/linux/systemdshared.h
+++ b/src/OVAL/probes/unix/linux/systemdshared.h
@@ -236,6 +236,13 @@ cleanup:
 
 static char *dbus_value_to_string(DBusMessageIter *iter)
 {
+	/* Unfortunately we don't know anything about semantics of data that we
+	 * recieved from DBus. We can only use conversion that fits in most generic
+	 * cases. This is a difference from behavior of systemctl show command.
+	 * Systemd knows semantics of DBus data and in some situation it uses a
+	 * different conversion, for example converts integer values to date and
+	 * time.
+	 */
 	const int arg_type = dbus_message_iter_get_arg_type(iter);
 	if (dbus_type_is_basic(arg_type)) {
 		_DBusBasicValue value;

--- a/src/OVAL/probes/unix/linux/systemdshared.h
+++ b/src/OVAL/probes/unix/linux/systemdshared.h
@@ -277,12 +277,6 @@ static char *dbus_value_to_string(DBusMessageIter *iter)
 			case DBUS_TYPE_SIGNATURE:
 				return oscap_strdup(value.str);
 
-			// non-basic types
-			//case DBUS_TYPE_ARRAY:
-			//case DBUS_TYPE_STRUCT:
-			//case DBUS_TYPE_DICT_ENTRY:
-			//case DBUS_TYPE_VARIANT:
-
 			//case DBUS_TYPE_UNIX_FD:
 			//	return oscap_sprintf("%i", value.fd);
 
@@ -291,7 +285,19 @@ static char *dbus_value_to_string(DBusMessageIter *iter)
 				return oscap_strdup("error, unknown basic type!");
 		}
 	}
-	else if (arg_type == DBUS_TYPE_ARRAY) {
+	else if (arg_type == DBUS_TYPE_ARRAY || arg_type == DBUS_TYPE_STRUCT ||
+			arg_type == DBUS_TYPE_VARIANT || arg_type == DBUS_TYPE_DICT_ENTRY) {
+		/* OVAL specification for systemdunitproperty_item says: "The value
+		 * of the property associated with a systemd unit. Exactly one value
+		 * shall be used for all property types except dbus arrays - each
+		 * array element shall be represented by one value."
+		 * The properties that are dbus arrays are handled by the caller
+		 * (get_all_properties_by_unit_path_using_interface). Therefore this
+		 * code handles only dbus arrays that are part of a different top
+		 * level dbus type. Also it handles other dbus container types which
+		 * are not mentioned in the OVAL specification. We assume that these
+		 * types should be serialized into a single value.
+		 */
 		DBusMessageIter array;
 		dbus_message_iter_recurse(iter, &array);
 

--- a/src/OVAL/probes/unix/linux/systemdunitproperty_probe.c
+++ b/src/OVAL/probes/unix/linux/systemdunitproperty_probe.c
@@ -50,7 +50,7 @@ struct unit_callback_vars {
 
 static int collect_property(const char *property, const char *value, struct unit_callback_vars *vars);
 
-static int get_all_properties_by_unit_path(DBusConnection *conn, const char *unit_path, void *vars)
+static int get_all_properties_by_unit_path_using_interface(DBusConnection *conn, const char *unit_path, const char *interface, void *vars)
 {
 	int ret = 1;
 	DBusMessage *msg = NULL;
@@ -69,7 +69,6 @@ static int get_all_properties_by_unit_path(DBusConnection *conn, const char *uni
 
 	DBusMessageIter args, property_iter;
 
-	const char *interface = "org.freedesktop.systemd1.Unit";
 
 	dbus_message_iter_init_append(msg, &args);
 	if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &interface)) {
@@ -178,6 +177,13 @@ cleanup:
 	if (msg != NULL)
 		dbus_message_unref(msg);
 
+	return ret;
+}
+
+static int get_all_properties_by_unit_path(DBusConnection *conn, const char *unit_path, void *vars)
+{
+	const char *interface = "org.freedesktop.systemd1.Unit";
+	int ret = get_all_properties_by_unit_path_using_interface(conn, unit_path, interface, vars);
 	return ret;
 }
 


### PR DESCRIPTION
This is an attempt to fix systemdunitproperty probe. This probe produces incomplete results. Some unit properties are not collected at all. The results are inconsistent with `systemctl show <unit>` command. It is reported in https://bugzilla.redhat.com/show_bug.cgi?id=1819773. This PR somehow improves the situation, but it doesn't make the results on par with `systemctl show` output.

I have identified 4 main problems in the probe:
1. All systemd unit objects implement the generic `org.freedesktop.systemd1.Unit` interface. But, depending on the unit type they also implement one unit-type-specific interface. For example, services implement `org.freedesktop.systemd1.Unit` and `org.freedesktop.systemd1.Service` interface. More on that on https://www.freedesktop.org/wiki/Software/systemd/dbus/ where you can find all the interfaces for all systemd unit types. However, our probe queries only the `org.freedesktop.systemd1.Unit` interface, which means that properties specific only for a certain unit type are not retrieved.

2. The code that converts the received dbus messages (function `dbus_value_to_string`) doesn't account for container types and complex types, s.a. structures or nested arrays. But some unit properties that are useful are complex. For example, `ExecStart` service property has a dbus signature `a(sasbttttuii)` which means it's an array of structures where each structure contain string, array, string, boolean, 4 64-bit unsigned integers, 1 32-bit unsigned integer and 2 32-bit unsigned integers. The dbus spec https://dbus.freedesktop.org/doc/dbus-specification.html has a lot of data types. If our code can't process them it skips the property and the property doesn't appear in results.

3. Our probe gets "raw' data from dbus and populate them into OVAL items directly, without any processing, because it doesn't know anything about their meaning. That's a difference from `systemctl show` command that analyzes data from dbus and knows their meaning. In the aforementioned example of `ExecStart` service property, the `systemctl show` command when it recieves the aforementioned array of structures, it knows which member of structure means what, so it can add descriptions for the data. Then, it looks like this: `ExecStart={ path=/sbin/auditd ; argv[]=/sbin/auditd ; ignore_errors=no ; start_time=[Wed 2020-05-20 06:55:41 CEST] ; stop_time=[Wed 2020-05-20 06:55:41 CEST] ; pid=3319 ; code=exited ; status=0 }`  This is possible because systemctl has a special code for presenting values of this property nicely instead of bumping raw data from dbus. For example here: https://github.com/systemd/systemd/blob/766507972b2e8ae1616a6db39231e19e4663f873/src/systemctl/systemctl.c#L5061

4. We don't care about special values - infinity, undefined, timestamps and we collect them in raw form as they are retreived from dbus.

I tried to address ad:
1. We can easily query also the type-specific interface. I have added a code that detects the unit type and then calls `GetAll` on both Unit and type-specific interface.

2. I have extended the code in `dbus_value_to_string` to recurse into container types. I'm not sure how to transform them to `value` elements because we don't have nested structures within OVAL items. So at this moment it keeps using the original mechanism of creating a single string of comma separated items, which means flattening of the structures. Hopefully that's acceptable.

3. I haven't fixed this and I have no idea how to fix that without having specific code and hard-coded values for many properties. That would effectively be copying a lot of code from systemd and in turn terrible to maintain.

4. I have only changed the boolean values format to be consistent with systemctl. We use "true" and "false" but `systemctl` displays it as "yes" and "no". Other things are harder. For example, you have to know the meaning of the property that a property is a timestamp, because there isn't a dedicated signature for timestamps and it's all integers.

For more details please see the commit message of each commit and comments in code.

Any thoughts?