### PR TITLE
Plug a memory leak

### DIFF
--- a/src/OVAL/probes/unix/file_probe.c
+++ b/src/OVAL/probes/unix/file_probe.c
@@ -391,7 +391,9 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr, 
 				"has_extended_acl", OVAL_DATATYPE_SEXP, se_acl,
                                          NULL);
 		if (se_acl == NULL) {
-			probe_item_ent_add(item, "has_extended_acl", NULL, SEXP_number_newb(true));
+			SEXP_t *sexp_true = SEXP_number_newb(true);
+			probe_item_ent_add(item, "has_extended_acl", NULL, sexp_true);
+			SEXP_free(sexp_true);
 			probe_itement_setstatus(item, "has_extended_acl", 1, SYSCHAR_STATUS_DOES_NOT_EXIST);
 		} else {
 			SEXP_free(se_acl);


### PR DESCRIPTION
Addressing:
17,500,110 (11,200,128 direct, 6,299,982 indirect) bytes in 350,004 blocks are definitely lost in loss record 246 of 246
   at 0x483A809: malloc (vg_replace_malloc.c:307)
   by 0x4942C84: SEXP_new (sexp-manip.c:1593)
   by 0x4940115: SEXP_number_newb (sexp-manip.c:96)
   by 0x494CC94: file_cb (file_probe.c:394)
   by 0x494D11A: file_probe_main (file_probe.c:510)
   by 0x49357AB: probe_worker (worker.c:1094)
   by 0x4933123: probe_worker_runfn (worker.c:85)
   by 0x4CDB431: start_thread (in /usr/lib64/libpthread-2.31.so)
   by 0x52A9912: clone (in /usr/lib64/libc-2.31.so)