### PR TITLE
Plug a memory leak

### DIFF
--- a/src/OVAL/probes/probe/probe_main.c
+++ b/src/OVAL/probes/probe/probe_main.c
@@ -153,6 +153,7 @@ static void probe_common_main_cleanup(void *arg)
 		fini_function(probe->probe_arg);
 	}
 
+	probe_ncache_free(probe->ncache);
 	probe_rcache_free(probe->rcache);
 	probe_icache_free(probe->icache);
 	rbt_i32_free(probe->workers);


### PR DESCRIPTION
Do not create the global name cache.  The ncache instance created in
`__init_once` is always replaced by a new instance of the cache in
`probe_common_main` (probe_main.c:217). The purpose of the removed
code is unclear to me, it seems to be a leftover from the multi-process
architecture used in branch maint-1.2.

Dicsovered when running valgrind on command:
oscap xccdf eval --results-arf /tmp/arf.xml --profile ospp --rule xccdf_org.ssgproject.content_rule_selinux_state /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml

Addressing:
==117734== 5,459 (640 direct, 4,819 indirect) bytes in 8 blocks are definitely lost in loss record 269 of 270
==117734==    at 0x483A809: malloc (vg_replace_malloc.c:307)
==117734==    by 0x4931C18: probe_ncache_new (ncache.c:81)
==117734==    by 0x49328AB: probe_common_main (probe_main.c:213)
==117734==    by 0x4CDA431: start_thread (in /usr/lib64/libpthread-2.31.so)
==117734==    by 0x52A8912: clone (in /usr/lib64/libc-2.31.so)