### PR TITLE
Include unistd.h file to fix MacOS build.

### DIFF
--- a/src/OVAL/probes/probe/probe_main.c
+++ b/src/OVAL/probes/probe/probe_main.c
@@ -26,6 +26,7 @@
 #  define _GNU_SOURCE
 # endif
 #endif
+#include <unistd.h>
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>


### PR DESCRIPTION
Attempt to fix MacOS build. `unistd.h` should have the `chroot` definition, let's see what the CI will tell.

```
 /Users/runner/work/openscap/openscap/src/OVAL/probes/probe/worker.c:1013:8: error: implicit declaration of function 'chroot' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                        if (chroot(rootdir) != 0) {
                            ^
/Users/runner/work/openscap/openscap/src/OVAL/probes/probe/worker.c:1176:7: error: implicit declaration of function 'chroot' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                if (chroot(".") == -1) {
                    ^
2 errors generated.
make[2]: *** [src/OVAL/probes/probe/CMakeFiles/probe_object.dir/worker.c.o] Error 1
make[1]: *** [src/OVAL/probes/probe/CMakeFiles/probe_object.dir/all] Error 2
make: *** [all] Error 2
```