### PR TITLE
Fix build failure on FreeBSD

### DIFF
--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -237,7 +237,8 @@ static fsdev_t *__fsdev_init(fsdev_t *lfs)
 {
 	struct statfs *mntbuf = NULL;
 	struct stat st;
-	int i;
+	size_t i;
+	int e;
 
 	lfs->cnt = getmntinfo(&mntbuf, MNT_NOWAIT);
 	lfs->ids = malloc(sizeof(dev_t) * lfs->cnt);


### PR DESCRIPTION
`__fsdev_init()` for FreeBSD does not declare the variable `e`, which
generates a compiler error. Fix this by declaring `e` before using it.

Fixes: bc36258ac ("Merge pull request #1584 from evgenyz/fix-reallocs")