### PR TITLE
Fix TestResult/benchmark/@href attribute

### DIFF
--- a/src/DS/ds_sds_session_priv.h
+++ b/src/DS/ds_sds_session_priv.h
@@ -37,6 +37,7 @@ xmlDoc *ds_sds_session_get_xmlDoc(struct ds_sds_session *session);
 int ds_sds_session_register_component_source(struct ds_sds_session *session, const char *relative_filepath, struct oscap_source *component);
 const char *ds_sds_session_get_target_dir(struct ds_sds_session *session);
 struct oscap_htable *ds_sds_session_get_component_sources(struct ds_sds_session *session);
+struct oscap_htable *ds_sds_session_get_component_uris(struct ds_sds_session *session);
 const char *ds_sds_session_get_readable_origin(const struct ds_sds_session *session);
 bool ds_sds_session_fetch_remote_resources(struct ds_sds_session *session);
 download_progress_calllback_t ds_sds_session_remote_resources_progress(struct ds_sds_session *session);

--- a/src/DS/public/ds_sds_session.h
+++ b/src/DS/public/ds_sds_session.h
@@ -120,6 +120,14 @@ OSCAP_API const char *ds_sds_session_get_datastream_id(const struct ds_sds_sessi
 OSCAP_API const char *ds_sds_session_get_checklist_id(const struct ds_sds_session *session);
 
 /**
+ * Return URI of currently selected component representing XCCDF within the DataStream
+ * @memberof ds_sds_session
+ * @param session The Source DataStream session
+ * @returns URI of selected component or NULL
+ */
+OSCAP_API const char *ds_sds_session_get_checklist_uri(const struct ds_sds_session *session);
+
+/**
  * Get component from Source DataStream by its href. This assumes that the component
  * has been already cached by the session. You can cache component or its dependencies
  * by calling ds_sds_session_select_checklist or ds_sds_session_register_component_with_dependencies.

--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -450,7 +450,10 @@ int ds_sds_dump_component_ref_as(const xmlNodePtr component_ref, struct ds_sds_s
 
 	char* component_id = NULL;
 
+	// make a copy of xlink_href because ds_sds_dump_component_by_href modifies its second argument
+	char *xlink_href_copy = oscap_strdup(xlink_href);
 	int ret = ds_sds_dump_component_by_href(session, xlink_href, target_filename_dirname, relative_filepath, cref_id, &component_id);
+	oscap_htable_add(ds_sds_session_get_component_uris(session), cref_id, xlink_href_copy);
 
 	xmlFree(xlink_href);
 	xmlFree(cref_id);

--- a/src/XCCDF/item.c
+++ b/src/XCCDF/item.c
@@ -1155,6 +1155,7 @@ struct xccdf_benchmark_item * xccdf_benchmark_item_clone(struct xccdf_item *pare
 	clone->items_dict = oscap_htable_new();
 	clone->profiles_dict = oscap_htable_new();
 	clone->results_dict = oscap_htable_new();
+	clone->clusters_dict = oscap_htable_new();
 	clone->notices = oscap_list_clone(item->notices, (oscap_clone_func) xccdf_notice_clone);
 	clone->plain_texts = oscap_list_clone(item->plain_texts, (oscap_clone_func) xccdf_plain_text_clone);
 	

--- a/tests/DS/test_ds_misc.sh
+++ b/tests/DS/test_ds_misc.sh
@@ -162,6 +162,7 @@ function test_eval_complex()
 	assert_exists 1 '//rule-result[@idref="xccdf_moc.elpmaxe.www_rule_second"]'
 	assert_exists 1 '//rule-result/result'
 	assert_exists 1 '//rule-result/result[text()="pass"]'
+	assert_exists 1 '//TestResult/benchmark[@href="#scap_org.open-scap_comp_second-xccdf.xml2"]'
 	rm $arf
 }
 
@@ -183,15 +184,30 @@ function test_oval_eval_id {
     echo "$OUT" | grep $4 > /dev/null
 }
 
-function test_sds_external_xccdf {
-    local SDS_FILE="${srcdir}/$2"
-    local XCCDF="$3"
-    local PROFILE="$4"
-    local result="${1}-${PROFILE}.xml"
+function test_sds_external_xccdf_in_ds {
+    local SDS_FILE="${srcdir}/sds_external_xccdf/sds.ds.xml"
+    local XCCDF="scap_org.open-scap_cref_xccdf.xml"
+    local PROFILE="xccdf_external_profile_datastream_1"
+    local result="$(mktemp)"
 
-    $OSCAP xccdf eval --xccdf-id "$XCCDF" --profile "$PROFILE" --results "$result" "$SDS_FILE"
+    $OSCAP xccdf eval --xccdf-id "$XCCDF" --profile "$PROFILE" --results-arf "$result" "$SDS_FILE"
 
     assert_exists 1 '//rule-result/result[text()="pass"]'
+    assert_exists 1 '//TestResult/benchmark[@href="file:xccdf.sds.xml#scap_1_comp_xccdf.xml"]'
+
+    rm -f "$result"
+}
+
+function test_sds_external_xccdf {
+    local SDS_FILE="${srcdir}/sds_external_xccdf/sds.ds.xml"
+    local XCCDF="scap_org.open-scap_cref_xccdf-file.xml"
+    local PROFILE="xccdf_external_profile_file_1"
+    local result="$(mktemp)"
+
+    $OSCAP xccdf eval --xccdf-id "$XCCDF" --profile "$PROFILE" --results-arf "$result" "$SDS_FILE"
+
+    assert_exists 1 '//rule-result/result[text()="pass"]'
+    assert_exists 1 '//TestResult/benchmark[@href="file:xccdf.xml"]'
 
     rm -f "$result"
 }
@@ -238,8 +254,8 @@ function test_ds_continue_without_remote_resources() {
 # Testing.
 test_init
 
-test_run "sds_external_xccdf" test_sds_external_xccdf sds_external_xccdf sds_external_xccdf/sds.ds.xml scap_org.open-scap_cref_xccdf.xml xccdf_external_profile_datastream_1
-test_run "sds_external_xccdf" test_sds_external_xccdf sds_external_xccdf sds_external_xccdf/sds.ds.xml scap_org.open-scap_cref_xccdf-file.xml xccdf_external_profile_file_1
+test_run "sds_external_xccdf_in_ds" test_sds_external_xccdf_in_ds
+test_run "sds_external_xccdf" test_sds_external_xccdf
 test_run "sds_tailoring" test_sds_tailoring sds_tailoring sds_tailoring/sds.ds.xml scap_com.example_datastream_with_tailoring xccdf_com.example_cref_tailoring_01 xccdf_com.example_profile_tailoring
 
 test_run "eval_simple" test_eval eval_simple/sds.xml


### PR DESCRIPTION
Make the href attribute an URI according to SCAP specification Section
4.5. This should fix SCAPVAL error RES-253-2 which occured when
validating ARFs by SCAPVAL. See #1629 for the problem description.

Also, it fixes a problem that xccdf_benchmark_item_clone didn't create
the clusters_dict hash table.

The existing tests are extended to test this property, the
function test_sds_external_xccdf has been split into 2 functions.

Fixes: #1629