### PR TITLE
Change local and remote file system detection

### DIFF
--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -94,6 +94,11 @@ static int is_local_fs(struct mntent *ment)
 		return 0;
 	}
 
+	/*
+	 * The following code is inspired by systemd, function fstype_is_network:
+	 * https://github.com/systemd/systemd/blob/21fd6bc263f49b57867d90d2e1f9f255e5509134/src/basic/mountpoint-util.c#L290
+	 */
+
 	const char *fstype = ment->mnt_type;
 	if (oscap_str_startswith(fstype, "fuse.")) {
 		fstype += strlen("fuse.");

--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -117,6 +117,7 @@ static int is_local_fs(struct mntent *ment)
 		"gfs",
 		"gfs2",
 		"glusterfs",
+		"gpfs",
 		"pvfs2", /* OrangeFS */
 		"ocfs2",
 		"lustre",


### PR DESCRIPTION
The previous way was unreliable because some remote file systems were
detected as local. For example, the SMB mounts that used paths with
backslashes were not recognized as remote file systems.  The `getmntent`
function returns a file system type, so we can use it for detection of
remote file systems.

The new solution is inspired by systemd, function `fstype_is_network`:
https://github.com/systemd/systemd/blob/21fd6bc263f49b57867d90d2e1f9f255e5509134/src/basic/mountpoint-util.c#L290

It also handles FUSE file systems. Also, we are cancelling the TODO idea
of providing the data at the build time and removing the dead code (if
0).

GPFS is also treated as remote system because we have multiple reports that GPFS shouldn't be scanned.

Resolves: RHBZ#1869195, RHBZ#1870087, RHBZ#1840575, RHBZ#1840578