### PR TITLE
Remove removing Python 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,6 @@ jobs:
     - name: Install packages
       run: |
         brew update
-        brew remove python@2
         brew install doxygen
         brew install opendbx
         brew install popt


### PR DESCRIPTION
It seems that we don't need to remove Python2 anymore.

Fixes the GitHub actions Error message on Mac OS X.
Error: No installed keg or cask with the name "python@2"
Error: Process completed with exit code 1.