### PR TITLE
Plug a memory leak

### DIFF
--- a/src/XCCDF/item.c
+++ b/src/XCCDF/item.c
@@ -773,6 +773,7 @@ void xccdf_item_add_applicable_platform(struct xccdf_item *item, xmlTextReaderPt
 	pcre *regex = pcre_compile("^(cpe:/o:microsoft:windows)(7.*)", 0, &pcreerror, &erroffset, NULL);
 	int ovector[OVECTOR_LEN];
 	int rc = pcre_exec(regex, NULL, platform_idref, strlen(platform_idref), 0, 0, ovector, OVECTOR_LEN);
+	pcre_free(regex);
 	/* 1 pattern + 2 groups = 3 */
 	if (rc == 3) {
 		const int first_group_start = ovector[2];


### PR DESCRIPTION
Discovered by running this command under valgrind:
oscap xccdf eval --results-arf /tmp/arf.xml --profile ospp --rule xccdf_org.ssgproject.content_rule_selinux_state /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml

Addressing:
==88532== 10,080 bytes in 72 blocks are definitely lost in loss record 340 of 342
==88532==    at 0x483A809: malloc (vg_replace_malloc.c:307)
==88532==    by 0x4BCE6A7: pcre_compile2 (in /usr/lib64/libpcre.so.1.2.12)
==88532==    by 0x4908587: xccdf_item_add_applicable_platform (item.c:773)
==88532==    by 0x49089A6: xccdf_item_process_element (item.c:847)
==88532==    by 0x4918226: xccdf_rule_parse (rule.c:361)
==88532==    by 0x4917484: xccdf_content_parse (rule.c:61)
==88532==    by 0x4917B40: xccdf_group_parse (rule.c:226)
==88532==    by 0x491749D: xccdf_content_parse (rule.c:64)
==88532==    by 0x4917B40: xccdf_group_parse (rule.c:226)
==88532==    by 0x491749D: xccdf_content_parse (rule.c:64)
==88532==    by 0x4902F09: xccdf_benchmark_parse (benchmark.c:199)
==88532==    by 0x4902843: xccdf_benchmark_import_source (benchmark.c:60)
==88532==
==88532== 58,100 bytes in 415 blocks are definitely lost in loss record 342 of 342
==88532==    at 0x483A809: malloc (vg_replace_malloc.c:307)
==88532==    by 0x4BCE6A7: pcre_compile2 (in /usr/lib64/libpcre.so.1.2.12)
==88532==    by 0x4908587: xccdf_item_add_applicable_platform (item.c:773)
==88532==    by 0x49089A6: xccdf_item_process_element (item.c:847)
==88532==    by 0x4918226: xccdf_rule_parse (rule.c:361)
==88532==    by 0x4917484: xccdf_content_parse (rule.c:61)
==88532==    by 0x4917B40: xccdf_group_parse (rule.c:226)
==88532==    by 0x491749D: xccdf_content_parse (rule.c:64)
==88532==    by 0x4917B40: xccdf_group_parse (rule.c:226)
==88532==    by 0x491749D: xccdf_content_parse (rule.c:64)
==88532==    by 0x4917B40: xccdf_group_parse (rule.c:226)
==88532==    by 0x491749D: xccdf_content_parse (rule.c:64)