### PR TITLE
Extend test_fsdev_is_local_fs to verify GPFS

### DIFF
--- a/tests/API/probes/fake_mtab
+++ b/tests/API/probes/fake_mtab
@@ -5,3 +5,4 @@ tmpfs /tmp tmpfs rw,seclabel,nosuid,nodev 0 0
 /dev/mapper/fedora-home /home ext4 rw,seclabel,relatime 0 0
 proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
 //192.168.0.5/storage /media/movies cifs guest,uid=myuser,iocharset=utf8,file_mode=0777,dir_mode=0777,noperm 0 0
+/dev/gpfsdev /gpfs gpfs rw,relatime 0 0


### PR DESCRIPTION
Test for commit 1541487 - add GPFS into fake_mtab (which is
utilized by the `test_fsdev_is_local_fs`) to make sure that it
is not detected as a local filesystem.

For more details also see
https://www.ibm.com/developerworks/systems/library/es-gpfs/index.html