### PR TITLE
Fix test for password probe

### DIFF
--- a/tests/probes/password/test_probes_password.xml.sh
+++ b/tests/probes/password/test_probes_password.xml.sh
@@ -32,7 +32,7 @@ function getField {
 	    echo $LINE | awk -F':' '{print $4}'
 	    ;;
 	'gcos' )
-	    echo $LINE | awk -F':' '{print $5}'
+	    echo $LINE | awk -F':' '{gsub(/&/,"&amp;",$5); print $5}'
 	    ;;
 	'home_dir' )
 	    echo $LINE | awk -F':' '{print $6}'


### PR DESCRIPTION
The `_apt:x:977:972:APT account for owning persistent & cache data:/var/lib/apt:/sbin/nologin`
entry in the /etc/passwd file generates an error:

```
145: Entity: line 863: parser error : xmlParseEntityRef: no name
145:       <gcos>APT account for owning persistent & cache data</gcos>
```