### PR TITLE
Remove superfluous free

### DIFF
--- a/src/CPE/cpedict.c
+++ b/src/CPE/cpedict.c
@@ -180,7 +180,6 @@ char *cpe_dict_detect_version_priv(xmlTextReader *reader)
 	const char* elm_name = (const char *) xmlTextReaderConstLocalName(reader);
 	if (!elm_name || strcmp("cpe-list", elm_name)) {
 		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Expected root element name 'cpe-list', found '%s'.", elm_name);
-		xmlFreeTextReader(reader);
 		return NULL;
 	}
 	const char* ns_uri = (const char *) xmlTextReaderConstNamespaceUri(reader);


### PR DESCRIPTION
When cpe_dict_detect_version_priv fails and returns NULL it
frees the reader and then the reader is freed again in the caller
function oscap_source_get_schema_version (oscap_source.c:405).