### PR TITLE
Make test_probes_file_multiple_file_paths work on FreeBSD.

### DIFF
--- a/tests/probes/file/test_probes_file_multiple_file_paths.sh
+++ b/tests/probes/file/test_probes_file_multiple_file_paths.sh
@@ -5,22 +5,32 @@ set -e -o pipefail
 . $builddir/tests/test_common.sh
 
 probecheck "file" || exit 255
-which strace || exit 255
 
-function check_strace_output {
-	strace_log="$1"
-	grep -q "/tmp/numbers/1" $strace_log && return 1
-	grep -q "/tmp/numbers/1/2" $strace_log && return 1
-	grep -q "/tmp/numbers/1/2/3" $strace_log && return 1
-	grep -q "/tmp/numbers/1/2/3/4" $strace_log && return 1
-	grep -q "/tmp/numbers/1/2/3/4/5" $strace_log && return 1
-	grep -q "/tmp/numbers/1/2/3/4/5/6" $strace_log && return 1
-	grep -q "/tmp/letters/a" $strace_log && return 1
-	grep -q "/tmp/letters/a/b" $strace_log && return 1
-	grep -q "/tmp/letters/a/b/c" $strace_log && return 1
-	grep -q "/tmp/letters/a/b/c/d" $strace_log && return 1
-	grep -q "/tmp/letters/a/b/c/d/e" $strace_log && return 1
-	grep -q "/tmp/letters/a/b/c/d/e/f" $strace_log && return 1
+case $(uname) in
+	FreeBSD)
+		which truss || exit 255
+		tracer="$(which truss) -f -o"
+		;;
+	*)
+		which strace || exit 255
+		tracer="$(which strace) -f -e openat -o"
+		;;
+esac
+
+function check_trace_output {
+	trace_log="$1"
+	grep -q "/tmp/numbers/1" $trace_log && return 1
+	grep -q "/tmp/numbers/1/2" $trace_log && return 1
+	grep -q "/tmp/numbers/1/2/3" $trace_log && return 1
+	grep -q "/tmp/numbers/1/2/3/4" $trace_log && return 1
+	grep -q "/tmp/numbers/1/2/3/4/5" $trace_log && return 1
+	grep -q "/tmp/numbers/1/2/3/4/5/6" $trace_log && return 1
+	grep -q "/tmp/letters/a" $trace_log && return 1
+	grep -q "/tmp/letters/a/b" $trace_log && return 1
+	grep -q "/tmp/letters/a/b/c" $trace_log && return 1
+	grep -q "/tmp/letters/a/b/c/d" $trace_log && return 1
+	grep -q "/tmp/letters/a/b/c/d/e" $trace_log && return 1
+	grep -q "/tmp/letters/a/b/c/d/e/f" $trace_log && return 1
 	return 0
 }
 
@@ -28,11 +38,11 @@ rm -rf /tmp/numbers
 mkdir -p /tmp/numbers/1/2/3/4/5/6
 rm -rf /tmp/letters
 mkdir -p /tmp/letters/a/b/c/d/e/f
-strace_log=$(mktemp)
-strace -f -e openat -o $strace_log $OSCAP oval eval --results results.xml "$srcdir/test_probes_file_multiple_file_paths.xml"
+trace_log=$(mktemp)
+$tracer $trace_log $OSCAP oval eval --results results.xml "$srcdir/test_probes_file_multiple_file_paths.xml"
 ret=0
-check_strace_output $strace_log || ret=$?
-rm -f $strace_log
+check_trace_output $trace_log || ret=$?
+rm -f $trace_log
 rm -f results.xml
 rm -rf /tmp/numbers
 rm -rf /tmp/letters


### PR DESCRIPTION
Use `truss(1)` rather than `strace(1)` on FreeBSD to trace system calls. This change allows FreeBSD systems to successfully run this test case. `truss(1)` is included in FreeBSD's base system, whereas `strace(1)` is Linux-specific.