### PR TITLE
Fix the build for FreeBSD.

### DIFF
--- a/swig/perl/CMakeLists.txt
+++ b/swig/perl/CMakeLists.txt
@@ -13,7 +13,7 @@ if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Cl
 	target_compile_options(${SWIG_MODULE_openscap_pm_REAL_NAME} PUBLIC "-w")
 endif()
 
-if (APPLE)
+if (APPLE OR (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD"))
         install(TARGETS ${SWIG_MODULE_openscap_pm_REAL_NAME}
                 DESTINATION ${CMAKE_INSTALL_LIBDIR}/perl5/vendor_perl)
         install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/openscap_pm.pm


### PR DESCRIPTION
After commit 69b9b1519 ("Changing hardcoded libperl path for FindPerlLibs method"), OpenSCAP no longer builds on FreeBSD.

Running `cmake ../` results in the following errors:

```
CMake Error at swig/perl/CMakeLists.txt:22 (install):
  install TARGETS given no LIBRARY DESTINATION for module target
  "openscap_pm".
CMake Error at swig/perl/CMakeLists.txt:24 (install):
  install PROGRAMS given no DESTINATION!
```

This is due to cmake on FreeBSD not defining `PERL_VENDORLIB` and `PERL_VENDORARCH`. To workaround this issue, I have added FreeBSD to use the same case as macOS, which falls back to the previous hard-coded paths. After this change OpenSCAP successfully builds on FreeBSD and passes all known-working tests.