### PR TITLE
Plug a memory leak

### DIFF
--- a/src/OVAL/results/oval_resultCriteriaNode.c
+++ b/src/OVAL/results/oval_resultCriteriaNode.c
@@ -258,8 +258,11 @@ struct oval_result_criteria_node *make_result_criteria_node_from_oval_criteria_n
 					    = oval_criteria_node_iterator_next(oval_subnodes);
 					struct oval_result_criteria_node *rslt_subnode
 						= make_result_criteria_node_from_oval_criteria_node(sys, oval_subnode, visited_definitions, variable_instance);
-					if (rslt_subnode == NULL)
+					if (rslt_subnode == NULL) {
+						oval_criteria_node_iterator_free(oval_subnodes);
+						oval_result_criteria_node_free(rslt_node);
 						return NULL;
+					}
 					oval_result_criteria_node_add_subnode(rslt_node, rslt_subnode);
 				}
 				oval_criteria_node_iterator_free(oval_subnodes);


### PR DESCRIPTION
Addressing:

8 bytes in 1 blocks are indirectly lost in loss record 7 of 235
   at 0x483A809: malloc (vg_replace_malloc.c:307)
   by 0x48F15CA: oval_collection_new (oval_collection.c:64)
   by 0x48F4FCC: oval_result_criteria_node_new (oval_resultCriteriaNode.c:106)
   by 0x48F5580: make_result_criteria_node_from_oval_criteria_node (oval_resultCriteriaNode.c:249)
   by 0x48F6B51: make_result_definition_from_oval_definition (oval_resultDefinition.c:130)
   by 0x48F7F41: oval_result_system_get_new_definition_with_check (oval_resultSystem.c:217)
   by 0x48F5686: make_result_criteria_node_from_oval_criteria_node (oval_resultCriteriaNode.c:279)
   by 0x48F55BD: make_result_criteria_node_from_oval_criteria_node (oval_resultCriteriaNode.c:260)
   by 0x48F6B51: make_result_definition_from_oval_definition (oval_resultDefinition.c:130)
   by 0x48F8794: oval_result_system_prepare_definition (oval_resultSystem.c:395)
   by 0x48F86A6: oval_result_system_eval_definition (oval_resultSystem.c:369)
   by 0x48C23FD: oval_agent_eval_definition (oval_agent.c:181)

8 bytes in 1 blocks are definitely lost in loss record 8 of 235
   at 0x483A809: malloc (vg_replace_malloc.c:307)
   by 0x48F1799: oval_collection_iterator (oval_collection.c:120)
   by 0x48CCE4C: oval_criteria_node_get_subnodes (oval_criteriaNode.c:161)
   by 0x48F5590: make_result_criteria_node_from_oval_criteria_node (oval_resultCriteriaNode.c:255)
   by 0x48F6B51: make_result_definition_from_oval_definition (oval_resultDefinition.c:130)
   by 0x48F7F41: oval_result_system_get_new_definition_with_check (oval_resultSystem.c:217)
   by 0x48F5686: make_result_criteria_node_from_oval_criteria_node (oval_resultCriteriaNode.c:279)
   by 0x48F55BD: make_result_criteria_node_from_oval_criteria_node (oval_resultCriteriaNode.c:260)
   by 0x48F6B51: make_result_definition_from_oval_definition (oval_resultDefinition.c:130)
   by 0x48F8794: oval_result_system_prepare_definition (oval_resultSystem.c:395)
   by 0x48F86A6: oval_result_system_eval_definition (oval_resultSystem.c:369)
   by 0x48C23FD: oval_agent_eval_definition (oval_agent.c:181)

48 (40 direct, 8 indirect) bytes in 1 blocks are definitely lost in loss record 125 of 235
   at 0x483A809: malloc (vg_replace_malloc.c:307)
   by 0x48F4F50: oval_result_criteria_node_new (oval_resultCriteriaNode.c:98)
   by 0x48F5580: make_result_criteria_node_from_oval_criteria_node (oval_resultCriteriaNode.c:249)
   by 0x48F6B51: make_result_definition_from_oval_definition (oval_resultDefinition.c:130)
   by 0x48F7F41: oval_result_system_get_new_definition_with_check (oval_resultSystem.c:217)
   by 0x48F5686: make_result_criteria_node_from_oval_criteria_node (oval_resultCriteriaNode.c:279)
   by 0x48F55BD: make_result_criteria_node_from_oval_criteria_node (oval_resultCriteriaNode.c:260)
   by 0x48F6B51: make_result_definition_from_oval_definition (oval_resultDefinition.c:130)
   by 0x48F8794: oval_result_system_prepare_definition (oval_resultSystem.c:395)
   by 0x48F86A6: oval_result_system_eval_definition (oval_resultSystem.c:369)
   by 0x48C23FD: oval_agent_eval_definition (oval_agent.c:181)
   by 0x48C2671: oval_agent_eval_system (oval_agent.c:286)

This leak has been created by #1610.