### PR TITLE
probes/xinted: Potential resource leak fix

### DIFF
--- a/src/OVAL/probes/unix/xinetd_probe.c
+++ b/src/OVAL/probes/unix/xinetd_probe.c
@@ -569,6 +569,12 @@ static int xiconf_add_cfile(xiconf_t *xiconf, const char *path, int depth)
 	void *cfile = realloc(xiconf->cfile, sizeof(xiconf_file_t *) * ++xiconf->count);
 	if (cfile == NULL) {
 		dE("Failed re-allocate memory for cfile");
+		xiconf->count--;
+		if (xifile->cpath)
+			free(xifile->cpath);
+		if (xifile->inmem)
+			free(xifile->inmem);
+		free(xifile);
 		return (-1);
 	}
 	xiconf->cfile = cfile;


### PR DESCRIPTION
xinetd_probe.c:572: leaked_storage: Variable "xifile" going out of scope leaks the storage it points to.