### PR TITLE
FreeBSD support fixes

### DIFF
--- a/src/OVAL/probes/unix/fileextendedattribute_probe.c
+++ b/src/OVAL/probes/unix/fileextendedattribute_probe.c
@@ -79,7 +79,6 @@ struct cbargs {
 #if defined(OS_FREEBSD)
 static int file_cb(const char *prefix, const char *p, const char *f, void *ptr, SEXP_t *gr_lastpath)
 {
-	return 0;
 	char path_buffer[PATH_MAX];
 	SEXP_t *item;
 	struct cbargs *args = (struct cbargs *) ptr;

--- a/src/OVAL/probes/unix/interface_probe.c
+++ b/src/OVAL/probes/unix/interface_probe.c
@@ -122,11 +122,11 @@ static void get_l2_info(const struct ifaddrs *ifa, char **mp, char **tp, int fd)
 			break;
 		}
 #elif defined(OS_FREEBSD)
-        if (ioctl(fd, SIOCGHWADDR, &ifr) >= 0) {
-                memcpy(mac, ifr.ifr_addr.sa_data, sizeof(mac));
-                snprintf(mac_buf, sizeof(mac_buf),
-                                "%02X:%02X:%02X:%02X:%02X:%02X",
-                                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+	if (ioctl(fd, SIOCGHWADDR, &ifr) >= 0) {
+		memcpy(mac, ifr.ifr_addr.sa_data, sizeof(mac));
+		snprintf(mac_buf, sizeof(mac_buf),
+			"%02X:%02X:%02X:%02X:%02X:%02X",
+			mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 		switch(ifr.ifr_addr.sa_family) {
 
 		case ARPHRD_ETHER:
@@ -140,7 +140,6 @@ static void get_l2_info(const struct ifaddrs *ifa, char **mp, char **tp, int fd)
 	} else
 		mac_buf[0] = 0;
 }
-
 
 #if defined(OS_LINUX)
 static void get_flags(const struct ifaddrs *ifa, char ***fp) {
@@ -438,12 +437,12 @@ static int get_ifs(SEXP_t *name_ent, probe_ctx *ctx, oval_schema_version_t over)
 			}
 #elif defined(OS_FREEBSD)
 			for (byte = 0; byte < 4 && sin6p->sin6_addr.__u6_addr.__u6_addr32[byte] == 0xffffffff; byte++) {
-			        prefix += 32;
+				prefix += 32;
 			}
 			if (byte < 4) {
-			        tmp = ntohl(sin6p->sin6_addr.__u6_addr.__u6_addr32[byte]);
-			        for (bit = 31; tmp & (1 << bit); bit--)
-			                prefix++;
+				tmp = ntohl(sin6p->sin6_addr.__u6_addr.__u6_addr32[byte]);
+				for (bit = 31; tmp & (1 << bit); bit--)
+					prefix++;
 			}
 #endif
 			host_len = strlen(host);

--- a/src/OVAL/probes/unix/sysctl_probe.c
+++ b/src/OVAL/probes/unix/sysctl_probe.c
@@ -284,21 +284,21 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
 #elif defined(OS_FREEBSD)
 int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
 {
-        FILE *fp;
-        char output[LINE_MAX];
-        const char* SEP = "=";
-        char* mib;
-        char* sysval;
-        SEXP_t *se_mib;
-        SEXP_t *name_entity, *probe_in;
+	FILE *fp;
+	char output[LINE_MAX];
+	const char* SEP = "=";
+	char* mib;
+	char* sysval;
+	SEXP_t *se_mib;
+	SEXP_t *name_entity, *probe_in;
 
-        probe_in    = probe_ctx_getobject(ctx);
-        name_entity = probe_obj_getent(probe_in, "name", 1);
+	probe_in    = probe_ctx_getobject(ctx);
+	name_entity = probe_obj_getent(probe_in, "name", 1);
 
-        if (name_entity == NULL) {
-                dE("Missing \"name\" entity in the input object");
-                return (PROBE_ENOENT);
-        }
+	if (name_entity == NULL) {
+		dE("Missing \"name\" entity in the input object");
+		return (PROBE_ENOENT);
+	}
 
 	/* FreeBSD's sysctl(8) uses undocumented, and potentially unstable,
 	 * kernel interfaces to obtain the list of system properties and values.
@@ -306,14 +306,14 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
 	 * implement the functionality ourselves which risks breakage if/when
 	 * the interfaces change.
 	 */
-        fp = popen(SYSCTL_CMD, "r");
+	fp = popen(SYSCTL_CMD, "r");
 
-        if (!fp) {
+	if (!fp) {
 		dE("Failed to open output of %s", SYSCTL_CMD);
 		return (PROBE_EFATAL);
-        }
+	}
 
-        while (fgets(output, sizeof(output), fp)) {
+	while (fgets(output, sizeof(output), fp)) {
 		char *strp;
 		mib = strtok_r(output, SEP, &strp);
 		sysval = strtok_r(NULL, SEP, &strp);
@@ -356,8 +356,8 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
 		SEXP_free(se_mib);
         }
 
-        pclose(fp);
-        return (0);
+	pclose(fp);
+	return (0);
 }
 #else
 int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)

--- a/src/common/memusage.c
+++ b/src/common/memusage.c
@@ -204,25 +204,25 @@ static int freebsd_sys_memusage(struct sys_memusage *mu)
 	unsigned int active_page_count = 0;
 	unsigned int inactive_page_count = 0;
 
-        /* Page size */
+	/* Page size */
 	size = sizeof(page_size);
 	if (sysctlbyname(GET_VM_PAGE_SIZE, &page_size, &size, NULL, 0) < 0) {
 		return -1;
 	}
 
-        /* Total pages */
-        size = sizeof(total_page_count);
+	/* Total pages */
+	size = sizeof(total_page_count);
 	if (sysctlbyname(GET_VM_TOTAL_PAGE_COUNT, &total_page_count, &size, NULL, 0) < 0) {
 		return -1;
 	}
 
-        /* Total free pages */
+	/* Total free pages */
 	size = sizeof(free_page_count);
 	if (sysctlbyname(GET_VM_FREE_PAGE_COUNT, &free_page_count, &size, NULL, 0) < 0) {
 		return -1;
 	}
 
-        /* Total active pages */
+	/* Total active pages */
 	size = sizeof(active_page_count);
 	if (sysctlbyname(GET_VM_ACT_PAGE_COUNT, &active_page_count , &size, NULL, 0) < 0) {
 		return -1;
@@ -252,36 +252,36 @@ static int freebsd_proc_memusage(struct proc_memusage *mu)
 	int count;
 	kvm_t *kd;
 	pid_t mypid;
-        char errbuf[LINE_MAX];
-        struct kinfo_proc *procinfo;
+	char errbuf[LINE_MAX];
+	struct kinfo_proc *procinfo;
 
-        mypid = getpid();
-        kd = kvm_openfiles(NULL, _PATH_DEVNULL, NULL, O_RDONLY, errbuf);
+	mypid = getpid();
+	kd = kvm_openfiles(NULL, _PATH_DEVNULL, NULL, O_RDONLY, errbuf);
 
-        if (!kd)
-                return -1;
+	if (!kd)
+		return -1;
 
-        procinfo = kvm_getprocs(kd, KERN_PROC_PID, mypid, &count);
+	procinfo = kvm_getprocs(kd, KERN_PROC_PID, mypid, &count);
 
-        if(!procinfo)
-                return -1;
+	if (!procinfo)
+		return -1;
 
-        mu->mu_rss = procinfo->ki_rssize;
-        mu->mu_text = procinfo->ki_tsize;
-        mu->mu_data = procinfo->ki_dsize;
-        mu->mu_stack = procinfo->ki_ssize;
+	mu->mu_rss = procinfo->ki_rssize;
+	mu->mu_text = procinfo->ki_tsize;
+	mu->mu_data = procinfo->ki_dsize;
+	mu->mu_stack = procinfo->ki_ssize;
 
-        /* ki_swrss is the resident set size before last swap, this
-         * is the closest approximation to Linux's "VmHWM" which is the
-         * peak resident set size of the process.
-         */
-        mu->mu_hwm = procinfo->ki_swrss;
+	/* ki_swrss is the resident set size before last swap, this
+	 * is the closest approximation to Linux's "VmHWM" which is the
+	 * peak resident set size of the process.
+	 */
+	mu->mu_hwm = procinfo->ki_swrss;
 
-        /* Not exposed on FreeBSD */
-        mu->mu_lib = 0;
-        mu->mu_lock = 0;
+	/* Not exposed on FreeBSD */
+	mu->mu_lib = 0;
+	mu->mu_lock = 0;
 
-        return 0;
+	return 0;
 }
 
 #endif /* OS_FREEBSD */

--- a/tests/probes/system_info/test_probes_system_info.sh
+++ b/tests/probes/system_info/test_probes_system_info.sh
@@ -19,6 +19,9 @@
 function test_probes_system_info {
 	probecheck "system_info" || return 255
 
+	# This test is dependent on /etc/os-release being present, so skip this test if it doesn't exist.
+	[ -f "/etc/os-release" ] || return 255
+
 	local ret_val=0;
 	local LOGFILE="test_probes_system_info.log"
 

--- a/tests/probes/system_info/test_probes_system_info_offline_mode.sh
+++ b/tests/probes/system_info/test_probes_system_info_offline_mode.sh
@@ -13,6 +13,9 @@
 set -e -o pipefail
 
 function test_offline_mode_system_info_offline {
+	# This test is dependent on /etc/os-release being present, so skip this test if it doesn't exist.
+	[ -f "/etc/os-release" ] || return 255
+
 	temp_dir="$(mktemp -d)"
 
 	ln -s /etc $temp_dir


### PR DESCRIPTION
This PR primarily consists of whitespace fixes along with two functional changes:

1. In the extended attribute probe, FreeBSD's `file_cb()` has an erroneous `return` statement which is now removed.

2. For the system_info tests, check for `/etc/os-release` so that the tests are skipped on systems that do not have the file. This is done to avoid test failure on older versions of FreeBSD (12.1-RELEASE and earlier).

This has been tested on:

Fedora 32
FreeBSD 12.1-RELEASE
FreeBSD 12.1-STABLE
FreeBSD 13-CURRENT
Ubuntu 18.04