### PR TITLE
probes/xinetd: Replace deprecated readdir_r call with readdir

### DIFF
--- a/src/OVAL/probes/unix/xinetd_probe.c
+++ b/src/OVAL/probes/unix/xinetd_probe.c
@@ -740,7 +740,7 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 				case XICONF_INCTYPE_DIR:
 				{
 					DIR           *dirfp;
-					struct dirent  dent, *dentp = NULL;
+					struct dirent *dent = NULL;
 
 					dD("includedir open: %s", inclarg);
 					dirfp = opendir (inclarg);
@@ -766,22 +766,22 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 					}
 
 					for (;;) {
-						if (readdir_r (dirfp, &dent, &dentp) != 0) {
-							dW("Can't read directory: %s; %d, %s.", inclarg, errno, strerror (errno));
+						errno = 0;
+						dent = readdir (dirfp);
+						if (dent == NULL) {
+							if (errno)
+								dW("Can't read directory: %s; %d, %s.", inclarg, errno, strerror (errno));
 							break;
 						}
 
-						if (dentp == NULL)
-							break;
-
-						if (fnmatch ("*~",  dent.d_name, FNM_PATHNAME) == 0 ||
-						    fnmatch ("*.*", dent.d_name, FNM_PATHNAME) == 0)
+						if (fnmatch ("*~",  dent->d_name, FNM_PATHNAME) == 0 ||
+						    fnmatch ("*.*", dent->d_name, FNM_PATHNAME) == 0)
 						{
-							dD("Skipping: %s", dent.d_name);
+							dD("Skipping: %s", dent->d_name);
 							continue;
 						}
 
-						strcpy(pathbuf + incllen, dent.d_name);
+						strcpy(pathbuf + incllen, dent->d_name);
 
 						if (xiconf_add_cfile (xiconf, pathbuf, xifile->depth + 1) != 0)
 							continue;


### PR DESCRIPTION
It is recommended that applications use  readdir(3)  instead  of  read‐
dir_r().   Furthermore,  since  version  2.24,  glibc  deprecates read‐
dir_r(). The reasons are as follows:

*  On systems where NAME_MAX is undefined, calling readdir_r()  may  be
   unsafe  because  the  interface does not allow the caller to specify
   the length of the buffer used for the returned directory entry.

*  On some systems, readdir_r() can't read directory entries with  very
   long  names.   When the glibc implementation encounters such a name,
   readdir_r() fails with the error ENAMETOOLONG after the final direc‐
   tory  entry  has  been read.  On some other systems, readdir_r() may
   return a success status, but the returned d_name field  may  not  be
   null terminated or may be truncated.

*  In  the  current POSIX.1 specification (POSIX.1-2008), readdir(3) is
   not required to be thread-safe.  However, in modern  implementations
   (including the glibc implementation), concurrent calls to readdir(3)
   that specify different directory streams  are  thread-safe.   There‐
   fore,  the  use  of  readdir_r()  is generally unnecessary in multi‐
   threaded programs.  In cases where multiple threads must  read  from
   the  same  directory stream, using readdir(3) with external synchro‐
   nization is still preferable to the use of readdir_r(), for the rea‐
   sons given in the points above.

*  It  is  expected  that  a  future version of POSIX.1 will make read‐
   dir_r() obsolete, and require that readdir(3)  be  thread-safe  when
   concurrently employed on different directory streams.