### PR TITLE
Remove ppc64le from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
       dist: bionic
       arch:
          - amd64
-         - ppc64le
       addons:
         apt:
           packages:


### PR DESCRIPTION
There is not much sense in running CI on this arch as there are
no code paths specific to it, it only prolongs PR gating procedure.