### PR TITLE
Plug a memory leak

### DIFF
--- a/src/OVAL/probes/unix/linux/partition_probe.c
+++ b/src/OVAL/probes/unix/linux/partition_probe.c
@@ -178,7 +178,7 @@ static int collect_item(probe_ctx *ctx, oval_schema_version_t over, struct mnten
 #if defined(HAVE_BLKID_GET_TAG_VALUE)
         uuid = blkid_get_tag_value(blkcache, "UUID", mnt_ent->mnt_fsname);
         if (uuid == NULL) {
-	        uuid = "";
+		uuid = strdup("");
         }
 #endif
         /*
@@ -245,6 +245,7 @@ static int collect_item(probe_ctx *ctx, oval_schema_version_t over, struct mnten
         if (strcmp(uuid, "") == 0) {
 	        probe_itement_setstatus(item, "uuid", 1, SYSCHAR_STATUS_DOES_NOT_EXIST);
         }
+	free(uuid);
 #else
 	/* Compiled without blkid library, we don't collect UUID */
 	probe_itement_setstatus(item, "uuid", 1, SYSCHAR_STATUS_NOT_COLLECTED);


### PR DESCRIPTION
Addressing:
 37 bytes in 1 blocks are definitely lost in loss record 1 of 1
    at 0x483A809: malloc (vg_replace_malloc.c:307)
    by 0x50252DE: strdup (in /usr/lib64/libc-2.31.so)
    by 0x4EC93FD: blkid_get_tag_value (in /usr/lib64/libblkid.so.1.1.0)
    by 0x492492B: collect_item (partition_probe.c:179)
    by 0x492504D: partition_probe_main (partition_probe.c:380)
    by 0x4909C87: probe_worker (worker.c:1102)
    by 0x4909520: probe_worker_runfn (worker.c:93)
    by 0x4C81431: start_thread (in /usr/lib64/libpthread-2.31.so)
    by 0x5096912: clone (in /usr/lib64/libc-2.31.so)