### PR TITLE
Memory leaks wave

### DIFF
--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -750,15 +750,18 @@ static int ds_rds_create_from_dom(xmlDocPtr* ret, xmlDocPtr sds_doc, xmlDocPtr t
 
 		xmlNodePtr tailoring_component_ref = xmlNewNode(sds_ns, BAD_CAST "component-ref");
 		xmlSetProp(tailoring_component_ref, BAD_CAST "id", BAD_CAST tailoring_component_ref_id);
+		free(tailoring_component_ref_id);
 		xmlNsPtr xlink_ns = xmlSearchNsByHref(doc, sds_res_node, BAD_CAST xlink_ns_uri);
 		if (!xlink_ns) {
 			oscap_seterr(OSCAP_EFAMILY_XML,
 					"Unable to find namespace '%s' in the XML DOM tree. "
 					"This is most likely an internal error!.",
 					xlink_ns_uri);
+			free(tailoring_component_id);
 			return -1;
 		}
 		char *tailoring_cref_href = oscap_sprintf("#%s", tailoring_component_id);
+		free(tailoring_component_id);
 		xmlSetNsProp(tailoring_component_ref, xlink_ns, BAD_CAST "href", BAD_CAST tailoring_cref_href);
 		free(tailoring_cref_href);
 		xmlAddChild(checklists_element, tailoring_component_ref);

--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -249,7 +249,9 @@ static int ds_sds_register_xmlDoc(struct ds_sds_session *session, xmlDoc* doc, x
 
 	struct oscap_source *component_source = oscap_source_new_from_xmlDoc(new_doc, relative_filepath);
 
-	ds_sds_session_register_component_source(session, relative_filepath, component_source);
+	if (ds_sds_session_register_component_source(session, relative_filepath, component_source) != 0) {
+		oscap_source_free(component_source);
+	}
 	return 0; // TODO: Return value of ds_sds_session_register_component_source(). (commit message)
 }
 

--- a/src/OVAL/probes/independent/yamlfilecontent_probe.c
+++ b/src/OVAL/probes/independent/yamlfilecontent_probe.c
@@ -61,6 +61,7 @@ static bool match_regex(const char *pattern, const char *value)
 	}
 	int ovector[OVECCOUNT];
 	int rc = pcre_exec(re, NULL, value, strlen(value), 0, 0, ovector, OVECCOUNT);
+	pcre_free(re);
 	if (rc > 0) {
 		return true;
 	}

--- a/src/OVAL/probes/unix/linux/partition_probe.c
+++ b/src/OVAL/probes/unix/linux/partition_probe.c
@@ -361,6 +361,9 @@ int partition_probe_main(probe_ctx *ctx, void *probe_arg)
 
                         if (re == NULL) {
                                 endmntent(mnt_fp);
+#if defined(HAVE_BLKID_GET_TAG_VALUE)
+                                blkid_put_cache(blkcache);
+#endif
                                 return (PROBE_EINVAL);
                         }
                 }
@@ -415,6 +418,9 @@ int partition_probe_main(probe_ctx *ctx, void *probe_arg)
 
                 if (mnt_op == OVAL_OPERATION_PATTERN_MATCH)
                         pcre_free(re);
+#if defined(HAVE_BLKID_GET_TAG_VALUE)
+                blkid_put_cache(blkcache);
+#endif
         }
 
         return (probe_ret);

--- a/src/OVAL/probes/unix/linux/systemdunitproperty_probe.c
+++ b/src/OVAL/probes/unix/linux/systemdunitproperty_probe.c
@@ -242,6 +242,7 @@ static int unit_callback(const char *unit, void *cbarg)
 
 	get_all_properties_by_unit_path(vars->dbus_conn, unit_path,
 					property_callback, vars);
+	free(unit_path);
 
 	if (vars->item != NULL) {
 		probe_item_collect(vars->ctx, vars->item);

--- a/src/OVAL/probes/unix/sysctl_probe.c
+++ b/src/OVAL/probes/unix/sysctl_probe.c
@@ -106,6 +106,7 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
         path_entity = probe_ent_creat1("path", ent_attrs, r1 = SEXP_string_new(PROC_SYS_DIR, strlen(PROC_SYS_DIR)));
 	SEXP_free(r0);
 	SEXP_free(r1);
+	SEXP_free(ent_attrs);
 
         ent_attrs = probe_attr_creat("operation", r0 = SEXP_number_newi(OVAL_OPERATION_PATTERN_MATCH),
                                      NULL);

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1493,8 +1493,12 @@ static char *_xccdf_session_export_oval_result_file(struct xccdf_session *sessio
 	char *report_id = oscap_sprintf("oval%d", counter++);
 	const char *original_name = oval_agent_get_filename(oval_session);
 	char *results_file_name = oscap_strdup(name);
-	oscap_htable_add(session->oval.results_mapping, original_name, results_file_name);
-	oscap_htable_add(session->oval.arf_report_mapping, original_name, report_id);
+	if (!oscap_htable_add(session->oval.results_mapping, original_name, results_file_name)){
+		free(results_file_name);
+	}
+	if (!oscap_htable_add(session->oval.arf_report_mapping, original_name, report_id)) {
+		free(report_id);
+	};
 
 	/* validate OVAL Results */
 	if (session->validate && session->full_validation) {

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1324,8 +1324,10 @@ static int _build_xccdf_result_source(struct xccdf_session *session)
 			if (oscap_source_save_as(stig_result, NULL) != 0) {
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not save file: %s",
 						oscap_source_readable_origin(stig_result));
+				oscap_source_free(stig_result);
 				return -1;
 			}
+			oscap_source_free(stig_result);
 		}
 
 		/* validate XCCDF Results */


### PR DESCRIPTION
Fixes some of the leaks (the easy ones) discovered by running valgrind inside upstream test suite:
https://jenkins.complianceascode.io/job/openscap-maint-1.3-valgrind-test/7/artifact/build/tests/valgrind_test.log

For more information, please read commit messages of each commit.