### PR TITLE
Added support on Linux on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ matrix:
   include:
     - os: linux
       dist: bionic
+      arch:
+         - ppc64le
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - os: linux
       dist: bionic
       arch:
+         - amd64
          - ppc64le
       addons:
         apt:


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/openscap/builds/182709409

Please have a look.

Regards,
ujjwal