### PR TITLE
Plug a memory leak

### DIFF
--- a/src/OVAL/oval_agent.c
+++ b/src/OVAL/oval_agent.c
@@ -333,6 +333,7 @@ void oval_agent_destroy_session(oval_agent_session_t * ag_sess) {
 		oval_probe_session_destroy(ag_sess->psess);
 		oval_results_model_free(ag_sess->res_model);
 #endif
+		oval_syschar_model_free(ag_sess->sys_model);
 	        free(ag_sess->filename);
 		free(ag_sess);
 	}


### PR DESCRIPTION
`oval_syschar_model_free(ag_sess->sys_model);` was accidentaly
removed when performing git merge in
ed7f5133cc0cbafe9f879927762aa6486900406d.

Addressing:
==91687== 5,663 (48 direct, 5,615 indirect) bytes in 1 blocks are
definitely lost in loss record 336 of 342
==91687==    at 0x483A809: malloc (vg_replace_malloc.c:307)
==91687==    by 0x48C58E9: oval_syschar_model_new (oval_sysModel.c:71)
==91687==    by 0x48C1FFA: oval_agent_new_session (oval_agent.c:106)
==91687==    by 0x49207E3: xccdf_session_load_oval
(xccdf_session.c:1035)
==91687==    by 0x491F213: xccdf_session_load (xccdf_session.c:599)
==91687==    by 0x410E38: app_evaluate_xccdf (oscap-xccdf.c:566)
==91687==    by 0x40FFF8: oscap_module_call (oscap-tool.c:292)
==91687==    by 0x4104C5: oscap_module_process (oscap-tool.c:382)
==91687==    by 0x4130A9: main (oscap.c:88)