### PR TITLE
Fix realloc calls to account for a possible NULL result

### DIFF
--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -137,13 +137,13 @@ static int oval_pdtbl_add(oval_pdtbl_t *tbl, oval_subtype_t type, int sd, const 
 	pd->sd      = sd;
 	pd->uri     = oscap_strdup(uri);
 
-	tbl->memb = realloc(tbl->memb, sizeof(oval_pd_t *) * (++tbl->count));
-
-	if (tbl->memb == NULL) {
+	void *new_memb = realloc(tbl->memb, sizeof(oval_pd_t *) * (++tbl->count));
+	if (new_memb == NULL) {
 		free(pd->uri);
 		free(pd);
 		return -1;
 	}
+	tbl->memb = new_memb;
 
 	tbl->memb[tbl->count - 1] = pd;
 

--- a/src/OVAL/oval_probe_handler.c
+++ b/src/OVAL/oval_probe_handler.c
@@ -96,7 +96,11 @@ int oval_probe_handler_set(oval_phtbl_t *phtbl, oval_subtype_t type, oval_probe_
                 }
         }
 
-        phtbl->ph = realloc(phtbl->ph, sizeof(oval_ph_t *) * ++phtbl->sz);
+        void *new_ph = realloc(phtbl->ph, sizeof(oval_ph_t *) * ++phtbl->sz);
+        if (new_ph == NULL)
+                return -1;
+        phtbl->ph = new_ph;
+
         phrec = phtbl->ph[phtbl->sz - 1] = malloc(sizeof(oval_ph_t));
         sort  = true;
 fillrec:

--- a/src/OVAL/probes/SEAP/generic/strbuf.c
+++ b/src/OVAL/probes/SEAP/generic/strbuf.c
@@ -297,7 +297,14 @@ ssize_t strbuf_write (strbuf_t *buf, int fd)
 			iot  = 0;
 		}
 
-		iov = realloc (iov, sizeof (struct iovec) * iow);
+		void *new_iov = realloc (iov, sizeof (struct iovec) * iow);
+		if (new_iov == NULL) {
+			int e = errno;
+			free(iov);
+			errno = e;
+			return -1;
+		}
+		iov = new_iov;
 		ioc = 0;
 
 		while (cur != NULL && ioc < iow) {

--- a/src/OVAL/probes/SEAP/seap-message.c
+++ b/src/OVAL/probes/SEAP/seap-message.c
@@ -119,7 +119,10 @@ int SEAP_msgattr_set (SEAP_msg_t *msg, const char *attr, SEXP_t *value)
         if (value != NULL)
                 SEXP_VALIDATE(value);
 #endif
-	msg->attrs = realloc(msg->attrs, sizeof(SEAP_attr_t) * (++msg->attrs_cnt));
+        void *new_attrs = realloc(msg->attrs, sizeof(SEAP_attr_t) * (++msg->attrs_cnt));
+        if (new_attrs == NULL)
+                return -1;
+        msg->attrs = new_attrs;
         msg->attrs[msg->attrs_cnt - 1].name  = strdup (attr);
         msg->attrs[msg->attrs_cnt - 1].value = (value != NULL ? SEXP_ref (value) : NULL);
 

--- a/src/OVAL/probes/SEAP/seap-packet.c
+++ b/src/OVAL/probes/SEAP/seap-packet.c
@@ -206,8 +206,10 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
         _A(attr_i >= (SEXP_list_length (sexp_msg) - 4)/2);
 
         seap_msg->attrs_cnt = attr_i;
-	seap_msg->attrs = realloc(seap_msg->attrs, sizeof(SEAP_attr_t) * seap_msg->attrs_cnt);
-        seap_msg->sexp      = SEXP_list_last (sexp_msg);
+        void *new_attrs = realloc(seap_msg->attrs, sizeof(SEAP_attr_t) * seap_msg->attrs_cnt);
+        if (new_attrs != NULL || seap_msg->attrs_cnt == 0)
+                seap_msg->attrs = new_attrs;
+        seap_msg->sexp = SEXP_list_last (sexp_msg);
 
         return (0);
 }

--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -199,15 +199,32 @@ static fsdev_t *__fsdev_init(fsdev_t *lfs)
 			continue;
 		if (i >= lfs->cnt) {
 			lfs->cnt += DEVID_ARRAY_ADD;
-			lfs->ids = realloc(lfs->ids, sizeof(dev_t) * lfs->cnt);
+			void *new_ids = realloc(lfs->ids, sizeof(dev_t) * lfs->cnt);
+			if (new_ids == NULL) {
+				e = errno;
+				free(lfs->ids);
+				free(lfs);
+				endmntent(fp);
+				errno = e;
+				return (NULL);
+			}
+			lfs->ids = new_ids;
 		}
 		memcpy(&(lfs->ids[i++]), &st.st_dev, sizeof(dev_t));
 	}
 
 	endmntent(fp);
 
-	lfs->ids = realloc(lfs->ids, sizeof(dev_t) * i);
-	lfs->cnt = (lfs->ids == NULL ? 0 : i);
+	void *new_ids = realloc(lfs->ids, sizeof(dev_t) * i);
+	if (new_ids == NULL) {
+		e = errno;
+		free(lfs->ids);
+		free(lfs);
+		errno = e;
+		return (NULL);
+	}
+	lfs->ids = new_ids;
+	lfs->cnt = i;
 
 	return (lfs);
 }
@@ -230,7 +247,15 @@ static fsdev_t *__fsdev_init(fsdev_t *lfs)
 	}
 
 	if (i != lfs->cnt) {
-		lfs->ids = realloc(lfs->ids, sizeof(dev_t) * i);
+		void *new_ids = realloc(lfs->ids, sizeof(dev_t) * i);
+		if (new_ids == NULL) {
+			e = errno;
+			free(lfs->ids);
+			free(lfs);
+			errno = e;
+			return (NULL);
+		}
+		lfs->ids = new_ids;
 		lfs->cnt = i;
 	}
 
@@ -263,7 +288,7 @@ static fsdev_t *__fsdev_init(fsdev_t *lfs)
 	if (lfs->ids == NULL) {
 		e = errno;
 		free(lfs);
-                fclose(fp);
+		fclose(fp);
 		errno = e;
 		return (NULL);
 	}
@@ -277,7 +302,16 @@ static fsdev_t *__fsdev_init(fsdev_t *lfs)
 
 			if (i >= lfs->cnt) {
 				lfs->cnt += DEVID_ARRAY_ADD;
-				lfs->ids = realloc(lfs->ids, sizeof(dev_t) * lfs->cnt);
+				void *new_ids = realloc(lfs->ids, sizeof(dev_t) * lfs->cnt);
+				if (new_ids == NULL) {
+					e = errno;
+					free(lfs->ids);
+					free(lfs);
+					fclose(fp);
+					errno = e;
+					return (NULL);
+				}
+				lfs->ids = new_ids;
 			}
 
 			memcpy(&(lfs->ids[i++]), &st.st_dev, sizeof(dev_t));
@@ -286,8 +320,16 @@ static fsdev_t *__fsdev_init(fsdev_t *lfs)
 
 	fclose(fp);
 
-	lfs->ids = realloc(lfs->ids, sizeof(dev_t) * i);
-	lfs->cnt = (lfs->ids == NULL ? 0 : i);
+	void *new_ids = realloc(lfs->ids, sizeof(dev_t) * i);
+	if (new_ids == NULL) {
+		e = errno;
+		free(lfs->ids);
+		free(lfs);
+		errno = e;
+		return (NULL);
+	}
+	lfs->ids = new_ids;
+	lfs->cnt = i;
 
 	return (lfs);
 }

--- a/src/OVAL/probes/probe/icache.c
+++ b/src/OVAL/probes/probe/icache.c
@@ -129,7 +129,13 @@ static int icache_lookup(rbt_t *tree, int64_t item_id, probe_iqpair_t *pair) {
 		*/
 		dD("cache MISS");
 
-		cached->item = realloc(cached->item, sizeof(SEXP_t *) * ++cached->count);
+		void *new_item = realloc(cached->item, sizeof(SEXP_t *) * (cached->count + 1));
+		if (new_item == NULL) {
+			dE("Unable to re-allocate memory for cache");
+			return -1;
+		}
+		cached->count++;
+		cached->item = new_item;
 		cached->item[cached->count - 1] = pair->p.item;
 
 		/* Assign an unique item ID */

--- a/src/OVAL/probes/probe/ncache.c
+++ b/src/OVAL/probes/probe/ncache.c
@@ -154,15 +154,15 @@ SEXP_t *probe_ncache_add (probe_ncache_t *cache, const char *name)
         PROBE_NCACHE_WLOCK(cache, NULL);
 
         if (cache->size <= cache->real) {
+                void *new_name = realloc (cache->name, sizeof (SEXP_t *) * (cache->size + PROBE_NCACHE_ADD_SIZE));
+                if (new_name == NULL) {
+                        SEXP_free(ref);
+                        PROBE_NCACHE_WUNLOCK(cache);
+                        return NULL;
+                }
+                cache->name  = new_name;
                 cache->size += PROBE_NCACHE_ADD_SIZE;
-                cache->name  = realloc (cache->name, sizeof (SEXP_t *) * cache->size);
         }
-
-	/* TODO: check if this is really needed */
-	if (cache->name == NULL || cache->size <= cache->real) {
-		SEXP_free(ref);
-		return NULL;
-	}
 
         cache->name[cache->real] = ref;
         ++cache->real;

--- a/src/OVAL/probes/probe/probe_main.c
+++ b/src/OVAL/probes/probe/probe_main.c
@@ -119,8 +119,12 @@ static int probe_opthandler_varref(int option, int op, va_list args)
 	if (o_temp != NULL)
 		return (0);
 
-	OSCAP_GSYM(no_varref_ents) = realloc(OSCAP_GSYM(no_varref_ents),
-						   sizeof (char *) * ++OSCAP_GSYM(no_varref_ents_cnt));
+	void *new_no_varref_ents = realloc(OSCAP_GSYM(no_varref_ents),
+						   sizeof (char *) * (OSCAP_GSYM(no_varref_ents_cnt)+1));
+	if (new_no_varref_ents == NULL)
+		return -2;
+	OSCAP_GSYM(no_varref_ents_cnt)++;
+	OSCAP_GSYM(no_varref_ents) = new_no_varref_ents;
 	OSCAP_GSYM(no_varref_ents)[OSCAP_GSYM(no_varref_ents_cnt) - 1] = strdup(o_name);
 
 	qsort(OSCAP_GSYM(no_varref_ents), OSCAP_GSYM(no_varref_ents_cnt),

--- a/src/OVAL/probes/unix/fileextendedattribute_probe.c
+++ b/src/OVAL/probes/unix/fileextendedattribute_probe.c
@@ -238,20 +238,22 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr, 
 		xattr_count = llistxattr(st_path_with_prefix, NULL, 0);
 
 		if (xattr_count == 0) {
-			free(st_path_with_prefix);
-			free(xattr_buf);
-			return 0;
+			goto exit;
 		}
 
 		if (xattr_count < 0) {
 			dD("FAIL: llistxattr(%s, %p, %zu): errno=%u, %s", st_path_with_prefix, NULL, (size_t)0, errno, strerror(errno));
-			free(st_path_with_prefix);
-			return 0;
+			goto exit;
 		}
 
 		/* allocate space for xattr names */
 		xattr_buflen = xattr_count;
-		xattr_buf    = realloc(xattr_buf, sizeof(char) * xattr_buflen);
+		void *new_xattr_buf = realloc(xattr_buf, sizeof(char) * xattr_buflen);
+		if (new_xattr_buf == NULL) {
+			dE("Failed to re-allocate memory for xattr_buf");
+			goto exit;
+		}
+		xattr_buf = new_xattr_buf;
 
 		/* fill the buffer */
 		xattr_count = llistxattr(st_path_with_prefix, xattr_buf, xattr_buflen);
@@ -291,11 +293,18 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr, 
 				// Check possible buffer overflow
 				if (sizeof(char) * (xattr_vallen + 1) <= sizeof(char) * xattr_vallen) {
 					dE("Attribute is too long.");
-					abort();
+					free(xattr_val);
+					goto exit;
 				}
 
 				// Allocate buffer, '+1' is for trailing '\0'
-				xattr_val    = realloc(xattr_val, sizeof(char) * (xattr_vallen + 1));
+				void *new_xattr_val = realloc(xattr_val, sizeof(char) * (xattr_vallen + 1));
+				if (xattr_val == NULL) {
+					dE("Failed to allocate memory for xattr_val");
+					free(xattr_val);
+					goto exit;
+				}
+				xattr_val = new_xattr_val;
 
 				// we don't want to override space for '\0' by call of 'lgetxattr'
 				// we pass only 'xattr_vallen' instead of 'xattr_vallen + 1'
@@ -336,6 +345,7 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr, 
 		++i;
 	} while (xattr_buf + i < xattr_buf + xattr_buflen - 1);
 
+exit:
 	free(xattr_buf);
 	free(st_path_with_prefix);
 	return 0;

--- a/src/OVAL/probes/unix/process58_probe.c
+++ b/src/OVAL/probes/unix/process58_probe.c
@@ -322,7 +322,15 @@ static char **get_posix_capability(int pid, int max_cap_id) {
 
 				cap_id = oscap_string_to_enum(CapabilityType, cap_name);
 				if (cap_id > -1 && cap_id <= max_cap_id) {
-					ret = realloc(ret, (ret_index + 1) * sizeof(char *));
+					void *new_ret = realloc(ret, (ret_index + 1) * sizeof(char *));
+					if (new_ret == NULL) {
+						dE("Unable to re-allocate memory for ret");
+						cap_free(cap_name);
+						free(ret);
+						ret = NULL;
+						goto exit;
+					}
+					ret = new_ret;
 					ret[ret_index] = strdup(cap_name);
 					ret_index++;
 				}
@@ -330,9 +338,17 @@ static char **get_posix_capability(int pid, int max_cap_id) {
 			}
 		}
 	}
-	ret = realloc(ret, (ret_index + 1) * sizeof(char *));
+	void *new_ret = realloc(ret, (ret_index + 1) * sizeof(char *));
+	if (new_ret == NULL) {
+		dE("Unable to re-allocate memory for ret");
+		free(ret);
+		ret = NULL;
+		goto exit;
+	}
+	ret = new_ret;
 	ret[ret_index] = NULL;
 
+exit:
 	cap_free(pid_caps);
 	return ret;
 #else

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -854,6 +854,8 @@ static char *_comment_multiline_text(char *text)
 	const char *filler = "\n# ";
 	size_t buffer_size = strlen(text) + 1; // +1 for terminating '\0'
 	char *buffer = malloc(buffer_size);
+	if (buffer == NULL)
+		return NULL;
 	char *saveptr;
 	size_t filler_len = strlen(filler);
 	size_t result_len = 0;
@@ -879,14 +881,24 @@ static char *_comment_multiline_text(char *text)
 			if (!first) {
 				if (buffer_size < result_len + filler_len + 1) {
 					buffer_size += filler_len;
-					buffer = realloc(buffer, buffer_size);
+					void *new_buffer = realloc(buffer, buffer_size);
+					if (new_buffer == NULL) {
+						free(buffer);
+						return NULL;
+					}
+					buffer = new_buffer;
 				}
 				strncpy(buffer + result_len, filler, filler_len + 1);
 				result_len += filler_len;
 			}
 			if (buffer_size < result_len + token_len + 1) {
 					buffer_size += token_len;
-					buffer = realloc(buffer, buffer_size);
+					void *new_buffer = realloc(buffer, buffer_size);
+					if (new_buffer == NULL) {
+						free(buffer);
+						return NULL;
+					}
+					buffer = new_buffer;
 			}
 			/* Copy token to output buffer */
 			strncpy(buffer + result_len, token, token_len + 1);

--- a/src/common/oscap_buffer.c
+++ b/src/common/oscap_buffer.c
@@ -85,8 +85,14 @@ void oscap_buffer_append_binary_data(struct oscap_buffer *s, const char *data, c
 		 * rather than only needed capacity in order to not fragment
 		 * the memory.
 		 */
+		size_t current_capacity = s->capacity;
 		s->capacity = ((s->capacity + append_length - 1) / INITIAL_CAPACITY + 1) * INITIAL_CAPACITY;
-		s->data = realloc(s->data, s->capacity);
+		void *new_data = realloc(s->data, s->capacity);
+		if (new_data == NULL) {
+			s->capacity = current_capacity;
+			return;
+		}
+		s->data = new_data;
 	}
 
 	memcpy(s->data + s->length, data, append_length);


### PR DESCRIPTION
And clean up the old handle wherever deems necessary.

While I tried to mitigate improper `realloc` handling this patch won't bring much to memory management of the project. The only real benefit: it will prevent some memory leaks under memory pressure.

The whole approach of the project is to crash and burn when memory could not be allocated. It seems to be stemming from the Linux idea of overcommitting allocator, where checks of the result of the `malloc` are futile and the whole end-game of memory hungry application is OOM onslaught. 

Windows (for example) does not have this behaviour, and even Linux's allocator could be configured to behave differently (`ulimit`, `cgroups` you name it). But for proper memory handling in these scenarios one would have to fix *all* memory allocations, and it is a huge effort given the size of the cursed code-base.

Fixes #974, but only formally. It is just a dent on memory management problems.