### PR TITLE
Initialize rpminfo_rep to avoid crash

### DIFF
--- a/src/OVAL/probes/unix/linux/rpminfo_probe.c
+++ b/src/OVAL/probes/unix/linux/rpminfo_probe.c
@@ -247,6 +247,7 @@ static int get_rpminfo(struct rpminfo_req *req, struct rpminfo_rep **rep, struct
 			pkgh2rep(pkgh, (*rep) + i, &keyid_regex);
                         else {
                                 /* XXX: emit warning */
+                                memset((*rep) + i, 0, sizeof(struct rpminfo_rep));
                                 break;
                         }
                 }


### PR DESCRIPTION
When `rpmdbNextIterator()` in `rpminfo_probe` returns NULL due to a potentially corrupt rpm database, `(*rep) + i` will not be correctly initialized, and could cause segmentation fault.  When this happens, its back trace is as below:

```
(gdb) bt
#0  0x00007fe079cc0d07 in __strlen_avx2 () from target:/lib64/libc.so.6
#1  0x00007fe079bb560f in vfprintf () from target:/lib64/libc.so.6
#2  0x00007fe079bdceb4 in vsnprintf () from target:/lib64/libc.so.6
#3  0x00007fe07c173a21 in SEXP_string_newf_rv () from target:
#4  0x00007fe07c17288b in SEXP_string_newf () from target:
#5  0x00007fe07c18460a in rpminfo_probe_main () from target:
#6  0x00007fe07c16a4b4 in probe_worker () from target:
#7  0x00007fe07c169e80 in probe_worker_runfn () from target:
#8  0x00007fe07b1e32de in start_thread () from target:/lib64/libpthread.so.0
#9  0x00007fe079c5f133 in clone () from target:/lib64/libc.so.6
(gdb) info registers
rdi            0x657361656c657220  7310293708390625824
```
The first parameter in __strlen_avx2() is not a valid pointer.

This PR fixes the issue by initializing the `(*rep) + i` when `rpmdbNextIterator()` returns NULL.