### PR TITLE
Free already serialized items

### DIFF
--- a/src/OVAL/adt/oval_string_map.c
+++ b/src/OVAL/adt/oval_string_map.c
@@ -213,6 +213,16 @@ void oval_string_map_put(struct oval_string_map *map, const char *key, void *val
         }
 }
 
+void oval_string_map_del(struct oval_string_map *map, const char *key)
+{
+	if (map == NULL || key == NULL) {
+		return;
+	}
+	if (rbt_str_del((rbt_t *)map, key, NULL) != 0) {
+		dD("rbt_str_del: non-zero return code");
+	}
+}
+
 void oval_string_map_put_string(struct oval_string_map *map, const char *key, const char *val)
 {
 	if (map == NULL || key == NULL) {

--- a/src/OVAL/adt/oval_string_map_impl.h
+++ b/src/OVAL/adt/oval_string_map_impl.h
@@ -38,6 +38,7 @@ struct oval_string_map;
 
 struct oval_string_map *oval_string_map_new(void);
 void oval_string_map_put(struct oval_string_map *, const char *, void *);
+void oval_string_map_del(struct oval_string_map *, const char *);
 
 void oval_string_map_put_string(struct oval_string_map *, const char *, const char *);
 struct oval_iterator *oval_string_map_keys(struct oval_string_map *);

--- a/src/OVAL/oval_sysModel.c
+++ b/src/OVAL/oval_sysModel.c
@@ -386,6 +386,20 @@ xmlNode *oval_syschar_model_to_dom(struct oval_syschar_model * syschar_model, xm
 			struct oval_sysitem *sysitem = (struct oval_sysitem *)
 			    oval_collection_iterator_next(sysitems);
 			oval_sysitem_to_dom(sysitem, doc, tag_items);
+			/*
+			 * WARNING: Memory optimization
+			 * Once the sysitem has been converted to DOM we don't need to keep
+			 * the original data. We can free the sysitem to prevent duplication
+			 * of information in memory. Normally, the sysitem would be freed in
+			 * oval_syschar_model_free. To prevent double frees we need to
+			 * remove the sysitem from the sysitem_map in the
+			 * oval_syschar_model. The local sysitem_map contains pointers to
+			 * same items, so freeing sysitem_map doesn't free the items. The
+			 * users of sysitems collection in oval_syschar structure are also
+			 * not responsible from freeing the sysitem.
+			 */
+			oval_string_map_del(syschar_model->sysitem_map, oval_sysitem_get_id(sysitem));
+			oval_sysitem_free(sysitem);
 		}
 	}
 	oval_collection_iterator_free(sysitems);


### PR DESCRIPTION
When serializing OVAL collected items, the serialized items weren’t freed  from memory. They existed both as a C structure and XML node in memory at the same time.

This PR tries to mitigate this problem by freeing items right after they are converted to XML nodes.

On a common scenario when evaluating a single OVAL definition which matches 10000 of file objects and OVAL results are generated, this change reduces the memory consumption at the highest peak from 180 MB to 159 MB (by 11.66 %).


However, there are problems.

I'm afraid that the change of behavior in `oval_syschar_model_to_dom` is breaking the API. The function used to only read the data from the map in OVAL syschar model (the `syschar_model->sysitem_map`). Now, it removes some items from this map. That leaves the map and the model unusable for further calls.

Also, `oval_syschar_model_to_dom` is called from many places so the change can affect many things. Here is the call graph:

- oval_syschar_model_to_dom
  - oval_syschar_model_export
    - app_collect_oval
  - oval_result_system_to_dom
    - oval_results_to_dom
      - oval_results_model_export_source
        - oval_session_export
          - app_collect_oval
        - oval_results_model_export
          - app_analyse_oval
        - _xccdf_session_export_oval_result_file
          - _build_oval_result_sources
            - xccdf_session_export_oval
              - app_evaluate_xccdf
              - app_xccdf_export_oval_variables
              - app_xccdf_remediate

Some of these symbols are a part of public API :scream: .

A solution could be not to modify an existing function but to introduce new functions. What are your opinions?