### PR TITLE
Prevent cloning source datastream in memory when generating ARF results

### DIFF
--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -668,7 +668,7 @@ static void ds_rds_add_xccdf_test_results(xmlDocPtr doc, xmlNodePtr reports,
 	}
 }
 
-static int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr tailoring_doc, const char* tailoring_filepath, char *tailoring_doc_timestamp, xmlDocPtr xccdf_result_file_doc, struct oscap_htable* oval_result_sources, struct oscap_htable* oval_result_mapping, struct oscap_htable *arf_report_mapping)
+int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr tailoring_doc, const char* tailoring_filepath, char *tailoring_doc_timestamp, xmlDocPtr xccdf_result_file_doc, struct oscap_htable* oval_result_sources, struct oscap_htable* oval_result_mapping, struct oscap_htable *arf_report_mapping)
 {
 	*ret = NULL;
 

--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -668,7 +668,7 @@ static void ds_rds_add_xccdf_test_results(xmlDocPtr doc, xmlNodePtr reports,
 	}
 }
 
-int ds_rds_create_from_dom(xmlDocPtr *ret, xmlDocPtr sds_doc,
+static int _ds_rds_create_from_dom(xmlDocPtr *ret, xmlDocPtr sds_doc,
 		xmlDocPtr tailoring_doc, const char *tailoring_filepath,
 		char *tailoring_doc_timestamp, xmlDocPtr xccdf_result_file_doc,
 		struct oscap_htable *oval_result_sources,
@@ -806,6 +806,32 @@ int ds_rds_create_from_dom(xmlDocPtr *ret, xmlDocPtr sds_doc,
 	return 0;
 }
 
+int ds_rds_create_from_dom(xmlDocPtr *ret, xmlDocPtr sds_doc,
+		xmlDocPtr tailoring_doc, const char *tailoring_filepath,
+		char *tailoring_doc_timestamp, xmlDocPtr xccdf_result_file_doc,
+		struct oscap_htable *oval_result_sources,
+		struct oscap_htable *oval_result_mapping,
+		struct oscap_htable *arf_report_mapping)
+{
+	return _ds_rds_create_from_dom(ret, sds_doc, tailoring_doc,
+			tailoring_filepath, tailoring_doc_timestamp,
+			xccdf_result_file_doc, oval_result_sources, oval_result_mapping,
+			arf_report_mapping, false);
+}
+
+static int ds_rds_create_from_dom_clone(xmlDocPtr *ret, xmlDocPtr sds_doc,
+		xmlDocPtr tailoring_doc, const char *tailoring_filepath,
+		char *tailoring_doc_timestamp, xmlDocPtr xccdf_result_file_doc,
+		struct oscap_htable *oval_result_sources,
+		struct oscap_htable *oval_result_mapping,
+		struct oscap_htable *arf_report_mapping)
+{
+	return _ds_rds_create_from_dom(ret, sds_doc, tailoring_doc,
+			tailoring_filepath, tailoring_doc_timestamp,
+			xccdf_result_file_doc, oval_result_sources, oval_result_mapping,
+			arf_report_mapping, true);
+}
+
 struct oscap_source *ds_rds_create_source(struct oscap_source *sds_source, struct oscap_source *tailoring_source, struct oscap_source *xccdf_result_source, struct oscap_htable *oval_result_sources, struct oscap_htable *oval_result_mapping, struct oscap_htable *arf_report_mapping, const char *target_file)
 {
 	xmlDoc *sds_doc = oscap_source_get_xmlDoc(sds_source);
@@ -837,8 +863,8 @@ struct oscap_source *ds_rds_create_source(struct oscap_source *sds_source, struc
 
 	xmlDocPtr rds_doc = NULL;
 
-	if (ds_rds_create_from_dom(&rds_doc, sds_doc, tailoring_doc, tailoring_filepath, tailoring_doc_timestamp, result_file_doc,
-			oval_result_sources, oval_result_mapping, arf_report_mapping, true) != 0) {
+	if (ds_rds_create_from_dom_clone(&rds_doc, sds_doc, tailoring_doc, tailoring_filepath, tailoring_doc_timestamp, result_file_doc,
+			oval_result_sources, oval_result_mapping, arf_report_mapping) != 0) {
 		free(tailoring_doc_timestamp);
 		return NULL;
 	}

--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -712,7 +712,7 @@ int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr tailorin
 
 		// Need unique id (ref_id) - if generated already exists, then create new one
 		int counter = 0;
-		while (lookup_component_in_collection(sds_doc, tailoring_component_id) != NULL) {
+		while (lookup_component_in_collection(sds_res_node, tailoring_component_id) != NULL) {
 			free(tailoring_component_id);
 			tailoring_component_id = oscap_sprintf("scap_org.open-scap_comp_%s_tailoring%03d", mangled_tailoring_filepath, counter++);
 		}

--- a/src/DS/rds_priv.h
+++ b/src/DS/rds_priv.h
@@ -39,5 +39,5 @@ int ds_rds_dump_arf_content(struct ds_rds_session *session, const char *containe
 struct oscap_source *ds_rds_create_source(struct oscap_source *sds_source, struct oscap_source *tailoring_source, struct oscap_source *xccdf_result_source, struct oscap_htable *oval_result_sources, struct oscap_htable *oval_result_mapping, struct oscap_htable *arf_report_mapping, const char *target_file);
 xmlNodePtr ds_rds_create_report(xmlDocPtr target_doc, xmlNodePtr reports_node, xmlDocPtr source_doc, const char* report_id);
 
-int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr tailoring_doc, const char* tailoring_filepath, char *tailoring_doc_timestamp, xmlDocPtr xccdf_result_file_doc, struct oscap_htable* oval_result_sources, struct oscap_htable* oval_result_mapping, struct oscap_htable *arf_report_mapping, bool clone);
+int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr tailoring_doc, const char* tailoring_filepath, char *tailoring_doc_timestamp, xmlDocPtr xccdf_result_file_doc, struct oscap_htable* oval_result_sources, struct oscap_htable* oval_result_mapping, struct oscap_htable *arf_report_mapping);
 #endif

--- a/src/DS/rds_priv.h
+++ b/src/DS/rds_priv.h
@@ -39,4 +39,5 @@ int ds_rds_dump_arf_content(struct ds_rds_session *session, const char *containe
 struct oscap_source *ds_rds_create_source(struct oscap_source *sds_source, struct oscap_source *tailoring_source, struct oscap_source *xccdf_result_source, struct oscap_htable *oval_result_sources, struct oscap_htable *oval_result_mapping, struct oscap_htable *arf_report_mapping, const char *target_file);
 xmlNodePtr ds_rds_create_report(xmlDocPtr target_doc, xmlNodePtr reports_node, xmlDocPtr source_doc, const char* report_id);
 
+int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr tailoring_doc, const char* tailoring_filepath, char *tailoring_doc_timestamp, xmlDocPtr xccdf_result_file_doc, struct oscap_htable* oval_result_sources, struct oscap_htable* oval_result_mapping, struct oscap_htable *arf_report_mapping);
 #endif

--- a/src/DS/rds_priv.h
+++ b/src/DS/rds_priv.h
@@ -39,5 +39,5 @@ int ds_rds_dump_arf_content(struct ds_rds_session *session, const char *containe
 struct oscap_source *ds_rds_create_source(struct oscap_source *sds_source, struct oscap_source *tailoring_source, struct oscap_source *xccdf_result_source, struct oscap_htable *oval_result_sources, struct oscap_htable *oval_result_mapping, struct oscap_htable *arf_report_mapping, const char *target_file);
 xmlNodePtr ds_rds_create_report(xmlDocPtr target_doc, xmlNodePtr reports_node, xmlDocPtr source_doc, const char* report_id);
 
-int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr tailoring_doc, const char* tailoring_filepath, char *tailoring_doc_timestamp, xmlDocPtr xccdf_result_file_doc, struct oscap_htable* oval_result_sources, struct oscap_htable* oval_result_mapping, struct oscap_htable *arf_report_mapping);
+int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr tailoring_doc, const char* tailoring_filepath, char *tailoring_doc_timestamp, xmlDocPtr xccdf_result_file_doc, struct oscap_htable* oval_result_sources, struct oscap_htable* oval_result_mapping, struct oscap_htable *arf_report_mapping, bool clone);
 #endif

--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -136,9 +136,8 @@ xmlNodePtr ds_sds_find_component_ref(xmlNodePtr datastream, const char* id)
 	return NULL;
 }
 
-xmlNodePtr lookup_component_in_collection(xmlDocPtr doc, const char *component_id)
+xmlNodePtr lookup_component_in_collection(xmlNodePtr root, const char *component_id)
 {
-	xmlNodePtr root = xmlDocGetRootElement(doc);
 	xmlNodePtr component = NULL;
 	xmlNodePtr candidate = root->children;
 
@@ -278,7 +277,8 @@ static xmlNodePtr ds_sds_get_component_root_by_id(xmlDoc *doc, const char* compo
 	if (component_id == NULL) {
 		component = (xmlNodePtr)doc;
 	} else {
-		component = lookup_component_in_collection(doc, component_id);
+		xmlNodePtr root = xmlDocGetRootElement(doc);
+		component = lookup_component_in_collection(root, component_id);
 		if (component == NULL)
 		{
 			oscap_seterr(OSCAP_EFAMILY_XML, "Component of given id '%s' was not found in the document.", component_id);
@@ -1044,7 +1044,8 @@ static int ds_sds_compose_add_component_source_with_ref(xmlDocPtr doc, xmlNodePt
 		extended_component ? "e" : "", mangled_filepath);
 
 	int counter = 0;
-	while (lookup_component_in_collection(doc, comp_id) != NULL) {
+	xmlNodePtr root = xmlDocGetRootElement(doc);
+	while (lookup_component_in_collection(root, comp_id) != NULL) {
 		// While a component of the given ID already exists, generate a new one
 		free(comp_id);
 		comp_id = oscap_sprintf("scap_org.open-scap_%scomp_%s%03d",

--- a/src/DS/sds_priv.h
+++ b/src/DS/sds_priv.h
@@ -45,7 +45,7 @@ int ds_sds_dump_component_ref_as(const xmlNodePtr component_ref, struct ds_sds_s
 xmlDocPtr ds_sds_compose_xmlDoc_from_xccdf(const char *xccdf_file);
 xmlDocPtr ds_sds_compose_xmlDoc_from_xccdf_source(struct oscap_source *xccdf_source);
 
-xmlNodePtr lookup_component_in_collection(xmlDocPtr doc, const char *component_id);
+xmlNodePtr lookup_component_in_collection(xmlNodePtr root, const char *component_id);
 xmlNodePtr ds_sds_find_component_ref(xmlNodePtr datastream, const char *id);
 
 char *ds_sds_mangle_filepath(const char *filepath);

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -567,11 +567,11 @@ OSCAP_API int xccdf_session_add_report_from_source(struct xccdf_session *session
 OSCAP_API int xccdf_session_generate_guide(struct xccdf_session *session, const char *outfile);
 
 /**
- * Export XCCDF, ARF, HTML and then free the session.
+ * Export XCCDF, ARF, HTML
  * @param session XCCDF Session
  * @returns zero on success
  */
-OSCAP_API int xccdf_session_export_and_free(struct xccdf_session *session);
+OSCAP_API int xccdf_session_export_all(struct xccdf_session *session);
 
 /// @}
 /// @}

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -567,7 +567,11 @@ OSCAP_API int xccdf_session_add_report_from_source(struct xccdf_session *session
 OSCAP_API int xccdf_session_generate_guide(struct xccdf_session *session, const char *outfile);
 
 /**
- * Export XCCDF, ARF, HTML
+ * Export XCCDF results, ARF results and HTML report from the given XCCDF
+ * session based on values set in the XCCDF session. This is a destructive
+ * operation that modifies the oscap_source structures, specifically the XML
+ * trees. Callers must not perform any operation with the session after this
+ * call and they must free the session immediately.
  * @param session XCCDF Session
  * @returns zero on success
  */

--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -566,6 +566,13 @@ OSCAP_API int xccdf_session_add_report_from_source(struct xccdf_session *session
  */
 OSCAP_API int xccdf_session_generate_guide(struct xccdf_session *session, const char *outfile);
 
+/**
+ * Export XCCDF, ARF, HTML and then free the session.
+ * @param session XCCDF Session
+ * @returns zero on success
+ */
+OSCAP_API int xccdf_session_export_and_free(struct xccdf_session *session);
+
 /// @}
 /// @}
 #endif

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1811,3 +1811,22 @@ int xccdf_session_generate_guide(struct xccdf_session *session, const char *outf
 	}
 	return 0;
 }
+
+int xccdf_session_export_and_free(struct xccdf_session *session)
+{
+	int ret = 0;
+
+	if (xccdf_session_export_xccdf(session) != 0) {
+		ret = 1;
+		goto cleanup;
+	}
+
+	if (xccdf_session_export_arf(session) != 0) {
+		ret = 1;
+		goto cleanup;
+	}
+
+cleanup:
+	xccdf_session_free(session);
+	return ret;
+}

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -287,8 +287,10 @@ static struct oscap_source *xccdf_session_extract_arf_source(struct xccdf_sessio
 
 	xmlDocPtr rds_doc = NULL;
 
-	if (ds_rds_create_from_dom(&rds_doc, sds_doc, tailoring_doc, tailoring_filepath, tailoring_doc_timestamp, result_file_doc,
-				session->oval.result_sources, session->oval.results_mapping, session->oval.arf_report_mapping) != 0) {
+	if (ds_rds_create_from_dom(&rds_doc, sds_doc, tailoring_doc,
+			tailoring_filepath, tailoring_doc_timestamp, result_file_doc,
+			session->oval.result_sources, session->oval.results_mapping,
+			session->oval.arf_report_mapping, false) != 0) {
 		goto cleanup;
 	}
 

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1844,14 +1844,11 @@ int xccdf_session_export_and_free(struct xccdf_session *session)
 
 	if (session->export.arf_file != NULL) {
 		if (oscap_source_save_as(arf_source, NULL) != 0) {
-			oscap_source_free(arf_source);
-			session->oval.arf_report = NULL;
 			ret = 1;
 			goto cleanup;
 		}
 		if (session->full_validation) {
 			if (oscap_source_validate(arf_source, _reporter, NULL) != 0) {
-				oscap_source_free(arf_source);
 				ret = 1;
 				goto cleanup;
 			}

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1821,15 +1821,19 @@ int xccdf_session_export_and_free(struct xccdf_session *session)
 		goto cleanup;
 	}
 
-	if (session->export.report_file != NULL) {
-		struct oscap_source *arf = xccdf_session_create_arf_source(session);
-		if (arf == NULL) {
-			ret = 1;
-			goto cleanup;
-		}
+	if (session->export.report_file == NULL && session->export.arf_file == NULL) {
+		goto cleanup;
+	}
 
+	struct oscap_source* arf_source = xccdf_session_create_arf_source(session);
+	if (arf_source == NULL) {
+		ret = 1;
+		goto cleanup;
+	}
+
+	if (session->export.report_file != NULL) {
 		/* generate report */
-		_xccdf_gen_report(arf,
+		_xccdf_gen_report(arf_source,
 				xccdf_result_get_id(session->xccdf.result),
 				session->export.report_file,
 				"",
@@ -1839,12 +1843,6 @@ int xccdf_session_export_and_free(struct xccdf_session *session)
 	}
 
 	if (session->export.arf_file != NULL) {
-		struct oscap_source* arf_source = xccdf_session_create_arf_source(session);
-		if (arf_source == NULL) {
-			ret = 1;
-			goto cleanup;
-		}
-
 		if (oscap_source_save_as(arf_source, NULL) != 0) {
 			oscap_source_free(arf_source);
 			session->oval.arf_report = NULL;

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1876,7 +1876,7 @@ int xccdf_session_generate_guide(struct xccdf_session *session, const char *outf
 	return 0;
 }
 
-int xccdf_session_export_and_free(struct xccdf_session *session)
+int xccdf_session_export_all(struct xccdf_session *session)
 {
 	int ret = 0;
 	struct oscap_source *arf_source = NULL;
@@ -1922,6 +1922,5 @@ int xccdf_session_export_and_free(struct xccdf_session *session)
 
 cleanup:
 	oscap_source_free(arf_source);
-	xccdf_session_free(session);
 	return ret;
 }

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -247,18 +247,17 @@ static struct oscap_source* xccdf_session_create_arf_source(struct xccdf_session
 
 static struct oscap_source *xccdf_session_extract_arf_source(struct xccdf_session *session)
 {
-	struct oscap_source *sds_source = NULL;
 	struct oscap_source *rds_source = NULL;
+	xmlDoc *sds_doc = NULL;
 
 	if (xccdf_session_is_sds(session)) {
-		sds_source = session->source;
-		session->source = NULL;
+		sds_doc = oscap_source_pop_xmlDoc(session->source);
 	} else {
-		xmlDocPtr tmp_sds_doc = ds_sds_compose_xmlDoc_from_xccdf_source(session->source);
-		sds_source = oscap_source_new_from_xmlDoc(tmp_sds_doc, NULL);
+		sds_doc = ds_sds_compose_xmlDoc_from_xccdf_source(session->source);
 	}
+	oscap_source_free(session->source);
+	session->source = NULL;
 
-	xmlDoc *sds_doc = oscap_source_get_xmlDoc(sds_source);
 	if (sds_doc == NULL) {
 		goto cleanup;
 	}
@@ -297,7 +296,7 @@ static struct oscap_source *xccdf_session_extract_arf_source(struct xccdf_sessio
 
 cleanup:
 	free(tailoring_doc_timestamp);
-	oscap_source_free(sds_source);
+	xmlFreeDoc(sds_doc);
 	return rds_source;
 }
 

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -280,8 +280,15 @@ static struct oscap_source *xccdf_session_extract_arf_source(struct xccdf_sessio
 		if (stat(tailoring_filepath, &file_stat) == 0) {
 			const size_t max_timestamp_len = 32;
 			tailoring_doc_timestamp = malloc(max_timestamp_len);
+			struct tm *tm_mtime = malloc(sizeof(struct tm));
+#ifdef OS_WINDOWS
+			tm_mtime = localtime_s(tm_mtime, &file_stat.st_mtime);
+#else
+			tm_mtime = localtime_r(&file_stat.st_mtime, tm_mtime);
+#endif
 			strftime(tailoring_doc_timestamp, max_timestamp_len,
-					"%Y-%m-%dT%H:%M:%S", localtime(&file_stat.st_mtime));
+					"%Y-%m-%dT%H:%M:%S", tm_mtime);
+			free(tm_mtime);
 		}
 	}
 

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1838,9 +1838,26 @@ int xccdf_session_export_and_free(struct xccdf_session *session)
 		);
 	}
 
-	if (xccdf_session_export_arf(session) != 0) {
-		ret = 1;
-		goto cleanup;
+	if (session->export.arf_file != NULL) {
+		struct oscap_source* arf_source = xccdf_session_create_arf_source(session);
+		if (arf_source == NULL) {
+			ret = 1;
+			goto cleanup;
+		}
+
+		if (oscap_source_save_as(arf_source, NULL) != 0) {
+			oscap_source_free(arf_source);
+			session->oval.arf_report = NULL;
+			ret = 1;
+			goto cleanup;
+		}
+		if (session->full_validation) {
+			if (oscap_source_validate(arf_source, _reporter, NULL) != 0) {
+				oscap_source_free(arf_source);
+				ret = 1;
+				goto cleanup;
+			}
+		}
 	}
 
 cleanup:

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1816,9 +1816,26 @@ int xccdf_session_export_and_free(struct xccdf_session *session)
 {
 	int ret = 0;
 
-	if (xccdf_session_export_xccdf(session) != 0) {
+	if (_build_xccdf_result_source(session)) {
 		ret = 1;
 		goto cleanup;
+	}
+
+	if (session->export.report_file != NULL) {
+		struct oscap_source *arf = xccdf_session_create_arf_source(session);
+		if (arf == NULL) {
+			ret = 1;
+			goto cleanup;
+		}
+
+		/* generate report */
+		_xccdf_gen_report(arf,
+				xccdf_result_get_id(session->xccdf.result),
+				session->export.report_file,
+				"",
+				(session->export.check_engine_plugins_results ? "%.result.xml" : ""),
+				session->xccdf.profile_id == NULL ? "" : session->xccdf.profile_id
+		);
 	}
 
 	if (xccdf_session_export_arf(session) != 0) {

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -297,7 +297,7 @@ static struct oscap_source *xccdf_session_extract_arf_source(struct xccdf_sessio
 	if (ds_rds_create_from_dom(&rds_doc, sds_doc, tailoring_doc,
 			tailoring_filepath, tailoring_doc_timestamp, result_file_doc,
 			session->oval.result_sources, session->oval.results_mapping,
-			session->oval.arf_report_mapping, false) != 0) {
+			session->oval.arf_report_mapping) != 0) {
 		goto cleanup;
 	}
 

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -325,6 +325,13 @@ xmlDoc *oscap_source_get_xmlDoc(struct oscap_source *source)
 	return source->xml.doc;
 }
 
+xmlDoc *oscap_source_pop_xmlDoc(struct oscap_source *source)
+{
+	xmlDoc *doc = oscap_source_get_xmlDoc(source);
+	source->xml.doc = NULL;
+	return doc;
+}
+
 int oscap_source_validate(struct oscap_source *source, xml_reporter reporter, void *user)
 {
 	int ret;

--- a/src/source/oscap_source_priv.h
+++ b/src/source/oscap_source_priv.h
@@ -76,5 +76,13 @@ xmlTextReader *oscap_source_get_xmlTextReader(struct oscap_source *source);
  */
 xmlDoc *oscap_source_get_xmlDoc(struct oscap_source *source);
 
+/**
+ * Get a DOM representation of this resource. The document is removed from
+ * oscap_source and isn't owned by oscap_source anymore.
+ * @memberof oscap_source
+ * @param source Resource to build DOM representation from
+ * @returns xmlDoc structure to read the content
+ */
+xmlDoc *oscap_source_pop_xmlDoc(struct oscap_source *source);
 
 #endif

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -617,7 +617,7 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 	xccdf_session_set_xccdf_export(session, action->f_results);
 	xccdf_session_set_xccdf_stig_viewer_export(session, action->f_results_stig);
 	xccdf_session_set_report_export(session, action->f_report);
-	if (xccdf_session_export_and_free(session) != 0)
+	if (xccdf_session_export_all(session) != 0)
 		goto cleanup;
 
 	if (action->validate && getenv("OSCAP_FULL_VALIDATION") != NULL &&
@@ -630,6 +630,7 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 	result = evaluation_result;
 
 cleanup:
+	xccdf_session_free(session);
 	oscap_print_error();
 	return result;
 }
@@ -736,12 +737,13 @@ int app_xccdf_remediate(const struct oscap_action *action)
 	/* Get the result from TestResult model and decide if end with error or with correct return code */
 	int evaluation_result = xccdf_session_contains_fail_result(session) ? OSCAP_FAIL : OSCAP_OK;
 
-	if (xccdf_session_export_and_free(session) != 0)
+	if (xccdf_session_export_all(session) != 0)
 		goto cleanup;
 
 	result = evaluation_result;
 
 cleanup:
+	xccdf_session_free(session);
 	oscap_print_error();
 	return result;
 }

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -605,25 +605,8 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 		xccdf_session_remediate(session);
 	}
 
-	xccdf_session_set_xccdf_export(session, action->f_results);
-	xccdf_session_set_xccdf_stig_viewer_export(session, action->f_results_stig);
-	xccdf_session_set_report_export(session, action->f_report);
-	if (xccdf_session_export_xccdf(session) != 0)
-		goto cleanup;
-	else if (action->validate && getenv("OSCAP_FULL_VALIDATION") != NULL &&
-		(action->f_results || action->f_report || action->f_results_arf || action->f_results_stig))
-		fprintf(stdout, "XCCDF Results are exported correctly.\n");
-
-	if (xccdf_session_export_arf(session) != 0)
-		goto cleanup;
-	else if (action->f_results_arf && getenv("OSCAP_FULL_VALIDATION") != NULL)
-		fprintf(stdout, "Result DataStream exported correctly.\n");
-
 	/* Get the result from TestResult model and decide if end with error or with correct return code */
-	result = xccdf_session_contains_fail_result(session) ? OSCAP_FAIL : OSCAP_OK;
-
-cleanup:
-	oscap_print_error();
+	int evaluation_result = xccdf_session_contains_fail_result(session) ? OSCAP_FAIL : OSCAP_OK;
 
 	/* syslog message */
 #if defined(HAVE_SYSLOG_H)
@@ -631,9 +614,23 @@ cleanup:
 		session == NULL ? 0 : xccdf_session_get_base_score(session));
 #endif
 
-	if (session != NULL)
-		xccdf_session_free(session);
+	xccdf_session_set_xccdf_export(session, action->f_results);
+	xccdf_session_set_xccdf_stig_viewer_export(session, action->f_results_stig);
+	xccdf_session_set_report_export(session, action->f_report);
+	if (xccdf_session_export_and_free(session) != 0)
+		goto cleanup;
 
+	if (action->validate && getenv("OSCAP_FULL_VALIDATION") != NULL &&
+		(action->f_results || action->f_report || action->f_results_arf || action->f_results_stig))
+		fprintf(stdout, "XCCDF Results are exported correctly.\n");
+
+	if (action->f_results_arf && getenv("OSCAP_FULL_VALIDATION") != NULL)
+		fprintf(stdout, "Result DataStream exported correctly.\n");
+
+	result = evaluation_result;
+
+cleanup:
+	oscap_print_error();
 	return result;
 }
 
@@ -736,16 +733,16 @@ int app_xccdf_remediate(const struct oscap_action *action)
 	if (xccdf_session_export_check_engine_plugins(session) != 0)
 		goto cleanup;
 
-	if (xccdf_session_export_xccdf(session) != 0)
-		goto cleanup;
-	if (xccdf_session_export_arf(session) != 0)
+	/* Get the result from TestResult model and decide if end with error or with correct return code */
+	int evaluation_result = xccdf_session_contains_fail_result(session) ? OSCAP_FAIL : OSCAP_OK;
+
+	if (xccdf_session_export_and_free(session) != 0)
 		goto cleanup;
 
-	/* Get the result from TestResult model and decide if end with error or with correct return code */
-	result = xccdf_session_contains_fail_result(session) ? OSCAP_FAIL : OSCAP_OK;
+	result = evaluation_result;
+
 cleanup:
 	oscap_print_error();
-	xccdf_session_free(session);
 	return result;
 }
 

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -610,7 +610,7 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 
 	/* syslog message */
 #if defined(HAVE_SYSLOG_H)
-	syslog(priority, "Evaluation finished. Return code: %d, Base score %f.", result,
+	syslog(priority, "Evaluation finished. Return code: %d, Base score %f.", evaluation_result,
 		session == NULL ? 0 : xccdf_session_get_base_score(session));
 #endif
 


### PR DESCRIPTION
This is an attempt to solve the problem that when evaluating a datastream and generating ARF results the document tree of input source datastream is loaded in memory multiple times due to generating ARF results.

ARF results contain a copy of the source datastream document. This is done by using [xmlDOMWrapCloneNode](http://www.xmlsoft.org/html/libxml-tree.html#xmlDOMWrapCloneNode). I tried to replace its usage by its sibling [xmlDOMWrapAdoptNode](http://www.xmlsoft.org/html/libxml-tree.html#xmlDOMWrapAdoptNode). These functions aren't well documented, so it's only a guess that it could help.

In order to do the change, I had to refactor the logic so that the source datastream isn't reused within the XCCDF session after the ARF generation finishes as I was afraid of double frees.

When running this command this scenario
`oscap xccdf eval --rule xccdf_org.ssgproject.content_rule_selinux_state --results-arf arf.xml --profile ospp /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml`
the highest peak of memory consumption reported by `massif` is reduced from aprox. 267 MB to 217 MB (by 50 MB which is 18.7 %). That looks promising, but more testing is needed.

