### PR TITLE
utils/oscap-podman: force umount and removal of temporary container

### DIFF
--- a/utils/oscap-podman
+++ b/utils/oscap-podman
@@ -110,8 +110,11 @@ shift 1
 $OSCAP_BINARY "$@"
 EXIT_CODE=$?
 
-podman umount $ID > /dev/null || die "Failed to unmount."
 if [ $CLEANUP -eq 1 ]; then
-    podman rm $ID > /dev/null || die "Failed to clean up."
+    # podman-rm should handle also unmounting of the container filesystem.
+    podman rm -f $ID > /dev/null || die "Failed to clean up."
+else
+    # If a running container is target of the scan just unmount its filesystem.
+    podman umount $ID > /dev/null || die "Failed to unmount."
 fi
 exit $EXIT_CODE


### PR DESCRIPTION
In some cases there are errors printed by `oscap-podman` script, it
reports about failure to remove certain paths related to a container
that is spawned by it. This seems as a race condition in `oscap-podman`
where the `podman-rm` is called right after the `podman-umount` - this
might cause that system is not fully finished with unmounting and we
request it to remove the container without waiting for the unmount of
its filesystem. This commit removes `podman-umount` command and adds
`-f` option to `podman-rm` which should take care about both, unmounting
and removing of the temporary container.

This issue is hard to reproduce (it mostly occurs on slower machines) and TBH I am not 100% sure if this PR fixes it in all cases.

Example of stderr output:
```
time="2020-05-19T08:10:25-04:00" level=error msg="Failed to remove paths: map[blkio:/sys/fs/cgroup/blkio/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope cpu:/sys/fs/cgroup/cpu,cpuacct/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope cpuacct:/sys/fs/cgroup/cpu,cpuacct/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope cpuset:/sys/fs/cgroup/cpuset/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope devices:/sys/fs/cgroup/devices/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope freezer:/sys/fs/cgroup/freezer/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope hugetlb:/sys/fs/cgroup/hugetlb/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope memory:/sys/fs/cgroup/memory/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope name=systemd:/sys/fs/cgroup/systemd/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope net_cls:/sys/fs/cgroup/net_cls,net_prio/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope net_prio:/sys/fs/cgroup/net_cls,net_prio/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope perf_event:/sys/fs/cgroup/perf_event/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope pids:/sys/fs/cgroup/pids/machine.slice/libpod-3ba98c6aa52c6f8b92b38b5b957b2675638c1a876c3c5bd26709d491dad51802.scope]"
```