### PR TITLE
Plug a memory leak

### DIFF
--- a/src/OVAL/probes/probe/ncache.c
+++ b/src/OVAL/probes/probe/ncache.c
@@ -111,6 +111,23 @@ void probe_ncache_free (probe_ncache_t *cache)
         return;
 }
 
+void probe_ncache_clear (probe_ncache_t *cache)
+{
+        size_t i;
+
+        if (cache == NULL)
+                return;
+
+        if (pthread_rwlock_wrlock(&(cache)->lock))
+                return;
+        for (i = 0; i < cache->real; ++i)
+                if (cache->name[i] != NULL)
+                        SEXP_free(cache->name[i]);
+        cache->real = 0;
+        if (pthread_rwlock_unlock(&(cache)->lock))
+                abort();
+}
+
 static int probe_ncache_cmp1 (const char *name, const SEXP_t **sexp)
 {
         return ((-1) * SEXP_strcmp (*sexp, name));

--- a/src/OVAL/probes/probe/ncache.h
+++ b/src/OVAL/probes/probe/ncache.h
@@ -57,6 +57,18 @@ probe_ncache_t *probe_ncache_new (void);
 void probe_ncache_free (probe_ncache_t *cache);
 
 /**
+ * Mark memory used by the element name cache as
+ * free, effectively emptying the cache (but not
+ * altering the amount of memomory allocated for it).
+ * The S-exp objects stored in the cache are
+ * also freed. However, if they are referenced
+ * somewhere else, the memory won't be freed, just
+ * the reference count will be decremented.
+ * @param cache the cache to be emptied
+ */
+void probe_ncache_clear (probe_ncache_t *cache);
+
+/**
  * Add a name to the cache. This will create a new S-exp
  * object and return a reference to it. Reference count
  * of such object will be 2 because the cache hold it's

--- a/src/OVAL/probes/probe/probe_main.c
+++ b/src/OVAL/probes/probe/probe_main.c
@@ -210,10 +210,9 @@ void *probe_common_main(void *arg)
 	 * Initialize result & name caching
 	 */
 	probe.rcache = probe_rcache_new();
-	probe.ncache = probe_ncache_new();
-        probe.icache = probe_icache_new();
-
-        OSCAP_GSYM(ncache) = probe.ncache;
+	probe.icache = probe_icache_new();
+	probe_ncache_clear(OSCAP_GSYM(ncache));
+	probe.ncache = OSCAP_GSYM(ncache);
 
 	/*
 	 * Initialize probe option handlers


### PR DESCRIPTION
Alternative for #1571.

Do not re-create global name cache, but clear the contents.

Dicsovered when running valgrind on command:
oscap xccdf eval --results-arf /tmp/arf.xml --profile ospp --rule xccdf_org.ssgproject.content_rule_selinux_state /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml

Addressing:
==117734== 5,459 (640 direct, 4,819 indirect) bytes in 8 blocks are definitely lost in loss record 269 of 270
==117734==    at 0x483A809: malloc (vg_replace_malloc.c:307)
==117734==    by 0x4931C18: probe_ncache_new (ncache.c:81)
==117734==    by 0x49328AB: probe_common_main (probe_main.c:213)
==117734==    by 0x4CDA431: start_thread (in /usr/lib64/libpthread-2.31.so)
==117734==    by 0x52A8912: clone (in /usr/lib64/libc-2.31.so)