### PR TITLE
Added the missing header for chroot() on macOS

### DIFF
--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -39,7 +39,7 @@
 #if defined(OS_OSX)
 /* XXX: please see https://github.com/OpenSCAP/openscap/pull/1626 for the
  *      reason of explicitly defining an external here instead of simply
- *      including the unistd.h headr file.
+ *      including the unistd.h header file.
  */
 extern int chroot(const char *);
 #endif

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -31,10 +31,13 @@
 #include <string.h>
 #include <pthread.h>
 #include <errno.h>
-#include <unistd.h>
 
 #if defined(OS_FREEBSD)
 #include <pthread_np.h>
+#endif
+
+#if defined(OS_OSX)
+external int chroot(const char *);
 #endif
 
 #include "probe-api.h"

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -37,7 +37,7 @@
 #endif
 
 #if defined(OS_OSX)
-external int chroot(const char *);
+extern int chroot(const char *);
 #endif
 
 #include "probe-api.h"

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -37,6 +37,10 @@
 #endif
 
 #if defined(OS_OSX)
+/* XXX: please see https://github.com/OpenSCAP/openscap/pull/1626 for the
+ *      reason of explicitly defining an external here instead of simply
+ *      including the unistd.h headr file.
+ */
 extern int chroot(const char *);
 #endif
 

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -31,14 +31,10 @@
 #include <string.h>
 #include <pthread.h>
 #include <errno.h>
+#include <unistd.h>
 
 #if defined(OS_FREEBSD)
 #include <pthread_np.h>
-#endif
-
-#if defined(OS_OSX)
-#undef _POSIX_SOURCE
-#include <unistd.h>
 #endif
 
 #include "probe-api.h"

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -37,6 +37,7 @@
 #endif
 
 #if defined(OS_OSX)
+#undef _POSIX_SOURCE
 #include <unistd.h>
 #endif
 

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -36,6 +36,10 @@
 #include <pthread_np.h>
 #endif
 
+#if defined(OS_OSX)
+#include <unistd.h>
+#endif
+
 #include "probe-api.h"
 #include "common/debug_priv.h"
 #include "entcmp.h"


### PR DESCRIPTION
Fixes #1624 