### PR TITLE
Prevent unwanted recursion in file probe

### DIFF
--- a/docs/developer/developer.adoc
+++ b/docs/developer/developer.adoc
@@ -152,7 +152,7 @@ After building the library you might want to run library self-checks. To do
 that you need to have these additional packages installed:
 
 ----
-wget lua which procps-ng initscripts chkconfig sendmail bzip2 rpm-build
+wget lua which procps-ng initscripts chkconfig sendmail bzip2 rpm-build strace
 ----
 
 On Ubuntu 18.04, also install:

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -1029,6 +1029,15 @@ static FTSENT *oval_fts_read_match_path(OVAL_FTS *ofts)
 
 		if (ores == OVAL_RESULT_TRUE)
 			break;
+		if (ofts->ofts_path_op == OVAL_OPERATION_EQUALS) {
+			/* At this point the comparison result isn't OVAL_RESULT_TRUE. Since
+			we passed the exact path (from filepath or path elements) to
+			fts_open() we surely know that we can't find other items that would
+			be equal. Therefore we can terminate the matching. This can happen
+			if the filepath or path element references a variable that has
+			multiple different values. */
+			return NULL;
+		}
 	} /* for (;;) */
 
 	/*

--- a/tests/probes/file/CMakeLists.txt
+++ b/tests/probes/file/CMakeLists.txt
@@ -1,3 +1,4 @@
 if(ENABLE_PROBES_UNIX)
 	add_oscap_test("test_probes_file.sh")
+	add_oscap_test("test_probes_file_multiple_file_paths.sh")
 endif()

--- a/tests/probes/file/test_probes_file_multiple_file_paths.sh
+++ b/tests/probes/file/test_probes_file_multiple_file_paths.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+. $builddir/tests/test_common.sh
+
+probecheck "file" || exit 255
+which strace || exit 255
+
+function check_strace_output {
+	strace_log="$1"
+	grep -q "/tmp/numbers/1" $strace_log && return 1
+	grep -q "/tmp/numbers/1/2" $strace_log && return 1
+	grep -q "/tmp/numbers/1/2/3" $strace_log && return 1
+	grep -q "/tmp/numbers/1/2/3/4" $strace_log && return 1
+	grep -q "/tmp/numbers/1/2/3/4/5" $strace_log && return 1
+	grep -q "/tmp/numbers/1/2/3/4/5/6" $strace_log && return 1
+	grep -q "/tmp/letters/a" $strace_log && return 1
+	grep -q "/tmp/letters/a/b" $strace_log && return 1
+	grep -q "/tmp/letters/a/b/c" $strace_log && return 1
+	grep -q "/tmp/letters/a/b/c/d" $strace_log && return 1
+	grep -q "/tmp/letters/a/b/c/d/e" $strace_log && return 1
+	grep -q "/tmp/letters/a/b/c/d/e/f" $strace_log && return 1
+	return 0
+}
+
+rm -rf /tmp/numbers
+mkdir -p /tmp/numbers/1/2/3/4/5/6
+rm -rf /tmp/letters
+mkdir -p /tmp/letters/a/b/c/d/e/f
+strace_log=$(mktemp)
+strace -f -e openat -o $strace_log $OSCAP oval eval --results results.xml "$srcdir/test_probes_file_multiple_file_paths.xml"
+ret=0
+check_strace_output $strace_log || ret=$?
+rm -f $strace_log
+rm -f results.xml
+rm -rf /tmp/numbers
+rm -rf /tmp/letters
+exit $ret

--- a/tests/probes/file/test_probes_file_multiple_file_paths.xml
+++ b/tests/probes/file/test_probes_file_multiple_file_paths.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<oval_definitions xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
+  <generator>
+    <oval:schema_version>5.10</oval:schema_version>
+    <oval:timestamp>0001-01-01T00:00:00+00:00</oval:timestamp>
+  </generator>
+
+  <definitions>
+    <definition class="compliance" version="1" id="oval:x:def:1">
+      <metadata>
+        <title>Specify a file path using variable with two values</title>
+        <description>x</description>
+        <affected family="unix">
+          <platform>multi_platform_all</platform>
+        </affected>
+      </metadata>
+          <criteria operator="AND">
+            <criterion comment="Check multiple paths" test_ref="oval:x:tst:1"/>
+          </criteria>
+    </definition>
+  </definitions>
+
+  <tests>
+        <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:x:tst:1" version="1" comment="Verify all paths exist" check_existence="all_exist" check="all">
+          <object object_ref="oval:x:obj:1"/>
+        </file_test>
+  </tests>
+
+  <objects>
+        <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:x:obj:1" version="1" comment="uses var_check=all together with operation=equals">
+          <path datatype="string" var_ref="oval:x:var:1" var_check="all" operation="equals"/>
+          <filename xsi:nil="true" datatype="string"/>
+        </file_object>
+  </objects>
+
+  <variables>
+        <constant_variable datatype="string" comment="2 file paths" version="1" id="oval:x:var:1">
+            <value>/tmp/numbers</value>
+            <value>/tmp/letters</value>
+        </constant_variable>
+  </variables>
+</oval_definitions>


### PR DESCRIPTION
There is a non-optimal behavior of file probe. It happens when file path
is specified using a variable with 2 values with `operation="equals"`
and `var_check="all"`. The probe recurses into a file system tree even
if it's obvious that it won't find any match. If one of values is a big
tree (for example `/`) it eventually runs out of memory and crashes. The
OVAL doesn't make sense because it's impossible that a single file would
have 2 different paths. But despite that it's a valid OVAL document.

We can fix this in oval_fts module. If the path is specified with operation "equals" we know that once we compared the given path with the OVAL object we don't have to continue examining the file system hierachy and we can decide right away.

This PR also adds a test.

Fixes: RHBZ#1686370