### PR TITLE
Make the HTML output valid

### DIFF
--- a/xsl/xccdf-branding.xsl
+++ b/xsl/xccdf-branding.xsl
@@ -29,9 +29,9 @@ logo to the HTML report / guide header.
 -->
 
 <xsl:stylesheet version="1.1"
-	xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:cdf="http://checklists.nist.gov/xccdf/1.2">
+	xmlns:cdf="http://checklists.nist.gov/xccdf/1.2"
+	exclude-result-prefixes="xsl cdf">
 
 <xsl:param name="oscap-version"/>
 

--- a/xsl/xccdf-branding.xsl
+++ b/xsl/xccdf-branding.xsl
@@ -48,7 +48,7 @@ logo to the HTML report / guide header.
 </xsl:template>
 
 <xsl:template name="xccdf-report-header">
-    <nav class="navbar navbar-default" role="navigation">
+    <nav class="navbar navbar-default">
         <div class="navbar-header" style="float: none">
             <a class="navbar-brand" href="#">
                 <xsl:call-template name="xccdf-branding-logo"/>
@@ -72,7 +72,7 @@ logo to the HTML report / guide header.
 </xsl:template>
 
 <xsl:template name="xccdf-guide-header">
-    <nav class="navbar navbar-default" role="navigation">
+    <nav class="navbar navbar-default">
         <div class="navbar-header" style="float: none">
             <a class="navbar-brand" href="#">
                 <xsl:call-template name="xccdf-branding-logo"/>

--- a/xsl/xccdf-guide-impl.xsl
+++ b/xsl/xccdf-guide-impl.xsl
@@ -27,7 +27,6 @@ Authors:
 -->
 
 <xsl:stylesheet version="1.1"
-    xmlns="http://www.w3.org/1999/xhtml"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:cdf="http://checklists.nist.gov/xccdf/1.2"
     exclude-result-prefixes="xsl cdf">

--- a/xsl/xccdf-guide-impl.xsl
+++ b/xsl/xccdf-guide-impl.xsl
@@ -209,12 +209,12 @@ Authors:
 
                         <tr><td colspan="2">
                             <xsl:if test="$item/cdf:description">
-                                <div class="description"><p>
+                                <div class="description">
                                     <xsl:apply-templates mode="sub-testresult" select="$item/cdf:description">
                                         <xsl:with-param name="benchmark" select="$item/ancestor::cdf:Benchmark"/>
                                         <xsl:with-param name="profile" select="$profile"/>
                                     </xsl:apply-templates>
-                                 </p></div>
+                                 </div>
                             </xsl:if>
 
                             <xsl:for-each select="$item/cdf:warning">
@@ -232,12 +232,10 @@ Authors:
 
                         <xsl:if test="$item/cdf:rationale">
                             <tr><td><span class="label label-primary">Rationale:</span></td><td><div class="rationale">
-                                <p>
                                     <xsl:apply-templates mode="sub-testresult" select="$item/cdf:rationale">
                                         <xsl:with-param name="benchmark" select="$item/ancestor::cdf:Benchmark"/>
                                         <xsl:with-param name="profile" select="$profile"/>
                                     </xsl:apply-templates>
-                                </p>
                             </div></td></tr>
                         </xsl:if>
 
@@ -462,7 +460,7 @@ Authors:
                 </xsl:attribute>
             </xsl:if>
 
-            <td style="padding-left: {$indent * 19}px" colspan="2">
+            <td style="padding-left: {$indent * 19}px">
                 <xsl:attribute name="id">
                     <xsl:value-of select="$item/@id"/>
                 </xsl:attribute>
@@ -492,14 +490,14 @@ Authors:
                     </xsl:attribute>
                 </xsl:if>
 
-                <td style="padding-left: {$indent * 19}px" colspan="2">
-                    <p>
+                <td style="padding-left: {$indent * 19}px">
+                    <div>
                         <a class="small" href="{concat('#', $item/@id)}">[ref]</a>&#160;&#160;
                         <xsl:apply-templates mode="sub-testresult" select="$item/cdf:description">
                             <xsl:with-param name="benchmark" select="$item/ancestor::cdf:Benchmark"/>
                             <xsl:with-param name="profile" select="$profile"/>
                         </xsl:apply-templates>
-                    </p>
+                    </div>
 
                     <xsl:for-each select="$item/cdf:warning">
                         <div class="panel panel-warning">

--- a/xsl/xccdf-guide-impl.xsl
+++ b/xsl/xccdf-guide-impl.xsl
@@ -633,7 +633,6 @@ Authors:
     <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html></xsl:text>
     <html lang="en">
     <head>
-        <meta charset="utf-8"/>
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <title>

--- a/xsl/xccdf-guide-impl.xsl
+++ b/xsl/xccdf-guide-impl.xsl
@@ -572,14 +572,14 @@ Authors:
                             </xsl:otherwise>
                         </xsl:choose>
                     </a>
+                    <xsl:if test="cdf:Group and $levels&gt;1">
+                        <xsl:call-template name="table-of-contents-items">
+                            <xsl:with-param name="item" select="."/>
+                            <xsl:with-param name="levels" select="$levels - 1"/>
+                            <xsl:with-param name="profile" select="$profile"/>
+                        </xsl:call-template>
+                    </xsl:if>
                 </li>
-                <xsl:if test="cdf:Group and $levels&gt;1">
-                    <xsl:call-template name="table-of-contents-items">
-                        <xsl:with-param name="item" select="."/>
-                        <xsl:with-param name="levels" select="$levels - 1"/>
-                        <xsl:with-param name="profile" select="$profile"/>
-                    </xsl:call-template>
-                </xsl:if>
             </xsl:if>
         </xsl:for-each>
     </ol>

--- a/xsl/xccdf-guide.xsl
+++ b/xsl/xccdf-guide.xsl
@@ -23,7 +23,6 @@ Authors:
 -->
 
 <xsl:stylesheet version="1.1"
-    xmlns="http://www.w3.org/1999/xhtml"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:cdf="http://checklists.nist.gov/xccdf/1.2"
     exclude-result-prefixes="xsl cdf">

--- a/xsl/xccdf-references.xsl
+++ b/xsl/xccdf-references.xsl
@@ -24,14 +24,13 @@ Authors:
 -->
 
 <xsl:stylesheet version="1.1"
-    xmlns="http://www.w3.org/1999/xhtml"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:cdf="http://checklists.nist.gov/xccdf/1.2"
     xmlns:ovalres="http://oval.mitre.org/XMLSchema/oval-results-5"
     xmlns:sceres="http://open-scap.org/page/SCE_result_file"
     xmlns:exsl="http://exslt.org/common"
     xmlns:arf="http://scap.nist.gov/schema/asset-reporting-format/1.1"
-    exclude-result-prefixes="xsl cdf ovalres sceres exsl">
+    exclude-result-prefixes="xsl cdf ovalres sceres exsl arf">
 
 <!-- This selects all the references, even if the SDS has multiple benchmarks.
      That is fine because we will go through just the benchmark references

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -826,24 +826,20 @@ Authors:
             </xsl:if>
             <xsl:if test="$item/cdf:description">
                 <tr><td>Description</td><td><div class="description">
-                    <p>
                         <xsl:apply-templates mode="sub-testresult" select="$item/cdf:description">
                             <xsl:with-param name="testresult" select="$testresult"/>
                             <xsl:with-param name="benchmark" select="$item/ancestor::cdf:Benchmark"/>
                             <xsl:with-param name="profile" select="$profile"/>
                         </xsl:apply-templates>
-                    </p>
                 </div></td></tr>
             </xsl:if>
             <xsl:if test="$item/cdf:rationale">
                 <tr><td>Rationale</td><td><div class="rationale">
-                    <p>
                         <xsl:apply-templates mode="sub-testresult" select="$item/cdf:rationale">
                             <xsl:with-param name="testresult" select="$testresult"/>
                             <xsl:with-param name="benchmark" select="$item/ancestor::cdf:Benchmark"/>
                             <xsl:with-param name="profile" select="$profile"/>
                         </xsl:apply-templates>
-                    </p>
                 </div></td></tr>
             </xsl:if>
             <xsl:if test="$item/cdf:warning">

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -1001,7 +1001,7 @@ Authors:
             <xsl:with-param name="item" select="$benchmark"/>
             <xsl:with-param name="profile" select="$profile"/>
         </xsl:call-template>
-        <a href="#result-details"><button type="button" class="btn btn-secondary noprint">Scroll back to the first rule</button></a>
+        <a href="#result-details" class="btn btn-info noprint">Scroll back to the first rule</a>
     </div>
 </xsl:template>
 

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -226,6 +226,7 @@ Authors:
         <xsl:variable name="passed_rules_count" select="count($testresult/cdf:rule-result[cdf:result/text() = 'pass' or cdf:result/text() = 'fixed'])"/>
         <xsl:variable name="failed_rules_count" select="count($testresult/cdf:rule-result[cdf:result/text() = 'fail'])"/>
         <xsl:variable name="uncertain_rules_count" select="count($testresult/cdf:rule-result[cdf:result/text() = 'error' or cdf:result/text() = 'unknown'])"/>
+        <xsl:variable name="not_ignored_rules_count" select="$total_rules_count - $ignored_rules_count"/>
 
         <xsl:choose>
             <xsl:when test="$failed_rules_count > 0">
@@ -251,17 +252,24 @@ Authors:
         </xsl:choose>
 
         <h3>Rule results</h3>
-        <div class="progress" title="Displays proportion of passed/fixed, failed/error, and other rules (in that order). There were {$total_rules_count - $ignored_rules_count} rules taken into account.">
-            <div class="progress-bar progress-bar-success" style="width: {$passed_rules_count div ($total_rules_count - $ignored_rules_count) * 100}%">
-                <xsl:value-of select="$passed_rules_count"/> passed
-            </div>
-            <div class="progress-bar progress-bar-danger" style="width: {$failed_rules_count div ($total_rules_count - $ignored_rules_count) * 100}%">
-                <xsl:value-of select="$failed_rules_count"/> failed
-            </div>
-            <div class="progress-bar progress-bar-warning" style="width: {(1 - ($passed_rules_count + $failed_rules_count) div ($total_rules_count - $ignored_rules_count)) * 100}%">
-                <xsl:value-of select="$total_rules_count - $ignored_rules_count - $passed_rules_count - $failed_rules_count"/> other
-            </div>
-        </div>
+        <xsl:choose>
+            <xsl:when test="$not_ignored_rules_count > 0" >
+                <div class="progress" title="Displays proportion of passed/fixed, failed/error, and other rules (in that order). There were $not_ignored_rules_count rules taken into account.">
+                    <div class="progress-bar progress-bar-success" style="width: {$passed_rules_count div $not_ignored_rules_count * 100}%">
+                        <xsl:value-of select="$passed_rules_count"/> passed
+                    </div>
+                    <div class="progress-bar progress-bar-danger" style="width: {$failed_rules_count div $not_ignored_rules_count * 100}%">
+                        <xsl:value-of select="$failed_rules_count"/> failed
+                    </div>
+                    <div class="progress-bar progress-bar-warning" style="width: {(1 - ($passed_rules_count + $failed_rules_count) div $not_ignored_rules_count) * 100}%">
+                        <xsl:value-of select="$not_ignored_rules_count - $passed_rules_count - $failed_rules_count"/> other
+                    </div>
+                </div>
+            </xsl:when>
+            <xsl:otherwise>
+                <div>No rules were evaluated.</div>
+            </xsl:otherwise>
+        </xsl:choose>
 
         <xsl:variable name="failed_rules_low_severity" select="count($testresult/cdf:rule-result[(cdf:result/text() = 'fail') and (@severity = 'low')])"/>
         <xsl:variable name="failed_rules_medium_severity" select="count($testresult/cdf:rule-result[(cdf:result/text() = 'fail') and (@severity = 'medium')])"/>
@@ -269,21 +277,23 @@ Authors:
 
         <xsl:variable name="failed_rules_other_severity" select="$failed_rules_count - $failed_rules_high_severity - $failed_rules_medium_severity - $failed_rules_low_severity"/>
 
-        <h3>Severity of failed rules</h3>
-        <div class="progress" title="Displays proportion of high, medium, low, and other severity failed rules (in that order). There were {$failed_rules_count} total failed rules.">
-            <div class="progress-bar progress-bar-success" style="width: {$failed_rules_other_severity div $failed_rules_count * 100}%">
-                <xsl:value-of select="$failed_rules_other_severity"/> other
+        <xsl:if test="$failed_rules_count > 0">
+            <h3>Severity of failed rules</h3>
+            <div class="progress" title="Displays proportion of high, medium, low, and other severity failed rules (in that order). There were {$failed_rules_count} total failed rules.">
+                <div class="progress-bar progress-bar-success" style="width: {$failed_rules_other_severity div $failed_rules_count * 100}%">
+                    <xsl:value-of select="$failed_rules_other_severity"/> other
+                </div>
+                <div class="progress-bar progress-bar-info" style="width: {$failed_rules_low_severity div $failed_rules_count * 100}%">
+                    <xsl:value-of select="$failed_rules_low_severity"/> low
+                </div>
+                <div class="progress-bar progress-bar-warning" style="width: {$failed_rules_medium_severity div $failed_rules_count * 100}%">
+                    <xsl:value-of select="$failed_rules_medium_severity"/> medium
+                </div>
+                <div class="progress-bar progress-bar-danger" style="width: {$failed_rules_high_severity div $failed_rules_count * 100}%">
+                    <xsl:value-of select="$failed_rules_high_severity"/> high
+                </div>
             </div>
-            <div class="progress-bar progress-bar-info" style="width: {$failed_rules_low_severity div $failed_rules_count * 100}%">
-                <xsl:value-of select="$failed_rules_low_severity"/> low
-            </div>
-            <div class="progress-bar progress-bar-warning" style="width: {$failed_rules_medium_severity div $failed_rules_count * 100}%">
-                <xsl:value-of select="$failed_rules_medium_severity"/> medium
-            </div>
-            <div class="progress-bar progress-bar-danger" style="width: {$failed_rules_high_severity div $failed_rules_count * 100}%">
-                <xsl:value-of select="$failed_rules_high_severity"/> high
-            </div>
-        </div>
+        </xsl:if>
 
         <h3 title="As per the XCCDF specification">Score</h3>
         <table class="table table-striped table-bordered">

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -1018,7 +1018,6 @@ Authors:
     <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html></xsl:text>
     <html lang="en">
     <head>
-        <meta charset="utf-8"/>
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <title><xsl:value-of select="$testresult/@id"/> | OpenSCAP Evaluation Report</title>

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -24,14 +24,13 @@ Authors:
 -->
 
 <xsl:stylesheet version="1.1"
-    xmlns="http://www.w3.org/1999/xhtml"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:cdf="http://checklists.nist.gov/xccdf/1.2"
     xmlns:ovalres="http://oval.mitre.org/XMLSchema/oval-results-5"
     xmlns:sceres="http://open-scap.org/page/SCE_result_file"
     xmlns:exsl="http://exslt.org/common"
     xmlns:arf="http://scap.nist.gov/schema/asset-reporting-format/1.1"
-    exclude-result-prefixes="xsl cdf ovalres sceres exsl">
+    exclude-result-prefixes="xsl cdf ovalres sceres exsl arf">
 
 <!-- This selects all the references, even if the SDS has multiple benchmarks.
      That is fine because we will go through just the benchmark references

--- a/xsl/xccdf-report-oval-details.xsl
+++ b/xsl/xccdf-report-oval-details.xsl
@@ -24,7 +24,6 @@ Authors:
 -->
 
 <xsl:stylesheet version="1.1"
-    xmlns="http://www.w3.org/1999/xhtml"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:ovalres="http://oval.mitre.org/XMLSchema/oval-results-5"
     xmlns:ovalsys="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"

--- a/xsl/xccdf-report.xsl
+++ b/xsl/xccdf-report.xsl
@@ -32,7 +32,6 @@ stylesheet only.
 -->
 
 <xsl:stylesheet version="1.1"
-    xmlns="http://www.w3.org/1999/xhtml"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:cdf="http://checklists.nist.gov/xccdf/1.2"
     xmlns:exsl="http://exslt.org/common"

--- a/xsl/xccdf-share.xsl
+++ b/xsl/xccdf-share.xsl
@@ -24,9 +24,9 @@ Authors:
 -->
 
 <xsl:stylesheet version="1.1"
-    xmlns="http://www.w3.org/1999/xhtml"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:cdf="http://checklists.nist.gov/xccdf/1.2">
+    xmlns:cdf="http://checklists.nist.gov/xccdf/1.2"
+    exclude-result-prefixes="xsl cdf">
 
 <xsl:param name="verbosity"/>
 


### PR DESCRIPTION
The HTML reports and guides were invalid. The main problem was the confusing namespace. The HTML output is HTML 5 according to doctype and according to its contents but the elements used the XHTML namespace. But, the HTML reports and guides aren't parseable as XML.

Also, there were some unpaired elements and elements that aren't allowed in the given context.

I managed to reduce the errors reported by W3C validator significantly. But, there remains error 
`CSS: Deprecated media feature max-device-width.`.

For more details, please see the commit message of each commit.

Fixes: #1540