### PR TITLE
Suppress most of the memory errors

### DIFF
--- a/tests/suppressions.supp
+++ b/tests/suppressions.supp
@@ -45,3 +45,125 @@
    fun:curl_multi_perform
    ...
 }
+
+{
+   SEXP_list_sort
+   Memcheck:Addr8
+   ...
+   fun:SEXP_list_sort
+   fun:probe_worker_runfn
+   fun:start_thread
+   fun:clone
+}
+
+{
+   process_file
+   Memcheck:Addr2
+   ...
+   fun:process_file
+   fun:xmlfilecontent_probe_main
+   ...
+}
+
+{
+   xmlDictFree
+   Memcheck:Leak
+   match-leak-kinds: all
+   ...
+   fun:xmlDictFree
+   fun:oscap_source_free
+   ...
+}
+
+{
+   xmlGetGlobalState
+   Memcheck:Leak
+   match-leak-kinds: all
+   ...
+   fun:xmlGetGlobalState
+   ...
+}
+
+{
+   curl_cond
+   Memcheck:Cond
+   fun:strlen
+   fun:__vfprintf_internal
+   fun:buffered_vfprintf
+   fun:__vfprintf_internal
+   fun:__oscap_dlprintf
+   fun:_curl_trace
+   ...
+   fun:curl_multi_perform
+   fun:curl_easy_perform
+}
+
+{
+   driver_name_cond
+   Memcheck:Cond
+   ...
+   fun:driver_name
+   fun:dev_to_tty
+   fun:read_process
+   fun:process58_probe_main
+   fun:probe_worker
+   fun:probe_worker_runfn
+   fun:start_thread
+   fun:clone
+}
+
+{
+   driver_name_leak
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:load_drivers
+   fun:driver_name
+   fun:dev_to_tty
+   fun:read_process
+   fun:process58_probe_main
+   fun:probe_worker
+   fun:probe_worker_runfn
+   fun:start_thread
+   fun:clone
+}
+
+{
+   rpmReadConfigFiles
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:realloc
+   fun:rrealloc
+   fun:rstrscat
+   fun:rpmReadConfigFiles
+   fun:rpmverify_probe_init
+   fun:probe_common_main
+   fun:start_thread
+   fun:clone
+}
+
+{
+   headerFormat
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:realloc
+   fun:rrealloc
+   fun:headerFormat
+   fun:rpmverify_collect
+   fun:rpmverify_probe_main
+   fun:probe_worker
+   fun:probe_worker_runfn
+   fun:start_thread
+   fun:clone
+}
+
+{
+   connect_dbus
+   Memcheck:Leak
+   match-leak-kinds: all
+   ...
+   fun:connect_dbus
+   fun:systemdunitdependency_probe_main
+   ...
+}


### PR DESCRIPTION
When we make the Jenkins job passing it will be easier to detect
freshly introduced memory problems. Until all memory problems
are fixed we risk that new problems will be ignored.