### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -248,6 +248,7 @@ static struct oscap_source* xccdf_session_create_arf_source(struct xccdf_session
 static struct oscap_source *xccdf_session_extract_arf_source(struct xccdf_session *session)
 {
 	struct oscap_source *rds_source = NULL;
+	char *tailoring_doc_timestamp = NULL;
 	xmlDoc *sds_doc = NULL;
 
 	if (xccdf_session_is_sds(session)) {
@@ -268,7 +269,6 @@ static struct oscap_source *xccdf_session_extract_arf_source(struct xccdf_sessio
 	}
 
 	xmlDoc *tailoring_doc = NULL;
-	char *tailoring_doc_timestamp = NULL;
 	const char *tailoring_filepath = NULL;
 	if (session->tailoring.user_file) {
 		tailoring_doc = oscap_source_get_xmlDoc(session->tailoring.user_file);
@@ -280,6 +280,10 @@ static struct oscap_source *xccdf_session_extract_arf_source(struct xccdf_sessio
 		if (stat(tailoring_filepath, &file_stat) == 0) {
 			const size_t max_timestamp_len = 32;
 			tailoring_doc_timestamp = malloc(max_timestamp_len);
+			if (tailoring_doc_timestamp == NULL) {
+				oscap_seterr(OSCAP_EFAMILY_GLIBC, "Failed to allocate %zu bytes for tailoring_doc_timestamp: %s", max_timestamp_len, strerror(errno));
+				goto cleanup;
+			}
 			struct tm *tm_mtime = malloc(sizeof(struct tm));
 #ifdef OS_WINDOWS
 			tm_mtime = localtime_s(tm_mtime, &file_stat.st_mtime);

--- a/tests/API/SEAP/test_api_seap_concurency.c
+++ b/tests/API/SEAP/test_api_seap_concurency.c
@@ -47,7 +47,7 @@ void *worker_thread (void *arg);
                 if (gettimeofday (&(t1), &(tz)) != 0) abort();          \
                                                                         \
                 flockfile (stdout);                                     \
-                fprintf (stdout, "[%u][%s] t= %.3g\n", (unsigned int)(pthread_self ()), ident, \
+                fprintf (stdout, "[%zu][%s] t= %.3g\n", (uintptr_t)(pthread_self ()), ident, \
                          ((double)t1.tv_sec + ((double)t1.tv_usec / 1000000.0)) - \
                          ((double)t0.tv_sec + ((double)t0.tv_usec / 1000000.0))); \
                 funlockfile(stdout);                                    \


### PR DESCRIPTION
#### 1. Fix a maybe-uninitialized warning in `xccdf_session.c`
Ensure that in `xccdf_session_extract_arf_source()` the variable `tailoring_doc_timestamp` is always initialized before attempting to free it. Previously, the function could jump to the `cleanup` label before `tailoring_doc_timestamp` was initialized and would then attempt to free the it. Fix this by initializing the variable before the function can go to `cleanup`.

Also check if `malloc()` succeeds when later allocating memory for `tailoring_doc_timestamp`.

#### 2. Fix a pointer-to-int warning in `test_api_seap_concurency.c`
Glibc's `pthread_t` is an `unsigned long int` [1], and FreeBSD's libc defines it as a pointer to a `struct pthread`[2].
In both cases we do not want to potentially truncate this value by casting it to an `unsigned int`. Fix this by casting the return value of `pthread_self()` to a `uintptr_t`.

[1] https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/nptl/bits/pthreadtypes.h#l25
[2] https://github.com/freebsd/freebsd/blob/master/sys/sys/_pthreadtypes.h#L67