### PR TITLE
Covscan fixes

### DIFF
--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -219,7 +219,7 @@ static fsdev_t *__fsdev_init(fsdev_t *lfs)
 	endmntent(fp);
 
 	void *new_ids = realloc(lfs->ids, sizeof(dev_t) * i);
-	if (new_ids == NULL) {
+	if (new_ids == NULL && i > 0) {
 		e = errno;
 		free(lfs->ids);
 		free(lfs);

--- a/src/OVAL/probes/independent/yamlfilecontent_probe.c
+++ b/src/OVAL/probes/independent/yamlfilecontent_probe.c
@@ -216,11 +216,12 @@ static int yaml_path_query(const char *filepath, const char *yaml_path_cstr, str
 			result_error("YAML parser error: %s", parser.problem);
 			goto cleanup;
 		}
+
+		event_type = event.type;
+
 		if (yaml_path_filter_event(yaml_path, &parser, &event) == YAML_PATH_FILTER_RESULT_OUT) {
 			goto next;
 		}
-
-		event_type = event.type;
 
 		if (sequence) {
 			if (event_type == YAML_SEQUENCE_END_EVENT) {

--- a/src/OVAL/probes/unix/fileextendedattribute_probe.c
+++ b/src/OVAL/probes/unix/fileextendedattribute_probe.c
@@ -298,7 +298,7 @@ static int file_cb(const char *prefix, const char *p, const char *f, void *ptr, 
 
 				// Allocate buffer, '+1' is for trailing '\0'
 				void *new_xattr_val = realloc(xattr_val, sizeof(char) * (xattr_vallen + 1));
-				if (xattr_val == NULL) {
+				if (new_xattr_val == NULL) {
 					dE("Failed to allocate memory for xattr_val");
 					free(xattr_val);
 					goto exit;

--- a/src/OVAL/probes/unix/linux/partition_probe.c
+++ b/src/OVAL/probes/unix/linux/partition_probe.c
@@ -207,7 +207,7 @@ static int collect_item(probe_ctx *ctx, oval_schema_version_t over, struct mnten
             mnt_ocnt = add_mnt_opt(&mnt_opts, mnt_ocnt, "move");
         }
 
-        dD("mnt_ocnt = %d, mnt_opts[mnt_ocnt]=%p", mnt_ocnt, mnt_opts[mnt_ocnt]);
+        dD("mnt_ocnt = %d, mnt_opts[mnt_ocnt]=%p", mnt_ocnt, mnt_opts == NULL ? NULL : mnt_opts[mnt_ocnt]);
 
 	/*
 	 * "Correct" the type (this won't be (hopefully) needed in a later version

--- a/src/OVAL/probes/unix/xinetd_probe.c
+++ b/src/OVAL/probes/unix/xinetd_probe.c
@@ -566,7 +566,12 @@ static int xiconf_add_cfile(xiconf_t *xiconf, const char *path, int depth)
 	}
 
 	xifile->depth = depth;
-	xiconf->cfile = realloc(xiconf->cfile, sizeof(xiconf_file_t *) * ++xiconf->count);
+	void *cfile = realloc(xiconf->cfile, sizeof(xiconf_file_t *) * ++xiconf->count);
+	if (cfile == NULL) {
+		dE("Failed re-allocate memory for cfile");
+		return (-1);
+	}
+	xiconf->cfile = cfile;
 	xiconf->cfile[xiconf->count - 1] = xifile;
 
 	dD("Added new file to the cfile queue: %s; fi=%zu", path, xiconf->count - 1);

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -286,9 +286,9 @@ static struct oscap_source *xccdf_session_extract_arf_source(struct xccdf_sessio
 			}
 			struct tm *tm_mtime = malloc(sizeof(struct tm));
 #ifdef OS_WINDOWS
-			tm_mtime = localtime_s(tm_mtime, &file_stat.st_mtime);
+			localtime_s(tm_mtime, &file_stat.st_mtime);
 #else
-			tm_mtime = localtime_r(&file_stat.st_mtime, tm_mtime);
+			localtime_r(&file_stat.st_mtime, tm_mtime);
 #endif
 			strftime(tailoring_doc_timestamp, max_timestamp_len,
 					"%Y-%m-%dT%H:%M:%S", tm_mtime);

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -315,7 +315,10 @@ static void getopt_parse_env(struct oscap_module *module, int *argc, char ***arg
 	opt = oscap_strtok_r(opts, delim, &state);
 	while (opt != NULL) {
 		eargc++;
-		eargv = realloc(eargv, eargc * sizeof(char *));
+		void *new_eargv = realloc(eargv, eargc * sizeof(char *));
+		if (new_eargv == NULL)
+			goto exit;
+		eargv = new_eargv;
 		eargv[eargc - 1] = strdup(opt);
 		opt = oscap_strtok_r(NULL, delim, &state);
 	}
@@ -334,6 +337,7 @@ static void getopt_parse_env(struct oscap_module *module, int *argc, char ***arg
 
 	*argc = nargc;
 	*argv = nargv;
+exit:
 	free(opts);
 	free(eargv);
 }

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -610,8 +610,7 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 
 	/* syslog message */
 #if defined(HAVE_SYSLOG_H)
-	syslog(priority, "Evaluation finished. Return code: %d, Base score %f.", evaluation_result,
-		session == NULL ? 0 : xccdf_session_get_base_score(session));
+	syslog(priority, "Evaluation finished. Return code: %d, Base score %f.", evaluation_result, xccdf_session_get_base_score(session));
 #endif
 
 	xccdf_session_set_xccdf_export(session, action->f_results);


### PR DESCRIPTION
Fixes for:
```
openscap-1.3.4/src/OVAL/probes/independent/yamlfilecontent_probe.c:317: uninit_use: Using uninitialized value "event_type". 

openscap-1.3.4/src/XCCDF/xccdf_session.c:291: overwrite_var: Overwriting "tm_mtime" in "tm_mtime = localtime_r(&file_stat.st_mtim.tv_sec, tm_mtime)" leaks the storage that "tm_mtime" points to. 

openscap-1.3.4/src/OVAL/probes/unix/xinetd_probe.c:570: dereference: Dereferencing "xiconf->cfile", which is known to be "NULL". 

openscap-1.3.4/utils/oscap-tool.c:319: dereference: Dereferencing "eargv", which is known to be "NULL". 

openscap-1.3.4/utils/oscap-xccdf.c:613: dead_error_line: Execution cannot reach the expression "0f" inside this statement: "syslog(priority, "Evaluatio...". 

openscap-1.3.4/src/OVAL/probes/unix/fileextendedattribute_probe.c:306: dead_error_begin: Execution cannot reach this statement: "xattr_val = new_xattr_val;". 

openscap-1.3.4/src/OVAL/probes/fsdev.c:224:3: warning: Attempt to free released memory [unix.Malloc]

openscap-1.3.4/src/OVAL/probes/unix/linux/partition_probe.c:210:62: warning: Array access (from variable 'mnt_opts') results in a null pointer dereference [core.NullDereference] 
```