### PR TITLE
Plug a memory leak

### DIFF
--- a/src/OVAL/probes/SEAP/seap-descriptor.h
+++ b/src/OVAL/probes/SEAP/seap-descriptor.h
@@ -60,6 +60,7 @@ typedef struct {
         SEAP_cmdtbl_t *cmd_c_table; /* Local SEAP commands */
         SEAP_cmdtbl_t *cmd_w_table; /* Waiting SEAP commands */
     oval_subtype_t subtype;
+	struct probe_common_main_argument *arg;
 } SEAP_desc_t;
 
 #define SEAP_DESC_FDIN  0x00000001


### PR DESCRIPTION
The argument of the `probe_common_main` thread needs to be freed
after this thread joins the parent thread, therefore we need to
make the argument accessible in the function which waits for joining
the thread (sch_queue_close).

Discovered when running valgrind on command:
oscap xccdf eval --results-arf /tmp/arf.xml --profile ospp --rule
xccdf_org.ssgproject.content_rule_selinux_state
/usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml

Addressing:
==132860== 232 (16 direct, 216 indirect) bytes in 1 blocks are definitely lost in loss record 250 of 270
==132860==    at 0x483A809: malloc (vg_replace_malloc.c:307)
==132860==    by 0x49394A1: sch_queue_connect (sch_queue.c:54)
==132860==    by 0x493E40F: SEAP_connect (seap.c:111)
==132860==    by 0x48EF305: oval_probe_comm (oval_probe_ext.c:443)
==132860==    by 0x48EFD7E: oval_probe_sys_eval (oval_probe_ext.c:619)
==132860==    by 0x48F07B9: oval_probe_sys_handler (oval_probe_ext.c:753)
==132860==    by 0x48E38A5: oval_probe_query_sysinfo (oval_probe.c:192)
==132860==    by 0x48C2031: oval_agent_new_session (oval_agent.c:113)
==132860==    by 0x4920806: xccdf_session_load_oval (xccdf_session.c:1035)
==132860==    by 0x491F236: xccdf_session_load (xccdf_session.c:599)
==132860==    by 0x410E38: app_evaluate_xccdf (oscap-xccdf.c:566)
==132860==    by 0x40FFF8: oscap_module_call (oscap-tool.c:292)

==132860== 464 (32 direct, 432 indirect) bytes in 2 blocks are definitely lost in loss record 259 of 270
==132860==    at 0x483A809: malloc (vg_replace_malloc.c:307)
==132860==    by 0x49394A1: sch_queue_connect (sch_queue.c:54)
==132860==    by 0x493E40F: SEAP_connect (seap.c:111)
==132860==    by 0x48EF305: oval_probe_comm (oval_probe_ext.c:443)
==132860==    by 0x48EFD7E: oval_probe_sys_eval (oval_probe_ext.c:619)
==132860==    by 0x48F07B9: oval_probe_sys_handler (oval_probe_ext.c:753)
==132860==    by 0x48E38A5: oval_probe_query_sysinfo (oval_probe.c:192)
==132860==    by 0x48C2031: oval_agent_new_session (oval_agent.c:113)
==132860==    by 0x48A084C: cpe_session_lookup_oval_session (cpe_session.c:117)
==132860==    by 0x4924948: _xccdf_policy_cpe_check_cb (xccdf_policy.c:788)
==132860==    by 0x48A0DC5: cpe_check_evaluate (cpedict.c:148)
==132860==    by 0x48A0E18: cpe_item_is_applicable (cpedict.c:158)

==132860== 1,392 (96 direct, 1,296 indirect) bytes in 6 blocks are definitely lost in loss record 265 of 270
==132860==    at 0x483A809: malloc (vg_replace_malloc.c:307)
==132860==    by 0x49394A1: sch_queue_connect (sch_queue.c:54)
==132860==    by 0x493E40F: SEAP_connect (seap.c:111)
==132860==    by 0x48EF305: oval_probe_comm (oval_probe_ext.c:443)
==132860==    by 0x48F10DF: oval_probe_ext_eval (oval_probe_ext.c:980)
==132860==    by 0x48F0D4C: oval_probe_ext_handler (oval_probe_ext.c:858)
==132860==    by 0x48E3738: oval_probe_query_object (oval_probe.c:156)
==132860==    by 0x48E3B1E: oval_probe_query_test (oval_probe.c:257)
==132860==    by 0x48FBBD3: _oval_result_test_result (oval_resultTest.c:1015)
==132860==    by 0x48FC0BE: oval_result_test_eval (oval_resultTest.c:1136)
==132860==    by 0x48F55A2: _oval_result_criteria_node_result (oval_resultCriteriaNode.c:358)
==132860==    by 0x48F567A: oval_result_criteria_node_eval (oval_resultCriteriaNode.c:381)