### PR TITLE
Add tests for xccdf:platform inheritance

### DIFF
--- a/tests/API/XCCDF/applicability/all.sh
+++ b/tests/API/XCCDF/applicability/all.sh
@@ -55,6 +55,7 @@ function test_api_xccdf_embedded_cpe_eval {
 test_init "test_api_xccdf_applicability.log"
 
 test_run "Populate TestResult/platform sub element" $srcdir/test_platform_element.sh
+test_run "test platform inheritance" $srcdir/test_platform_inheritance.sh
 test_run "test_api_xccdf_applicability_cpe_applicable_rule" test_api_xccdf_cpe_eval applicable-rule-xccdf.xml cpe-dict.xml 0
 test_run "test_api_xccdf_applicability_cpe_applicable_embedded_rule" test_api_xccdf_embedded_cpe_eval applicable-rule-embedded-xccdf.xml 0
 test_run "test_api_xccdf_applicability_cpe_applicable_benchmark" test_api_xccdf_cpe_eval applicable-benchmark-xccdf.xml cpe-dict.xml 0

--- a/tests/API/XCCDF/applicability/test_platform_inheritance.cpe.xml
+++ b/tests/API/XCCDF/applicability/test_platform_inheritance.cpe.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <cpe-item name="cpe:/a:true">
+            <title xml:lang="en-us">True on any platform</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="test_platform_inheritance.oval.xml">oval:true:def:1</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:false">
+            <title xml:lang="en-us">False on any platform</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="test_platform_inheritance.oval.xml">oval:false:def:1</check>
+      </cpe-item>
+</cpe-list>
+

--- a/tests/API/XCCDF/applicability/test_platform_inheritance.oval.xml
+++ b/tests/API/XCCDF/applicability/test_platform_inheritance.oval.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<oval_definitions
+    xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
+    xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+    xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
+    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <generator>
+            <oval:product_name>vim</oval:product_name>
+            <oval:schema_version>5.10.1</oval:schema_version>
+            <oval:timestamp>2020-06-24T00:00:00+01:00</oval:timestamp>
+      </generator>
+      <definitions>
+            <definition class="inventory" id="oval:true:def:1" version="1">
+                  <metadata>
+                        <title>Always succeed</title>
+                        <reference ref_id="cpe:/a:true" source="CPE"/>
+                        <description>Should pass on every platform</description>
+                  </metadata>
+                  <criteria>
+                        <criterion comment="x" test_ref="oval:x:tst:1"/>
+                  </criteria>
+            </definition>
+            <definition class="inventory" id="oval:false:def:1" version="1">
+                  <metadata>
+                        <title>Always fail</title>
+                        <reference ref_id="cpe:/a:true" source="CPE"/>
+                        <description>Should fail on every platform</description>
+                  </metadata>
+                  <criteria>
+                        <criterion comment="x" negate="true" test_ref="oval:x:tst:1"/>
+                  </criteria>
+            </definition>
+            <definition class="compliance" id="oval:rule:def:1" version="1">
+                  <metadata>
+                        <title>Always true rule check</title>
+                        <reference ref_id="oval:x:tst:1" source="elpmaxe"/>
+                        <description>Should pass on every platform</description>
+                  </metadata>
+                  <criteria>
+                        <criterion comment="x" test_ref="oval:x:tst:1"/>
+                  </criteria>
+            </definition>
+      </definitions>
+    <tests>
+      <ind-def:variable_test id="oval:x:tst:1" version="1" check="all" comment=".">
+        <ind-def:object object_ref="oval:x:obj:1"/>
+        <ind-def:state state_ref="oval:x:ste:1"/>
+      </ind-def:variable_test>
+    </tests>
+    <objects>
+      <ind-def:variable_object id="oval:x:obj:1" version="1">
+        <ind-def:var_ref>oval:x:var:1</ind-def:var_ref>
+      </ind-def:variable_object>
+    </objects>
+    <states>
+      <ind-def:variable_state id="oval:x:ste:1" version="1">
+        <ind-def:value operation="greater than" datatype="float">1.0</ind-def:value>
+      </ind-def:variable_state>
+    </states>
+    <variables>
+      <constant_variable id="oval:x:var:1" version="1" datatype="float" comment=".">
+        <value>4.0</value>
+      </constant_variable>
+    </variables>
+</oval_definitions>

--- a/tests/API/XCCDF/applicability/test_platform_inheritance.sh
+++ b/tests/API/XCCDF/applicability/test_platform_inheritance.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+name=$(basename $0 .sh)
+stderr=$(mktemp -t ${name}.out.XXXXXX)
+tmpdir=$(mktemp -d -t ${name}.out.XXXXXX)
+result=$(mktemp -p $tmpdir ${name}.out.XXXXXX)
+cpe=$srcdir/${name}.cpe.xml
+echo "Stderr file = $stderr"
+echo "Result file = $result"
+
+$OSCAP xccdf eval --cpe $cpe --results $result $srcdir/${name}.xccdf.xml 2> $stderr
+[ "$?" == "0" ]
+[ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+assert_exists 1 '//TestResult'
+assert_exists 1 '//TestResult/rule-result[@idref="xccdf_moc.elpmaxe.www_rule_gtrue_rtrue"]/result[text()="pass"]'
+assert_exists 1 '//TestResult/rule-result[@idref="xccdf_moc.elpmaxe.www_rule_gtrue_rfalse"]/result[text()="notapplicable"]'
+assert_exists 1 '//TestResult/rule-result[@idref="xccdf_moc.elpmaxe.www_rule_gtrue_rnone"]/result[text()="pass"]'
+
+assert_exists 1 '//TestResult/rule-result[@idref="xccdf_moc.elpmaxe.www_rule_gfalse_rtrue"]/result[text()="notapplicable"]'
+assert_exists 1 '//TestResult/rule-result[@idref="xccdf_moc.elpmaxe.www_rule_gfalse_rfalse"]/result[text()="notapplicable"]'
+assert_exists 1 '//TestResult/rule-result[@idref="xccdf_moc.elpmaxe.www_rule_gfalse_rnone"]/result[text()="notapplicable"]'
+
+rm $result

--- a/tests/API/XCCDF/applicability/test_platform_inheritance.xccdf.xml
+++ b/tests/API/XCCDF/applicability/test_platform_inheritance.xccdf.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_moc.elpmaxe.www_benchmark_test" resolved="1">
+  <status>accepted</status>
+  <version>1.0</version>
+  <model system="urn:xccdf:scoring:default"/>
+
+  <Group id="xccdf_moc.eplmaxe.www_group_true">
+    <title>Applicable group</title>
+    <description>This group is applicable</description>
+    <platform idref="cpe:/a:true"/>
+    <Rule id="xccdf_moc.elpmaxe.www_rule_gtrue_rtrue" selected="true">
+      <title>This rule is applicable</title>
+      <platform idref="cpe:/a:true"/>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:rule:def:1" href="test_platform_inheritance.oval.xml"/>
+      </check>
+    </Rule>
+    <Rule id="xccdf_moc.elpmaxe.www_rule_gtrue_rfalse" selected="true">
+      <title>This rule is not applicable</title>
+      <platform idref="cpe:/a:false"/>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:rule:def:1" href="test_platform_inheritance.oval.xml"/>
+      </check>
+    </Rule>
+    <Rule id="xccdf_moc.elpmaxe.www_rule_gtrue_rnone" selected="true">
+      <title>This rule inherits from group</title>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:rule:def:1" href="test_platform_inheritance.oval.xml"/>
+      </check>
+    </Rule>
+  </Group>
+
+  <Group id="xccdf_moc.eplmaxe.www_group_false">
+    <title>Not applicable group</title>
+    <description>This group is not applicable</description>
+    <platform idref="cpe:/a:false"/>
+    <Rule id="xccdf_moc.elpmaxe.www_rule_gfalse_rtrue" selected="true">
+      <title>This rule is applicable</title>
+      <platform idref="cpe:/a:true"/>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:rule:def:1" href="test_platform_inheritance.oval.xml"/>
+      </check>
+    </Rule>
+    <Rule id="xccdf_moc.elpmaxe.www_rule_gfalse_rfalse" selected="true">
+      <title>This rule is not applicable</title>
+      <platform idref="cpe:/a:false"/>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:rule:def:1" href="test_platform_inheritance.oval.xml"/>
+      </check>
+    </Rule>
+    <Rule id="xccdf_moc.elpmaxe.www_rule_gfalse_rnone" selected="true">
+      <title>This rule inherits from group</title>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:rule:def:1" href="test_platform_inheritance.oval.xml"/>
+      </check>
+    </Rule>
+  </Group>
+
+</Benchmark>


### PR DESCRIPTION
This test aims to check scanner behavior of inherited `xccdf:platform` elements.