### PR TITLE
Refactoring rpmverifyfile probe and fix memory leaks

### DIFF
--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -94,6 +94,8 @@ struct rpmverify_res {
 
 #define RPMVERIFY_UNLOCK RPM_MUTEX_UNLOCK(&g_rpm->mutex)
 
+static int rpmverify_additem(probe_ctx *ctx, struct rpmverify_res *res);
+
 /* modify passed-in iterator to test also given entity */
 static int adjust_filter(rpmdbMatchIterator iterator, SEXP_t *ent, rpmTag rpm_tag) {
 	oval_operation_t ent_op;
@@ -127,7 +129,6 @@ static int rpmverify_collect(probe_ctx *ctx,
 			     const char *file, oval_operation_t file_op,
 			     SEXP_t *name_ent, SEXP_t *epoch_ent, SEXP_t *version_ent, SEXP_t *release_ent, SEXP_t *arch_ent,
 			     uint64_t flags,
-		int (*callback)(probe_ctx *, struct rpmverify_res *),
 		struct rpm_probe_global *g_rpm)
 {
 	rpmdbMatchIterator match;
@@ -304,7 +305,7 @@ static int rpmverify_collect(probe_ctx *ctx,
 			if (rpmVerifyFile(g_rpm->rpmts, fi, &res.vflags, omit) != 0)
 		      res.vflags = RPMVERIFY_FAILURES;
 
-		    if (callback(ctx, &res) != 0) {
+		    if (rpmverify_additem(ctx, &res) != 0) {
 			    ret = 0;
 					free(res.name);
 					free(res.epoch);
@@ -556,7 +557,7 @@ int rpmverifyfile_probe_main(probe_ctx *ctx, void *arg)
 			      file, file_op,
 			      name_ent, epoch_ent, version_ent, release_ent, arch_ent,
 			      collect_flags,
-			rpmverify_additem, g_rpm) != 0)
+			g_rpm) != 0)
 	{
 		dE("An error ocured while collecting rpmverifyfile data");
 		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_ERROR);

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -274,22 +274,20 @@ static int rpmverify_collect(probe_ctx *ctx,
 					}
 					ret = pcre_exec(re, NULL, current_file, strlen(current_file), 0, 0, NULL, 0);
 					pcre_free(re);
-
-		      switch(ret) {
-		      case 0: /* match */
+					if (ret == 0) {
+						/* match */
 						res.file = oscap_strdup(current_file);
-			break;
-		      case -1:
-			/* mismatch */
+					} else if (ret == -1) {
+						/* no match */
 						free(current_file_realpath);
-			continue;
-		      default:
-			dE("pcre_exec() failed!");
-			ret = -1;
+						continue;
+					} else {
+						dE("pcre_exec() failed!");
+						ret = -1;
 						free(current_file_realpath);
-			goto ret;
-		      }
-		      break;
+						goto ret;
+					}
+					break;
 		    default:
 		      /* unsupported operation */
 		      dE("Operation \"%d\" on `filepath' not supported", file_op);

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -242,8 +242,7 @@ static int rpmverify_collect(probe_ctx *ctx,
 				char *file_realpath = oscap_realpath(file, NULL);
 				char *current_file_realpath = oscap_realpath(current_file, NULL);
 
-		    switch(file_op) {
-		    case OVAL_OPERATION_EQUALS:
+				if (file_op == OVAL_OPERATION_EQUALS) {
 					if (strcmp(current_file, file) != 0 &&
 							current_file_realpath && file_realpath &&
 							strcmp(current_file_realpath, file_realpath) != 0) {
@@ -252,8 +251,7 @@ static int rpmverify_collect(probe_ctx *ctx,
 						continue;
 					}
 					res.file = oscap_strdup(file);
-		      break;
-		    case OVAL_OPERATION_NOT_EQUAL:
+				} else if (file_op == OVAL_OPERATION_NOT_EQUAL) {
 					if (strcmp(current_file, file) == 0 ||
 							(current_file_realpath && file_realpath &&
 							strcmp(current_file_realpath, file_realpath) == 0)) {
@@ -262,8 +260,7 @@ static int rpmverify_collect(probe_ctx *ctx,
 						continue;
 					}
 					res.file = current_file_realpath ? oscap_strdup(current_file_realpath) : oscap_strdup(current_file);
-		      break;
-		    case OVAL_OPERATION_PATTERN_MATCH:
+				} else if (file_op == OVAL_OPERATION_PATTERN_MATCH) {
 					re = pcre_compile(file, PCRE_UTF8, &errmsg,  &erroff, NULL);
 					if (re == NULL) {
 						dE("pcre_compile pattern='%s': %s", file, errmsg);
@@ -289,15 +286,14 @@ static int rpmverify_collect(probe_ctx *ctx,
 						free(current_file_realpath);
 						goto ret;
 					}
-					break;
-		    default:
+				} else {
 		      /* unsupported operation */
 		      dE("Operation \"%d\" on `filepath' not supported", file_op);
 		      ret = -1;
 						free(file_realpath);
 						free(current_file_realpath);
 		      goto ret;
-		    }
+				}
 				free(file_realpath);
 				free(current_file_realpath);
 

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -316,10 +316,8 @@ static int rpmverify_collect(probe_ctx *ctx,
 			oscap_streq(res.epoch, "(none)") ? "0" : res.epoch,
 			res.version, res.release, res.arch);
 
-		if (rpmverify_collect_package_files_or_directories(g_rpm, ctx, pkgh, file, file_op, RPMTAG_BASENAMES, &res, flags) != 0) {
-			ret = -1;
-		}
-		if (rpmverify_collect_package_files_or_directories(g_rpm, ctx, pkgh, file, file_op, RPMTAG_DIRNAMES, &res, flags) != 0) {
+		if (rpmverify_collect_package_files_or_directories(g_rpm, ctx, pkgh, file, file_op, RPMTAG_BASENAMES, &res, flags) != 0 ||
+				rpmverify_collect_package_files_or_directories(g_rpm, ctx, pkgh, file, file_op, RPMTAG_DIRNAMES, &res, flags) != 0) {
 			ret = -1;
 		}
 

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -333,9 +333,9 @@ static int rpmverify_collect(probe_ctx *ctx,
 		}
 	}
 
-	match = rpmdbFreeIterator (match);
 	ret   = 0;
 ret:
+	match = rpmdbFreeIterator(match);
 	RPMVERIFY_UNLOCK;
 	return (ret);
 }

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -61,10 +61,10 @@
 
 struct rpmverify_res {
 	char *name;  /**< package name */
-	const char *epoch;
-	const char *version;
-	const char *release;
-	const char *arch;
+	char *epoch;
+	char *version;
+	char *release;
+	char *arch;
 	char *file;  /**< filepath */
 	char extended_name[1024];
 	rpmVerifyAttrs vflags; /**< rpm verify flags */
@@ -272,14 +272,14 @@ static int rpmverify_collect(probe_ctx *ctx,
 						free(current_file_realpath);
 						continue;
 					}
-					res.file = current_file_realpath ? current_file_realpath : strdup(current_file);
+					res.file = current_file_realpath ? oscap_strdup(current_file_realpath) : oscap_strdup(current_file);
 		      break;
 		    case OVAL_OPERATION_PATTERN_MATCH:
 					ret = pcre_exec(re, NULL, current_file, strlen(current_file), 0, 0, NULL, 0);
 
 		      switch(ret) {
 		      case 0: /* match */
-						res.file = strdup(current_file);
+						res.file = oscap_strdup(current_file);
 			break;
 		      case -1:
 			/* mismatch */
@@ -299,12 +299,18 @@ static int rpmverify_collect(probe_ctx *ctx,
 						free(current_file_realpath);
 		      goto ret;
 		    }
+		    free(current_file_realpath);
 
 			if (rpmVerifyFile(g_rpm->rpmts, fi, &res.vflags, omit) != 0)
 		      res.vflags = RPMVERIFY_FAILURES;
 
 		    if (callback(ctx, &res) != 0) {
 			    ret = 0;
+					free(res.name);
+					free(res.epoch);
+					free(res.version);
+					free(res.release);
+					free(res.arch);
 					free(res.file);
 			    goto ret;
 		    }
@@ -313,6 +319,12 @@ static int rpmverify_collect(probe_ctx *ctx,
 
 		  rpmfiFree(fi);
 		}
+
+		free(res.name);
+		free(res.epoch);
+		free(res.version);
+		free(res.release);
+		free(res.arch);
 	}
 
 	match = rpmdbFreeIterator (match);

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -293,11 +293,6 @@ static int rpmverify_collect(probe_ctx *ctx,
 		struct rpmverify_res res;
 		errmsg_t rpmerr;
 
-		/*
-+SEXP_t *probe_ent_from_cstr(const char *name, oval_datatype_t type,
-+                            const char *value, size_t vallen)
-		 */
-
 #define COMPARE_ENT(XXX) \
 		if (XXX ## _ent != NULL) { \
 			ent = probe_entval_from_cstr( \

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -190,6 +190,53 @@ cleanup:
 	return ret;
 }
 
+static int inspect_package_files_and_directories(
+		struct rpm_probe_global *g_rpm, probe_ctx *ctx, Header pkgh,
+		const char *file, oval_operation_t file_op,
+		struct rpmverify_res *res, uint64_t flags)
+{
+	int ret = 0;
+	rpmTag tag[2] = {RPMTAG_BASENAMES, RPMTAG_DIRNAMES};
+	rpmVerifyAttrs omit = (rpmVerifyAttrs)(flags & RPMVERIFY_RPMATTRMASK);
+	for (int i = 0; i < 2; ++i) {
+		rpmfi fi = rpmfiNew(g_rpm->rpmts, pkgh, tag[i], 1);
+
+		while (rpmfiNext(fi) != -1) {
+			const char *current_file = rpmfiFN(fi);
+			res->fflags = rpmfiFFlags(fi);
+			res->oflags = omit;
+
+			if (((res->fflags & RPMFILE_CONFIG) && (flags & RPMVERIFY_SKIP_CONFIG)) ||
+					((res->fflags & RPMFILE_GHOST)  && (flags & RPMVERIFY_SKIP_GHOST))) {
+					continue;
+				}
+				int cmp_res = _compare_file_with_current_file(file_op, file, current_file, &res->file);
+				if (cmp_res == 1) {
+					/* no match */
+					continue;
+				}
+				if (cmp_res == -1) {
+					ret = -1;
+					goto cleanup;
+				}
+
+			if (rpmVerifyFile(g_rpm->rpmts, fi, &res->vflags, omit) != 0)
+				res->vflags = RPMVERIFY_FAILURES;
+
+			if (rpmverify_additem(ctx, res) != 0) {
+				ret = -1;
+				free(res->file);
+				goto cleanup;
+			}
+			free(res->file);
+		}
+		rpmfiFree(fi);
+	}
+
+cleanup:
+	return ret;
+}
+
 static int rpmverify_collect(probe_ctx *ctx,
 			     const char *file, oval_operation_t file_op,
 			     SEXP_t *name_ent, SEXP_t *epoch_ent, SEXP_t *version_ent, SEXP_t *release_ent, SEXP_t *arch_ent,
@@ -281,50 +328,10 @@ static int rpmverify_collect(probe_ctx *ctx,
 			oscap_streq(res.epoch, "(none)") ? "0" : res.epoch,
 			res.version, res.release, res.arch);
 
-		/*
-		 * Inspect package files & directories
-		 */
-		rpmTag tag[2] = { RPMTAG_BASENAMES, RPMTAG_DIRNAMES };
-		rpmVerifyAttrs omit = (rpmVerifyAttrs)(flags & RPMVERIFY_RPMATTRMASK);
-		for (int i = 0; i < 2; ++i) {
-			rpmfi fi = rpmfiNew(g_rpm->rpmts, pkgh, tag[i], 1);
 
-		  while (rpmfiNext(fi) != -1) {
-				const char *current_file = rpmfiFN(fi);
-		    res.fflags = rpmfiFFlags(fi);
-		    res.oflags = omit;
-
-		    if (((res.fflags & RPMFILE_CONFIG) && (flags & RPMVERIFY_SKIP_CONFIG)) ||
-					((res.fflags & RPMFILE_GHOST)  && (flags & RPMVERIFY_SKIP_GHOST))) {
-					continue;
-				}
-				int cmp_res = _compare_file_with_current_file(file_op, file, current_file, &res.file);
-				if (cmp_res == 1) {
-					/* no match */
-					continue;
-				}
-				if (cmp_res == -1) {
-					ret = -1;
-					goto ret;
-				}
-
-			if (rpmVerifyFile(g_rpm->rpmts, fi, &res.vflags, omit) != 0)
-		      res.vflags = RPMVERIFY_FAILURES;
-
-		    if (rpmverify_additem(ctx, &res) != 0) {
-			    ret = 0;
-					free(res.name);
-					free(res.epoch);
-					free(res.version);
-					free(res.release);
-					free(res.arch);
-					free(res.file);
-			    goto ret;
-		    }
-			free(res.file);
-		  }
-
-		  rpmfiFree(fi);
+		if (inspect_package_files_and_directories(g_rpm, ctx, pkgh, file, file_op, &res, flags) != 0) {
+			ret = -1;
+			goto ret;
 		}
 
 		free(res.name);

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -283,11 +283,6 @@ static int rpmverify_collect(probe_ctx *ctx,
 		goto ret;
 	}
 
-	if (RPMTAG_BASENAMES == 0 || RPMTAG_DIRNAMES == 0) {
-		return -1;
-	}
-
-
 	while ((pkgh = rpmdbNextIterator (match)) != NULL) {
 		SEXP_t *ent;
 		struct rpmverify_res res;

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -197,7 +197,6 @@ static int rpmverify_collect(probe_ctx *ctx,
 		struct rpm_probe_global *g_rpm)
 {
 	rpmdbMatchIterator match;
-	rpmVerifyAttrs omit = (rpmVerifyAttrs)(flags & RPMVERIFY_RPMATTRMASK);
 	Header pkgh;
 	int  ret = -1;
 
@@ -246,12 +245,8 @@ static int rpmverify_collect(probe_ctx *ctx,
 
 	while ((pkgh = rpmdbNextIterator (match)) != NULL) {
 		SEXP_t *ent;
-		rpmfi  fi;
-		rpmTag tag[2] = { RPMTAG_BASENAMES, RPMTAG_DIRNAMES };
 		struct rpmverify_res res;
 		errmsg_t rpmerr;
-		int i;
-		const char *current_file;
 
 		/*
 +SEXP_t *probe_ent_from_cstr(const char *name, oval_datatype_t type,
@@ -289,11 +284,13 @@ static int rpmverify_collect(probe_ctx *ctx,
 		/*
 		 * Inspect package files & directories
 		 */
-		for (i = 0; i < 2; ++i) {
-			fi = rpmfiNew(g_rpm->rpmts, pkgh, tag[i], 1);
+		rpmTag tag[2] = { RPMTAG_BASENAMES, RPMTAG_DIRNAMES };
+		rpmVerifyAttrs omit = (rpmVerifyAttrs)(flags & RPMVERIFY_RPMATTRMASK);
+		for (int i = 0; i < 2; ++i) {
+			rpmfi fi = rpmfiNew(g_rpm->rpmts, pkgh, tag[i], 1);
 
 		  while (rpmfiNext(fi) != -1) {
-				current_file = rpmfiFN(fi);
+				const char *current_file = rpmfiFN(fi);
 		    res.fflags = rpmfiFFlags(fi);
 		    res.oflags = omit;
 

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -189,7 +189,6 @@ static int rpmverify_collect(probe_ctx *ctx,
 		errmsg_t rpmerr;
 		int i;
 		const char *current_file;
-		char *current_file_realpath;
 
 		/*
 +SEXP_t *probe_ent_from_cstr(const char *name, oval_datatype_t type,
@@ -232,18 +231,17 @@ static int rpmverify_collect(probe_ctx *ctx,
 
 		  while (rpmfiNext(fi) != -1) {
 				current_file = rpmfiFN(fi);
-				current_file_realpath = oscap_realpath(current_file, NULL);
 		    res.fflags = rpmfiFFlags(fi);
 		    res.oflags = omit;
 
 		    if (((res.fflags & RPMFILE_CONFIG) && (flags & RPMVERIFY_SKIP_CONFIG)) ||
 					((res.fflags & RPMFILE_GHOST)  && (flags & RPMVERIFY_SKIP_GHOST))) {
-					free(current_file_realpath);
 					continue;
 				}
 				pcre *re = NULL;
 				const char *errmsg;
 				int erroff;
+				char *current_file_realpath = oscap_realpath(current_file, NULL);
 
 		    switch(file_op) {
 		    case OVAL_OPERATION_EQUALS:


### PR DESCRIPTION
This aims to refactor rpmverifyfile probe to reduce complexity and fix some memory leaks.

I admit this is harder to review. It should be easier to review if you check each commit separately and read commit messages of every commit. Also, check the newly introduced functions.

The memory leaks can be checked eg. by running `build/run valgrind --leak-check=full build/utils/oscap oval eval tests/probes/rpm/rpmverifyfile/test_probes_rpmverifyfile.xml`

The biggest leak that was addressed is:

```
==495238==    at 0x483A809: malloc (vg_replace_malloc.c:307)           
==495238==    by 0x51F1386: realpath@@GLIBC_2.3 (in /usr/lib64/libc-2.31.so)
==495238==    by 0x489F8CA: oscap_realpath (util.c:251)                                        
==495238==    by 0x495E6EF: rpmverify_collect (rpmverifyfile_probe.c:248)                      
==495238==    by 0x495F461: rpmverifyfile_probe_main (rpmverifyfile_probe.c:543)               
==495238==    by 0x4935598: probe_worker (worker.c:1090)                                       
==495238==    by 0x4932F10: probe_worker_runfn (worker.c:81)                                                                                                                                  
==495238==    by 0x4CDA431: start_thread (in /usr/lib64/libpthread-2.31.so)
==495238==    by 0x52A8912: clone (in /usr/lib64/libc-2.31.so) 
```

There were also multiple smaller leaks caused by not freeing memory returned by headerFormat:

```
==495238== 5 bytes in 1 blocks are definitely lost in loss record 2 of 297                                                                                                                    
==495238==    at 0x483CCE8: realloc (vg_replace_malloc.c:834)                                                                                                                                 
==495238==    by 0x4D9DCD8: rrealloc (in /usr/lib64/librpmio.so.9.0.1)                                                                                                                        
==495238==    by 0x4D25B88: headerFormat (in /usr/lib64/librpm.so.9.0.1)                                                                                                                      
==495238==    by 0x495E467: rpmverify_collect (rpmverifyfile_probe.c:230)                                                                                                                     
==495238==    by 0x495F461: rpmverifyfile_probe_main (rpmverifyfile_probe.c:543)                                                                                                              
==495238==    by 0x4935598: probe_worker (worker.c:1090)                                                                                                                                      
==495238==    by 0x4932F10: probe_worker_runfn (worker.c:81)                                                                                                                                  
==495238==    by 0x4CDA431: start_thread (in /usr/lib64/libpthread-2.31.so)                                                                                                                   
==495238==    by 0x52A8912: clone (in /usr/lib64/libc-2.31.so)                                                                                                                                
==495238==                                                                                                                                                                                    
==495238== 7 bytes in 1 blocks are definitely lost in loss record 6 of 297                                                                                                                    
==495238==    at 0x483CCE8: realloc (vg_replace_malloc.c:834)                                                                                                                                 
==495238==    by 0x4D9DCD8: rrealloc (in /usr/lib64/librpmio.so.9.0.1)                                                                                                                        
==495238==    by 0x4D25B88: headerFormat (in /usr/lib64/librpm.so.9.0.1)                                                                                                                      
==495238==    by 0x495E3C4: rpmverify_collect (rpmverifyfile_probe.c:227)                                                                                                                     
==495238==    by 0x495F461: rpmverifyfile_probe_main (rpmverifyfile_probe.c:543)                                                                                                              
==495238==    by 0x4935598: probe_worker (worker.c:1090)                                                                                                                                      
==495238==    by 0x4932F10: probe_worker_runfn (worker.c:81)                                                                                                                                  
==495238==    by 0x4CDA431: start_thread (in /usr/lib64/libpthread-2.31.so)                    
==495238==    by 0x52A8912: clone (in /usr/lib64/libc-2.31.so)                                                                                                                                
==495238==                                                                                     
==495238== 7 bytes in 1 blocks are definitely lost in loss record 7 of 297
==495238==    at 0x483CCE8: realloc (vg_replace_malloc.c:834)                                  
==495238==    by 0x4D9DCD8: rrealloc (in /usr/lib64/librpmio.so.9.0.1)                         
==495238==    by 0x4D25B88: headerFormat (in /usr/lib64/librpm.so.9.0.1)                       
==495238==    by 0x495E59E: rpmverify_collect (rpmverifyfile_probe.c:234)                      
==495238==    by 0x495F461: rpmverifyfile_probe_main (rpmverifyfile_probe.c:543)                                                                                                              
==495238==    by 0x4935598: probe_worker (worker.c:1090)                 
==495238==    by 0x4932F10: probe_worker_runfn (worker.c:81)                                   
==495238==    by 0x4CDA431: start_thread (in /usr/lib64/libpthread-2.31.so)                    
==495238==    by 0x52A8912: clone (in /usr/lib64/libc-2.31.so)                                                                                                                                
==495238==                                                                                                                                                                                    
==495238== 9 bytes in 1 blocks are definitely lost in loss record 23 of 297                    
==495238==    at 0x483CCE8: realloc (vg_replace_malloc.c:834)                    
==495238==    by 0x4D9DCD8: rrealloc (in /usr/lib64/librpmio.so.9.0.1) 
==495238==    by 0x4D25B88: headerFormat (in /usr/lib64/librpm.so.9.0.1)        
==495238==    by 0x495E50A: rpmverify_collect (rpmverifyfile_probe.c:232)                      
==495238==    by 0x495F461: rpmverifyfile_probe_main (rpmverifyfile_probe.c:543)               
==495238==    by 0x4935598: probe_worker (worker.c:1090)                                       
==495238==    by 0x4932F10: probe_worker_runfn (worker.c:81)                                   
==495238==    by 0x4CDA431: start_thread (in /usr/lib64/libpthread-2.31.so)                                                                                                                   
==495238==    by 0x52A8912: clone (in /usr/lib64/libc-2.31.so)             
==495238==                                                                                                                                                                                    
==495238== 10 bytes in 1 blocks are definitely lost in loss record 24 of 297                   
==495238==    at 0x483CCE8: realloc (vg_replace_malloc.c:834)
==495238==    by 0x4D9DCD8: rrealloc (in /usr/lib64/librpmio.so.9.0.1)
==495238==    by 0x4D25B88: headerFormat (in /usr/lib64/librpm.so.9.0.1)
==495238==    by 0x495E321: rpmverify_collect (rpmverifyfile_probe.c:224)
==495238==    by 0x495F461: rpmverifyfile_probe_main (rpmverifyfile_probe.c:543)
==495238==    by 0x4935598: probe_worker (worker.c:1090)
==495238==    by 0x4932F10: probe_worker_runfn (worker.c:81)
```

Bugzillas:
* https://bugzilla.redhat.com/show_bug.cgi?id=1861300
* https://bugzilla.redhat.com/show_bug.cgi?id=1861301