### PR TITLE
Plug memory leaks

### DIFF
--- a/src/OVAL/probes/independent/yamlfilecontent_probe.c
+++ b/src/OVAL/probes/independent/yamlfilecontent_probe.c
@@ -241,6 +241,7 @@ static int yaml_path_query(const char *filepath, const char *yaml_path_cstr, str
 			} else if (event_type == YAML_SEQUENCE_START_EVENT) {
 				if (mapping || fake_mapping) {
 					result_error("YAML path '%s' points to a multi-dimensional structure (a map or a sequence containing other sequences)", yaml_path_cstr);
+					yaml_event_delete(&event);
 					goto cleanup;
 				} else {
 					fake_mapping = true;
@@ -267,16 +268,19 @@ static int yaml_path_query(const char *filepath, const char *yaml_path_cstr, str
 				record = NULL;
 			} else if (event_type == YAML_MAPPING_START_EVENT) {
 				result_error("YAML path '%s' points to a multi-dimensional structure (map containing another map)", yaml_path_cstr);
+				yaml_event_delete(&event);
 				goto cleanup;
 			}
 		} else {
 			if (event_type == YAML_MAPPING_START_EVENT) {
 				if (record) {
 					result_error("YAML path '%s' points to an invalid structure (map containing another map)", yaml_path_cstr);
+					yaml_event_delete(&event);
 					goto cleanup;
 				}
 				if (fake_mapping) {
 					result_error("YAML path '%s' points to a multi-dimensional structure (two-dimensional sequence containing a map)", yaml_path_cstr);
+					yaml_event_delete(&event);
 					goto cleanup;
 				}
 				mapping = true;
@@ -300,6 +304,7 @@ static int yaml_path_query(const char *filepath, const char *yaml_path_cstr, str
 			SEXP_t *sexp = yaml_scalar_event_to_sexp(&event);
 			if (sexp == NULL) {
 				result_error("Can't convert '%s %s' to SEXP", event.data.scalar.tag, event.data.scalar.value);
+				yaml_event_delete(&event);
 				goto cleanup;
 			}
 
@@ -377,6 +382,7 @@ static int process_yaml_file(const char *prefix, const char *path, const char *f
 					SEXP_t *field = probe_ent_creat1("field", NULL, value_sexp);
 					probe_item_attr_add(field, "name", key);
 					SEXP_list_add(result_ent, field);
+					SEXP_free(field);
 				}
 				oscap_iterator_free(item_value_it);
 				SEXP_free_r(&se_tmp_mem);


### PR DESCRIPTION
Addressing:

 125 bytes in 5 blocks are indirectly lost in loss record 227 of 253
    at 0x483CE14: memalign (vg_replace_malloc.c:906)
    by 0x483CF14: posix_memalign (vg_replace_malloc.c:1070)
    by 0x4947529: oscap_aligned_malloc (util.h:348)
    by 0x4947587: SEXP_val_new (sexp-value.c:36)
    by 0x4946076: SEXP_number_newf_r (sexp-manip_r.c:163)
    by 0x4942BC5: SEXP_number_newf (sexp-manip.c:522)
    by 0x494D8F2: yaml_scalar_event_to_sexp (yamlfilecontent_probe.c:124)
    by 0x494E1BF: yaml_path_query (yamlfilecontent_probe.c:300)
    by 0x494E401: process_yaml_file (yamlfilecontent_probe.c:348)
    by 0x494E7DF: yamlfilecontent_probe_main (yamlfilecontent_probe.c:420)
    by 0x49377B6: probe_worker (worker.c:1102)
    by 0x493512E: probe_worker_runfn (worker.c:93)

 8,888 (704 direct, 8,184 indirect) bytes in 22 blocks are definitely lost in loss record 252 of 253
    at 0x483A809: malloc (vg_replace_malloc.c:307)
    by 0x4944EC5: SEXP_new (sexp-manip.c:1613)
    by 0x49437CB: SEXP_list_new (sexp-manip.c:933)
    by 0x48E6E4B: probe_ent_creat1 (probe-api.c:1003)
    by 0x494E56D: process_yaml_file (yamlfilecontent_probe.c:377)
    by 0x494E7DF: yamlfilecontent_probe_main (yamlfilecontent_probe.c:420)
    by 0x49377B6: probe_worker (worker.c:1102)
    by 0x493512E: probe_worker_runfn (worker.c:93)
    by 0x4CDE431: start_thread (in /usr/lib64/libpthread-2.31.so)
    by 0x52AD912: clone (in /usr/lib64/libc-2.31.so)