### PR TITLE
Add severity and role attributes

### DIFF
--- a/src/XCCDF/rule.c
+++ b/src/XCCDF/rule.c
@@ -273,8 +273,6 @@ void xccdf_group_free(struct xccdf_item *group)
 struct xccdf_item *xccdf_rule_new_internal(struct xccdf_item *parent)
 {
 	struct xccdf_item *rule = xccdf_item_new(XCCDF_RULE, parent);
-	rule->sub.rule.role = 0;
-	rule->sub.rule.severity = 0;
 	rule->sub.rule.role = XCCDF_ROLE_FULL;
 	rule->sub.rule.severity = XCCDF_UNKNOWN;
 

--- a/src/XCCDF/rule.c
+++ b/src/XCCDF/rule.c
@@ -275,6 +275,8 @@ struct xccdf_item *xccdf_rule_new_internal(struct xccdf_item *parent)
 	struct xccdf_item *rule = xccdf_item_new(XCCDF_RULE, parent);
 	rule->sub.rule.role = 0;
 	rule->sub.rule.severity = 0;
+	rule->sub.rule.role = XCCDF_ROLE_FULL;
+	rule->sub.rule.severity = XCCDF_UNKNOWN;
 
 	rule->sub.rule.idents = oscap_list_new();
 	rule->sub.rule.checks = oscap_list_new();

--- a/tests/API/XCCDF/parser/xccdf11-results.xml
+++ b/tests/API/XCCDF/parser/xccdf11-results.xml
@@ -48,7 +48,7 @@
       <value selector="5_minutes">300</value>
       <value selector="10_minutes">600</value>
     </Value>
-    <Rule id="ssh_server_disabled" selected="true" severity="low">
+    <Rule id="ssh_server_disabled" selected="true" severity="low" role="full">
       <title xml:lang="en-US">Disable SSH Server If Possible (Unusual)</title>
       <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">Bla bla</description>
       <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">

--- a/tests/API/XCCDF/parser/xccdf11.xml
+++ b/tests/API/XCCDF/parser/xccdf11.xml
@@ -432,7 +432,7 @@
         <Group id="scap-rhel5-group-2.1.2.2" hidden="false">
           <title xml:lang="en">Disable the rhnsd Daemon </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rhnsd daemon polls the Red Hat Network web site for scheduled actions. Unless it is actually necessary to schedule updates remotely through the RHN website, it is recommended that the service be disabled. # chkconfig rhnsd off The rhnsd daemon is enabled by default, but until the system has been registered with the Red Hat Network, it will not run. However, once the registration process is complete, the rhnsd daemon will run in the background and periodically call the rhn check utility. It is the rhn check utility that communicates with the Red Hat Network web site. This utility is not required for the system to be able to access and install system updates. Once the system has been registered, either use the provided yum-updatesd service or create a cron job to automatically apply updates. </description>
-          <Rule id="scap-rhel5-rule-0" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-0" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable the rhnsd Daemon </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rhnsd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3416-5</ident>
@@ -451,7 +451,7 @@
           <Group id="scap-rhel5-group-2.1.2.3.2" hidden="false">
             <title xml:lang="en">Configure Automatic Update Retrieval and Installation with Cron </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The yum-updatesd service is not mature enough for an enterprise environment, and the service may introduce unnecessary overhead. When possible, replace this service with a cron job that calls yum directly. Disable the yum-updatesd service: # chkconfig yum-updatesd off Create the file yum.cron, make it executable, and place it in /etc/cron.daily: #!/bin/sh /usr/bin/yum -R 120 -e 0 -d 0 -y update yum /usr/bin/yum -R 10 -e 0 -d 0 -y update This particular script instructs yum to update any packages it finds. Placing the script in /etc/cron.daily ensures its daily execution. To only apply updates once a week, place the script in /etc/cron.weekly instead. </description>
-            <Rule id="scap-rhel5-rule-1" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-1" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Configure Automatic Update Retrieval and Installation with Cron </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The yum-updatesd service should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4218-4</ident>
@@ -471,7 +471,7 @@
           <Group id="scap-rhel5-group-2.1.3.1.1" hidden="false">
             <title xml:lang="en">Install AIDE </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">AIDE is not installed by default. Install it with the command: # yum install aide </description>
-            <Rule id="scap-rhel5-rule-2" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-2" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Install AIDE </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The AIDE package should be installed or not as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4209-3</ident>
@@ -508,7 +508,7 @@
         <Group id="scap-rhel5-group-2.2.1.1" hidden="false">
           <title xml:lang="en">Add nodev Option to Non-Root Local Partitions </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/fstab. The important columns for purposes of this section are column 2 (mount point), column 3 (filesystem type), and column 4 (mount options). For any line which satisfies all of the conditions: * The filesystem type is ext2 or ext3 * The mount point is not / add the text “,nodev” to the list of mount options in column 4. The nodev option prevents users from mounting unauthorized devices on any partition which is known not to contain any authorized devices. The root partition typically contains the /dev partition, which is the primary location for authorized devices, so this option should not be set on /. However, if system programs are being run in chroot jails, this advice may need to be modified further, since it is often necessary to create device files inside the chroot directory for use by the restricted program. </description>
-          <Rule id="scap-rhel5-rule-3" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-3" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Add nodev Option to Non-Root Local Partitions </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nodev option should be enabled or disabled as appropriate for all non-root partitions.</description>
             <ident system="http://cce.mitre.org">CCE-4249-9</ident>
@@ -520,7 +520,7 @@
         <Group id="scap-rhel5-group-2.2.1.2" hidden="false">
           <title xml:lang="en">Add nodev, nosuid, and noexec Options to Removable Media Partitions </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/fstab. Filesystems which represent removable media can be located by finding lines whose mount points contain strings like floppy or cdrom, or whose types are iso9660, vfat, or msdos. For each line representing a removable media mountpoint, add the text ,nodev,nosuid to the list of mount options in column 4. If appropriate, also add the text ,noexec. Users should not be allowed to introduce arbitrary devices or setuid programs to a system. These options are used to prevent that. In addition, while users are usually allowed to add executable programs to a system, the noexec option prevents code from being executed directly from the media itself, and may therefore provide a line of defense against certain types of worms or malicious code. </description>
-          <Rule id="scap-rhel5-rule-4" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-4" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Add nodev, nosuid, and noexec Options to Removable Media Partitions </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nodev option should be enabled or disabled as appropriate for all removable media.</description>
             <ident system="http://cce.mitre.org">CCE-3522-0</ident>
@@ -528,7 +528,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:5" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-5" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-5" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Add nodev, nosuid, and noexec Options to Removable Media Partitions </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The noexec option should be enabled or disabled as appropriate for all removable media.</description>
             <ident system="http://cce.mitre.org">CCE-4275-4</ident>
@@ -536,7 +536,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:6" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-6" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-6" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Add nodev, nosuid, and noexec Options to Removable Media Partitions </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nosuid option should be enabled or disabled as appropriate for all removable media.</description>
             <ident system="http://cce.mitre.org">CCE-4042-8</ident>
@@ -552,7 +552,7 @@
         <Group id="scap-rhel5-group-2.2.2.1" hidden="false">
           <title xml:lang="en">Restrict Console Device Access </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default system configuration grants the console user enhanced privileges normally reserved for the root user, including temporary ownership of most system devices. If not necessary, these privileges should be removed and restricted to root only. Restrict device ownership to root only. Edit /etc/security/console.perms.d/50-default.perms and locate the section prefaced by the following comment: # permission definitions Prepend a # symbol to comment out each line in that section which starts with &lt;console&gt; or &lt;xconsole&gt;: #&lt;console&gt; 0660 &lt;floppy&gt; 0660 root.floppy #&lt;console&gt; 0600 &lt;sound&gt; 0600 root ... #&lt;xconsole&gt; 0600 /dev/console 0600 root.root #&lt;console&gt; 0600 &lt;dri&gt; 0600 root Edit /etc/security/console.perms and make the following changes: &lt;console&gt;=tty[0-9][0-9]* vc/[0-9][0-9]* :0\.[0-9] :0 &lt;xconsole&gt;=:0\.[0-9] :0 </description>
-          <Rule id="scap-rhel5-rule-7" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-7" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Console Device Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Console device ownership should be restricted to root-only as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3685-5</ident>
@@ -567,7 +567,7 @@
           <Group id="scap-rhel5-group-2.2.2.2.1" hidden="false">
             <title xml:lang="en">Disable Modprobe Loading of USB Storage Driver </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If USB storage devices should not be used, the modprobe program used for automatic kernel module loading should be configured to not load the USB storage driver upon demand. Add the following line to /etc/modprobe.conf to prevent loading of the usb-storage kernel module: install usb-storage : This will prevent the modprobe program from loading the usb-storage module, but will not prevent an administrator (or another program) from using the insmod program to load the module manually. </description>
-            <Rule id="scap-rhel5-rule-8" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-8" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Modprobe Loading of USB Storage Driver </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The USB device support module should be loaded or not as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4187-1</ident>
@@ -579,7 +579,7 @@
           <Group id="scap-rhel5-group-2.2.2.2.2" hidden="false">
             <title xml:lang="en">Remove USB Storage Driver </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If your system never requires the use of USB storage devices, then the supporting driver can be removed. Though more effective (as USB storage certainly cannot be used if the driver is not available at all), this is less elegant than the method described in Section 2.2.2.2.1. To remove the USB storage driver from the system: rm /lib/modules/kernelversion(s) /kernel/drivers/usb/storage/usb-storage.ko This command will need to be repeated every time the kernel is updated. This command will also cause the command rpm -q --verify kernel to fail, which may be an undesirable side effect. Note that this guidance will not prevent USB storage devices from being mounted if a custom kernel (i.e., not the one supplied with the system) with built-in USB support is used. </description>
-            <Rule id="scap-rhel5-rule-9" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-9" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Remove USB Storage Driver </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The USB device support module should be installed or not as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4006-3</ident>
@@ -591,7 +591,7 @@
           <Group id="scap-rhel5-group-2.2.2.2.3" hidden="false">
             <title xml:lang="en">Disable Kernel Support for USB via Bootloader Configuration </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Another means of disabling USB storage is to disable all USB support provided by the operating system. This can be accomplished by adding the “nousb” argument to the kernel’s boot loader configuration. Disabling all kernel support for USB will cause problems for systems with USB-based keyboards, mice, or printers. This guidance is inappropriate for systems which require USB connectivity. To disable kernel support for USB, append “nousb” to the kernel line in /etc/grub.conf as follows: kernel /vmlinuz-version ro vga=ext root=/dev/VolGroup00/LogVol00 rhgb quiet nousb </description>
-            <Rule id="scap-rhel5-rule-10" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-10" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Kernel Support for USB via Bootloader Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">USB kernel support should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4173-1</ident>
@@ -603,7 +603,7 @@
           <Group id="scap-rhel5-group-2.2.2.2.4" hidden="false">
             <title xml:lang="en">Disable Booting from USB Devices </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">An attacker with physical access could try to boot the system from a USB flash drive and then access any data on the system’s hard drive, circumventing the normal operating system’s access controls. To prevent this, configure the BIOS to disallow booting from USB drives. Also configure the BIOS or firmware password as described in Section 2.3.5.1 to prevent unauthorized configuration changes. </description>
-            <Rule id="scap-rhel5-rule-11" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-11" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Booting from USB Devices </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ability to boot from USB devices should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-3944-6</ident>
@@ -616,7 +616,7 @@
         <Group id="scap-rhel5-group-2.2.2.3" hidden="false">
           <title xml:lang="en">Disable the Automounter if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If the autofs service is not needed to dynamically mount NFS filesystems or removable media, disable the service: # chkconfig autofs off The autofs daemon mounts and unmounts filesystems, such as user home directories shared via NFS, on demand. In addition, autofs can be used to handle removable media, and the default configuration provides the cdrom device as /misc/cd. However, this method of providing access to removable media is not common, so autofs can almost always be disabled if NFS is not in use. Even if NFS is required, it is almost always possible to configure filesystem mounts statically by editing /etc/ fstab rather than relying on the automounter. </description>
-          <Rule id="scap-rhel5-rule-12" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-12" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable the Automounter if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The autofs service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4072-5</ident>
@@ -628,7 +628,7 @@
         <Group id="scap-rhel5-group-2.2.2.4" hidden="false">
           <title xml:lang="en">Disable GNOME Automounting if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The system’s default desktop environment, GNOME, runs the program gnome-volume-manager to mount devices and removable media (such as DVDs, CDs and USB flash drives) whenever they are inserted into the system. Execute the following commands to prevent gnome-volume-manager from automatically mounting devices and media: # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type bool \ --set /desktop/gnome/volume_manager/automount_media false # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type bool \ --set /desktop/gnome/volume_manager/automount_drives false Verify the changes by executing the following command, which should return a list of settings: # gconftool-2 -R /desktop/gnome/volume_manager The automount drives and automount media settings should be set to false. Survey the list for any other options that should be adjusted. The system’s capabilities for automatic mounting should be configured to match whatever is defined by security policy. Disabling USB storage as described in Section 2.2.2.2.1 will prevent the use of USB storage devices, but this step can also be taken as an additional layer of prevention and to prevent automatic mounting of CDs and DVDs if required. Particularly for kiosk-style systems, where users should have extremely limited access to the system, more detailed information can be found in Red Hat Desktop: Deployment Guide [5]. The gconf-editor program, available in an RPM of the same name, can be used to explore other settings available in the GNOME environment. </description>
-          <Rule id="scap-rhel5-rule-13" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-13" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable GNOME Automounting if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The GNOME automounter (gnome-volume-manager) should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4231-7</ident>
@@ -644,7 +644,7 @@
         <Group id="scap-rhel5-group-2.2.3.1" hidden="false">
           <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en"># cd /etc # chown root:root passwd shadow group gshadow # chmod 644 passwd group # chmod 400 shadow gshadow These are the default permissions for these files. Many utilities need read access to the passwd file in order to function properly, but read access to the shadow file allows malicious attacks against system passwords, and should never be enabled. </description>
-          <Rule id="scap-rhel5-rule-14" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-14" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/shadow file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3988-3</ident>
@@ -652,7 +652,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:15" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-15" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-15" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/group file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3883-6</ident>
@@ -660,7 +660,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:16" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-16" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-16" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/group file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-3276-3</ident>
@@ -668,7 +668,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:17" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-17" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-17" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/gshadow should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-3932-1</ident>
@@ -676,7 +676,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:18" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-18" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-18" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/gshadow file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-4064-2</ident>
@@ -684,7 +684,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:19" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-19" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-19" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/gshadow file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-4210-1</ident>
@@ -692,7 +692,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:20" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-20" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-20" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/shadow file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-3918-0</ident>
@@ -700,7 +700,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:21" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-21" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-21" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/passwd should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-3566-7</ident>
@@ -708,7 +708,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:22" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-22" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-22" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/passwd file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-3958-6</ident>
@@ -716,7 +716,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:23" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-23" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-23" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/group should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-3967-7</ident>
@@ -724,7 +724,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:24" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-24" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-24" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/passwd file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3495-9</ident>
@@ -732,7 +732,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:25" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-25" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-25" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/shadow should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4130-1</ident>
@@ -744,7 +744,7 @@
         <Group id="scap-rhel5-group-2.2.3.2" hidden="false">
           <title xml:lang="en">Verify that All World-Writable Directories Have Sticky Bits Set </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Locate any directories in local partitions which are world-writable and do not have their sticky bits set. The following command will discover and print these. Run it once for each local partition PART: # find PART -xdev -type d \( -perm -0002 -a ! -perm -1000 \) -print If this command produces any output, fix each reported directory /dir using the command: # chmod +t /dir When the so-called “sticky bit” is set on a directory, only the owner of a given file may remove that file from the directory. Without the sticky bit, any user with write access to a directory may remove any file in the directory. Setting the sticky bit prevents users from removing each other’s files. In cases where there is no reason for a directory to be world-writable, a better solution is to remove that permission rather than to set the sticky bit. However, if a directory is used by a particular application, consult that application’s documentation instead of blindly changing modes. </description>
-          <Rule id="scap-rhel5-rule-26" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-26" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify that All World-Writable Directories Have Sticky Bits Set </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The sticky bit should be set or not set as appropriate for all world-writable directories.</description>
             <ident system="http://cce.mitre.org">CCE-3399-3</ident>
@@ -756,7 +756,7 @@
         <Group id="scap-rhel5-group-2.2.3.3" hidden="false">
           <title xml:lang="en">Find Unauthorized World-Writable Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The following command discovers and prints any world-writable files in local partitions. Run it once for each local partition PART: # find PART -xdev -type f -perm -0002 -print If this command produces any output, fix each reported file file using the command: # chmod o-w file Data in world-writable files can be modified by any user on the system. In almost all circumstances, files can be configured using a combination of user and group permissions to support whatever legitimate access is needed without the risk caused by world-writable files. It is generally a good idea to remove global (other) write access to a file when it is discovered. However, check with documentation for specific applications before making changes. Also, monitor for recurring world-writable files, as these may be symptoms of a misconfigured application or user account. </description>
-          <Rule id="scap-rhel5-rule-27" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-27" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Find Unauthorized World-Writable Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The world-write permission should be enabled or disabled as appropriate for all files.</description>
             <ident system="http://cce.mitre.org">CCE-3795-2</ident>
@@ -768,7 +768,7 @@
         <Group id="scap-rhel5-group-2.2.3.4" hidden="false">
           <title xml:lang="en">Find Unauthorized SUID/SGID System Executables </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The following command discovers and prints any setuid or setgid files on local partitions. Run it once for each local partition PART: # find PART -xdev \( -perm -4000 -o -perm -2000 \) -type f -print If the file does not require a setuid or setgid bit as discussed below, then these bits can be removed with the command: # chmod -s file The following table contains all setuid and setgid files which are expected to be on a stock system. The setuid or setgid bit on these files may be disabled to reduce system risk if only an administrator requires their functionality. The table indicates those files which may not be needed. Note: Several of these files are used for applications which are unlikely to be relevant to most production environments, such as ISDN networking, SSH hostbased authentication, or modification of network interfaces by unprivileged users. It is extremely likely that your site can disable a subset of these files with no loss of functionality. Any files found by the above command which are not in the table should be examined. If the files are not authorized, they should have permissions removed, and further investigation may be warranted. File Set-ID Subsystem/Ref Disable? /bin/mount uid root filesystems no /bin/ping uid root net (3.3.9) no /bin/ping6 uid root net (3.3.9),IPv6 (2.5.3) unless IPv6 is used /bin/su uid root auth (2.3.1.2) no /bin/umount uid root filesystems no /sbin/mount.nfs uid root NFS (3.13) unless NFS is used /sbin/mount.nfs4 uid root NFS (3.13) unless NFSv4 is used /sbin/netreport gid root net (3.3.9) unless users must modify interfaces /sbin/pam timestamp check uid root PAM auth (2.3.3) no /sbin/umount.nfs uid root NFS (3.13) unless NFS is used /sbin/umount.nfs4 uid root NFS (3.13) unless NFSv4 is used /sbin/unix chkpwd uid root PAM auth (2.3.3) no /usr/bin/at uid root cron/at (3.4) no /usr/bin/chage uid root passwd expiry (2.3.1.7) unless users must view expiry info /usr/bin/chfn uid root user info unless users must change finger info /usr/bin/chsh uid root user info unless users must change shells /usr/bin/crontab uid/gid root cron/at (3.4) unless users must use cron /usr/bin/gpasswd uid root group auth no /usr/bin/locate gid slocate locate database no /usr/bin/lockfile gid mail procmail unless procmail is used /usr/bin/newgrp uid root group auth no /usr/bin/passwd uid root passwd auth no /usr/bin/rcp uid root rsh (3.2.3) yes (rsh is obsolete) /usr/bin/rlogin uid root rsh (3.2.3) yes (rsh is obsolete) /usr/bin/rsh uid root rsh (3.2.3) yes (rsh is obsolete) /usr/bin/ssh-agent gid nobody SSH (3.5) no /usr/bin/sudo uid root sudo (2.3.1.3) no /usr/bin/sudoedit uid root sudo (2.3.1.3) no /usr/bin/wall gid tty console messaging unless console messaging is used /usr/bin/write gid tty console messaging unless console messaging is used /usr/bin/Xorg uid root X11 (3.6) unless X11 is used /usr/kerberos/bin/ksu uid root Kerberos auth (2.3.6) unless Kerberos is used /usr/libexec/openssh/ssh-keysign uid root SSH (3.5) unless sshd uses hostbased auth /usr/libexec/utempter/utempter gid utmp terminal support no /usr/lib/squid/pam auth uid root squid (3.19) unless squid is used /usr/lib/squid/ncsa auth uid root squid (3.19) unless squid is used /usr/lib/vte/gnome-pty-helper gid utmp X11, Gnome (3.6) unless X11 is used /usr/sbin/ccreds validate uid root PAM auth (2.3.3) unless PAM auth caching is used /usr/sbin/lockdev gid lock filesystems no /usr/sbin/sendmail.sendmail gid smmsp sendmail client (3.11.2) no /usr/sbin/suexec uid root apache (3.16) unless apache is used /usr/sbin/userhelper uid root PAM auth (2.3.3.4) restrict (see section) /usr/sbin/userisdnctl uid root ISDN unless ISDN is used /usr/sbin/usernetctl uid root user network control unless users must modify interfaces </description>
-          <Rule id="scap-rhel5-rule-28" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-28" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Find Unauthorized SUID/SGID System Executables </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The sgid bit should be set or not set as appropriate for all files.</description>
             <ident system="http://cce.mitre.org">CCE-4178-0</ident>
@@ -776,7 +776,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:29" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-29" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-29" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Find Unauthorized SUID/SGID System Executables </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The suid bit should be set or not set as appropriate for all files.</description>
             <ident system="http://cce.mitre.org">CCE-3324-1</ident>
@@ -788,7 +788,7 @@
         <Group id="scap-rhel5-group-2.2.3.5" hidden="false">
           <title xml:lang="en">Find and Repair Unowned Files</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The following command will discover and print any files on local partitions which do not belong to a valid user and a valid group. Run it once for each local partition PART: # find PART -xdev \( -nouser -o -nogroup \) -print If this command prints any results, investigate each reported file and either assign it to an appropriate user and group or remove it. Unowned files are not directly exploitable, but they are generally a sign that something is wrong with some system process. They may be caused by an intruder, by incorrect software installation or incomplete software removal, or by failure to remove all files belonging to a deleted account. The files should be repaired so that they will not cause problems when accounts are created in the future, and the problem which led to unowned files should be discovered and addressed. </description>
-          <Rule id="scap-rhel5-rule-30" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-30" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Find and Repair Unowned Files</title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All files should be owned by a user as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4223-4</ident>
@@ -796,7 +796,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:31" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-31" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-31" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Find and Repair Unowned Files</title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All files should be owned by a group as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3573-3</ident>
@@ -812,7 +812,7 @@
         <Group id="scap-rhel5-group-2.2.4.1" hidden="false">
           <title xml:lang="en">Set Daemon umask </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/sysconfig/init, and add or correct the following line: umask 027 The settings file /etc/sysconfig/init contains settings which apply to all processes started at boot time. The system umask must be set to at least 022, or daemon processes may create world-writable files. The more restrictive setting 027 protects files, including temporary files and log files, from unauthorized reading by unprivileged users on the system. If a particular daemon needs a less restrictive umask, consider editing the startup script or sysconfig file of that daemon to make a specific exception. </description>
-          <Rule id="scap-rhel5-rule-32" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-32" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Daemon umask </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The daemon umask should be set as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4220-0</ident>
@@ -824,7 +824,7 @@
         <Group id="scap-rhel5-group-2.2.4.2" hidden="false">
           <title xml:lang="en">Disable Core Dumps </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To disable core dumps for all users, add or correct the following line in /etc/security/limits.conf: * hard core 0 In addition, to ensure that core dumps can never be made by setuid programs, edit /etc/sysctl.conf and add or correct the line: fs.suid_dumpable = 0 A core dump file is the memory image of an executable program when it was terminated by the operating system due to errant behavior. In most cases, only software developers would legitimately need to access these files. The core dump files may also contain sensitive information, or unnecessarily occupy large amounts of disk space. By default, the system sets a soft limit to stop the creation of core dump files for all users. This is accomplished in /etc/profile with the line: ulimit -S -c 0 &gt; /dev/null 2&gt;&amp;1 However, compliance with this limit is voluntary; it is a default intended only to protect users from the annoyance of generating unwanted core files. Users can increase the allowed core file size up to the hard limit, which is unlimited by default. Once a hard limit is set in /etc/security/limits.conf, the user cannot increase that limit within his own session. If access to core dumps is required, consider restricting them to only certain users or groups. See the limits.conf(5) man page for more information. The core dumps of setuid programs are further protected. The sysctl variable fs.suid dumpable controls whether the kernel allows core dumps from these programs at all. The default value of 0 is recommended. </description>
-          <Rule id="scap-rhel5-rule-33" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-33" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Core Dumps </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Core dumps for all users should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4225-9</ident>
@@ -832,7 +832,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:34" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-34" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-34" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Core Dumps </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Core dumps for setuid programs should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4247-3</ident>
@@ -844,7 +844,7 @@
         <Group id="scap-rhel5-group-2.2.4.3" hidden="false">
           <title xml:lang="en">Enable ExecShield </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">ExecShield comprises a number of kernel features to provide protection against buffer overflows. These features include random placement of the stack and other memory regions, prevention of execution in memory that should only hold data, and special handling of text buffers. This protection is enabled by default, but the sysctl variables kernel.exec-shield and kernel.randomize va space should be checked to ensure that it has not been disabled. To ensure ExecShield (including random placement of virtual memory regions) is activated at boot, add or correct the following settings in /etc/sysctl.conf: kernel.exec-shield = 1 kernel.randomize_va_space = 1 ExecShield uses the segmentation feature on all x86 systems to prevent execution in memory higher than a certain address. It writes an address as a limit in the code segment descriptor, to control where code can be executed, on a per-process basis. When the kernel places a process’s memory regions such as the stack and heap higher than this address, the hardware prevents execution there. However, this cannot always be done for all memory regions in which execution should not occur, so follow guidance in Section 2.2.4.4 to further protect the system. </description>
-          <Rule id="scap-rhel5-rule-35" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-35" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable ExecShield </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">ExecShield randomized placement of virtual memory regions should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4146-7</ident>
@@ -852,7 +852,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:36" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-36" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-36" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable ExecShield </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">ExecShield should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4168-1</ident>
@@ -871,7 +871,7 @@
           <Group id="scap-rhel5-group-2.2.4.4.2" hidden="false">
             <title xml:lang="en">Install New Kernel on Supported x86 Systems </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If supported as determined in the previous section, the kernel-PAE package should be installed to enable XD or NX support: # yum install kernel-PAE The installation process should also have configured the bootloader to load the new kernel at boot. Verify this at reboot and modify /etc/grub.conf if necessary. The kernel-PAE package should not be installed on older systems that do not support the XD or NX bit, as this may prevent them from booting. </description>
-            <Rule id="scap-rhel5-rule-37" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-37" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Install New Kernel on Supported x86 Systems </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Kernel support for the XD/NX processor feature should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4172-3</ident>
@@ -883,7 +883,7 @@
           <Group id="scap-rhel5-group-2.2.4.4.3" hidden="false">
             <title xml:lang="en">Enable Support in the BIOS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Computers with the ability to prevent this type of code execution frequently put an option in the BIOS that will allow users to turn the feature on or off at will. Reboot the system and enter the BIOS or “Setup” configuration menu. Navigate the BIOS configuration menu and make sure that the option is enabled. The setting may be located under a “Security” section. Look for Execute Disable (XD) on Intel-based systems and No Execute (NX) on AMD-based systems. See Section 2.3.5.1 for information on protecting this and other BIOS settings. </description>
-            <Rule id="scap-rhel5-rule-38" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-38" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Enable Support in the BIOS </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The XD/NX processor feature should be enabled or disabled as appropriate in the BIOS</description>
               <ident system="http://cce.mitre.org">CCE-4177-2</ident>
@@ -904,7 +904,7 @@
         <Group id="scap-rhel5-group-2.3.1.1" hidden="false">
           <title xml:lang="en">Restrict Root Logins to System Console </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/securetty. Ensure that the file contains only the following lines: * The primary system console device: console * The virtual console devices: tty1 tty2 tty3 tty4 tty5 tty6 ... * If required by your organization, the deprecated virtual console interface may be retained for backwards compatibility: vc/1 vc/2 vc/3 vc/4 vc/5 vc/6 ... * If required by your organization, the serial consoles may be added: ttyS0 ttyS1 Direct root logins should be allowed only for emergency use. In normal situations, the administrator should access the system via a unique unprivileged account, and use su or sudo to execute privileged commands. Discouraging administrators from accessing the root account directly ensures an audit trail in organizations with multiple administrators. Locking down the channels through which root can connect directly reduces opportunities for password-guessing against the root account. The login program uses the file /etc/securetty to determine which interfaces should allow root logins. The virtual devices /dev/console and /dev/tty* represent the system consoles (accessible via the Ctrl-Alt-F1 through Ctrl-Alt-F6 keyboard sequences on a default installation). The default securetty file also contains /dev/vc/*. These are likely to be deprecated in most environments, but may be retained for compatibility. Root should also be prohibited from connecting via network protocols. See Section 3.5 for instructions on preventing root from logging in via SSH. </description>
-          <Rule id="scap-rhel5-rule-39" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-39" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Root Logins to System Console </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Logins through the specified virtual console interface should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3820-8</ident>
@@ -912,7 +912,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:40" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-40" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-40" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Root Logins to System Console </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Logins through the specified virtual console device should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3485-0</ident>
@@ -920,7 +920,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:41" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-41" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-41" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Root Logins to System Console </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Logins through the primary console device should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4111-1</ident>
@@ -928,7 +928,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:42" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-42" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-42" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Root Logins to System Console </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Login prompts on serial ports should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4256-4</ident>
@@ -940,7 +940,7 @@
         <Group id="scap-rhel5-group-2.3.1.2" hidden="false">
           <title xml:lang="en">Limit su Access to the Root Account </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">1. Ensure that the group wheel exists, and that the usernames of all administrators who should be allowed to execute commands as root are members of that group. # grep ^wheel /etc/group 2. Edit the file /etc/pam.d/su. Add, uncomment, or correct the line: auth required pam_wheel.so use_uid The su command allows a user to gain the privileges of another user by entering the password for that user’s account. It is desirable to restrict the root user so that only known administrators are ever allowed to access the root account. This restricts password-guessing against the root account by unauthorized users or by accounts which have been compromised. By convention, the group wheel contains all users who are allowed to run privileged commands. The PAM module pam wheel.so is used to restrict root access to this set of users. </description>
-          <Rule id="scap-rhel5-rule-43" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-43" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Limit su Access to the Root Account </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Command access to the root account should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4274-7</ident>
@@ -952,7 +952,7 @@
         <Group id="scap-rhel5-group-2.3.1.3" hidden="false">
           <title xml:lang="en">Configure sudo to Improve Auditing of Root Access </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">1. Ensure that the group wheel exists, and that the usernames of all administrators who should be allowed to execute commands as root are members of that group. # grep ^wheel /etc/group 2. Edit the file /etc/sudoers. Add, uncomment, or correct the line: %wheel ALL=(ALL) ALL The sudo command allows fine-grained control over which users can execute commands using other accounts. The primary benefit of sudo when configured as above is that it provides an audit trail of every command run by a privileged user. It is possible for a malicious administrator to circumvent this restriction, but, if there is an established procedure that all root commands are run using sudo, then it is easy for an auditor to detect unusual behavior when this procedure is not followed. Editing /etc/sudoers by hand can be dangerous, since a configuration error may make it impossible to access the root account remotely. The recommended means of editing this file is using the visudo command, which checks the file’s syntax for correctness before allowing it to be saved. Note that sudo allows any attacker who gains access to the password of an administrator account to run commands as root. This is a downside which must be weighed against the benefits of increased audit capability and of being able to heavily restrict the use of the high-value root password (which can be logistically difficult to change often). As a basic precaution, never use the NOPASSWD directive, which would allow anyone with access to an administrator account to execute commands as root without knowing the administrator’s password. The sudo command has many options which can be used to further customize its behavior. See the sudoers(5) man page for details. </description>
-          <Rule id="scap-rhel5-rule-44" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-44" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure sudo to Improve Auditing of Root Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Sudo privileges should granted or rejected to the wheel group as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4044-4</ident>
@@ -964,7 +964,7 @@
         <Group id="scap-rhel5-group-2.3.1.4" hidden="false">
           <title xml:lang="en">Block Shell and Login Access for Non-Root System Accounts </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Do not perform the steps in this section on the root account. Doing so might cause the system to become inaccessible. Using /etc/passwd, obtain a listing of all users, their UIDs, and their shells, for instance by running: # awk -F: '{print $1 ":" $3 ":" $7}' /etc/passwd Identify the system accounts from this listing. These will primarily be the accounts with UID numbers less than 500, other than root. For each identified system account SYSACCT , lock the account: # usermod -L SYSACCT and disable its shell: # usermod -s /sbin/nologin SYSACCT These are the accounts which are not associated with a human user of the system, but which exist to perform some administrative function. Make it more difficult for an attacker to use these accounts by locking their passwords and by setting their shells to some non-valid shell. The RHEL5 default non-valid shell is /sbin/nologin, but any command which will exit with a failure status and disallow execution of any further commands, such as /bin/false or /dev/null, will work. </description>
-          <Rule id="scap-rhel5-rule-45" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-45" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Block Shell and Login Access for Non-Root System Accounts </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Login access to non-root system accounts should be enabled or disabled as appropriate </description>
             <ident system="http://cce.mitre.org">CCE-3987-5</ident>
@@ -976,7 +976,7 @@
         <Group id="scap-rhel5-group-2.3.1.5" hidden="false">
           <title xml:lang="en">Verify that No Accounts Have Empty Password Fields </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Run the command: # awk -F: '($2 == "") {print}' /etc/shadow If this produces any output, fix the problem by locking each account (see Section 2.3.1.4 above) or by setting a password. If an account has an empty password, anybody may log in and run commands with the privileges of that account. Accounts with empty passwords should never be used in operational environments. </description>
-          <Rule id="scap-rhel5-rule-46" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-46" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify that No Accounts Have Empty Password Fields </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Login access to accounts without passwords should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4238-2</ident>
@@ -988,7 +988,7 @@
         <Group id="scap-rhel5-group-2.3.1.6" hidden="false">
           <title xml:lang="en">Verify that No Non-Root Accounts Have UID 0 </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">This command will print all password file entries for accounts with UID 0: # awk -F: '($3 == "0") {print}' /etc/passwd This should print only one line, for the user root. If any other lines appear, ensure that these additional UID-0 accounts are authorized, and that there is a good reason for them to exist. In general, the best practice solution for auditing use of the root account is to restrict the set of cases in which root must be accessed anonymously by requiring use of su or sudo in almost all cases. Some sites choose to have more than one account with UID 0 in order to differentiate between administrators, but this practice may have unexpected side effects, and is therefore not recommended. </description>
-          <Rule id="scap-rhel5-rule-47" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-47" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify that No Non-Root Accounts Have UID 0 </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Anonymous root logins are enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4009-7</ident>
@@ -1000,7 +1000,7 @@
         <Group id="scap-rhel5-group-2.3.1.7" hidden="false">
           <title xml:lang="en">Set Password Expiration Parameters </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/login.defs to specify password expiration settings for new accounts. Add or correct the following lines: PASS_MAX_DAYS=180 PASS_MIN_DAYS=7 PASS_MIN_LEN=8 PASS_WARN_AGE=7 For each existing human user USER , modify the current expiration settings to match these: # chage -M 180 -m 7 -W 7 USER Users should be forced to change their passwords, in order to decrease the utility of compromised passwords. However, the need to change passwords often should be balanced against the risk that users will reuse or write down passwords if forced to change them too often. Forcing password changes every 90-360 days, depending on the environment, is recommended. Set the appropriate value as PASS MAX DAYS and apply it to existing accounts with the -M flag. The PASS MIN DAYS (-m) setting prevents password changes for 7 days after the first change, to discourage password cycling. If you use this setting, train users to contact an administrator for an emergency password change in case a new password becomes compromised. The PASS WARN AGE (-W) setting gives users 7 days of warnings at login time that their passwords are about to expire. </description>
-          <Rule id="scap-rhel5-rule-48" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-48" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Password Expiration Parameters </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The password minimum length should be set appropriately</description>
             <ident system="http://cce.mitre.org">CCE-4154-1</ident>
@@ -1008,7 +1008,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:49" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-49" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-49" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Password Expiration Parameters </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The "minimum password age" policy should meet minimum requirements. </description>
             <ident system="http://cce.mitre.org">CCE-4180-6</ident>
@@ -1016,7 +1016,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:50" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-50" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-50" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Password Expiration Parameters </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The "maximum password age" policy should meet minimum requirements. </description>
             <ident system="http://cce.mitre.org">CCE-4092-3</ident>
@@ -1024,7 +1024,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:51" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-51" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-51" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Password Expiration Parameters </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The password warn age should be set appropriately</description>
             <ident system="http://cce.mitre.org">CCE-4097-2</ident>
@@ -1036,7 +1036,7 @@
         <Group id="scap-rhel5-group-2.3.1.8" hidden="false">
           <title xml:lang="en">Remove Legacy + Entries from Password Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The command: # grep "^+:" /etc/passwd /etc/shadow /etc/group should produce no output. The + symbol was used by systems to include data from NIS maps into existing files. However, a certain configuration error in which a NIS inclusion line appears in /etc/passwd, but NIS is not running, could lead to anyone being able to access the system with the username + and no password. Therefore, it is important to verify that no such line appears in any of the relevant system files. The correct way to tell the local system to consult network databases such as LDAP or NIS for user information is to make appropriate modifications to /etc/nsswitch.conf. </description>
-          <Rule id="scap-rhel5-rule-52" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-52" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove Legacy + Entries from Password Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">NIS file inclusions should be set appropriately in the /etc/passwd file</description>
             <ident system="http://cce.mitre.org">CCE-4114-5</ident>
@@ -1064,7 +1064,7 @@
         <Group id="scap-rhel5-group-2.3.3.1" hidden="false">
           <title xml:lang="en">Set Password Quality Requirements </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default pam cracklib PAM module provides strength checking for passwords. It performs a number of checks, such as making sure passwords are not similar to dictionary words, are of at least a certain length, are not the previous password reversed, and are not simply a change of case from the previous password. The pam passwdqc PAM module provides the ability to enforce even more stringent password strength requirements. It is provided in an RPM of the same name. The man pages pam cracklib(8) and pam passwdqc(8) provide information on the capabilities and configuration of each. If password strength stronger than that guaranteed by pam cracklib is required, configure PAM to use pam passwdqc. To activate pam passwdqc, locate the following line in /etc/pam.d/system-auth: password requisite pam_cracklib.so try_first_pass retry=3 and then replace it with the line: password requisite pam_passwdqc.so min=disabled,disabled,16,12,8 If necessary, modify the arguments (min=disabled,disabled,16,12,8) to ensure compliance with your organization’s security policy. Configuration options are described in the man page pam passwdqc(8) and also in /usr/share/doc/pam passwdqc-version. The minimum lengths provided here supercede that specified by the argument PASS MIN LEN as described in Section 2.3.1.7. The options given in the example above set a minimum length for each of the password “classes” that pam passwdqc recognizes. Setting a particular minimum value to disabled will stop users from choosing a password that falls into that category alone. </description>
-          <Rule id="scap-rhel5-rule-53" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-53" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Password Quality Requirements </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The password strength should meet minimum requirements</description>
             <ident system="http://cce.mitre.org">CCE-3762-2</ident>
@@ -1076,7 +1076,7 @@
         <Group id="scap-rhel5-group-2.3.3.2" hidden="false">
           <title xml:lang="en">Set Lockouts for Failed Password Attempts </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The pam tally2 PAM module provides the capability to lock out user accounts after a number of failed login attempts. Its documentation is available in /usr/share/doc/pam-version/txts/README.pam tally2. If locking out accounts after a number of incorrect login attempts is required by your security policy, implement use of pam tally2.so for the relevant PAM-aware programs such as login, sshd, and vsftpd. Find the following line in /etc/pam.d/system-auth: auth sufficient pam_unix.so nullok try_first_pass and then change it so that it reads as follows: auth required pam_unix.so nullok try_first_pass In the same file, comment out or delete the lines: auth requisite pam_succeed_if.so uid &gt;= 500 quiet auth required pam_deny.so To enforce password lockout, add the following to the individual programs’ configuration files in /etc/pam.d. First, add to end of the auth lines: auth required pam_tally2.so deny=5 onerr=fail Second, add to the end of the account lines: account required pam_tally2.so Adjust the deny argument to conform to your system security policy. The pam tally2 utility can be used to unlock user accounts as follows: # /sbin/pam_tally2 --user username --reset Locking out user accounts presents the risk of a denial-of-service attack. The security policy regarding system lockout must weigh whether the risk of such a denial-of-service attack outweighs the benefits of thwarting password guessing attacks. The pam tally2 utility can be run from a cron job on a hourly or daily basis to try and offset this risk. </description>
-          <Rule id="scap-rhel5-rule-54" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-54" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Lockouts for Failed Password Attempts </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The "account lockout threshold" policy should meet minimum requirements. </description>
             <ident system="http://cce.mitre.org">CCE-3410-8</ident>
@@ -1092,7 +1092,7 @@
         <Group id="scap-rhel5-group-2.3.3.4" hidden="false">
           <title xml:lang="en">Restrict Execution of userhelper to Console Users </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If your environment has defined a group, usergroup containing all the human users of your system, restrict execution of the userhelper program to only that group: # chgrp usergroup /usr/sbin/userhelper # chmod 4710 /usr/sbin/userhelper The userhelper program provides authentication for graphical services which must run with root privileges, such as the system-config- family of graphical configuration utilities. Only human users logged into the system console are likely to ever have a legitimate need to run these utilities. This step provides some protection against possible flaws in userhelper’s implementation, and against further privilege escalation when system accounts are compromised. See Section 2.3.2.2 for more information on creating a group of human users. The userhelper program is configured by the files in /etc/security/console.apps/. Each file specifies, for some program, what user the program should run as, and what program should be executed after successful authentication. Note: The configuration in /etc/security/console.apps/ is applied in combination with the PAM configuration of the service defined in /etc/pam.d/. First, userhelper determines what user the service should run as. (Typically, this will be root.) Next, userhelper uses the PAM API to allow the user who ran the program to attempt to authenticate as the desired user. The PAM API exchange is wrapped in a GUI if the application’s configuration requests one. </description>
-          <Rule id="scap-rhel5-rule-55" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-55" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Execution of userhelper to Console Users </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /usr/sbin/userhelper file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-4185-5</ident>
@@ -1100,7 +1100,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:56" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-56" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-56" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Execution of userhelper to Console Users </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /usr/sbin/userhelper should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-3952-9</ident>
@@ -1116,7 +1116,7 @@
         <Group id="scap-rhel5-group-2.3.4.1" hidden="false">
           <title xml:lang="en">Ensure that No Dangerous Directories Exist in Roots Path '</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The active path of the root account can be obtained by starting a new root shell and running: # echo $PATH This will produce a colon-separated list of directories in the path. For each directory DIR in the path, ensure that DIR is not equal to a single . character. Also ensure that there are no “empty” elements in the path, such as in these examples: PATH=:/bin PATH=/bin: PATH=/bin::/sbin These empty elements have the same effect as a single . character. For each element in the path, run: # ls -ld DIR and ensure that write permissions are disabled for group and other. It is important to prevent root from executing unknown or untrusted programs, since such programs could contain malicious code. Therefore, root should not run programs installed by unprivileged users. Since root may often be working inside untrusted directories, the . character, which represents the current directory, should never be in the root path, nor should any directory which can be written to by an unprivileged or semi-privileged (system) user. It is a good practice for administrators to always execute privileged commands by typing the full path to the command. </description>
-          <Rule id="scap-rhel5-rule-57" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-57" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure that No Dangerous Directories Exist in Root's Path </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The PATH variable should be set correctly for user root</description>
             <ident system="http://cce.mitre.org">CCE-3301-9</ident>
@@ -1128,7 +1128,7 @@
         <Group id="scap-rhel5-group-2.3.4.2" hidden="false">
           <title xml:lang="en">Ensure that User Home Directories are not Group-Writable or World-Readable </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Sections 2.3.4.2–2.3.4.5 recommend modifying user home directories. Notify your user community, and solicit input if appropriate, before making this type of change. For each human user USER of the system, view the permissions of the user’s home directory: # ls -ld /home/USER Ensure that the directory is not group-writable and that it is not world-readable. If necessary, repair the permissions: # chmod g-w /home/USER # chmod o-rwx /home/USER User home directories contain many configuration files which affect the behavior of a user’s account. No user should ever have write permission to another user’s home directory. Group shared directories can be configured in subdirectories or elsewhere in the filesystem if they are needed. Typically, user home directories should not be world-readable. If a subset of users need read access to one another’s home directories, this can be provided using groups. </description>
-          <Rule id="scap-rhel5-rule-58" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-58" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure that User Home Directories are not Group-Writable or World-Readable </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions should be set correctly for the home directories for all user accounts.</description>
             <ident system="http://cce.mitre.org">CCE-4090-7</ident>
@@ -1144,7 +1144,7 @@
         <Group id="scap-rhel5-group-2.3.4.4" hidden="false">
           <title xml:lang="en">Ensure that Users Have Sensible Umask Values </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">1. Edit the global configuration files /etc/profile, /etc/bashrc, and /etc/csh.cshrc. Add or correct the line: umask 077 2. Edit the user definitions file /etc/login.defs. Add or correct the line: UMASK 077 3. View the additional configuration files /etc/csh.login and /etc/profile.d/*, and ensure that none of these files redefine the umask to a more permissive value unless there is a good reason for it. 4. Edit the root shell configuration files /root/.bashrc, /root/.bash profile, /root/.cshrc, and /root/.tcshrc. Add or correct the line: umask 077 With a default umask setting of 077, files and directories created by users will not be readable by any other user on the system. Users who wish to make specific files group- or world-readable can accomplish this using the chmod command. Additionally, users can make all their files readable to their group by default by setting a umask of 027 in their shell configuration files. If default per-user groups exist (that is, if every user has a default group whose name is the same as that user’s username and whose only member is the user), then it may even be safe for users to select a umask of 007, making it very easy to intentionally share files with group s of which the user is a member. In addition, it may be necessary to change root’s umask temporarily in order to install software or files which must be readable by other users, or to change the default umasks of certain service accounts such as the FTP user. However, setting a restrictive default protects the files of users who have not taken steps to make their files more available, and preventing files from being inadvertently shared. </description>
-          <Rule id="scap-rhel5-rule-59" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-59" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure that Users Have Sensible Umask Values </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default umask for all users should be set correctly for the bash shell</description>
             <ident system="http://cce.mitre.org">CCE-3844-8</ident>
@@ -1152,7 +1152,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:60" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-60" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-60" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure that Users Have Sensible Umask Values </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default umask for all users should be set correctly for the csh shell</description>
             <ident system="http://cce.mitre.org">CCE-4227-5</ident>
@@ -1160,7 +1160,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:61" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-61" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-61" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure that Users Have Sensible Umask Values </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default umask for all users should be set correctly</description>
             <ident system="http://cce.mitre.org">CCE-3870-3</ident>
@@ -1184,7 +1184,7 @@
         <Group id="scap-rhel5-group-2.3.5.2" hidden="false">
           <title xml:lang="en">Set Boot Loader Password </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">During the boot process, the boot loader is responsible for starting the execution of the kernel and passing options to it. The boot loader allows for the selection of different kernels – possibly on different partitions or media. Options it can pass to the kernel include “single-user mode,” which provides root access without any authentication, and the ability to disable SELinux. To prevent local users from modifying the boot parameters and endangering security, the boot loader configuration should be protected with a password. The default RHEL boot loader for x86 systems is called GRUB. To protect its configuration: 1. Select a password and then generate a hash from it by running: # grub-md5-crypt 2. Insert the following line into /etc/grub.conf immediately after the header comments. (Use the output from grub-md5-crypt as the value of password-hash ): password --md5 password-hash 3. Verify the permissions on /etc/grub.conf (which is a symlink to ../boot/grub/grub.conf): # chown root:root /etc/grub.conf # chmod 600 /etc/grub.conf Boot loaders for other platforms should offer a similar password protection feature. </description>
-          <Rule id="scap-rhel5-rule-62" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-62" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Boot Loader Password </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/grub.conf file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-4144-2</ident>
@@ -1192,7 +1192,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:63" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-63" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-63" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Boot Loader Password </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/grub.conf should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-3923-0</ident>
@@ -1200,7 +1200,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:64" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-64" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-64" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Boot Loader Password </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The grub boot loader should have password protection enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3818-2</ident>
@@ -1208,7 +1208,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:65" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-65" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-65" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Boot Loader Password </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/grub.conf file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-4197-0</ident>
@@ -1220,7 +1220,7 @@
         <Group id="scap-rhel5-group-2.3.5.3" hidden="false">
           <title xml:lang="en">Require Authentication for Single-User Mode </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Single-user mode is intended as a system recovery method, providing a single user root access to the system by providing a boot option at startup. By default, no authentication is performed if single-user mode is selected. This provides a trivial mechanism of bypassing security on the machine and gaining root access. To require entry of the root password even if the system is started in single-user mode, add the following line to the /etc/inittab file: ~~:S:wait:/sbin/sulogin </description>
-          <Rule id="scap-rhel5-rule-66" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-66" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Require Authentication for Single-User Mode </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The requirement for a password to boot into single-user mode should be configured correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4241-6</ident>
@@ -1232,7 +1232,7 @@
         <Group id="scap-rhel5-group-2.3.5.4" hidden="false">
           <title xml:lang="en">Disable Interactive Boot</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/sysconfig/init. Add or correct the setting: PROMPT=no The PROMPT option allows the console user to perform an interactive system startup, in which it is possible to select the set of services which are started on boot. Using interactive boot, the console user could disable auditing, firewalls, or other services, weakening system security. </description>
-          <Rule id="scap-rhel5-rule-67" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-67" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Interactive Boot</title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ability for users to perform interactive startups should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4245-7</ident>
@@ -1244,7 +1244,7 @@
         <Group id="scap-rhel5-group-2.3.5.5" hidden="false">
           <title xml:lang="en">Implement Inactivity Time-out for Login Shells </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If the system does not run X Windows, then the login shells can be configured to automatically log users out after a period of inactivity. The following instructions are not practical for systems which run X Windows, as they will close terminal windows in the X environment. For information on how to automatically lock those systems, see Section 2.3.5.6. To implement a 10-minute idle time-out for the default /bin/bash shell, create a new file tmout.sh in the directory /etc/profile.d with the following lines: TMOUT=600 readonly TMOUT export TMOUT To implement a 10-minute idle time-out for the tcsh shell, create a new file autologout.csh in the directory /etc/profile.d with the following line: set -r autologout 10 Similar actions should be taken for any other login shells used. The example time-out here of 10 minutes should be adjusted to whatever your security policy requires. The readonly line for bash and the -r option for tcsh can be omitted if policy allows users to override the value. The automatic shell logout only occurs when the shell is the foreground process. If, for example, a vi session is left idle, then automatic logout would not occur. When logging in through a remote connection, as with SSH, it may be more effective to set the timeout value directly through that service. To learn how to set automatic timeout intervals for SSH, see Section 3.5.2.3. </description>
-          <Rule id="scap-rhel5-rule-68" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-68" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Implement Inactivity Time-out for Login Shells </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The idle time-out value for the default /bin/tcsh shell should meet the minimum requirements.</description>
             <ident system="http://cce.mitre.org">CCE-3689-7</ident>
@@ -1252,7 +1252,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:69" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-69" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-69" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Implement Inactivity Time-out for Login Shells </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The idle time-out value for the default /bin/bash shell should meet the minimum requirements.</description>
             <ident system="http://cce.mitre.org">CCE-3707-7</ident>
@@ -1267,7 +1267,7 @@
           <Group id="scap-rhel5-group-2.3.5.6.1" hidden="false">
             <title xml:lang="en">Configure GUI Screen Locking </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">In the default GNOME desktop, the screen can be locked by choosing Lock Screen from the System menu. The gconftool-2 program can be used to enforce mandatory screen locking settings for the default GNOME environment. Run the following commands to enforce idle activation of the screen saver, screen locking, a blank-screen screensaver, and 10-minute idle activation time: # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type bool \ --set /apps/gnome-screensaver/idle_activation_enabled true # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type bool \ --set /apps/gnome-screensaver/lock_enabled true # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type string \ --set /apps/gnome-screensaver/mode blank-only # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type int \ --set /apps/gnome-screensaver/idle_delay 10 The default setting of 10 minutes for idle activation is reasonable for many office environments, but the setting should conform to whatever policy is defined. The screensaver mode blank-only is selected to conceal the contents of the display from passersby. Because users should be trained to lock the screen when they step away from the computer, the automatic locking feature is only meant as a backup. The Lock Screen icon from the System menu can also be dragged to the taskbar in order to facilitate even more convenient screen-locking. The root account cannot be screen-locked, but this should have no practical effect as the root account should never be used to log into an X Windows environment, and should only be used to for direct login via console in emergency circumstances. For more information about configuring GNOME screensaver, see http://live.gnome.org/GnomeScreensaver. For more information about enforcing preferences in the GNOME environment using the GConf configuration system, see http://www.gnome.org/projects/gconf and the man page gconftool-2(1). </description>
-            <Rule id="scap-rhel5-rule-70" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-70" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Configure GUI Screen Locking </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The allowed period of inactivity gnome desktop lockout should be configured correctly.</description>
               <ident system="http://cce.mitre.org">CCE-3315-9</ident>
@@ -1275,7 +1275,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:71" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-71" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-71" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Configure GUI Screen Locking </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The vlock package should be installed or not as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-3910-7</ident>
@@ -1300,7 +1300,7 @@
         <Group id="scap-rhel5-group-2.3.7.1" hidden="false">
           <title xml:lang="en">Modify the System Login Banner </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The contents of the file /etc/issue are displayed on the screen just above the login prompt for users logging directly into a terminal. Remote login programs such as SSH or FTP can be configured to display /etc/issue as well. Instructions for configuring each server daemon to show this file can be found in the relevant sections of Chapter 3. By default, the system will display the version of the OS, the kernel version, and the host name. Edit /etc/issue. Replace the default text with a message compliant with the local site policy or a legal disclaimer. </description>
-          <Rule id="scap-rhel5-rule-72" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-72" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Modify the System Login Banner </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The system login banner text should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4060-0</ident>
@@ -1312,7 +1312,7 @@
         <Group id="scap-rhel5-group-2.3.7.2" hidden="false">
           <title xml:lang="en">Implement a GUI Warning Banner </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">In the default graphical environment, users logging directly into the system are greeted with a login screen provided by the GNOME display manager. The warning banner should be displayed in this graphical environment for these users. The files for the default RHEL theme can be found in /usr/share/gdm/themes/RHEL. Add the following sample block of XML to /usr/share/gdm/themes/RHEL/RHEL.xml after the first two ”pixmap” entries: &lt;item type="rect"/&gt; &lt;pos anchor="n" x="50%" y="10" width="box" height="box"/&gt; &lt;box&gt; &lt;item type="label"/&gt; &lt;normal font="Sans 14" color="#ffffff"/&gt; &lt;text&gt; Insert the text of your warning banner here. &lt;/text&gt; &lt;/item&gt; &lt;/box&gt; &lt;/item&gt; The full syntax that GDM theme files expect is documented elsewhere, but the above XML will create a text box centered at the top of the screen. The font, text color, and exact positioning can all be easily modified by editing the appropriate values. The latest current GDM theme manual can be found at http://www.gnome.org/ projects/gdm/docs/thememanual.html. </description>
-          <Rule id="scap-rhel5-rule-73" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-73" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Implement a GUI Warning Banner </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The direct gnome login warning banner should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4188-9</ident>
@@ -1333,7 +1333,7 @@
       <Group id="scap-rhel5-group-2.4.2" hidden="false">
         <title xml:lang="en">Enable SELinux</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/selinux/config. Add or correct the following lines: SELINUX=enforcing SELINUXTYPE=targeted Edit the file /etc/grub.conf. Ensure that the following arguments DO NOT appear on any kernel command line in the file: selinux=0 enforcing=0 The directive SELINUX=enforcing enables SELinux at boot time. If SELinux is causing a lot of problems or preventing the system from booting, it is possible to boot into the warning-only mode SELINUX=permissive for debugging purposes. Make certain to change the mode back to enforcing after debugging, set the filesystems to be relabelled for consistency using the command touch /.autorelabel, and reboot. However, the RHEL5 default SELinux configuration should be sufficiently reasonable that most systems will boot without serious problems. Some applications that require deep or unusual system privileges, such as virtual machine software, may not be compatible with SELinux in its default configuration. However, this should be uncommon, and SELinux’s application support continues to improve. In other cases, SELinux may reveal unusual or insecure program behavior by design. The directive SELINUXTYPE=targeted configures SELinux to use the default targeted policy. See Section 2.4.6 if a stricter policy is appropriate for your site. The SELinux boot mode specified in /etc/selinux/config can be overridden by command-line arguments passed to the kernel. It is necessary to check grub.conf to ensure that this has not been done and to protect the bootloader as described in Section 2.3.5.2. </description>
-        <Rule id="scap-rhel5-rule-74" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-74" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Enable SELinux</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SELinux should be enabled or disabled as appropriate</description>
           <ident system="http://cce.mitre.org">CCE-3977-6</ident>
@@ -1341,7 +1341,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:75" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-75" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-75" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Enable SELinux</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The SELinux state should be set appropriately.</description>
           <ident system="http://cce.mitre.org">CCE-3999-0</ident>
@@ -1349,7 +1349,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:76" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-76" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-76" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Enable SELinux</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The SELinux policy should be set appropriately.</description>
           <ident system="http://cce.mitre.org">CCE-3624-4</ident>
@@ -1364,7 +1364,7 @@
         <Group id="scap-rhel5-group-2.4.3.1" hidden="false">
           <title xml:lang="en">Disable and Remove SETroubleshoot if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason to allow users to view SELinux denial information using the sealert GUI? If not, disable the service and remove the RPM: # chkconfig setroubleshoot off # yum erase setroubleshoot The setroubleshoot service is a facility for notifying the desktop user of SELinux denials in a user-friendly fashion. SELinux errors may provide important information about intrusion attempts in progress, or may give information about SELinux configuration problems which are preventing correct system operation. In order to maintain a secure and usable SELinux installation, error logging and notification is necessary. However, setroubleshoot is a service which has complex functionality, which runs a daemon and uses IPC to distribute information which may be sensitive, or even to allow users to modify SELinux settings, and which does not yet implement real authentication mechanisms. This guide recommends disabling setroubleshoot and using the kernel audit functionality to monitor SELinux’s behavior. In addition, since setroubleshoot automatically runs client-side code whenever a denial occurs, regardless of whether the setroubleshootd daemon is running, it is recommended that the program be removed entirely unless it is needed. </description>
-          <Rule id="scap-rhel5-rule-77" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-77" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable and Remove SETroubleshoot if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The setroubleshoot service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4254-9</ident>
@@ -1372,7 +1372,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:78" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-78" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-78" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable and Remove SETroubleshoot if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The setroubleshoot package should be installed or uninstalled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4148-3</ident>
@@ -1384,7 +1384,7 @@
         <Group id="scap-rhel5-group-2.4.3.2" hidden="false">
           <title xml:lang="en">Disable MCS Translation Service (mcstrans) if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Unless there is some overriding need for the convenience of category label translation, disable the MCS translation service: # chkconfig mcstrans off The mcstransd daemon provides the category label translation information defined in /etc/selinux/targeted/ setrans.conf to client processes which request this information. Category labelling is unlikely to be used except in sites with special requirements. Therefore, it should be disabled in order to reduce the amount of potentially vulnerable code running on the system. See Section 2.4.6 for more information about systems which use category labelling. </description>
-          <Rule id="scap-rhel5-rule-79" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-79" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable MCS Translation Service (mcstrans) if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The mcstrans service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3668-1</ident>
@@ -1396,7 +1396,7 @@
         <Group id="scap-rhel5-group-2.4.3.3" hidden="false">
           <title xml:lang="en">Restorecon Service (restorecond) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The restorecond daemon monitors a list of files which are frequently created or modified on running systems, and whose SELinux contexts are not set correctly. It looks for creation events related to files listed in /etc/ selinux/restorecond.conf, and sets the contexts of those files when they are discovered. The restorecond program is fairly simple, so it brings low risk, but, in its default configuration, does not add much value to a system. An automated program such as restorecond may be used to monitor problematic files for context problems, or system administrators may be trained to check file contexts of newly-created files using the command ls -lZ, and to repair contexts manually using the restorecon command. This guide makes no recommendation either for or against the use of restorecond. </description>
-          <Rule id="scap-rhel5-rule-80" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-80" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restorecon Service (restorecond) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The restorecond service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4129-3</ident>
@@ -1440,7 +1440,7 @@
         <Group id="scap-rhel5-group-2.5.1.1" hidden="false">
           <title xml:lang="en">Network Parameters for Hosts Only </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is this system going to be used as a firewall or gateway to pass IP traffic between different networks? If not, edit the file /etc/sysctl.conf and add or correct the following lines: net.ipv4.ip forward = 0 net.ipv4.conf.all.send redirects = 0 net.ipv4.conf.default.send redirects = 0 These settings disable hosts from performing network functionality which is only appropriate for routers. </description>
-          <Rule id="scap-rhel5-rule-81" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-81" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts Only </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for sending ICMP redirects should be enabled or disabled for network interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4151-7</ident>
@@ -1448,7 +1448,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:82" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-82" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-82" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts Only </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Sending ICMP redirects should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4155-8</ident>
@@ -1456,7 +1456,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:83" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-83" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-83" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts Only </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">IP forwarding should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3561-8</ident>
@@ -1468,7 +1468,7 @@
         <Group id="scap-rhel5-group-2.5.1.2" hidden="false">
           <title xml:lang="en">Network Parameters for Hosts and Routers </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/sysctl.conf and add or correct the following lines: net.ipv4.conf.all.accept_source_route = 0 net.ipv4.conf.all.accept_redirects = 0 net.ipv4.conf.all.secure_redirects = 0 net.ipv4.conf.all.log_martians = 1 net.ipv4.conf.default.accept_source_route = 0 net.ipv4.conf.default.accept_redirects = 0 net.ipv4.conf.default.secure_redirects = 0 net.ipv4.icmp_echo_ignore_broadcasts = 1 net.ipv4.icmp_ignore_bogus_error_messages = 1 net.ipv4.tcp_syncookies = 1 net.ipv4.conf.all.rp_filter = 1 net.ipv4.conf.default.rp_filter = 1 These options improve Linux’s ability to defend against certain types of IPv4 protocol attacks. The accept source route, accept redirects, and secure redirects options are turned off to disable IPv4 protocol features which are considered to have few legitimate uses and to be easy to abuse. The net.ipv4.conf.all.log martians option logs several types of suspicious packets, such as spoofed packets, source-routed packets, and redirects. The icmp echo ignore broadcasts icmp ignore bogus error messages options protect against ICMP attacks. The tcp syncookies option uses a cryptographic feature called SYN cookies to allow machines to continue to accept legitimate connections when faced with a SYN flood attack. See [12] for further information on this option. The rp filter option enables RFC-recommended source validation. It should not be used on machines which are routers for very complicated networks, but is helpful for end hosts and routers serving small networks. For more information on any of these, see the kernel source documentation file /Documentation/networking/ip-sysctl.txt.2 </description>
-          <Rule id="scap-rhel5-rule-84" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-84" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Accepting "secure" ICMP redirects (those from gateways listed in the default gateways list) should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3472-8</ident>
@@ -1476,7 +1476,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:85" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-85" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-85" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Accepting ICMP redirects should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4217-6</ident>
@@ -1484,7 +1484,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:86" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-86" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-86" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Ignoring bogus ICMP responses to broadcasts should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4133-5</ident>
@@ -1492,7 +1492,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:87" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-87" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-87" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Sending TCP syncookies should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4265-5</ident>
@@ -1500,7 +1500,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:88" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-88" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-88" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Ignoring ICMP echo requests (pings) sent to broadcast / multicast addresses should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3644-2</ident>
@@ -1508,7 +1508,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:89" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-89" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-89" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting ICMP redirects should be enabled or disabled for network interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4186-3</ident>
@@ -1516,7 +1516,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:90" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-90" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-90" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Performing source validation by reverse path should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4080-8</ident>
@@ -1524,7 +1524,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:91" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-91" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-91" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting "secure" ICMP redirects (those from gateways listed in the default gateways list) should be enabled or disabled for network interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3339-9</ident>
@@ -1532,7 +1532,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:92" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-92" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-92" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Logging of "martian" packets (those with impossible addresses) should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4320-8</ident>
@@ -1540,7 +1540,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:93" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-93" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-93" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for performing source validation by reverse path should be enabled or disabled for network interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3840-6</ident>
@@ -1548,7 +1548,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:94" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-94" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-94" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting source routed packets should be enabled or disabled for network interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4091-5</ident>
@@ -1556,7 +1556,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:95" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-95" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-95" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Accepting source routed packets should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4236-6</ident>
@@ -1579,7 +1579,7 @@
           <Group id="scap-rhel5-group-2.5.2.2.1" hidden="false">
             <title xml:lang="en">Disable Wireless in BIOS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Some laptops that include built-in wireless support offer the ability to disable the device through the BIOS. This is system-specific; consult your hardware manual or explore the BIOS setup during boot. 2A recent version of this file can be found online at http://lxr.linux.no/source/Documentation/networking/ip-sysctl.txt. </description>
-            <Rule id="scap-rhel5-rule-96" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-96" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Wireless in BIOS </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All wireless devices should be enabled or disabled in the BIOS as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-3628-5</ident>
@@ -1591,7 +1591,7 @@
           <Group id="scap-rhel5-group-2.5.2.2.2" hidden="false">
             <title xml:lang="en">Deactivate Wireless Interfaces </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Deactivating the wireless interfaces should prevent normal usage of the wireless capability. First, identify the interfaces available with the command: # ifconfig -a Additionally,the following command may also be used to determine whether wireless support (“extensions”) is included for a particular interface, though this may not always be a clear indicator: # iwconfig After identifying any wireless interfaces (which may have names like wlan0, ath0, wifi0, or eth0), deactivate the interface with the command: # ifdown interface These changes will only last until the next reboot. To disable the interface for future boots, remove the appropriate interface file from /etc/sysconfig/network-scripts: # rm /etc/sysconfig/network-scripts/ifcfg-interface </description>
-            <Rule id="scap-rhel5-rule-97" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-97" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Deactivate Wireless Interfaces </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All wireless interfaces should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4276-2</ident>
@@ -1603,7 +1603,7 @@
           <Group id="scap-rhel5-group-2.5.2.2.3" hidden="false">
             <title xml:lang="en">Disable Wireless Drivers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Removing the kernel drivers that provide support for wireless Ethernet devices will prevent users from easily activating the devices. To remove the wireless drivers from the system: # rm -r /lib/modules/kernelversion(s) /kernel/drivers/net/wireless This command must also be repeated every time the kernel is upgraded. </description>
-            <Rule id="scap-rhel5-rule-98" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-98" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Wireless Drivers </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Device drivers for wireless devices should be included or excluded from the kernel as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4170-7</ident>
@@ -1623,7 +1623,7 @@
           <Group id="scap-rhel5-group-2.5.3.1.1" hidden="false">
             <title xml:lang="en">Disable Automatic Loading of IPv6 Kernel Module </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To prevent the IPv6 kernel module (ipv6) from being loaded, add the following line to /etc/modprobe.conf: alias net-pf-10 off The unexpected name is a result of how the kernel requests modules for network protocol families; net-pf-10 is an alias for the ipv6 module. </description>
-            <Rule id="scap-rhel5-rule-99" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-99" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Automatic Loading of IPv6 Kernel Module </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Automatic loading of the IPv6 kernel module should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-3562-6</ident>
@@ -1635,7 +1635,7 @@
           <Group id="scap-rhel5-group-2.5.3.1.2" hidden="false">
             <title xml:lang="en">Disable Interface Usage of IPv6 </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To prevent configuration of IPv6 for all interfaces, add or correct the following lines in /etc/sysconfig/ network: NETWORKING_IPV6=no IPV6INIT=no For each network interface IFACE , add or correct the following lines in /etc/sysconfig/network-scripts/ ifcfg-IFACE as an additional prevention mechanism: IPV6INIT=no If it becomes necessary later to configure IPv6, only the interfaces requiring it should be enabled. </description>
-            <Rule id="scap-rhel5-rule-100" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-100" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Interface Usage of IPv6 </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Global IPv6 initialization should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-3377-9</ident>
@@ -1643,7 +1643,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:101" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-101" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-101" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Interface Usage of IPv6 </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">IPv6 configuration should be enabled or disabled as appropriate for all interfaces.</description>
               <ident system="http://cce.mitre.org">CCE-4296-0</ident>
@@ -1651,7 +1651,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:102" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-102" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-102" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Interface Usage of IPv6 </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for IPv6 configuration should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-3381-1</ident>
@@ -1667,7 +1667,7 @@
           <Group id="scap-rhel5-group-2.5.3.2.1" hidden="false">
             <title xml:lang="en">Disable Automatic Configuration </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Disable the system’s acceptance of router advertisements and redirects by adding or correcting the following line in /etc/sysconfig/network (note that this does not disable sending router solicitations): IPV6_AUTOCONF=no </description>
-            <Rule id="scap-rhel5-rule-103" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-103" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Automatic Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Accepting IPv6 router advertisements should be enabled or disabled as appropriate for all network interfaces.</description>
               <ident system="http://cce.mitre.org">CCE-4269-7</ident>
@@ -1675,7 +1675,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:104" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-104" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-104" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Automatic Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting IPv6 router advertisements should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4291-1</ident>
@@ -1683,7 +1683,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:105" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-105" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-105" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Automatic Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Accepting redirects from IPv6 routers should be enabled or disabled as appropriate for all network interfaces.</description>
               <ident system="http://cce.mitre.org">CCE-4313-3</ident>
@@ -1691,7 +1691,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:106" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-106" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-106" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Automatic Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting redirects from IPv6 routers should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4198-8</ident>
@@ -1707,7 +1707,7 @@
           <Group id="scap-rhel5-group-2.5.3.2.3" hidden="false">
             <title xml:lang="en">Use Privacy Extensions for Address if Necessary </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To introduce randomness into the automatic generation of IPv6 addresses, add or correct the following line in /etc/sysconfig/network-scripts/ifcfg-IFACE: IPV6_PRIVACY=rfc3041 Automatically-generated IPv6 addresses are based on the underlying hardware (e.g. Ethernet) address, and so it becomes possible to track a piece of hardware over its lifetime using its traffic. If it is important for a system’s IP address to not trivially reveal its hardware address, this setting should be applied. </description>
-            <Rule id="scap-rhel5-rule-107" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-107" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Use Privacy Extensions for Address if Necessary </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">IPv6 privacy extensions should be configured appropriately for all interfaces.</description>
               <ident system="http://cce.mitre.org">CCE-3842-2</ident>
@@ -1723,7 +1723,7 @@
           <Group id="scap-rhel5-group-2.5.3.2.5" hidden="false">
             <title xml:lang="en">Limit Network-Transmitted Configuration </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Add the following lines to /etc/sysctl.conf to limit the configuration information requested from other systems, and accepted from the network: net.ipv6.conf.default.router_solicitations = 0 net.ipv6.conf.default.accept_ra_rtr_pref = 0 net.ipv6.conf.default.accept_ra_pinfo = 0 net.ipv6.conf.default.accept_ra_defrtr = 0 net.ipv6.conf.default.autoconf = 0 net.ipv6.conf.default.dad_transmits = 0 net.ipv6.conf.default.max_addresses = 1 The router solicitations setting determines how many router solicitations are sent when bringing up the interface. If addresses are statically assigned, there is no need to send any solicitations. The accept ra pinfo setting controls whether the system will accept prefix info from the router. The accept ra defrtr setting controls whether the system will accept Hop Limit settings from a router advertisement. Setting it to 0 prevents a router from changing your default IPv6 Hop Limit for outgoing packets. The autoconf setting controls whether router advertisements can cause the system to assign a global unicast address to an interface. The dad transmits setting determines how many neighbor solicitations to send out per address (global and link-local) when bringing up an interface to ensure the desired address is unique on the network. The max addresses setting determines how many global unicast IPv6 addresses can be assigned to each interface. The default is 16, but it should be set to exactly the number of statically configured global addresses required. </description>
-            <Rule id="scap-rhel5-rule-108" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-108" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting router preference via IPv6 router advertisement should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4221-8</ident>
@@ -1731,7 +1731,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:109" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-109" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-109" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default number of global unicast IPv6 addresses allowed per network interface should be set appropriately. </description>
               <ident system="http://cce.mitre.org">CCE-4137-6</ident>
@@ -1739,7 +1739,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:110" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-110" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-110" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default number of IPv6 router solicitations for network interfaces to send should be set appropriately. </description>
               <ident system="http://cce.mitre.org">CCE-4159-0</ident>
@@ -1747,7 +1747,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:111" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-111" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-111" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default number of IPv6 duplicate address detection solicitations for network interfaces to send per configured address should be set appropriately. </description>
               <ident system="http://cce.mitre.org">CCE-3895-0</ident>
@@ -1755,7 +1755,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:112" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-112" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-112" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for autoconfiguring network interfaces using prefix information in IPv6 router advertisements should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4287-9</ident>
@@ -1763,7 +1763,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:113" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-113" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-113" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting prefix information via IPv6 router advertisement should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4058-4</ident>
@@ -1771,7 +1771,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:114" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-114" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-114" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting a default router via IPv6 router advertisement should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4128-5</ident>
@@ -1812,7 +1812,7 @@
         <Group id="scap-rhel5-group-2.5.5.1" hidden="false">
           <title xml:lang="en">Inspect and Activate Default Rules </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">View the currently-enforced iptables rules by running the command: # iptables -nL --line-numbers The command is analogous for the ip6tables program. If the firewall does not appear to be active (i.e., no rules appear), activate it and ensure that it starts at boot by issuing the following commands (and analogously for ip6tables): # service iptables restart # chkconfig iptables on The default iptables rules are: Chain INPUT (policy ACCEPT) num target prot opt source destination 1 RH-Firewall-1-INPUT all -- 0.0.0.0/0 0.0.0.0/0 Chain FORWARD (policy ACCEPT) num target prot opt source destination 1 RH-Firewall-1-INPUT all -- 0.0.0.0/0 0.0.0.0/0 Chain OUTPUT (policy ACCEPT) num target prot opt source destination Chain RH-Firewall-1-INPUT (2 references) num target prot opt source destination 1 ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 2 ACCEPT icmp -- 0.0.0.0/0 0.0.0.0/0 icmp type 255 3 ACCEPT esp -- 0.0.0.0/0 0.0.0.0/0 4 ACCEPT ah -- 0.0.0.0/0 0.0.0.0/0 5 ACCEPT udp -- 0.0.0.0/0 224.0.0.251 udp dpt:5353 6 ACCEPT udp -- 0.0.0.0/0 0.0.0.0/0 udp dpt:631 7 ACCEPT tcp -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:631 8 ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 state RELATED,ESTABLISHED 9 ACCEPT tcp -- 0.0.0.0/0 0.0.0.0/0 state NEW tcp dpt:22 10 REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-host-prohibited The ip6tables default rules are similar, with its rules 2 and 10 reflecting protocol naming and addressing differences. Instead of rule 8, however, ip6tables includes two rules that accept all incoming udp and tcp packets with a particular destination port range. This is because the current Netfilter implementation for IPv6 lacks reliable connection-tracking functionality. </description>
-          <Rule id="scap-rhel5-rule-115" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-115" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Inspect and Activate Default Rules </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ip6tables service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4167-3</ident>
@@ -1820,7 +1820,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:116" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-116" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-116" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Inspect and Activate Default Rules </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The iptables service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4189-7</ident>
@@ -1905,7 +1905,7 @@
       <Group id="scap-rhel5-group-2.6.1" hidden="false">
         <title xml:lang="en">Configure Syslog</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Syslog has been the default Unix logging mechanism for many years. It has a number of downsides, including inconsistent log format, lack of authentication for received messages, and lack of authentication, encryption, or reliable transport for messages sent over a network. However, due to its long history, syslog is an accepted standard which is supported by almost all Unix applications. This section discusses how to configure syslog for best effect, and how to use tools provided with the system to maintain and monitor your logs. </description>
-        <Rule id="scap-rhel5-rule-117" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-117" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Configure Syslog</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The syslog service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3679-8</ident>
@@ -1920,7 +1920,7 @@
         <Group id="scap-rhel5-group-2.6.1.2" hidden="false">
           <title xml:lang="en">Confirm Existence and Permissions of System Log Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">For each log file LOGFILE referenced in /etc/syslog.conf, run the commands: # touch LOGFILE # chown root:root LOGFILE # chmod 0600 LOGFILE Syslog will refuse to log to a file which does not exist. All messages intended for that file will be silently discarded, so it is important to verify that all log files exist. Some logs may contain sensitive information, so it is better to restrict permissions so that only administrative users can read or write logfiles. </description>
-          <Rule id="scap-rhel5-rule-118" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-118" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Confirm Existence and Permissions of System Log Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All syslog log files should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3701-0</ident>
@@ -1928,7 +1928,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:119" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-119" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-119" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Confirm Existence and Permissions of System Log Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for all syslog log files should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4233-3</ident>
@@ -1936,7 +1936,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:120" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-120" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-120" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Confirm Existence and Permissions of System Log Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All syslog log files should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-4366-1</ident>
@@ -1948,7 +1948,7 @@
         <Group id="scap-rhel5-group-2.6.1.3" hidden="false">
           <title xml:lang="en">Send Logs to a Remote Loghost </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/syslog.conf. Add or correct the line: *.* @loghost.example.com where loghost.example.com is the name of your central log server. If system logs are to be useful in detecting malicious activities, it is necessary to send logs to a remote server. An intruder who has compromised the root account on a machine may delete the log entries which indicate that the system was attacked before they are seen by an administrator. However, it is recommended that logs be stored on the local host in addition to being sent to the loghost, because syslog uses the UDP protocol to send messages over a network. UDP does not guarantee reliable delivery, and moderately busy sites will lose log messages occasionally, especially in periods of high traffic which may be the result of an attack. In addition, remote syslog messages are not authenticated in any way, so it is easy for an attacker to introduce spurious messages to the central log server. Also, some problems cause loss of network connectivity, which will prevent the sending of messages to the central server. For all of these reasons, it is better to store log messages both centrally and on each host, so that they can be correlated if necessary. </description>
-          <Rule id="scap-rhel5-rule-121" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-121" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Send Logs to a Remote Loghost </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Syslog logs should be sent to a remote loghost or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4260-6</ident>
@@ -1960,7 +1960,7 @@
         <Group id="scap-rhel5-group-2.6.1.4" hidden="false">
           <title xml:lang="en">Enable syslogd to Accept Remote Messages on Loghosts Only </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is this machine the central log server for your organization? If so, edit the file /etc/sysconfig/syslog. Add or correct the following line: SYSLOGD_OPTIONS="-m 0 -r -s example.com " where example.com is the name of your domain. If the machine is not a log server, edit /etc/sysconfig/syslog, and instead add or correct the line: SYSLOGD_OPTIONS="-m 0" By default, RHEL5’s syslog does not listen over the network for log messages. The -r flag enables syslogd to listen over a network, and should be used only if necessary. The -s example.com flag strips the domain name example.com from each sending machine’s hostname before logging messages from that host, to reduce the amount of redundant information placed in log files. See the syslogd(8) man page for further information. </description>
-          <Rule id="scap-rhel5-rule-122" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-122" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable syslogd to Accept Remote Messages on Loghosts Only </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Syslogd should accept remote messages or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3382-9</ident>
@@ -1972,7 +1972,7 @@
         <Group id="scap-rhel5-group-2.6.1.5" hidden="false">
           <title xml:lang="en">Ensure All Logs are Rotated by logrotate </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/logrotate.d/syslog. Find the first line, which should look like this (wrapped for clarity): /var/log/messages /var/log/secure /var/log/maillog /var/log/spooler \ /var/log/boot.log /var/log/cron { Edit this line so that it contains a one-space-separated listing of each log file referenced in /etc/syslog.conf. All logs in use on a system must be rotated regularly, or the log files will consume disk space over time, eventually interfering with system operation. The file /etc/logrotate.d/syslog is the configuration file used by the logrotate program to maintain all log files written by syslog. By default, it rotates logs weekly and stores four archival copies of each log. These settings can be modified by editing /etc/logrotate.conf, but the defaults are sufficient for purposes of this guide. Note that logrotate is run nightly by the cron job /etc/cron.daily/logrotate. If particularly active logs need to be rotated more often than once a day, some other mechanism must be used. </description>
-          <Rule id="scap-rhel5-rule-123" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-123" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure All Logs are Rotated by logrotate </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The logrotate (syslog rotater) service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4182-2</ident>
@@ -1984,7 +1984,7 @@
         <Group id="scap-rhel5-group-2.6.1.6" hidden="false">
           <title xml:lang="en">Monitor Suspicious Log Messages using Logwatch </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The system includes an extensible program called Logwatch for reporting on unusual items in syslog. Logwatch is valuable because it provides a parser for the syslog entry format and a number of signatures for types of lines which are considered to be mundane or noteworthy. Logwatch has a number of downsides: the signatures can be inaccurate and are not always categorized consistently, and you must be able to program in Perl in order to customize the signature database. However, it is recommended that all Linux sites which do not have time to deploy a third-party log monitoring application run Logwatch in its default configuration. This provides some useful information about system activity in exchange for very little administrator effort. This guide recommends that Logwatch be run only on the central logserver, if your site has one, in order to focus administrator attention by sending all daily logs in a single e-mail. </description>
-          <Rule id="scap-rhel5-rule-124" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-124" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Monitor Suspicious Log Messages using Logwatch </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The logwatch service should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4323-2</ident>
@@ -2008,7 +2008,7 @@
         <Group id="scap-rhel5-group-2.6.2.1" hidden="false">
           <title xml:lang="en">Enable the auditd Service </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Ensure that the auditd service is enabled (this is the default): # chkconfig auditd on By default, auditd logs only SELinux denials, which are helpful for debugging SELinux and discovering intrusion attempts, and certain types of security events, such as modifications to user accounts (useradd, passwd, etc), login events, and calls to sudo. Data is stored in /var/log/audit/audit.log. By default, auditd rotates 4 logs by size (5MB), retaining a maximum of 20MB of data in total, and refuses to write entries when the disk is too full. This minimizes the risk of audit data filling its partition and impacting other services. However, it is possible to lose audit data if the system is busy. </description>
-          <Rule id="scap-rhel5-rule-125" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-125" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable the auditd Service </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The auditd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4292-9</ident>
@@ -2060,7 +2060,7 @@
       <Group id="scap-rhel5-group-3.2.1" hidden="false">
         <title xml:lang="en">Inetd and Xinetd</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there an operational need to run the deprecated inetd or xinetd software packages? If not, ensure that they are removed from the system: # yum erase inetd xinetd Beginning with Red Hat Enterprise Linux 5, the xinetd service is no longer installed by default. This change represents increased awareness that the dedicated network listener model does not improve security or reliability of services, and that restriction of network listeners is better handled using a granular model such as SELinux than using xinetd’s limited security options. </description>
-        <Rule id="scap-rhel5-rule-126" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-126" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Inetd and Xinetd</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The inetd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4234-1</ident>
@@ -2068,7 +2068,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:127" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-127" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-127" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Inetd and Xinetd</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The xinetd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4252-3</ident>
@@ -2076,7 +2076,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:128" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-128" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-128" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Inetd and Xinetd</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The inetd package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4023-8</ident>
@@ -2084,7 +2084,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:129" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-129" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-129" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Inetd and Xinetd</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The xifnetd package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4164-0</ident>
@@ -2096,7 +2096,7 @@
       <Group id="scap-rhel5-group-3.2.2" hidden="false">
         <title xml:lang="en">Telnet</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for users to access the system via the insecure telnet protocol, rather than the more secure SSH protocol? If not, ensure that the telnet server is removed from the system: # yum erase telnet-server The telnet protocol uses unencrypted network communication, which means that data from the login session, including passwords and all other information transmitted during the session, can be stolen by eavesdroppers on the network, and also that outsiders can easily hijack the session to gain authenticated access to the telnet server. Organizations which use telnet should be actively working to migrate to a more secure protocol. See Section 3.5 for information about the SSH service. </description>
-        <Rule id="scap-rhel5-rule-130" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-130" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Telnet</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The telnet service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3390-2</ident>
@@ -2104,7 +2104,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:131" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-131" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-131" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Telnet</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The telnet-server package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4330-7</ident>
@@ -2119,7 +2119,7 @@
         <Group id="scap-rhel5-group-3.2.3.1" hidden="false">
           <title xml:lang="en">Remove the Rsh Server Commands from the System </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for users to access the system via the insecure rlogin, rsh, or rcp commands rather than the more secure ssh and scp? If not, ensure that the rsh server is removed from the system: # yum erase rsh-server SSH was designed to be a drop-in replacement for the r-commands, which suffer from the same hijacking and eavesdropping problems as telnet. There is unlikely to be a case in which these commands cannot be replaced with SSH. </description>
-          <Rule id="scap-rhel5-rule-132" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-132" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove the Rsh Server Commands from the System </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rcp service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3974-3</ident>
@@ -2127,7 +2127,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:133" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-133" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-133" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove the Rsh Server Commands from the System </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rsh service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4141-8</ident>
@@ -2135,7 +2135,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:134" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-134" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-134" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove the Rsh Server Commands from the System </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rlogin service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3537-8</ident>
@@ -2143,7 +2143,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:135" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-135" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-135" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove the Rsh Server Commands from the System </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rsh packagee should be installed or uninstalled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4308-3</ident>
@@ -2160,7 +2160,7 @@
       <Group id="scap-rhel5-group-3.2.4" hidden="false">
         <title xml:lang="en">NIS</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The NIS client service ypbind is not activated by default. In the event that it was activated at some point, disable it by executing the command: # chkconfig ypbind off The NIS server package is not installed by default. In the event that it was installed at some point, remove it from the system by executing the command: # yum erase ypserv The Network Information Service (NIS), also known as “Yellow Pages” (YP), and its successor NIS+ have been made obsolete by Kerberos, LDAP, and other modern centralized authentication services. NIS should not be used because it suffers from security problems inherent in its design, such as inadequate protection of important authentication information. </description>
-        <Rule id="scap-rhel5-rule-136" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-136" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">NIS</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ypbind service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3705-1</ident>
@@ -2168,7 +2168,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:137" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-137" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-137" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">NIS</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ypserv package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4348-9</ident>
@@ -2180,7 +2180,7 @@
       <Group id="scap-rhel5-group-3.2.5" hidden="false">
         <title xml:lang="en">TFTP Server</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there an operational need to run the deprecated TFTP server software? If not, ensure that it is removed from the system: # yum erase tftp-server TFTP is a lightweight version of the FTP protocol which has traditionally been used to configure networking equipment. However, TFTP provides little security, and modern versions of networking operating systems fre77 quently support configuration via SSH or other more secure protocols. A TFTP server should be run only if no more secure method of supporting existing equipment can be found. </description>
-        <Rule id="scap-rhel5-rule-138" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-138" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">TFTP Server</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The tftp service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4273-9</ident>
@@ -2188,7 +2188,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:139" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-139" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-139" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">TFTP Server</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The tftp-server package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3916-4</ident>
@@ -2204,7 +2204,7 @@
       <Group id="scap-rhel5-group-3.3.1" hidden="false">
         <title xml:lang="en">Installation Helper Service (firstboot)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Firstboot is a daemon specific to the Red Hat installation process. It handles “one-time” configuration following successful installation of the operating system. As such, there is no reason for this service to remain enabled. Disable firstboot by issuing the command: # chkconfig firstboot off </description>
-        <Rule id="scap-rhel5-rule-140" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-140" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Installation Helper Service (firstboot)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The firstboot service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3412-4</ident>
@@ -2216,7 +2216,7 @@
       <Group id="scap-rhel5-group-3.3.2" hidden="false">
         <title xml:lang="en">Console Mouse Service (gpm)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">GPM is the service that controls the text console mouse pointer. (The X Windows mouse pointer is unaffected by this service.) If mouse functionality in the console is not required, disable this service: # chkconfig gpm off Although it is preferable to run as few services as possible, the console mouse pointer can be useful for preventing administrator mistakes in runlevel 3 by enabling copy-and-paste operations. </description>
-        <Rule id="scap-rhel5-rule-141" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-141" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Console Mouse Service (gpm)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The gpm service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4229-1</ident>
@@ -2228,7 +2228,7 @@
       <Group id="scap-rhel5-group-3.3.3" hidden="false">
         <title xml:lang="en">Interrupt Distribution on Multiprocessor Systems (irqbalance)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The goal of the irqbalance service is to optimize the balance between power savings and performance through distribution of hardware interrupts across multiple processors. In a server environment with multiple processors, this provides a useful service and should be left enabled. If a machine has only one processor, the service may be disabled: # chkconfig irqbalance off </description>
-        <Rule id="scap-rhel5-rule-142" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-142" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Interrupt Distribution on Multiprocessor Systems (irqbalance)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The irqbalance service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4123-6</ident>
@@ -2240,7 +2240,7 @@
       <Group id="scap-rhel5-group-3.3.4" hidden="false">
         <title xml:lang="en">ISDN Support (isdn)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ISDN service facilitates Internet connectivity in the presence of an ISDN modem. If an ISDN modem is not being used, disable this service: # chkconfig isdn off </description>
-        <Rule id="scap-rhel5-rule-143" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-143" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">ISDN Support (isdn)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The isdn service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4286-1</ident>
@@ -2252,7 +2252,7 @@
       <Group id="scap-rhel5-group-3.3.5" hidden="false">
         <title xml:lang="en">Kdump Kernel Crash Analyzer (kdump)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Kdump is a new kernel crash dump analyzer. It uses kexec to boot a secondary kernel (“capture” kernel) following a system crash. The kernel dump from the system crash is loaded into the capture kernel for analysis. Unless the system is used for kernel development or testing, disable the service: # chkconfig kdump off </description>
-        <Rule id="scap-rhel5-rule-144" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-144" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Kdump Kernel Crash Analyzer (kdump)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The kdump service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3425-6</ident>
@@ -2264,7 +2264,7 @@
       <Group id="scap-rhel5-group-3.3.6" hidden="false">
         <title xml:lang="en">Kudzu Hardware Probing Utility (kudzu)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for console users to add new hardware to the system? If not: # chkconfig kudzu off Kudzu, Red Hat’s hardware detection program, represents an unnecessary security risk as it allows unprivileged users to perform hardware configuration without authorization. Unless this specific functionality is required, Kudzu should be disabled. </description>
-        <Rule id="scap-rhel5-rule-145" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-145" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Kudzu Hardware Probing Utility (kudzu)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The kudzu service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4211-9</ident>
@@ -2276,7 +2276,7 @@
       <Group id="scap-rhel5-group-3.3.7" hidden="false">
         <title xml:lang="en">Software RAID Monitor (mdmonitor)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The mdmonitor service is used for monitoring a software RAID (hardware RAID setups do not use this service). This service is extraneous unless software RAID is in use (which is not common). If software RAID monitoring is not required, disable this service: # chkconfig mdmonitor off </description>
-        <Rule id="scap-rhel5-rule-146" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-146" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Software RAID Monitor (mdmonitor)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The mdmonitor service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3854-7</ident>
@@ -2288,7 +2288,7 @@
       <Group id="scap-rhel5-group-3.3.8" hidden="false">
         <title xml:lang="en">IA32 Microcode Utility(microcodectl)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">microcode ctl is a microcode utility for use with Intel IA32 processors (Pentium Pro, PII, Celeron, PIII, Xeon, Pentium 4, etc) If the system is not running an Intel IA32 processor, disable this service: # chkconfig microcode ctl off </description>
-        <Rule id="scap-rhel5-rule-147" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-147" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">IA32 Microcode Utility(microcodectl)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The microcode_ctl service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4356-2</ident>
@@ -2300,7 +2300,7 @@
       <Group id="scap-rhel5-group-3.3.9" hidden="false">
         <title xml:lang="en">Network Service (network)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The network service allows associated network interfaces to access the network. This section contains general guidance for controlling the operation of the service. For kernel parameters which affect networking, see Section </description>
-        <Rule id="scap-rhel5-rule-148" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-148" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Network Service (network)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The network service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4369-5</ident>
@@ -2324,7 +2324,7 @@
       <Group id="scap-rhel5-group-3.3.10" hidden="false">
         <title xml:lang="en">Smart Card Support (pcscd)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The pcscd service provides support for Smart Cards and Smart Card Readers. If Smart Cards are not in use on the system, disable this service: # chkconfig pcscd off </description>
-        <Rule id="scap-rhel5-rule-149" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-149" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Smart Card Support (pcscd)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The pcscd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4100-4</ident>
@@ -2336,7 +2336,7 @@
       <Group id="scap-rhel5-group-3.3.11" hidden="false">
         <title xml:lang="en">SMART Disk Monitoring Support (smartd)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SMART (Self-Monitoring, Analysis, and Reporting Technology) is a feature of hard drives that allows them to detect symptoms of disk failure and relay an appropriate warning. This technology is considered to bring relatively low security risk, and can be useful. Leave this service running if the system’s hard drives are SMART-capable. Otherwise, disable it: # chkconfig smartd off </description>
-        <Rule id="scap-rhel5-rule-150" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-150" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">SMART Disk Monitoring Support (smartd)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The smartd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3455-3</ident>
@@ -2348,7 +2348,7 @@
       <Group id="scap-rhel5-group-3.3.12" hidden="false">
         <title xml:lang="en">Boot Caching (readahead early/readahead later)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The following services provide one-time caching of files belonging to some boot services, with the goal of allowing the system to boot faster. It is recommended that this service be disabled on most machines: # chkconfig readahead early off # chkconfig readahead later off The readahead services do not substantially increase a system’s risk exposure, but they also do not provide great benefit. Unless the system is running a specialized application for which the file caching substantially improves system boot time, this guide recommends disabling the services. </description>
-        <Rule id="scap-rhel5-rule-151" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-151" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Boot Caching (readahead early/readahead later)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The readahead_early service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4421-4</ident>
@@ -2356,7 +2356,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:152" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-152" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-152" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Boot Caching (readahead early/readahead later)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The readahead_later service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4302-6</ident>
@@ -2371,7 +2371,7 @@
         <Group id="scap-rhel5-group-3.3.13.1" hidden="false">
           <title xml:lang="en">D-Bus IPC Service (messagebus) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">D-Bus is an IPC mechanism that provides a common channel for inter-process communication. If no services which require D-Bus are in use, disable this service: # chkconfig messagebus off A number of default services make use of D-Bus, including X Windows (Section 3.6), Bluetooth (Section 3.3.14) and Avahi (Section 3.7). This guide recommends that D-Bus and all its dependencies be disabled unless there is a mission-critical need for them. Stricter configuration of D-Bus is possible and documented in the man page dbus-daemon(1). D-Bus maintains two separate configuration files, located in /etc/dbus-1/, one for system-specific configuration and the other for session-specific configuration. </description>
-          <Rule id="scap-rhel5-rule-153" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-153" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">D-Bus IPC Service (messagebus) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The messagebus service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3822-4</ident>
@@ -2383,7 +2383,7 @@
         <Group id="scap-rhel5-group-3.3.13.2" hidden="false">
           <title xml:lang="en">HAL Daemon (haldaemon) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The haldaemon service provides a dynamic way of managing device interfaces. It automates device configuration and provides an API for making devices accessible to applications through the D-Bus interface. </description>
-          <Rule id="scap-rhel5-rule-154" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-154" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">HAL Daemon (haldaemon) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The haldaemon service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4364-6</ident>
@@ -2407,7 +2407,7 @@
         <Group id="scap-rhel5-group-3.3.14.1" hidden="false">
           <title xml:lang="en">Bluetooth Host Controller Interface Daemon (bluetooth) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The bluetooth service enables the system to use Bluetooth devices. If the system requires no Bluetooth devices, disable this service: # chkconfig bluetooth off </description>
-          <Rule id="scap-rhel5-rule-155" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-155" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Bluetooth Host Controller Interface Daemon (bluetooth) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The bluetooth service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4355-4</ident>
@@ -2419,7 +2419,7 @@
         <Group id="scap-rhel5-group-3.3.14.2" hidden="false">
           <title xml:lang="en">Bluetooth Input Devices (hidd) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The hidd service provides support for Bluetooth input devices. If the system has no Bluetooth input devices (e.g. keyboard or mouse), disable this service: # chkconfig hidd off </description>
-          <Rule id="scap-rhel5-rule-156" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-156" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Bluetooth Input Devices (hidd) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The hidd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4377-8</ident>
@@ -2439,7 +2439,7 @@
         <Group id="scap-rhel5-group-3.3.15.1" hidden="false">
           <title xml:lang="en">Advanced Power Management Subsystem (apmd) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The apmd service provides last generation power management support. If the system is capable of ACPI support, or if power management is not necessary, disable this service: # chkconfig apmd off APM is being replaced by ACPI and should be considered deprecated. As such, it can be disabled if ACPI is supported by your hardware and kernel. If the file /proc/acpi/info exists and contains ACPI version information, then APM can safely be disabled without loss of functionality. </description>
-          <Rule id="scap-rhel5-rule-157" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-157" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Advanced Power Management Subsystem (apmd) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The apmd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4289-5</ident>
@@ -2451,7 +2451,7 @@
         <Group id="scap-rhel5-group-3.3.15.2" hidden="false">
           <title xml:lang="en">Advanced Configuration and Power Interface (acpid) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The acpid service provides next generation power management support. Unless power management features are not necessary, leave this service enabled. </description>
-          <Rule id="scap-rhel5-rule-158" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-158" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Advanced Configuration and Power Interface (acpid) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The acpid service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4298-6</ident>
@@ -2463,7 +2463,7 @@
         <Group id="scap-rhel5-group-3.3.15.3" hidden="false">
           <title xml:lang="en">CPU Throttling (cpuspeed) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The cpuspeed service uses hardware support to throttle the CPU when the system is idle. Unless CPU power optimization is unnecessary, leave this service enabled. </description>
-          <Rule id="scap-rhel5-rule-159" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-159" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">CPU Throttling (cpuspeed) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The cpuspeed service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4051-9</ident>
@@ -2477,7 +2477,7 @@
     <Group id="scap-rhel5-group-3.4" hidden="false">
       <title xml:lang="en">Cron and At Daemons</title>
       <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The cron and at services are used to allow commands to be executed at a later time. The cron service is required by almost all systems to perform necessary maintenance tasks, while at may or may not be required on a given system. Both daemons should be configured defensively. </description>
-      <Rule id="scap-rhel5-rule-160" selected="false" weight="10.000000">
+      <Rule id="scap-rhel5-rule-160" selected="false" weight="10.000000" role="full" severity="unknown">
         <title xml:lang="en">Cron and At Daemons</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The crond service should be enabled or disabled as appropriate.</description>
         <ident system="http://cce.mitre.org">CCE-4324-0</ident>
@@ -2488,7 +2488,7 @@
       <Group id="scap-rhel5-group-3.4.1" hidden="false">
         <title xml:lang="en">Disable anacron if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is this a machine which is designed to run all the time, such as a server or a workstation which is left on at night? If so: # yum erase anacron The anacron subsystem is designed to provide cron functionality for machines which may be shut down during the normal times that system cron jobs run, frequently in the middle of the night. Laptops and workstations which are shut down at night should keep anacron enabled, so that standard system cron jobs will run when the machine boots. However, on machines which do not need this additional functionality, anacron represents another piece of privileged software which could contain vulnerabilities. Therefore, it should be removed when possible to reduce system risk. </description>
-        <Rule id="scap-rhel5-rule-161" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-161" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable anacron if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The anacron service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4406-5</ident>
@@ -2496,7 +2496,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:162" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-162" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-162" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable anacron if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The anacron package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4428-9</ident>
@@ -2508,7 +2508,7 @@
       <Group id="scap-rhel5-group-3.4.2" hidden="false">
         <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">1. Restrict the permissions on the primary system crontab file: # chown root:root /etc/crontab # chmod 600 /etc/crontab 2. If anacron has not been removed, restrict the permissions on its primary configuration file: # chown root:root /etc/anacrontab # chmod 600 /etc/anacrontab 3. Restrict the permission on all system crontab directories: # cd /etc # chown -R root:root cron.hourly cron.daily cron.weekly cron.monthly cron.d # chmod -R go-rwx cron.hourly cron.daily cron.weekly cron.monthly cron.d 4. Restrict the permissions on the spool directory for user crontab files: # chown root:root /var/spool/cron # chmod -R go-rwx /var/spool/cron Cron and anacron make use of a number of configuration files and directories. The system crontabs need only be edited by root, and user crontabs are edited using the setuid root crontab command. If unprivileged users can modify system cron configuration files, they may be able to gain elevated privileges, so all unnecessary access to these files should be disabled. </description>
-        <Rule id="scap-rhel5-rule-163" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-163" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.monthly file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-4322-4</ident>
@@ -2516,7 +2516,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:164" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-164" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-164" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/cron.daily should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4450-3</ident>
@@ -2524,7 +2524,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:165" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-165" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-165" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.weekly file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-4331-5</ident>
@@ -2532,7 +2532,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:166" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-166" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-166" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/crontab file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-3851-3</ident>
@@ -2540,7 +2540,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:167" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-167" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-167" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/anacrontab file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-4379-4</ident>
@@ -2548,7 +2548,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:168" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-168" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-168" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/crontab should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4388-5</ident>
@@ -2556,7 +2556,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:169" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-169" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-169" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.hourly file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-4054-3</ident>
@@ -2564,7 +2564,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:170" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-170" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-170" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.monthly file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-4441-2</ident>
@@ -2572,7 +2572,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:171" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-171" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-171" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.d file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-4212-7</ident>
@@ -2580,7 +2580,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:172" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-172" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-172" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.d file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-4380-2</ident>
@@ -2588,7 +2588,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:173" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-173" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-173" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.weekly file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-3833-1</ident>
@@ -2596,7 +2596,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:174" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-174" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-174" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/anacrontab file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-3604-6</ident>
@@ -2604,7 +2604,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:175" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-175" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-175" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/cron.hourly should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4106-1</ident>
@@ -2612,7 +2612,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:176" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-176" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-176" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.hourly file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-3983-4</ident>
@@ -2620,7 +2620,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:177" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-177" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-177" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/crontab file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-3626-9</ident>
@@ -2628,7 +2628,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:178" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-178" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-178" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.daily file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-4022-0</ident>
@@ -2636,7 +2636,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:179" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-179" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-179" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/anacrontab should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4304-2</ident>
@@ -2644,7 +2644,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:180" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-180" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-180" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/cron.weekly should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4203-6</ident>
@@ -2652,7 +2652,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:181" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-181" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-181" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/cron.monthly should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4251-5</ident>
@@ -2660,7 +2660,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:182" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-182" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-182" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.daily file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-3481-9</ident>
@@ -2668,7 +2668,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:183" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-183" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-183" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/cron.d should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4250-7</ident>
@@ -2691,7 +2691,7 @@
         <Group id="scap-rhel5-group-3.5.1.1" hidden="false">
           <title xml:lang="en">Disable and Remove OpenSSH Software </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Disable and remove openssh-server with the commands: # chkconfig sshd off # yum erase openssh-server Users of the system will still be able to use the SSH client program /usr/bin/ssh to access SSH servers on other systems. </description>
-          <Rule id="scap-rhel5-rule-184" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-184" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable and Remove OpenSSH Software </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The sshd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4268-9</ident>
@@ -2699,7 +2699,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:185" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-185" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-185" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable and Remove OpenSSH Software </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH should be installed or uninstalled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4272-1</ident>
@@ -2711,7 +2711,7 @@
         <Group id="scap-rhel5-group-3.5.1.2" hidden="false">
           <title xml:lang="en">Remove SSH Server iptables Firewall Exception </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the files /etc/sysconfig/iptables and /etc/sysconfig/ip6tables (if IPv6 is in use). In each file, locate and delete the line: -A RH-Firewall-1-INPUT -m state --state NEW -m tcp -p tcp --dport 22 -j ACCEPT By default, inbound connections to SSH’s port are allowed. If the SSH server is not being used, this exception should be removed from the firewall configuration. See Section 2.5.5 for more information about Iptables. </description>
-          <Rule id="scap-rhel5-rule-186" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-186" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove SSH Server iptables Firewall Exception </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Inbound connections to the ssh port should be allowed or denied as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4295-2</ident>
@@ -2727,7 +2727,7 @@
         <Group id="scap-rhel5-group-3.5.2.1" hidden="false">
           <title xml:lang="en">Ensure Only Protocol 2 Connections Allowed </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Only SSH protocol version 2 connections should be permitted. Version 1 of the protocol contains security vulnerabilities. The default setting shipped in the configuration file is correct, but it is important enough to check. Verify that the following line appears: Protocol 2 </description>
-          <Rule id="scap-rhel5-rule-187" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-187" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure Only Protocol 2 Connections Allowed </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH version 1 protocol support should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4325-7</ident>
@@ -2743,7 +2743,7 @@
         <Group id="scap-rhel5-group-3.5.2.3" hidden="false">
           <title xml:lang="en">Set Idle Timeout Interval for User Logins </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH allows administrators to set an idle timeout interval. After this interval has passed, the idle user will be automatically logged out. Find and edit the following lines in /etc/ssh/sshd config as follows: ClientAliveInterval interval ClientAliveCountMax 0 The timeout interval is given in seconds. To have a timeout of 5 minutes, set interval to 300. If a shorter timeout has already been set for the login shell, as in Section 2.3.5.5, that value will prempt any SSH setting made here. Keep in mind that some processes may stop SSH from correctly detecting that the user is idle. </description>
-          <Rule id="scap-rhel5-rule-188" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-188" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Idle Timeout Interval for User Logins </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The SSH idle timout interval should be set to an appropriate value</description>
             <ident system="http://cce.mitre.org">CCE-3845-5</ident>
@@ -2755,7 +2755,7 @@
         <Group id="scap-rhel5-group-3.5.2.4" hidden="false">
           <title xml:lang="en">Disable .rhosts Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH can emulate the behavior of the obsolete rsh command in allowing users to enable insecure access to their accounts via .rhosts files. To ensure that this behavior is disabled, add or correct the following line: IgnoreRhosts yes </description>
-          <Rule id="scap-rhel5-rule-189" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-189" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable .rhosts Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Emulation of the rsh command through the ssh server should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4475-0</ident>
@@ -2767,7 +2767,7 @@
         <Group id="scap-rhel5-group-3.5.2.5" hidden="false">
           <title xml:lang="en">Disable Host-Based Authentication </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH’s cryptographic host-based authentication is slightly more secure than .rhosts authentication, since hosts are cryptographically authenticated. However, it is not recommended that hosts unilaterally trust one another, even within an organization. To disable host-based authentication, add or correct the following line: HostbasedAuthentication no </description>
-          <Rule id="scap-rhel5-rule-190" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-190" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Host-Based Authentication </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH host-based authentication should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4370-3</ident>
@@ -2779,7 +2779,7 @@
         <Group id="scap-rhel5-group-3.5.2.6" hidden="false">
           <title xml:lang="en">Disable root Login via SSH </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The root user should never be allowed to login directly over a network, as this both reduces auditable information about who ran privileged commands on the system and allows direct attack attempts on root’s password. To disable root login via SSH, add or correct the following line: PermitRootLogin no </description>
-          <Rule id="scap-rhel5-rule-191" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-191" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable root Login via SSH </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Root login via SSH should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4387-7</ident>
@@ -2791,7 +2791,7 @@
         <Group id="scap-rhel5-group-3.5.2.7" hidden="false">
           <title xml:lang="en">Disable Empty Passwords</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To explicitly disallow remote login from accounts with empty passwords, add or correct the following line: PermitEmptyPasswords no Measures should also be taken to disable accounts with empty passwords system-wide, as described in Section 2.3.1.5. </description>
-          <Rule id="scap-rhel5-rule-192" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-192" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Empty Passwords</title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Remote connections from accounts with empty passwords should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3660-8</ident>
@@ -2803,7 +2803,7 @@
         <Group id="scap-rhel5-group-3.5.2.8" hidden="false">
           <title xml:lang="en">Enable a Warning Banner </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Section 2.3.7 contains information on how to create an appropriate warning banner. To enable a warning banner, add or correct the following line: Banner /etc/issue </description>
-          <Rule id="scap-rhel5-rule-193" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-193" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable a Warning Banner </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH warning banner should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4431-3</ident>
@@ -2827,7 +2827,7 @@
         <Group id="scap-rhel5-group-3.6.1.1" hidden="false">
           <title xml:lang="en">Disable X Windows at System Boot </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/inittab, and correct the line id:5:initdefault: to: id:3:initdefault: This action changes the default boot runlevel of the system from 5 to 3. These two runlevels should be identical except that runlevel 5 starts X on boot, while runlevel 3 does not. </description>
-          <Rule id="scap-rhel5-rule-194" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-194" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable X Windows at System Boot </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">X Windows should be enabled or disabled at system boot as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4462-8</ident>
@@ -2839,7 +2839,7 @@
         <Group id="scap-rhel5-group-3.6.1.2" hidden="false">
           <title xml:lang="en">Remove X Windows from the System if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Remove the X11 RPMs from the system: # yum groupremove "X Window System" As long as X.org remains installed on the system, users can still run X Windows by typing startx at the shell prompt. This may run X Windows using configuration settings which are less secure than the system defaults. Therefore, if the machine is a dedicated server which does not need to provide graphical logins at all, it is safest to remove the X.org software entirely. The command given here will remove over 100 packages. It should safely and effectively remove X from machines which do not need it. </description>
-          <Rule id="scap-rhel5-rule-195" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-195" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove X Windows from the System if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">X Windows should be installed or removed as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4422-2</ident>
@@ -2879,7 +2879,7 @@
         <Group id="scap-rhel5-group-3.7.1.1" hidden="false">
           <title xml:lang="en">Disable Avahi Server Software </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Issue the command: # chkconfig avahi-daemon off </description>
-          <Rule id="scap-rhel5-rule-196" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-196" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Avahi Server Software </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The avahi-daemon service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4365-3</ident>
@@ -2899,7 +2899,7 @@
         <Group id="scap-rhel5-group-3.7.2.1" hidden="false">
           <title xml:lang="en">Serve Only via Required Protocol </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting in the configuration file allows Avahi to use both IPv4 and IPv6 sockets. If you are using only IPv4, edit /etc/avahi/avahi-daemon.conf and ensure the following line exists in the [server] section: use-ipv6=no Similarly, if you are using only IPv6, disable IPv4 sockets with the line: use-ipv4=no </description>
-          <Rule id="scap-rhel5-rule-197" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-197" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Serve Only via Required Protocol </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Avahi daemon should be configured to serve via Ipv6 or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4136-8</ident>
@@ -2907,7 +2907,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:202" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-198" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-198" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Serve Only via Required Protocol </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Avahi daemon should be configured to serve via Ipv4 or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4409-9</ident>
@@ -2919,7 +2919,7 @@
         <Group id="scap-rhel5-group-3.7.2.2" hidden="false">
           <title xml:lang="en">Check Responses TTL Field '</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi can be set to ignore IP packets unless their TTL field is 255. To make Avahi ignore packets unless the TTL field is 255, edit /etc/avahi/avahi-daemon.conf and ensure the following line appears in the [server] section: check-response-ttl=yes This helps to ensure that only mDNS responses from the local network are processed, because the TTL field in a packet is decremented from its initial value of 255 whenever it is routed from one network to another. Although a properly-configured router or firewall should not allow mDNS packets into the local network at all, this option provides another check to ensure they are not trusted. </description>
-          <Rule id="scap-rhel5-rule-199" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-199" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Check Responses' TTL Field </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi should be configured to accept packets with a TTL field not equal to 255 or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4426-3</ident>
@@ -2931,7 +2931,7 @@
         <Group id="scap-rhel5-group-3.7.2.3" hidden="false">
           <title xml:lang="en">Prevent Other Programs from Using Avahis Port '</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi can stop other mDNS stacks from running on the host by preventing other processes from binding to port 5353. To prevent other mDNS stacks from running, edit /etc/avahi/avahi-daemon.conf and ensure the following line appears in the [server] section: disallow-other-stacks=yes This is designed to help ensure that only Avahi is responsible for mDNS traffic coming from that port on the system. </description>
-          <Rule id="scap-rhel5-rule-200" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-200" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Prevent Other Programs from Using Avahi's Port </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi should be configured to allow other stacks from binding to port 5353 or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4193-9</ident>
@@ -2943,7 +2943,7 @@
         <Group id="scap-rhel5-group-3.7.2.4" hidden="false">
           <title xml:lang="en">Disable Publishing if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting in the configuration file allows the avahi-daemon to send information about the local host, such as its address records and the services it offers, to the local network. To stop sending this information but still allow Avahi to query the network for services, ensure the configuration file includes the following line in the [publish] section: disable-publishing=yes This line may be particularly useful if Avahi is needed for printer discovery, but not to advertise services. This configuration is highly recommended for client systems that should not advertise their services (or existence). </description>
-          <Rule id="scap-rhel5-rule-201" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-201" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Publishing if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of local information should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4444-6</ident>
@@ -2955,7 +2955,7 @@
         <Group id="scap-rhel5-group-3.7.2.5" hidden="false">
           <title xml:lang="en">Restrict Published Information </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If it is necessary to publish some information to the network, it should not be joined by any extraneous information, or by information supplied by a non-trusted source on the system. Prevent user applications from using Avahi to publish services by adding or correcting the following line in the [publish] section: disable-user-service-publishing=yes Implement as many of the following lines as possible, to restrict the information published by Avahi: publish-addresses=no publish-hinfo=no publish-workstation=no publish-domain=no Inspect the files in the directory /etc/avahi/services/. Unless there is an operational need to publish information about each of these services, delete the corresponding file. These options should be used even if publishing is disabled entirely via disable-publishing, since that option prevents publishing attempts from succeeding, while these options prevent the attempts from being made in the first place. Using both approaches is recommended for completeness. </description>
-          <Rule id="scap-rhel5-rule-202" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-202" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Published Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of local information by user applications should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4352-1</ident>
@@ -2963,7 +2963,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:207" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-203" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-203" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Published Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of hardware information should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4433-9</ident>
@@ -2971,7 +2971,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:208" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-204" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-204" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Published Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of workstation name should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4451-1</ident>
@@ -2979,7 +2979,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:209" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-205" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-205" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Published Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of IP addresses should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4341-4</ident>
@@ -2987,7 +2987,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:210" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-206" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-206" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Published Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of domain name should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4358-8</ident>
@@ -3004,7 +3004,7 @@
       <Group id="scap-rhel5-group-3.8.1" hidden="false">
         <title xml:lang="en">Disable the CUPS Service if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Do you need the ability to print from this machine or to allow others to print to it? If not: # chkconfig cups off </description>
-        <Rule id="scap-rhel5-rule-207" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-207" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable the CUPS Service if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The cups service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4112-9</ident>
@@ -3016,7 +3016,7 @@
       <Group id="scap-rhel5-group-3.8.2" hidden="false">
         <title xml:lang="en">Disable Firewall Access to Printing Service if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Does this system need to operate as a network print server? If not, edit the files /etc/sysconfig/iptables and /etc/sysconfig/ip6tables (if IPv6 is in use). In each file, locate and delete the lines: -A RH-Firewall-1-INPUT -p udp -m udp --dport 631 -j ACCEPT -A RH-Firewall-1-INPUT -p tcp -m tcp --dport 631 -j ACCEPT By default, inbound connections to the Internet Printing Protocol port are allowed. If the print server does not need to be accessed, either because the machine is not running the print service at all or because the machine is not providing a remote network printer to other machines, this exception should be removed from the firewall configuration. See Section 2.5.5 for more information about the Iptables firewall. </description>
-        <Rule id="scap-rhel5-rule-208" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-208" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Firewall Access to Printing Service if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Firewall access to printing service should be enabled or disabled as appropriate</description>
           <ident system="http://cce.mitre.org">CCE-3649-1</ident>
@@ -3034,7 +3034,7 @@
           <Group id="scap-rhel5-group-3.8.3.1.1" hidden="false">
             <title xml:lang="en">Disable Printer Browsing Entirely if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To disable printer browsing entirely, edit the CUPS configuration file, located at /etc/cups/cupsd.conf: Browsing Off BrowseAllow none The CUPS print service can be configured to broadcast a list of available printers to the network. Other machines on the network, also running the CUPS print service, can be configured to listen to these broadcasts and add and configure these printers for immediate use. By disabling this browsing capability, the machine will no longer generate or receive such broadcasts. </description>
-            <Rule id="scap-rhel5-rule-209" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-209" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Printer Browsing Entirely if Possible </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Remote print browsing should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4420-6</ident>
@@ -3042,7 +3042,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:215" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="scap-rhel5-rule-210" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-210" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Printer Browsing Entirely if Possible </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">CUPS should be allowed or denied the ability to listen for Incoming printer information as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4407-3</ident>
@@ -3075,7 +3075,7 @@
         <Group id="scap-rhel5-group-3.8.4.1" hidden="false">
           <title xml:lang="en">Disable HPLIP Service if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Since the HPIJS driver will still function without the added HPLIP service, HPLIP should be disabled unless the specific higher level functions that HPLIP provides are needed by a non-PostScript HP printer on the system. # chkconfig hplip off Note: If installing the HPLIP package from scratch, it should be noted that HPIJS can be installed directly without HPLIP. Please see the FAQ at the HPLIP web site at http://hplip.sourceforge.net/faqs.html for more information on how to do this. </description>
-          <Rule id="scap-rhel5-rule-211" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-211" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable HPLIP Service if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The hplip service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4425-5</ident>
@@ -3092,7 +3092,7 @@
       <Group id="scap-rhel5-group-3.9.1" hidden="false">
         <title xml:lang="en">Disable DHCP Client if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">For each interface IFACE on the system (e.g. eth0), edit /etc/sysconfig/network-scripts/ifcfg-IFACE and make the following changes: 1. Correct the BOOTPROTO line to read: BOOTPROTO=static 2. Add or correct the following lines, substituting the appropriate values based on your site’s addressing scheme: NETMASK=255.255.255.0 IPADDR=192.168.1.2 GATEWAY=192.168.1.1 DHCP is the default network configuration method provided by the system installer, so it may be enabled on many systems. </description>
-        <Rule id="scap-rhel5-rule-212" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-212" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable DHCP Client if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dhcp client service should be enabled or disabled as appropriate for each interface.</description>
           <ident system="http://cce.mitre.org">CCE-4191-3</ident>
@@ -3112,7 +3112,7 @@
       <Group id="scap-rhel5-group-3.9.3" hidden="false">
         <title xml:lang="en">Disable DHCP Server if possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If the dhcp package has been installed on a machine which does not need to operate as a DHCP server, disable the daemon: # chkconfig dhcpd off If possible, remove the software as well: # yum erase dhcp The DHCP server dhcpd is not installed or activated by default. If the software was installed and activated, but the system does not need to act as a DHCP server, it should be disabled and removed. Unmanaged DHCP servers will provide faulty information to clients, interfering with the operation of a legitimate site DHCP server if there is one, or causing misconfigured machines to exhibit unpredictable behavior if there is not. </description>
-        <Rule id="scap-rhel5-rule-213" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-213" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable DHCP Server if possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dhcpd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4336-4</ident>
@@ -3120,7 +3120,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:219" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-214" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-214" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable DHCP Server if possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dhcp package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4464-4</ident>
@@ -3135,7 +3135,7 @@
         <Group id="scap-rhel5-group-3.9.4.1" hidden="false">
           <title xml:lang="en">Do Not Use Dynamic DNS </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To prevent the DHCP server from receiving DNS information from clients, edit /etc/dhcpd.conf, and add or correct the following global option: ddns-update-style none; The Dynamic DNS protocol is used to remotely update the data served by a DNS server. DHCP servers can use Dynamic DNS to publish information about their clients. This setup carries security risks, and its use is not recommended. If Dynamic DNS must be used despite the risks it poses, it is critical that Dynamic DNS transactions be protected using TSIG or some other cryptographic authentication mechanism. See Section 3.14 for more information about DNS servers, including further information about TSIG and Dynamic DNS. Also see dhcpd.conf(5) for more information about protecting the DHCP server from passing along malicious DNS data from its clients. Note: The ddns-update-style option controls only whether the DHCP server will attempt to act as a Dynamic DNS client. As long as the DNS server itself is correctly configured to reject DDNS attempts, an incorrect ddns-update-style setting on the client is harmless (but should be fixed as a best practice). </description>
-          <Rule id="scap-rhel5-rule-215" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-215" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Do Not Use Dynamic DNS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dynamic DNS feature of the DHCP server should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4257-2</ident>
@@ -3147,7 +3147,7 @@
         <Group id="scap-rhel5-group-3.9.4.2" hidden="false">
           <title xml:lang="en">Deny Decline Messages </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/dhcpd.conf and add or correct the following global option to prevent the DHCP server from responding the DHCPDECLINE messages, if possible: deny declines; The DHCPDECLINE message can be sent by a DHCP client to indicate that it does not consider the lease offered by the server to be valid. By issuing many DHCPDECLINE messages, a malicious client can exhaust the DHCP server’s pool of IP addresses, causing the DHCP server to forget old address allocations. </description>
-          <Rule id="scap-rhel5-rule-216" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-216" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Deny Decline Messages </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">DHCPDECLINE messages should be accepted or denied by the DHCP server as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4403-2</ident>
@@ -3159,7 +3159,7 @@
         <Group id="scap-rhel5-group-3.9.4.3" hidden="false">
           <title xml:lang="en">Deny BOOTP Queries </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Unless your network needs to support older BOOTP clients, disable support for the bootp protocol by adding or correcting the global option: deny bootp; The bootp option tells dhcpd to respond to BOOTP queries. If support for this simpler protocol is not needed, it should be disabled to remove attack vectors against the DHCP server. </description>
-          <Rule id="scap-rhel5-rule-217" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-217" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Deny BOOTP Queries </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">BOOTP queries should be accepted or denied by the DHCP server as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4345-5</ident>
@@ -3171,7 +3171,7 @@
         <Group id="scap-rhel5-group-3.9.4.4" hidden="false">
           <title xml:lang="en">Minimize Served Information </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/dhcpd.conf. Examine each address range section within the file, and ensure that the following options are not defined unless there is an operational need to provide this information via DHCP: option domain-name option domain-name-servers option nis-domain option nis-servers option ntp-servers option routers option time-offset Because the configuration information provided by the DHCP server could be maliciously provided to clients by a rogue DHCP server, the amount of information provided via DHCP should be minimized. Remove these definitions from the DHCP server configuration to ensure that legitimate clients do not unnecessarily rely on DHCP for this information. Note: By default, the RHEL5 client installation uses DHCP to request much of the above information from the DHCP server. In particular, domain-name, domain-name-servers, and routers are configured via DHCP. These settings are typically necessary for proper network functionality, but are also usually static across machines at a given site. See Section 3.9.2.1 for a description of how to configure static site information within the DHCP client configuration. </description>
-          <Rule id="scap-rhel5-rule-218" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-218" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Domain name server information should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3724-2</ident>
@@ -3179,7 +3179,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:224" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-219" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-219" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Default routers should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4243-2</ident>
@@ -3187,7 +3187,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:225" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-220" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-220" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Domain name should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4389-3</ident>
@@ -3195,7 +3195,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:226" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-221" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-221" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">NIS domain should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3913-1</ident>
@@ -3203,7 +3203,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:227" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-222" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-222" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">NIS servers should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4169-9</ident>
@@ -3211,7 +3211,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:228" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-223" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-223" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Time offset should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4318-2</ident>
@@ -3219,7 +3219,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:229" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-224" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-224" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">NTP servers should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4319-0</ident>
@@ -3231,7 +3231,7 @@
         <Group id="scap-rhel5-group-3.9.4.5" hidden="false">
           <title xml:lang="en">Configure Logging </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Ensure that the following line exists in /etc/syslog.conf: daemon.* /var/log/daemon.log Configure logwatch or other log monitoring tools to summarize error conditions reported by the dhcpd process. By default, dhcpd logs notices to the daemon facility. Sending all daemon messages to a dedicated log file is part of the syslog configuration outlined in Section 2.6.1.1. </description>
-          <Rule id="scap-rhel5-rule-225" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-225" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure Logging </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">dhcpd logging should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3733-3</ident>
@@ -3270,7 +3270,7 @@
           <Group id="scap-rhel5-group-3.10.2.2.1" hidden="false">
             <title xml:lang="en">Enable the NTP Daemon </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If this machine is an NTP server, ensure that ntpd is enabled at boot time: # chkconfig ntpd on </description>
-            <Rule id="scap-rhel5-rule-226" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-226" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Enable the NTP Daemon </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ntpd service should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4376-0</ident>
@@ -3282,7 +3282,7 @@
           <Group id="scap-rhel5-group-3.10.2.2.2" hidden="false">
             <title xml:lang="en">Deny All Access to ntpd by Default </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/ntp.conf. Prepend or correct the following line: restrict default ignore Since ntpd is a complex software package which listens for network connections and runs as root, it must be protected from network access by unauthorized machines. This setting uses ntpd’s internal authorization to deny all access to any machine, server or client, which is not specifically authorized by other policy settings. </description>
-            <Rule id="scap-rhel5-rule-227" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-227" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Deny All Access to ntpd by Default </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Network access to ntpd should be allowed or denied as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4134-3</ident>
@@ -3294,7 +3294,7 @@
           <Group id="scap-rhel5-group-3.10.2.2.3" hidden="false">
             <title xml:lang="en">Specify a Remote NTP Server for Time Data </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Find the IP address, server-ip , of an appropriate remote NTP server. Edit the file /etc/ntp.conf, and add or correct the following lines: restrict server-ip mask 255.255.255.255 nomodify notrap noquery server server-ip If your site does not require time data to be accurate, but merely to be synchronized among local machines, this step can be omitted, and the NTP server will default to providing time data from the local clock. However, it is a good idea to periodically synchronize the clock to some source of accurate time, even if it is not appropriate to do so automatically. The previous step disabled all remote access to this NTP server’s state data. This NTP server must contact a remote server to obtain accurate data, so NTP’s configuration must allow that remote data to be used to modify the system clock. The restrict line changes the default access permissions for that remote server. The server line specifies the remote server as the preferred NTP server for time data. If you intend to synchronize to more than one server, specify restrict and server lines for each server. Note: It would be possible to specify a hostname, rather than an IP address, for the server field. However, the restrict setting applies only to network blocks of IP addresses, so it is considered more maintainable to use the IP address in both fields. </description>
-            <Rule id="scap-rhel5-rule-228" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-228" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Specify a Remote NTP Server for Time Data </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">A remote NTP Server for time synchronization should be specified or not as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4385-1</ident>
@@ -3315,7 +3315,7 @@
         <Group id="scap-rhel5-group-3.10.3.1" hidden="false">
           <title xml:lang="en">Obtain NTP Software </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If your site intends to use the OpenNTPD implementation, it is necessary to compile and install the software. (If your site intends to use the reference NTP implementation, no installation is necessary.) 1. Obtain the software by downloading an appropriate source version, openntpd-version .tar.gz, from http://www.openntpd.org/portable.html. 2. Unpack the source code: $ tar xzf openntpd-version .tar.gz 3. Configure and compile the source. (By default, the code will be compiled for installation into /usr/ local): $ cd openntpd-version $ ./configure --with-privsep-user=ntp $ make 4. As root, install the resulting program into /usr/local: # make install The configuration option --with-privsep-user=ntp tells OpenNTPD to use the existing system account ntp for the non-root portion of its operation. </description>
-          <Rule id="scap-rhel5-rule-229" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-229" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Obtain NTP Software </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">OpenNTPD should be installed or uninstalled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4032-9</ident>
@@ -3330,7 +3330,7 @@
           <Group id="scap-rhel5-group-3.10.3.2.1" hidden="false">
             <title xml:lang="en">Enable the NTP Daemon </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/rc.local. Add or correct the following line: /usr/local/sbin/ntpd -s </description>
-            <Rule id="scap-rhel5-rule-230" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-230" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Enable the NTP Daemon </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ntp daemon should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4424-8</ident>
@@ -3342,7 +3342,7 @@
           <Group id="scap-rhel5-group-3.10.3.2.2" hidden="false">
             <title xml:lang="en">Configure the Client NTP Daemon to Use the Local Server</title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /usr/local/etc/ntpd.conf. Add or correct the following line: server local-server.example.com where local-server.example.com is the hostname of the site’s local NTP or SNTP server. </description>
-            <Rule id="scap-rhel5-rule-231" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-231" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Configure the Client NTP Daemon to Use the Local Server</title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ntp daemon synchronization server should be set appropriately</description>
               <ident system="http://cce.mitre.org">CCE-3487-6</ident>
@@ -3377,7 +3377,7 @@
     <Group id="scap-rhel5-group-3.11" hidden="false">
       <title xml:lang="en">Mail Transfer Agent</title>
       <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Mail servers are used to send and receive mail over a network on behalf of site users. Mail is a very common service, and MTAs are frequent targets of network attack. Ensure that machines are not running MTAs unnecessarily, and configure needed MTAs as defensively as possible. </description>
-      <Rule id="scap-rhel5-rule-232" selected="false" weight="10.000000">
+      <Rule id="scap-rhel5-rule-232" selected="false" weight="10.000000" role="full" severity="unknown">
         <title xml:lang="en">Mail Transfer Agent</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The sendmail service should be enabled or disabled as appropriate.</description>
         <ident system="http://cce.mitre.org">CCE-4416-4</ident>
@@ -3395,7 +3395,7 @@
         <Group id="scap-rhel5-group-3.11.2.1" hidden="false">
           <title xml:lang="en">Disable the Listening Sendmail Daemon </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/sysconfig/sendmail. Add or modify the line: DAEMON=no The MTA performs two functions: listening over a network for incoming SMTP e-mail requests, and sending mail from the local machine. Since outbound mail may be delayed due to network outages or other problems, the outbound MTA runs in a queue-only mode, in which it periodically attempts to resend any delayed mail. Setting DAEMON=no tells sendmail to execute only the queue runner on this machine, and never to receive SMTP mail requests. </description>
-          <Rule id="scap-rhel5-rule-233" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-233" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable the Listening Sendmail Daemon </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The listening sendmail daemon should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4293-7</ident>
@@ -3551,7 +3551,7 @@
         <Group id="scap-rhel5-group-3.12.3.1" hidden="false">
           <title xml:lang="en">Install OpenLDAP Server RPM </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is this machine the OpenLDAP server? If so: # yum install openldap-servers # chkconfig ldap on The openldap-servers RPM is not installed by default on RHEL5 machines. It is needed only by the OpenLDAP server, not by the clients which use LDAP for authentication. </description>
-          <Rule id="scap-rhel5-rule-234" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-234" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Install OpenLDAP Server RPM </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ldap service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3501-4</ident>
@@ -3615,7 +3615,7 @@
         <Group id="scap-rhel5-group-3.12.3.7" hidden="false">
           <title xml:lang="en">Correct Permissions on LDAP Server Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Correct the permissions on the ldap server’s files: # chown ldap:root /var/lib/ldap/* Some manual methods of inserting information into the LDAP database may leave these files with incorrect permissions. This will prevent slapd from starting correctly. </description>
-          <Rule id="scap-rhel5-rule-235" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-235" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Correct Permissions on LDAP Server Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /var/lib/ldap/* files should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-4484-2</ident>
@@ -3623,7 +3623,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:253" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-236" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-236" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Correct Permissions on LDAP Server Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /var/lib/ldap/* files should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-4502-1</ident>
@@ -3651,7 +3651,7 @@
         <Group id="scap-rhel5-group-3.13.1.1" hidden="false">
           <title xml:lang="en">Disable Services Used Only by NFS </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If NFS is not needed, perform the following steps to disable NFS client daemons: # chkconfig nfslock off # chkconfig rpcgssd off # chkconfig rpcidmapd off The nfslock, rpcgssd, and rpcidmapd daemons all perform NFS client functions. All of these daemons run with elevated privileges, and many listen for network connections. If they are not needed, they should be disabled to improve system security posture. </description>
-          <Rule id="scap-rhel5-rule-237" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-237" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Services Used Only by NFS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nfslock service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4396-8</ident>
@@ -3659,7 +3659,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:255" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-238" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-238" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Services Used Only by NFS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rpcgssd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3535-2</ident>
@@ -3667,7 +3667,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:256" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-239" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-239" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Services Used Only by NFS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rpcidmapd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3568-3</ident>
@@ -3679,7 +3679,7 @@
         <Group id="scap-rhel5-group-3.13.1.2" hidden="false">
           <title xml:lang="en">Disable netfs if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Determine whether any network filesystems handled by netfs are mounted on this system: # mount -t nfs,nfs4,smbfs,cifs,ncpfs If this command returns no output, disable netfs to improve system security: # chkconfig netfs off The netfs script manages the boot-time mounting of several types of networked filesystems, of which NFS and Samba (see Section 3.18) are the most common. If these filesystem types are not in use, the script can be disabled, protecting the system somewhat against accidental or malicious changes to /etc/fstab and against flaws in the netfs script itself. </description>
-          <Rule id="scap-rhel5-rule-240" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-240" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable netfs if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The netfs service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4533-6</ident>
@@ -3691,7 +3691,7 @@
         <Group id="scap-rhel5-group-3.13.1.3" hidden="false">
           <title xml:lang="en">Disable RPC Portmapper if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If: * NFS is not needed * The site does not rely on NIS for authentication information, and * The machine does not run any other RPC-based service then disable the RPC portmapper service: # chkconfig portmap off By design, the RPC model does not require particular services to listen on fixed ports, but instead uses a daemon, portmap, to tell prospective clients which ports to use to contact the services they are trying to reach. This model weakens system security by introducing another privileged daemon which may be directly attacked, and is unnecessary because RPC was never adopted by enough services to risk using up all the ports on a system. Unfortunately, the portmapper is central to RPC design, so it cannot be disabled if your site is using any RPCbased services, including NFS, NIS (see Section 3.2.4 for information about NIS, which is not recommended), or any third-party or custom RPC-based program. If none of these programs are in use, however, portmap should be disabled to improve system security. In order to get more information about whether portmap may be disabled on a given host, query the local portmapper using the command: # rpcinfo -p If the only services listed are portmapper and status, it is safe to disable the portmapper. If other services are listed and your site is not running NFS or NIS, investigate these services and disable them if possible. </description>
-          <Rule id="scap-rhel5-rule-241" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-241" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable RPC Portmapper if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The portmap service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4550-0</ident>
@@ -3715,7 +3715,7 @@
         <Group id="scap-rhel5-group-3.13.2.3" hidden="false">
           <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/sysconfig/nfs. Add or correct the following lines: LOCKD_TCPPORT=lockd-port LOCKD_UDPPORT=lockd-port MOUNTD_PORT=mountd-port RQUOTAD_PORT=rquotad-port STATD_PORT=statd-port STATD_OUTGOING_PORT=statd-outgoing-port where each X-port is a port which is not used by any other service on your network. Firewalling should be done at each host and at the border firewalls to protect the NFS daemons from remote access, since NFS servers should never be accessible from outside the organization. However, by default, the portmapper assigns each NFS service to a port dynamically at service startup time. Dynamic ports cannot be protected by port filtering firewalls such as iptables (Section 2.5.5). Therefore, restrict each service to always use a given port, so that firewalling can be done effectively. Note that, because of the way RPC is implemented, it is not possible to disable the portmapper even if ports are assigned statically to all RPC services. </description>
-          <Rule id="scap-rhel5-rule-242" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-242" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The lockd service should be configured to use a static port or a dynamic portmapper port for TCP as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4559-1</ident>
@@ -3723,7 +3723,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:260" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-243" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-243" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The statd service should be configured to use an outgoing static port or an outgoing dynamic portmapper port as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4015-4</ident>
@@ -3731,7 +3731,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:261" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-244" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-244" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The statd service should be configured to use a static port or a dynamic portmapper port as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3667-3</ident>
@@ -3739,7 +3739,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:262" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-245" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-245" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The lockd service should be configured to use a static port or a dynamic portmapper port for UDP as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4310-9</ident>
@@ -3747,7 +3747,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:263" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-246" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-246" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The mountd service should be configured to use a static port or a dynamic portmapper port as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4438-8</ident>
@@ -3755,7 +3755,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:264" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-247" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-247" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rquotad service should be configured to use a static port or a dynamic portmapper port as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3579-0</ident>
@@ -3771,7 +3771,7 @@
         <Group id="scap-rhel5-group-3.13.3.1" hidden="false">
           <title xml:lang="en">Disable NFS Server Daemons </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en"># chkconfig nfs off # chkconfig rpcsvcgssd off There is no need to run the NFS server daemons except on a small number of properly secured machines designated as NFS servers. Ensure that these daemons are turned off on clients. </description>
-          <Rule id="scap-rhel5-rule-248" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-248" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable NFS Server Daemons </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nfs service should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4473-5</ident>
@@ -3779,7 +3779,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:266" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-249" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-249" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable NFS Server Daemons </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rpcsvcgssd service should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4491-7</ident>
@@ -3791,7 +3791,7 @@
         <Group id="scap-rhel5-group-3.13.3.2" hidden="false">
           <title xml:lang="en">Mount Remote Filesystems with Restrictive Options </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/fstab. For each filesystem whose type (column 3) is nfs or nfs4, add the text ,nodev,nosuid to the list of mount options in column 4. If appropriate, also add ,noexec. See Section 2.2.1.2 for a description of the effects of these options. In general, execution of files mounted via NFS should be considered risky because of the possibility that an adversary could intercept the request and substitute a malicious file. Allowing setuid files to be executed from remote servers is particularly risky, both for this reason and because it requires the clients to extend root-level trust to the NFS server. </description>
-          <Rule id="scap-rhel5-rule-250" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-250" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Mount Remote Filesystems with Restrictive Options </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nodev option should be enabled or disabled for all NFS mounts as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4368-7</ident>
@@ -3799,7 +3799,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:268" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-251" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-251" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Mount Remote Filesystems with Restrictive Options </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nosuid option should be enabled or disabled for all NFS mounts as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4024-6</ident>
@@ -3807,7 +3807,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:269" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-252" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-252" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Mount Remote Filesystems with Restrictive Options </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The noexec option should be enabled or disabled for all NFS mounts as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4526-0</ident>
@@ -3830,7 +3830,7 @@
           <Group id="scap-rhel5-group-3.13.4.1.2" hidden="false">
             <title xml:lang="en">Use Root-Squashing on All Exports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/exports. Ensure that no line contains the option no root squash. If a filesystem is exported using root squashing, requests from root on the client are considered to be unprivileged (mapped to a user such as nobody). This provides some mild protection against remote abuse of an NFS server. Root squashing is enabled by default, and should not be disabled. </description>
-            <Rule id="scap-rhel5-rule-253" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-253" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Use Root-Squashing on All Exports </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Root squashing should be enabled or disabled as appropriate for all NFS shares</description>
               <ident system="http://cce.mitre.org">CCE-4544-3</ident>
@@ -3842,7 +3842,7 @@
           <Group id="scap-rhel5-group-3.13.4.1.3" hidden="false">
             <title xml:lang="en">Restrict NFS Clients to Privileged Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/exports. Ensure that no line contains the option insecure. By default, Linux’s NFS implementation requires that all client requests be made from ports less than 1024. If your organization has control over machines connected to its network, and if NFS requests are prohibited at the border firewall, this offers some protection against malicious requests from unprivileged users. Therefore, the default should not be changed. </description>
-            <Rule id="scap-rhel5-rule-254" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-254" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Restrict NFS Clients to Privileged Ports </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Restriction of NFS clients to privileged ports should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4465-1</ident>
@@ -3854,7 +3854,7 @@
           <Group id="scap-rhel5-group-3.13.4.1.4" hidden="false">
             <title xml:lang="en">Export Filesystems Read-Only if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/exports. Ensure that every line contains the option ro and does not contain the option rw, unless there is an operational need for remote clients to modify that filesystem. If a filesystem is being exported so that users can view the files in a convenient fashion, but there is no need for users to edit those files, exporting the filesystem read-only removes an attack vector against the server. The default filesystem export mode is ro, so do not specify rw without a good reason. </description>
-            <Rule id="scap-rhel5-rule-255" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-255" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Export Filesystems Read-Only if Possible </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Write access to NFS shares should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4350-5</ident>
@@ -3876,7 +3876,7 @@
       <Group id="scap-rhel5-group-3.14.1" hidden="false">
         <title xml:lang="en">Disable DNS Server if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there an operational need for this machine to act as a DNS server for this site? If not, disable the software and remove it from the system: # chkconfig named off # yum erase bind DNS software should be disabled on any machine which does not need to be a nameserver. Note that the BIND DNS server software is not installed on RHEL5 by default. The remainder of this section discusses secure configuration of machines which must be nameservers. </description>
-        <Rule id="scap-rhel5-rule-256" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-256" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable DNS Server if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The named service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3578-2</ident>
@@ -3884,7 +3884,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:274" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-257" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-257" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable DNS Server if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The bind package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4219-2</ident>
@@ -3907,7 +3907,7 @@
         <Group id="scap-rhel5-group-3.14.3.2" hidden="false">
           <title xml:lang="en">Run DNS Software in a chroot Jail </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Install the bind-chroot package: # yum install bind-chroot Place a valid named.conf file inside the chroot jail: # cp /etc/named.conf /var/named/chroot/etc/named.conf # chown root:root /var/named/chroot/etc/named.conf # chmod 644 /var/named/chroot/etc/named.conf Create and populate an appropriate zone directory within the jail, based on the options directive. If your named.conf includes: options { directory "/path/to/DIRNAME "; ... } then copy that directory and its contents from the original zone directory: # cp -r /path/to/DIRNAME /var/named/chroot/DIRNAME Edit the file /etc/sysconfig/named. Add or correct the line: ROOTDIR=/var/named/chroot Chroot jails are not foolproof. However, they serve to make it more difficult for a compromised program to be used to attack the entire host. They do this by restricting a program’s ability to traverse the directory upward, so that files outside the jail are not visible to the chrooted process. Since RHEL5 supports a standard mechanism for placing BIND in a chroot jail, you should take advantage of this feature. Note: If you are running BIND in a chroot jail, then you should use the jailed named.conf as the primary nameserver configuration file. That is, when this guide recommends editing /etc/named.conf, you should instead edit /var/named/chroot/etc/named.conf. </description>
-          <Rule id="scap-rhel5-rule-258" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-258" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Run DNS Software in a chroot Jail </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /var/named/chroot/etc/named.conf file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3985-9</ident>
@@ -3915,7 +3915,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:276" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-259" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-259" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Run DNS Software in a chroot Jail </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /var/named/chroot/etc/named.conf should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4487-5</ident>
@@ -3923,7 +3923,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:277" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-260" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-260" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Run DNS Software in a chroot Jail </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /var/named/chroot/etc/named.conf file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-4258-0</ident>
@@ -3959,7 +3959,7 @@
         <Group id="scap-rhel5-group-3.14.4.5" hidden="false">
           <title xml:lang="en">Disable Dynamic Updates if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason to enable the risky dynamic update functionality? If not: Edit /etc/named.conf. For each zone specification, correct the following directive if necessary: zone "example.com " IN { allow-update { none; }; ... } Dynamic updates allow remote servers to add, delete, or modify any entries in your zone file. Therefore, they should be considered highly risky, and disabled unless there is a very good reason for their use. If dynamic updates must be allowed, IP-based ACLs are insufficient protection, since they are easily spoofed. Instead, use TSIG keys (see the previous section for an example), and consider using the update-policy directive to restrict changes to only the precise type of change needed. </description>
-          <Rule id="scap-rhel5-rule-261" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-261" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Dynamic Updates if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">LDAP's dynamic updates feature should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4399-2</ident>
@@ -3976,7 +3976,7 @@
       <Group id="scap-rhel5-group-3.15.1" hidden="false">
         <title xml:lang="en">Disable vsftpd if Possible </title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for the machine to act as an FTP server? If not, disable vsftpd if it has been installed: # chkconfig vsftpd off </description>
-        <Rule id="scap-rhel5-rule-262" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-262" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable vsftpd if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The vsftpd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3919-8</ident>
@@ -3995,7 +3995,7 @@
         <Group id="scap-rhel5-group-3.15.3.1" hidden="false">
           <title xml:lang="en">Enable Logging of All FTP Transactions </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the vsftpd configuration file. Add or correct the following configuration options: xferlog_std_format=NO log_ftp_protocol=YES The modifications above ensure that all commands sent to the ftp server are logged using the verbose vsftpd log format. The default vsftpd log file is /var/log/vsftpd.log. Note: If verbose logging to vsftpd.log is done, sparse logging of downloads to /var/log/xferlog will not also occur. However, the information about what files were downloaded is included in the information logged to vsftpd.log. </description>
-          <Rule id="scap-rhel5-rule-263" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-263" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable Logging of All FTP Transactions </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Logging of vsftpd transactions should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4549-2</ident>
@@ -4007,7 +4007,7 @@
         <Group id="scap-rhel5-group-3.15.3.2" hidden="false">
           <title xml:lang="en">Create Warning Banners for All FTP Users </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the vsftpd configuration file. Add or correct the following configuration options: banner_file=/etc/issue See Section 2.3.7 for an explanation of banner file use. This setting will cause the system greeting banner to be used for FTP connections as well. </description>
-          <Rule id="scap-rhel5-rule-264" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-264" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Create Warning Banners for All FTP Users </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">A warning banner for all FTP users should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4554-2</ident>
@@ -4022,7 +4022,7 @@
           <Group id="scap-rhel5-group-3.15.3.3.1" hidden="false">
             <title xml:lang="en">Restrict Access to Anonymous Users if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for users to transfer files to/from their own accounts using FTP, rather than using a secure protocol like SCP/SFTP? If not: Edit the vsftpd configuration file. Add or correct the following configuration option: local_enable=NO If non-anonymous FTP logins are necessary, follow the guidance in the remainder of this section to secure these logins as much as possible. The use of non-anonymous FTP logins is strongly discouraged. Since SSH clients and servers are widely available, and since SSH provides support for a transfer mode which resembles FTP in user interface, there is no good reason to allow password-based FTP access. See Section 3.5 for more information about SSH. </description>
-            <Rule id="scap-rhel5-rule-265" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-265" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Restrict Access to Anonymous Users if Possible </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Local user login to the vsftpd service should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4443-8</ident>
@@ -4039,7 +4039,7 @@
         <Group id="scap-rhel5-group-3.15.3.4" hidden="false">
           <title xml:lang="en">Disable FTP Uploads if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for users to upload files via FTP? If not: Edit the vsftpd configuration file. Add or correct the following configuration options: write_enable=NO If FTP uploads are necessary, follow the guidance in the remainder of this section to secure these transactions as much as possible. Anonymous FTP can be a convenient way to make files available for universal download. However, it is less common to have a need to allow unauthenticated users to place files on the FTP server. If this must be done, it is necessary to ensure that files cannot be uploaded and downloaded from the same directory. </description>
-          <Rule id="scap-rhel5-rule-266" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-266" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable FTP Uploads if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File uploads via vsftpd should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4461-0</ident>
@@ -4064,7 +4064,7 @@
       <Group id="scap-rhel5-group-3.16.1" hidden="false">
         <title xml:lang="en">Disable Apache if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If Apache was installed and activated, but the system does not need to act as a web server, then it should be disabled and removed from the system: # chkconfig httpd off # yum erase httpd </description>
-        <Rule id="scap-rhel5-rule-267" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-267" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Apache if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The httpd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4338-0</ident>
@@ -4072,7 +4072,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:285" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-268" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-268" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Apache if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The httpd package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4514-6</ident>
@@ -4099,7 +4099,7 @@
         <Group id="scap-rhel5-group-3.16.3.1" hidden="false">
           <title xml:lang="en">Restrict Information Leakage </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ServerTokens and ServerSignature directives determine how much information the web server discloses about the configuration of the system. ServerTokens Prod restricts information in page headers, returning only the word “Apache.” ServerSignature Off keeps Apache from displaying the server version on error pages. It is a good security practice to limit the information provided to clients. Add or correct the following directives in /etc/httpd/conf/httpd.conf so that as little information as possible is released: ServerTokens Prod ServerSignature Off </description>
-          <Rule id="scap-rhel5-rule-269" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-269" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Information Leakage </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The apache2 server's ServerTokens value should be set appropriately</description>
             <ident system="http://cce.mitre.org">CCE-4474-3</ident>
@@ -4107,7 +4107,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:288" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-270" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-270" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Information Leakage </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The apache2 server's ServerSignature value should be set appropriately</description>
             <ident system="http://cce.mitre.org">CCE-3756-4</ident>
@@ -4263,7 +4263,7 @@
         <Group id="scap-rhel5-group-3.16.5.1" hidden="false">
           <title xml:lang="en">Restrict File and Directory Access </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Minimize access to critical Apache files and directories: # chmod 511 /usr/sbin/httpd # chmod 750 /var/log/httpd/ # chmod 750 /etc/httpd/conf/ # chmod 640 /etc/httpd/conf/* # chgrp -R apache /etc/httpd/conf </description>
-          <Rule id="scap-rhel5-rule-271" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-271" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict File and Directory Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/httpd/conf should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4509-6</ident>
@@ -4271,7 +4271,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:290" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-272" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-272" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict File and Directory Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/httpd/conf/* should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4386-9</ident>
@@ -4279,7 +4279,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:291" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-273" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-273" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict File and Directory Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /usr/sbin/httpd should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4029-5</ident>
@@ -4287,7 +4287,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:292" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-274" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-274" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict File and Directory Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/httpd/conf/* files should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3581-6</ident>
@@ -4295,7 +4295,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:293" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-275" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-275" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict File and Directory Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /var/log/httpd should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4574-0</ident>
@@ -4324,7 +4324,7 @@
       <Group id="scap-rhel5-group-3.17.1" hidden="false">
         <title xml:lang="en">Disable Dovecot if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If the system does not need to operate as an IMAP or POP3 server, disable and remove Dovecot if it was installed: # chkconfig dovecot off # yum erase dovecot </description>
-        <Rule id="scap-rhel5-rule-276" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-276" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Dovecot if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dovecot service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3847-1</ident>
@@ -4332,7 +4332,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:295" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-277" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-277" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Dovecot if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dovecot package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4239-0</ident>
@@ -4347,7 +4347,7 @@
         <Group id="scap-rhel5-group-3.17.2.1" hidden="false">
           <title xml:lang="en">Support Only the Necessary Protocols </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/dovecot.conf. Add or correct the following lines, replacing PROTOCOL with only the subset of protocols (imap, imaps, pop3, pop3s) required: protocols = PROTOCOL Dovecot supports the IMAP and POP3 protocols, as well as SSL-protected versions of those protocols. Configure the Dovecot server to support only the protocols needed by your site. If possible, require SSL protection for all transactions. The SSL protocol variants listen on alternate ports (995 instead of 110 for pop3s, and 993 instead of 143 for imaps), and require SSL-aware clients. An alternate approach is to listen on the standard port and require the client to use the STARTTLS command before authenticating. </description>
-          <Rule id="scap-rhel5-rule-278" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-278" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Support Only the Necessary Protocols </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Dovecot should be configured to support the imaps protocol or not as necessary</description>
             <ident system="http://cce.mitre.org">CCE-4384-4</ident>
@@ -4355,7 +4355,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:297" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-279" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-279" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Support Only the Necessary Protocols </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Dovecot should be configured to support the pop3s protocol or not as necessary</description>
             <ident system="http://cce.mitre.org">CCE-3887-7</ident>
@@ -4363,7 +4363,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:298" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-280" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-280" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Support Only the Necessary Protocols </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Dovecot should be configured to support the pop3 protocol or not as necessary</description>
             <ident system="http://cce.mitre.org">CCE-4530-2</ident>
@@ -4371,7 +4371,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:299" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-281" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-281" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Support Only the Necessary Protocols </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Dovecot should be configured to support the imap protocol or not as necessary</description>
             <ident system="http://cce.mitre.org">CCE-4547-6</ident>
@@ -4398,7 +4398,7 @@
           <Group id="scap-rhel5-group-3.17.2.2.4" hidden="false">
             <title xml:lang="en">Disable Plaintext Authentication </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To prevent Dovecot from attempting plaintext authentication of clients, edit /etc/dovecot.conf and add or correct the following line: disable_plaintext_auth = yes The disable plaintext auth command disallows login-related commands until an encrypted session has been negotiated using SSL. If client compatibility requires you to allow connections to the pop3 or imap ports, rather than the alternate SSL ports, you should use this command to require STARTTLS before authentication. </description>
-            <Rule id="scap-rhel5-rule-282" selected="false" weight="10.000000">
+            <Rule id="scap-rhel5-rule-282" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Plaintext Authentication </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Dovecot plaintext authentication of clients should be enabled or disabled as necessary</description>
               <ident system="http://cce.mitre.org">CCE-4552-6</ident>
@@ -4411,7 +4411,7 @@
         <Group id="scap-rhel5-group-3.17.2.3" hidden="false">
           <title xml:lang="en">Enable Dovecot Options to Protect Against Code Flaws </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/dovecot.conf and add or correct the following line: login_process_per_connection = yes mail_drop_priv_before_exec = yes IMAP and POP3 are remote authenticated protocols, meaning that the server must accept remote connections from anyone, but provide substantial services only to clients who have successfully authenticated. To protect against security problems, Dovecot splits these functions into separate server processes. The imap-login and/or pop3-login processes accept connections from unauthenticated users, and only spawn imap or pop3 processes on successful authentication. However, the imap-login and pop3-login processes themselves may contain vulnerabilities. Since each of these processes operates as a daemon, handling multiple sequential client connections from different users, bugs in the code could allow unauthenticated users to steal credential data. If the login process per connection option is enabled, then a separate imap-login or pop3-login process is created for each new connection, protecting against this class of problems. This option has an efficiency cost, but is strongly recommended. If the mail drop priv before exec option is on, the imap-login or pop3-login process will drop privileges to the user’s ID after authentication and before executing the imap or pop3 process itself. Under some very limited circumstances, this could protect against privilege escalation by authenticated users. However, if the mail executable option is used to run code before starting each user’s session, it is important to drop privileges to prevent the custom code from running as root. </description>
-          <Rule id="scap-rhel5-rule-283" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-283" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable Dovecot Options to Protect Against Code Flaws </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Dovecot option to drop privileges to user before executing mail process should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4371-1</ident>
@@ -4419,7 +4419,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:302" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-284" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-284" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable Dovecot Options to Protect Against Code Flaws </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Dovecot option to spawn a new login process per connection should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4410-7</ident>
@@ -4440,7 +4440,7 @@
       <Group id="scap-rhel5-group-3.18.1" hidden="false">
         <title xml:lang="en">Disable Samba if Possible </title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If the Samba service has been enabled and will not be used, disable it: # chkconfig smb off Even after the Samba server package has been installed, it will remain disabled. Do not enable this service unless it is absolutely necessary to provide Microsoft Windows file and print sharing functionality. </description>
-        <Rule id="scap-rhel5-rule-285" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-285" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Samba if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The smb service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4551-8</ident>
@@ -4516,7 +4516,7 @@
       <Group id="scap-rhel5-group-3.19.1" hidden="false">
         <title xml:lang="en">Disable Squid if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If Squid was installed and activated, but the system does not need to act as a proxy server, then it should be disabled and removed: # chkconfig squid off # yum erase squid </description>
-        <Rule id="scap-rhel5-rule-286" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-286" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Squid if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The squid service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4556-7</ident>
@@ -4524,7 +4524,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:305" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-287" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-287" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Squid if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The squid package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4076-6</ident>
@@ -4543,7 +4543,7 @@
         <Group id="scap-rhel5-group-3.19.2.2" hidden="false">
           <title xml:lang="en">Verify Default Secure Settings </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Several security-enhancing settings in the Squid configuration file are enabled by default, but appear as comments in the configuration file (as mentioned in Section 3.19.2). In these instances, the explicit directive is not present, which means it is implicitly enabled. If you are operating with a default configuration file, this section can be ignored. Ensure that the following security settings are NOT explicitly changed from their default values: ftp_passive on ftp_sanitycheck on check_hostnames on request_header_max_size 20 KB reply_header_max_size 20 KB cache_effective_user squid cache_effective_group squid ignore_unknown_nameservers on ftp passive forces FTP passive connections. ftp sanitycheck performs additional sanity checks on FTP data connections. check hostnames ensures that hostnames meet RFC compliance. request header max size and reply header max size place an upper limit on HTTP header length, precautions against denial-of-service and buffer overflow vulnerabilities. cache effective user and cache effective group designate the EUID and EGID of Squid following initialization (it is essential that the EUID/EGID be set to an unprivileged sandbox account). ignore unknown nameservers checks to make sure that DNS responses come from the same IP the request was sent to. </description>
-          <Rule id="scap-rhel5-rule-288" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-288" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to force FTP passive connections should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4454-5</ident>
@@ -4551,7 +4551,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:307" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-289" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-289" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid max request HTTP header length should be set to an appropriate value</description>
             <ident system="http://cce.mitre.org">CCE-4353-9</ident>
@@ -4559,7 +4559,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:308" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-290" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-290" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to check for RFC compliant hostnames should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4503-9</ident>
@@ -4567,7 +4567,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:309" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-291" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-291" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to ignore unknown nameservers should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3585-7</ident>
@@ -4575,7 +4575,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:310" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-292" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-292" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid max reply HTTP header length should be set to an appropriate value</description>
             <ident system="http://cce.mitre.org">CCE-4419-8</ident>
@@ -4583,7 +4583,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:311" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-293" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-293" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid EUID should be set to an appropriate user</description>
             <ident system="http://cce.mitre.org">CCE-3692-1</ident>
@@ -4591,7 +4591,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:312" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-294" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-294" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to perform FTP sanity checks should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4459-4</ident>
@@ -4599,7 +4599,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:313" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-295" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-295" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid GUID should be set to an appropriate group</description>
             <ident system="http://cce.mitre.org">CCE-4476-8</ident>
@@ -4611,7 +4611,7 @@
         <Group id="scap-rhel5-group-3.19.2.3" hidden="false">
           <title xml:lang="en">Change Default Insecure Settings </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default configuration settings for the following tags are considered to be weak security and NOT recommended. Add or modify the configuration file to include the following lines: allow_underscore off httpd_suppress_version_string on forwarded_for off log_mime_hdrs on allow underscore enforces RFC 1034 compliance on hostnames by disallowing the use of underscores. httpd suppress version string prevents Squid from revealing version information in web headers and error pages. forwarded for reveals proxy client IP addresses in HTTP headers and should be disabled to prevent the leakage of internal network configuration details. log mime hdrs enables logging of HTTP response/request headers. </description>
-          <Rule id="scap-rhel5-rule-296" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-296" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Change Default Insecure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to show proxy client IP addresses in HTTP headers should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4181-4</ident>
@@ -4619,7 +4619,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:315" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-297" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-297" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Change Default Insecure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to log HTTP MIME headers should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4577-3</ident>
@@ -4627,7 +4627,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:316" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-298" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-298" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Change Default Insecure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to allow underscores in hostnames should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4344-8</ident>
@@ -4635,7 +4635,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:317" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-299" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-299" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Change Default Insecure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to suppress the httpd version string should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4494-1</ident>
@@ -4651,7 +4651,7 @@
         <Group id="scap-rhel5-group-3.19.2.5" hidden="false">
           <title xml:lang="en">Access Control Lists (ACL) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Be very careful with the order of access control tags. Access control is handled top-down. The first rule that matches is the only rule adhered to. The last rule on the list defines the default behavior in the case of no rule match. The acl and http access tags are used in combination to allow filtering based on a series of access control lists. Squid has a list of default ACLs for localhost, SSL ports, and “safe” ports. Following the definition of these ACLs, a series of http access directives establish the following default filtering policy: * Allow cachemgr access only from localhost * Allow access to only ports in the “safe” access control list * Limit CONNECT method to SSL ports only * Allow access from localhost * Deny all other requests The default ACL policies are reasonable from a security standpoint. However, the number of ports listed as “safe” could be significantly trimmed depending on the needs of your network. Out of the box, ports 21, 70, 80, 210, 280, 443, 488, 591, 777, and 1025 through 65535 are all considered safe. Some of these ports are associated with deprecated or rarely used protocols. As such, this list could be trimmed to further tighten filtering. The following actions should be taken to tighten the ACL policies: 1. There is a filter line in the configuration file that is recommended but commented out. This line should be uncommented or added to prevent access to localhost from the proxy: http access deny to_localhost 2. An access list should be setup for the specific network or networks that the proxy is intended to serve. Only this subset of IP addresses should be allowed access. Add these lines where the following comment appears: # INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS acl your-network-acl-name src ip-range http_access allow your-network-acl-name Note: ip-range is of the format xxx.xxx.xxx.xxx/xx 3. Ensure that the final http access line to appear in the document is the following: http access deny all This guarantees that all traffic not meeting an explicit filtering rule is denied. Further filters should be established to meet the specific needs of a network, explicitly allowing access only where necessary. 4. Consult the chart below. Corresponding acl entries for unused protocols should be commented out and thus denied. Port Service Summary Recommendation 21 ftp File Transfer Protocol(FTP) is a widely used file transfer protocol. ALLOW 70 gopher The gopher protocol is a deprecated search and retrieval protocol that is almost extinct, with as few as 100 gopher servers present worldwide. Support for gopher is disabled in most modern browsers. DENY 80 http A web proxy needs to allow access to HTTP traffic. ALLOW 210 wais The Wide Area Information Server port is similar to gopher, serving as a text searching system to scour indexes on remote machines. Today, it is deprecated and nearly non-existent on the Internet. DENY 280 http-mgmt No documentation of any kind could be found on the obscure service that resides on this port. DENY 443 https SSL traffic is likely (and recommended) for any proxy and should be allowed. ALLOW 488 gss-http No documentation of any kind could be found on the obscure service that resides on this port. DENY 591 filemaker Filemaker is a database application originally offered by Apple in the 1980s. Although development continues and it remains in use today, it should be disabled if your network does not require such traffic. DENY the obscure service that resides on this port. DENY Port Service Summary Recommendation 1025-65535 unregistered ports Random high ports are used by a variety of applications and should be allowed. ALLOW </description>
-          <Rule id="scap-rhel5-rule-300" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-300" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow gss-http traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4511-2</ident>
@@ -4659,7 +4659,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:319" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-301" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-301" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow https traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4529-4</ident>
@@ -4667,7 +4667,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:320" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-302" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-302" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow wais traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3610-3</ident>
@@ -4675,7 +4675,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:321" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-303" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-303" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow multiling http traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4466-9</ident>
@@ -4683,7 +4683,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:322" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-304" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-304" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow http traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4607-8</ident>
@@ -4691,7 +4691,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:323" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-305" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-305" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow ftp traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4255-6</ident>
@@ -4699,7 +4699,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:324" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-306" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-306" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow gopher traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4127-7</ident>
@@ -4707,7 +4707,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:325" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-307" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-307" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow filemaker traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4519-5</ident>
@@ -4715,7 +4715,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:326" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-308" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-308" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid proxy access to localhost should be allowed or denied as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4413-1</ident>
@@ -4723,7 +4723,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:327" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="scap-rhel5-rule-309" selected="false" weight="10.000000">
+          <Rule id="scap-rhel5-rule-309" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow http-mgmt traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4373-7</ident>
@@ -4764,7 +4764,7 @@
       <Group id="scap-rhel5-group-3.20.1" hidden="false">
         <title xml:lang="en">Disable SNMP Server if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The system includes an SNMP daemon that allows for its remote monitoring, though it not installed by default. If it was installed and activated, it is important that the software be disabled and removed. If there is not a mission-critical need for hosts at this site to be remotely monitored by a SNMP tool, then disable and remove SNMP as follows: # chkconfig snmpd off # yum erase net-snmpd </description>
-        <Rule id="scap-rhel5-rule-310" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-310" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable SNMP Server if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The snmpd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3765-5</ident>
@@ -4772,7 +4772,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:329" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="scap-rhel5-rule-311" selected="false" weight="10.000000">
+        <Rule id="scap-rhel5-rule-311" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable SNMP Server if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The net-smtp package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4404-0</ident>

--- a/tests/API/XCCDF/parser/xccdf12.xml
+++ b/tests/API/XCCDF/parser/xccdf12.xml
@@ -445,7 +445,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.1.2.2" hidden="false">
           <title xml:lang="en">Disable the rhnsd Daemon </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rhnsd daemon polls the Red Hat Network web site for scheduled actions. Unless it is actually necessary to schedule updates remotely through the RHN website, it is recommended that the service be disabled. # chkconfig rhnsd off The rhnsd daemon is enabled by default, but until the system has been registered with the Red Hat Network, it will not run. However, once the registration process is complete, the rhnsd daemon will run in the background and periodically call the rhn check utility. It is the rhn check utility that communicates with the Red Hat Network web site. This utility is not required for the system to be able to access and install system updates. Once the system has been registered, either use the provided yum-updatesd service or create a cron job to automatically apply updates. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-0" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-0" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable the rhnsd Daemon </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rhnsd service should be enabled or disabled as appropriate.</description>
             <metadata xmlns:xhtml="http://www.w3.org/1999/xhtml">
@@ -467,7 +467,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.1.2.3.2" hidden="false">
             <title xml:lang="en">Configure Automatic Update Retrieval and Installation with Cron </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The yum-updatesd service is not mature enough for an enterprise environment, and the service may introduce unnecessary overhead. When possible, replace this service with a cron job that calls yum directly. Disable the yum-updatesd service: # chkconfig yum-updatesd off Create the file yum.cron, make it executable, and place it in /etc/cron.daily: #!/bin/sh /usr/bin/yum -R 120 -e 0 -d 0 -y update yum /usr/bin/yum -R 10 -e 0 -d 0 -y update This particular script instructs yum to update any packages it finds. Placing the script in /etc/cron.daily ensures its daily execution. To only apply updates once a week, place the script in /etc/cron.weekly instead. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-1" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-1" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Configure Automatic Update Retrieval and Installation with Cron </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The yum-updatesd service should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4218-4</ident>
@@ -488,7 +488,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.1.3.1.1" hidden="false">
             <title xml:lang="en">Install AIDE </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">AIDE is not installed by default. Install it with the command: # yum install aide </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-2" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-2" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Install AIDE </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The AIDE package should be installed or not as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4209-3</ident>
@@ -528,7 +528,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.1.1" hidden="false">
           <title xml:lang="en">Add nodev Option to Non-Root Local Partitions </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/fstab. The important columns for purposes of this section are column 2 (mount point), column 3 (filesystem type), and column 4 (mount options). For any line which satisfies all of the conditions: * The filesystem type is ext2 or ext3 * The mount point is not / add the text “,nodev” to the list of mount options in column 4. The nodev option prevents users from mounting unauthorized devices on any partition which is known not to contain any authorized devices. The root partition typically contains the /dev partition, which is the primary location for authorized devices, so this option should not be set on /. However, if system programs are being run in chroot jails, this advice may need to be modified further, since it is often necessary to create device files inside the chroot directory for use by the restricted program. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-3" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-3" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Add nodev Option to Non-Root Local Partitions </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nodev option should be enabled or disabled as appropriate for all non-root partitions.</description>
             <ident system="http://cce.mitre.org">CCE-4249-9</ident>
@@ -540,7 +540,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.1.2" hidden="false">
           <title xml:lang="en">Add nodev, nosuid, and noexec Options to Removable Media Partitions </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/fstab. Filesystems which represent removable media can be located by finding lines whose mount points contain strings like floppy or cdrom, or whose types are iso9660, vfat, or msdos. For each line representing a removable media mountpoint, add the text ,nodev,nosuid to the list of mount options in column 4. If appropriate, also add the text ,noexec. Users should not be allowed to introduce arbitrary devices or setuid programs to a system. These options are used to prevent that. In addition, while users are usually allowed to add executable programs to a system, the noexec option prevents code from being executed directly from the media itself, and may therefore provide a line of defense against certain types of worms or malicious code. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-4" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-4" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Add nodev, nosuid, and noexec Options to Removable Media Partitions </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nodev option should be enabled or disabled as appropriate for all removable media.</description>
             <ident system="http://cce.mitre.org">CCE-3522-0</ident>
@@ -548,7 +548,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:5" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-5" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-5" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Add nodev, nosuid, and noexec Options to Removable Media Partitions </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The noexec option should be enabled or disabled as appropriate for all removable media.</description>
             <ident system="http://cce.mitre.org">CCE-4275-4</ident>
@@ -556,7 +556,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:6" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-6" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-6" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Add nodev, nosuid, and noexec Options to Removable Media Partitions </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nosuid option should be enabled or disabled as appropriate for all removable media.</description>
             <ident system="http://cce.mitre.org">CCE-4042-8</ident>
@@ -572,7 +572,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.2.1" hidden="false">
           <title xml:lang="en">Restrict Console Device Access </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default system configuration grants the console user enhanced privileges normally reserved for the root user, including temporary ownership of most system devices. If not necessary, these privileges should be removed and restricted to root only. Restrict device ownership to root only. Edit /etc/security/console.perms.d/50-default.perms and locate the section prefaced by the following comment: # permission definitions Prepend a # symbol to comment out each line in that section which starts with &lt;console&gt; or &lt;xconsole&gt;: #&lt;console&gt; 0660 &lt;floppy&gt; 0660 root.floppy #&lt;console&gt; 0600 &lt;sound&gt; 0600 root ... #&lt;xconsole&gt; 0600 /dev/console 0600 root.root #&lt;console&gt; 0600 &lt;dri&gt; 0600 root Edit /etc/security/console.perms and make the following changes: &lt;console&gt;=tty[0-9][0-9]* vc/[0-9][0-9]* :0\.[0-9] :0 &lt;xconsole&gt;=:0\.[0-9] :0 </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-7" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-7" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Console Device Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Console device ownership should be restricted to root-only as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3685-5</ident>
@@ -587,7 +587,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.2.2.1" hidden="false">
             <title xml:lang="en">Disable Modprobe Loading of USB Storage Driver </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If USB storage devices should not be used, the modprobe program used for automatic kernel module loading should be configured to not load the USB storage driver upon demand. Add the following line to /etc/modprobe.conf to prevent loading of the usb-storage kernel module: install usb-storage : This will prevent the modprobe program from loading the usb-storage module, but will not prevent an administrator (or another program) from using the insmod program to load the module manually. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-8" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-8" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Modprobe Loading of USB Storage Driver </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The USB device support module should be loaded or not as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4187-1</ident>
@@ -599,7 +599,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.2.2.2" hidden="false">
             <title xml:lang="en">Remove USB Storage Driver </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If your system never requires the use of USB storage devices, then the supporting driver can be removed. Though more effective (as USB storage certainly cannot be used if the driver is not available at all), this is less elegant than the method described in Section 2.2.2.2.1. To remove the USB storage driver from the system: rm /lib/modules/kernelversion(s) /kernel/drivers/usb/storage/usb-storage.ko This command will need to be repeated every time the kernel is updated. This command will also cause the command rpm -q --verify kernel to fail, which may be an undesirable side effect. Note that this guidance will not prevent USB storage devices from being mounted if a custom kernel (i.e., not the one supplied with the system) with built-in USB support is used. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-9" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-9" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Remove USB Storage Driver </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The USB device support module should be installed or not as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4006-3</ident>
@@ -611,7 +611,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.2.2.3" hidden="false">
             <title xml:lang="en">Disable Kernel Support for USB via Bootloader Configuration </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Another means of disabling USB storage is to disable all USB support provided by the operating system. This can be accomplished by adding the “nousb” argument to the kernel’s boot loader configuration. Disabling all kernel support for USB will cause problems for systems with USB-based keyboards, mice, or printers. This guidance is inappropriate for systems which require USB connectivity. To disable kernel support for USB, append “nousb” to the kernel line in /etc/grub.conf as follows: kernel /vmlinuz-version ro vga=ext root=/dev/VolGroup00/LogVol00 rhgb quiet nousb </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-10" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-10" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Kernel Support for USB via Bootloader Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">USB kernel support should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4173-1</ident>
@@ -623,7 +623,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.2.2.4" hidden="false">
             <title xml:lang="en">Disable Booting from USB Devices </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">An attacker with physical access could try to boot the system from a USB flash drive and then access any data on the system’s hard drive, circumventing the normal operating system’s access controls. To prevent this, configure the BIOS to disallow booting from USB drives. Also configure the BIOS or firmware password as described in Section 2.3.5.1 to prevent unauthorized configuration changes. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-11" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-11" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Booting from USB Devices </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ability to boot from USB devices should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-3944-6</ident>
@@ -636,7 +636,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.2.3" hidden="false">
           <title xml:lang="en">Disable the Automounter if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If the autofs service is not needed to dynamically mount NFS filesystems or removable media, disable the service: # chkconfig autofs off The autofs daemon mounts and unmounts filesystems, such as user home directories shared via NFS, on demand. In addition, autofs can be used to handle removable media, and the default configuration provides the cdrom device as /misc/cd. However, this method of providing access to removable media is not common, so autofs can almost always be disabled if NFS is not in use. Even if NFS is required, it is almost always possible to configure filesystem mounts statically by editing /etc/ fstab rather than relying on the automounter. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-12" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-12" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable the Automounter if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The autofs service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4072-5</ident>
@@ -648,7 +648,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.2.4" hidden="false">
           <title xml:lang="en">Disable GNOME Automounting if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The system’s default desktop environment, GNOME, runs the program gnome-volume-manager to mount devices and removable media (such as DVDs, CDs and USB flash drives) whenever they are inserted into the system. Execute the following commands to prevent gnome-volume-manager from automatically mounting devices and media: # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type bool \ --set /desktop/gnome/volume_manager/automount_media false # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type bool \ --set /desktop/gnome/volume_manager/automount_drives false Verify the changes by executing the following command, which should return a list of settings: # gconftool-2 -R /desktop/gnome/volume_manager The automount drives and automount media settings should be set to false. Survey the list for any other options that should be adjusted. The system’s capabilities for automatic mounting should be configured to match whatever is defined by security policy. Disabling USB storage as described in Section 2.2.2.2.1 will prevent the use of USB storage devices, but this step can also be taken as an additional layer of prevention and to prevent automatic mounting of CDs and DVDs if required. Particularly for kiosk-style systems, where users should have extremely limited access to the system, more detailed information can be found in Red Hat Desktop: Deployment Guide [5]. The gconf-editor program, available in an RPM of the same name, can be used to explore other settings available in the GNOME environment. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-13" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-13" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable GNOME Automounting if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The GNOME automounter (gnome-volume-manager) should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4231-7</ident>
@@ -664,7 +664,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.3.1" hidden="false">
           <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en"># cd /etc # chown root:root passwd shadow group gshadow # chmod 644 passwd group # chmod 400 shadow gshadow These are the default permissions for these files. Many utilities need read access to the passwd file in order to function properly, but read access to the shadow file allows malicious attacks against system passwords, and should never be enabled. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-14" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-14" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/shadow file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3988-3</ident>
@@ -672,7 +672,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:15" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-15" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-15" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/group file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3883-6</ident>
@@ -680,7 +680,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:16" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-16" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-16" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/group file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-3276-3</ident>
@@ -688,7 +688,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:17" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-17" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-17" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/gshadow should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-3932-1</ident>
@@ -696,7 +696,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:18" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-18" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-18" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/gshadow file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-4064-2</ident>
@@ -704,7 +704,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:19" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-19" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-19" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/gshadow file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-4210-1</ident>
@@ -712,7 +712,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:20" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-20" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-20" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/shadow file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-3918-0</ident>
@@ -720,7 +720,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:21" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-21" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-21" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/passwd should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-3566-7</ident>
@@ -728,7 +728,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:22" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-22" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-22" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/passwd file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-3958-6</ident>
@@ -736,7 +736,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:23" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-23" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-23" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/group should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-3967-7</ident>
@@ -744,7 +744,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:24" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-24" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-24" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/passwd file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3495-9</ident>
@@ -752,7 +752,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:25" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-25" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-25" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Permissions on passwd, shadow, group and gshadow Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/shadow should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4130-1</ident>
@@ -764,7 +764,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.3.2" hidden="false">
           <title xml:lang="en">Verify that All World-Writable Directories Have Sticky Bits Set </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Locate any directories in local partitions which are world-writable and do not have their sticky bits set. The following command will discover and print these. Run it once for each local partition PART: # find PART -xdev -type d \( -perm -0002 -a ! -perm -1000 \) -print If this command produces any output, fix each reported directory /dir using the command: # chmod +t /dir When the so-called “sticky bit” is set on a directory, only the owner of a given file may remove that file from the directory. Without the sticky bit, any user with write access to a directory may remove any file in the directory. Setting the sticky bit prevents users from removing each other’s files. In cases where there is no reason for a directory to be world-writable, a better solution is to remove that permission rather than to set the sticky bit. However, if a directory is used by a particular application, consult that application’s documentation instead of blindly changing modes. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-26" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-26" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify that All World-Writable Directories Have Sticky Bits Set </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The sticky bit should be set or not set as appropriate for all world-writable directories.</description>
             <ident system="http://cce.mitre.org">CCE-3399-3</ident>
@@ -776,7 +776,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.3.3" hidden="false">
           <title xml:lang="en">Find Unauthorized World-Writable Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The following command discovers and prints any world-writable files in local partitions. Run it once for each local partition PART: # find PART -xdev -type f -perm -0002 -print If this command produces any output, fix each reported file file using the command: # chmod o-w file Data in world-writable files can be modified by any user on the system. In almost all circumstances, files can be configured using a combination of user and group permissions to support whatever legitimate access is needed without the risk caused by world-writable files. It is generally a good idea to remove global (other) write access to a file when it is discovered. However, check with documentation for specific applications before making changes. Also, monitor for recurring world-writable files, as these may be symptoms of a misconfigured application or user account. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-27" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-27" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Find Unauthorized World-Writable Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The world-write permission should be enabled or disabled as appropriate for all files.</description>
             <ident system="http://cce.mitre.org">CCE-3795-2</ident>
@@ -788,7 +788,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.3.4" hidden="false">
           <title xml:lang="en">Find Unauthorized SUID/SGID System Executables </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The following command discovers and prints any setuid or setgid files on local partitions. Run it once for each local partition PART: # find PART -xdev \( -perm -4000 -o -perm -2000 \) -type f -print If the file does not require a setuid or setgid bit as discussed below, then these bits can be removed with the command: # chmod -s file The following table contains all setuid and setgid files which are expected to be on a stock system. The setuid or setgid bit on these files may be disabled to reduce system risk if only an administrator requires their functionality. The table indicates those files which may not be needed. Note: Several of these files are used for applications which are unlikely to be relevant to most production environments, such as ISDN networking, SSH hostbased authentication, or modification of network interfaces by unprivileged users. It is extremely likely that your site can disable a subset of these files with no loss of functionality. Any files found by the above command which are not in the table should be examined. If the files are not authorized, they should have permissions removed, and further investigation may be warranted. File Set-ID Subsystem/Ref Disable? /bin/mount uid root filesystems no /bin/ping uid root net (3.3.9) no /bin/ping6 uid root net (3.3.9),IPv6 (2.5.3) unless IPv6 is used /bin/su uid root auth (2.3.1.2) no /bin/umount uid root filesystems no /sbin/mount.nfs uid root NFS (3.13) unless NFS is used /sbin/mount.nfs4 uid root NFS (3.13) unless NFSv4 is used /sbin/netreport gid root net (3.3.9) unless users must modify interfaces /sbin/pam timestamp check uid root PAM auth (2.3.3) no /sbin/umount.nfs uid root NFS (3.13) unless NFS is used /sbin/umount.nfs4 uid root NFS (3.13) unless NFSv4 is used /sbin/unix chkpwd uid root PAM auth (2.3.3) no /usr/bin/at uid root cron/at (3.4) no /usr/bin/chage uid root passwd expiry (2.3.1.7) unless users must view expiry info /usr/bin/chfn uid root user info unless users must change finger info /usr/bin/chsh uid root user info unless users must change shells /usr/bin/crontab uid/gid root cron/at (3.4) unless users must use cron /usr/bin/gpasswd uid root group auth no /usr/bin/locate gid slocate locate database no /usr/bin/lockfile gid mail procmail unless procmail is used /usr/bin/newgrp uid root group auth no /usr/bin/passwd uid root passwd auth no /usr/bin/rcp uid root rsh (3.2.3) yes (rsh is obsolete) /usr/bin/rlogin uid root rsh (3.2.3) yes (rsh is obsolete) /usr/bin/rsh uid root rsh (3.2.3) yes (rsh is obsolete) /usr/bin/ssh-agent gid nobody SSH (3.5) no /usr/bin/sudo uid root sudo (2.3.1.3) no /usr/bin/sudoedit uid root sudo (2.3.1.3) no /usr/bin/wall gid tty console messaging unless console messaging is used /usr/bin/write gid tty console messaging unless console messaging is used /usr/bin/Xorg uid root X11 (3.6) unless X11 is used /usr/kerberos/bin/ksu uid root Kerberos auth (2.3.6) unless Kerberos is used /usr/libexec/openssh/ssh-keysign uid root SSH (3.5) unless sshd uses hostbased auth /usr/libexec/utempter/utempter gid utmp terminal support no /usr/lib/squid/pam auth uid root squid (3.19) unless squid is used /usr/lib/squid/ncsa auth uid root squid (3.19) unless squid is used /usr/lib/vte/gnome-pty-helper gid utmp X11, Gnome (3.6) unless X11 is used /usr/sbin/ccreds validate uid root PAM auth (2.3.3) unless PAM auth caching is used /usr/sbin/lockdev gid lock filesystems no /usr/sbin/sendmail.sendmail gid smmsp sendmail client (3.11.2) no /usr/sbin/suexec uid root apache (3.16) unless apache is used /usr/sbin/userhelper uid root PAM auth (2.3.3.4) restrict (see section) /usr/sbin/userisdnctl uid root ISDN unless ISDN is used /usr/sbin/usernetctl uid root user network control unless users must modify interfaces </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-28" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-28" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Find Unauthorized SUID/SGID System Executables </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The sgid bit should be set or not set as appropriate for all files.</description>
             <ident system="http://cce.mitre.org">CCE-4178-0</ident>
@@ -796,7 +796,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:29" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-29" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-29" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Find Unauthorized SUID/SGID System Executables </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The suid bit should be set or not set as appropriate for all files.</description>
             <ident system="http://cce.mitre.org">CCE-3324-1</ident>
@@ -808,7 +808,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.3.5" hidden="false">
           <title xml:lang="en">Find and Repair Unowned Files</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The following command will discover and print any files on local partitions which do not belong to a valid user and a valid group. Run it once for each local partition PART: # find PART -xdev \( -nouser -o -nogroup \) -print If this command prints any results, investigate each reported file and either assign it to an appropriate user and group or remove it. Unowned files are not directly exploitable, but they are generally a sign that something is wrong with some system process. They may be caused by an intruder, by incorrect software installation or incomplete software removal, or by failure to remove all files belonging to a deleted account. The files should be repaired so that they will not cause problems when accounts are created in the future, and the problem which led to unowned files should be discovered and addressed. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-30" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-30" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Find and Repair Unowned Files</title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All files should be owned by a user as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4223-4</ident>
@@ -816,7 +816,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:31" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-31" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-31" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Find and Repair Unowned Files</title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All files should be owned by a group as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3573-3</ident>
@@ -832,7 +832,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.4.1" hidden="false">
           <title xml:lang="en">Set Daemon umask </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/sysconfig/init, and add or correct the following line: umask 027 The settings file /etc/sysconfig/init contains settings which apply to all processes started at boot time. The system umask must be set to at least 022, or daemon processes may create world-writable files. The more restrictive setting 027 protects files, including temporary files and log files, from unauthorized reading by unprivileged users on the system. If a particular daemon needs a less restrictive umask, consider editing the startup script or sysconfig file of that daemon to make a specific exception. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-32" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-32" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Daemon umask </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The daemon umask should be set as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4220-0</ident>
@@ -844,7 +844,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.4.2" hidden="false">
           <title xml:lang="en">Disable Core Dumps </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To disable core dumps for all users, add or correct the following line in /etc/security/limits.conf: * hard core 0 In addition, to ensure that core dumps can never be made by setuid programs, edit /etc/sysctl.conf and add or correct the line: fs.suid_dumpable = 0 A core dump file is the memory image of an executable program when it was terminated by the operating system due to errant behavior. In most cases, only software developers would legitimately need to access these files. The core dump files may also contain sensitive information, or unnecessarily occupy large amounts of disk space. By default, the system sets a soft limit to stop the creation of core dump files for all users. This is accomplished in /etc/profile with the line: ulimit -S -c 0 &gt; /dev/null 2&gt;&amp;1 However, compliance with this limit is voluntary; it is a default intended only to protect users from the annoyance of generating unwanted core files. Users can increase the allowed core file size up to the hard limit, which is unlimited by default. Once a hard limit is set in /etc/security/limits.conf, the user cannot increase that limit within his own session. If access to core dumps is required, consider restricting them to only certain users or groups. See the limits.conf(5) man page for more information. The core dumps of setuid programs are further protected. The sysctl variable fs.suid dumpable controls whether the kernel allows core dumps from these programs at all. The default value of 0 is recommended. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-33" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-33" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Core Dumps </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Core dumps for all users should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4225-9</ident>
@@ -852,7 +852,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:34" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-34" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-34" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Core Dumps </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Core dumps for setuid programs should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4247-3</ident>
@@ -864,7 +864,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.4.3" hidden="false">
           <title xml:lang="en">Enable ExecShield </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">ExecShield comprises a number of kernel features to provide protection against buffer overflows. These features include random placement of the stack and other memory regions, prevention of execution in memory that should only hold data, and special handling of text buffers. This protection is enabled by default, but the sysctl variables kernel.exec-shield and kernel.randomize va space should be checked to ensure that it has not been disabled. To ensure ExecShield (including random placement of virtual memory regions) is activated at boot, add or correct the following settings in /etc/sysctl.conf: kernel.exec-shield = 1 kernel.randomize_va_space = 1 ExecShield uses the segmentation feature on all x86 systems to prevent execution in memory higher than a certain address. It writes an address as a limit in the code segment descriptor, to control where code can be executed, on a per-process basis. When the kernel places a process’s memory regions such as the stack and heap higher than this address, the hardware prevents execution there. However, this cannot always be done for all memory regions in which execution should not occur, so follow guidance in Section 2.2.4.4 to further protect the system. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-35" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-35" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable ExecShield </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">ExecShield randomized placement of virtual memory regions should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4146-7</ident>
@@ -872,7 +872,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:36" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-36" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-36" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable ExecShield </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">ExecShield should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4168-1</ident>
@@ -891,7 +891,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.4.4.2" hidden="false">
             <title xml:lang="en">Install New Kernel on Supported x86 Systems </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If supported as determined in the previous section, the kernel-PAE package should be installed to enable XD or NX support: # yum install kernel-PAE The installation process should also have configured the bootloader to load the new kernel at boot. Verify this at reboot and modify /etc/grub.conf if necessary. The kernel-PAE package should not be installed on older systems that do not support the XD or NX bit, as this may prevent them from booting. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-37" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-37" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Install New Kernel on Supported x86 Systems </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Kernel support for the XD/NX processor feature should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4172-3</ident>
@@ -903,7 +903,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.2.4.4.3" hidden="false">
             <title xml:lang="en">Enable Support in the BIOS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Computers with the ability to prevent this type of code execution frequently put an option in the BIOS that will allow users to turn the feature on or off at will. Reboot the system and enter the BIOS or “Setup” configuration menu. Navigate the BIOS configuration menu and make sure that the option is enabled. The setting may be located under a “Security” section. Look for Execute Disable (XD) on Intel-based systems and No Execute (NX) on AMD-based systems. See Section 2.3.5.1 for information on protecting this and other BIOS settings. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-38" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-38" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Enable Support in the BIOS </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The XD/NX processor feature should be enabled or disabled as appropriate in the BIOS</description>
               <ident system="http://cce.mitre.org">CCE-4177-2</ident>
@@ -924,7 +924,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.1.1" hidden="false">
           <title xml:lang="en">Restrict Root Logins to System Console </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/securetty. Ensure that the file contains only the following lines: * The primary system console device: console * The virtual console devices: tty1 tty2 tty3 tty4 tty5 tty6 ... * If required by your organization, the deprecated virtual console interface may be retained for backwards compatibility: vc/1 vc/2 vc/3 vc/4 vc/5 vc/6 ... * If required by your organization, the serial consoles may be added: ttyS0 ttyS1 Direct root logins should be allowed only for emergency use. In normal situations, the administrator should access the system via a unique unprivileged account, and use su or sudo to execute privileged commands. Discouraging administrators from accessing the root account directly ensures an audit trail in organizations with multiple administrators. Locking down the channels through which root can connect directly reduces opportunities for password-guessing against the root account. The login program uses the file /etc/securetty to determine which interfaces should allow root logins. The virtual devices /dev/console and /dev/tty* represent the system consoles (accessible via the Ctrl-Alt-F1 through Ctrl-Alt-F6 keyboard sequences on a default installation). The default securetty file also contains /dev/vc/*. These are likely to be deprecated in most environments, but may be retained for compatibility. Root should also be prohibited from connecting via network protocols. See Section 3.5 for instructions on preventing root from logging in via SSH. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-39" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-39" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Root Logins to System Console </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Logins through the specified virtual console interface should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3820-8</ident>
@@ -932,7 +932,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:40" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-40" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-40" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Root Logins to System Console </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Logins through the specified virtual console device should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3485-0</ident>
@@ -940,7 +940,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:41" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-41" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-41" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Root Logins to System Console </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Logins through the primary console device should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4111-1</ident>
@@ -948,7 +948,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:42" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-42" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-42" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Root Logins to System Console </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Login prompts on serial ports should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4256-4</ident>
@@ -960,7 +960,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.1.2" hidden="false">
           <title xml:lang="en">Limit su Access to the Root Account </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">1. Ensure that the group wheel exists, and that the usernames of all administrators who should be allowed to execute commands as root are members of that group. # grep ^wheel /etc/group 2. Edit the file /etc/pam.d/su. Add, uncomment, or correct the line: auth required pam_wheel.so use_uid The su command allows a user to gain the privileges of another user by entering the password for that user’s account. It is desirable to restrict the root user so that only known administrators are ever allowed to access the root account. This restricts password-guessing against the root account by unauthorized users or by accounts which have been compromised. By convention, the group wheel contains all users who are allowed to run privileged commands. The PAM module pam wheel.so is used to restrict root access to this set of users. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-43" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-43" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Limit su Access to the Root Account </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Command access to the root account should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4274-7</ident>
@@ -972,7 +972,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.1.3" hidden="false">
           <title xml:lang="en">Configure sudo to Improve Auditing of Root Access </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">1. Ensure that the group wheel exists, and that the usernames of all administrators who should be allowed to execute commands as root are members of that group. # grep ^wheel /etc/group 2. Edit the file /etc/sudoers. Add, uncomment, or correct the line: %wheel ALL=(ALL) ALL The sudo command allows fine-grained control over which users can execute commands using other accounts. The primary benefit of sudo when configured as above is that it provides an audit trail of every command run by a privileged user. It is possible for a malicious administrator to circumvent this restriction, but, if there is an established procedure that all root commands are run using sudo, then it is easy for an auditor to detect unusual behavior when this procedure is not followed. Editing /etc/sudoers by hand can be dangerous, since a configuration error may make it impossible to access the root account remotely. The recommended means of editing this file is using the visudo command, which checks the file’s syntax for correctness before allowing it to be saved. Note that sudo allows any attacker who gains access to the password of an administrator account to run commands as root. This is a downside which must be weighed against the benefits of increased audit capability and of being able to heavily restrict the use of the high-value root password (which can be logistically difficult to change often). As a basic precaution, never use the NOPASSWD directive, which would allow anyone with access to an administrator account to execute commands as root without knowing the administrator’s password. The sudo command has many options which can be used to further customize its behavior. See the sudoers(5) man page for details. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-44" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-44" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure sudo to Improve Auditing of Root Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Sudo privileges should granted or rejected to the wheel group as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4044-4</ident>
@@ -984,7 +984,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.1.4" hidden="false">
           <title xml:lang="en">Block Shell and Login Access for Non-Root System Accounts </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Do not perform the steps in this section on the root account. Doing so might cause the system to become inaccessible. Using /etc/passwd, obtain a listing of all users, their UIDs, and their shells, for instance by running: # awk -F: '{print $1 ":" $3 ":" $7}' /etc/passwd Identify the system accounts from this listing. These will primarily be the accounts with UID numbers less than 500, other than root. For each identified system account SYSACCT , lock the account: # usermod -L SYSACCT and disable its shell: # usermod -s /sbin/nologin SYSACCT These are the accounts which are not associated with a human user of the system, but which exist to perform some administrative function. Make it more difficult for an attacker to use these accounts by locking their passwords and by setting their shells to some non-valid shell. The RHEL5 default non-valid shell is /sbin/nologin, but any command which will exit with a failure status and disallow execution of any further commands, such as /bin/false or /dev/null, will work. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-45" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-45" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Block Shell and Login Access for Non-Root System Accounts </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Login access to non-root system accounts should be enabled or disabled as appropriate </description>
             <ident system="http://cce.mitre.org">CCE-3987-5</ident>
@@ -996,7 +996,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.1.5" hidden="false">
           <title xml:lang="en">Verify that No Accounts Have Empty Password Fields </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Run the command: # awk -F: '($2 == "") {print}' /etc/shadow If this produces any output, fix the problem by locking each account (see Section 2.3.1.4 above) or by setting a password. If an account has an empty password, anybody may log in and run commands with the privileges of that account. Accounts with empty passwords should never be used in operational environments. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-46" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-46" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify that No Accounts Have Empty Password Fields </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Login access to accounts without passwords should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4238-2</ident>
@@ -1008,7 +1008,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.1.6" hidden="false">
           <title xml:lang="en">Verify that No Non-Root Accounts Have UID 0 </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">This command will print all password file entries for accounts with UID 0: # awk -F: '($3 == "0") {print}' /etc/passwd This should print only one line, for the user root. If any other lines appear, ensure that these additional UID-0 accounts are authorized, and that there is a good reason for them to exist. In general, the best practice solution for auditing use of the root account is to restrict the set of cases in which root must be accessed anonymously by requiring use of su or sudo in almost all cases. Some sites choose to have more than one account with UID 0 in order to differentiate between administrators, but this practice may have unexpected side effects, and is therefore not recommended. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-47" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-47" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify that No Non-Root Accounts Have UID 0 </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Anonymous root logins are enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4009-7</ident>
@@ -1020,7 +1020,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.1.7" hidden="false">
           <title xml:lang="en">Set Password Expiration Parameters </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/login.defs to specify password expiration settings for new accounts. Add or correct the following lines: PASS_MAX_DAYS=180 PASS_MIN_DAYS=7 PASS_MIN_LEN=8 PASS_WARN_AGE=7 For each existing human user USER , modify the current expiration settings to match these: # chage -M 180 -m 7 -W 7 USER Users should be forced to change their passwords, in order to decrease the utility of compromised passwords. However, the need to change passwords often should be balanced against the risk that users will reuse or write down passwords if forced to change them too often. Forcing password changes every 90-360 days, depending on the environment, is recommended. Set the appropriate value as PASS MAX DAYS and apply it to existing accounts with the -M flag. The PASS MIN DAYS (-m) setting prevents password changes for 7 days after the first change, to discourage password cycling. If you use this setting, train users to contact an administrator for an emergency password change in case a new password becomes compromised. The PASS WARN AGE (-W) setting gives users 7 days of warnings at login time that their passwords are about to expire. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-48" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-48" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Password Expiration Parameters </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The password minimum length should be set appropriately</description>
             <ident system="http://cce.mitre.org">CCE-4154-1</ident>
@@ -1028,7 +1028,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:49" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-49" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-49" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Password Expiration Parameters </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The "minimum password age" policy should meet minimum requirements. </description>
             <ident system="http://cce.mitre.org">CCE-4180-6</ident>
@@ -1036,7 +1036,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:50" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-50" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-50" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Password Expiration Parameters </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The "maximum password age" policy should meet minimum requirements. </description>
             <ident system="http://cce.mitre.org">CCE-4092-3</ident>
@@ -1044,7 +1044,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:51" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-51" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-51" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Password Expiration Parameters </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The password warn age should be set appropriately</description>
             <ident system="http://cce.mitre.org">CCE-4097-2</ident>
@@ -1056,7 +1056,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.1.8" hidden="false">
           <title xml:lang="en">Remove Legacy + Entries from Password Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The command: # grep "^+:" /etc/passwd /etc/shadow /etc/group should produce no output. The + symbol was used by systems to include data from NIS maps into existing files. However, a certain configuration error in which a NIS inclusion line appears in /etc/passwd, but NIS is not running, could lead to anyone being able to access the system with the username + and no password. Therefore, it is important to verify that no such line appears in any of the relevant system files. The correct way to tell the local system to consult network databases such as LDAP or NIS for user information is to make appropriate modifications to /etc/nsswitch.conf. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-52" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-52" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove Legacy + Entries from Password Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">NIS file inclusions should be set appropriately in the /etc/passwd file</description>
             <ident system="http://cce.mitre.org">CCE-4114-5</ident>
@@ -1084,7 +1084,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.3.1" hidden="false">
           <title xml:lang="en">Set Password Quality Requirements </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default pam cracklib PAM module provides strength checking for passwords. It performs a number of checks, such as making sure passwords are not similar to dictionary words, are of at least a certain length, are not the previous password reversed, and are not simply a change of case from the previous password. The pam passwdqc PAM module provides the ability to enforce even more stringent password strength requirements. It is provided in an RPM of the same name. The man pages pam cracklib(8) and pam passwdqc(8) provide information on the capabilities and configuration of each. If password strength stronger than that guaranteed by pam cracklib is required, configure PAM to use pam passwdqc. To activate pam passwdqc, locate the following line in /etc/pam.d/system-auth: password requisite pam_cracklib.so try_first_pass retry=3 and then replace it with the line: password requisite pam_passwdqc.so min=disabled,disabled,16,12,8 If necessary, modify the arguments (min=disabled,disabled,16,12,8) to ensure compliance with your organization’s security policy. Configuration options are described in the man page pam passwdqc(8) and also in /usr/share/doc/pam passwdqc-version. The minimum lengths provided here supercede that specified by the argument PASS MIN LEN as described in Section 2.3.1.7. The options given in the example above set a minimum length for each of the password “classes” that pam passwdqc recognizes. Setting a particular minimum value to disabled will stop users from choosing a password that falls into that category alone. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-53" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-53" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Password Quality Requirements </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The password strength should meet minimum requirements</description>
             <ident system="http://cce.mitre.org">CCE-3762-2</ident>
@@ -1096,7 +1096,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.3.2" hidden="false">
           <title xml:lang="en">Set Lockouts for Failed Password Attempts </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The pam tally2 PAM module provides the capability to lock out user accounts after a number of failed login attempts. Its documentation is available in /usr/share/doc/pam-version/txts/README.pam tally2. If locking out accounts after a number of incorrect login attempts is required by your security policy, implement use of pam tally2.so for the relevant PAM-aware programs such as login, sshd, and vsftpd. Find the following line in /etc/pam.d/system-auth: auth sufficient pam_unix.so nullok try_first_pass and then change it so that it reads as follows: auth required pam_unix.so nullok try_first_pass In the same file, comment out or delete the lines: auth requisite pam_succeed_if.so uid &gt;= 500 quiet auth required pam_deny.so To enforce password lockout, add the following to the individual programs’ configuration files in /etc/pam.d. First, add to end of the auth lines: auth required pam_tally2.so deny=5 onerr=fail Second, add to the end of the account lines: account required pam_tally2.so Adjust the deny argument to conform to your system security policy. The pam tally2 utility can be used to unlock user accounts as follows: # /sbin/pam_tally2 --user username --reset Locking out user accounts presents the risk of a denial-of-service attack. The security policy regarding system lockout must weigh whether the risk of such a denial-of-service attack outweighs the benefits of thwarting password guessing attacks. The pam tally2 utility can be run from a cron job on a hourly or daily basis to try and offset this risk. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-54" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-54" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Lockouts for Failed Password Attempts </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The "account lockout threshold" policy should meet minimum requirements. </description>
             <ident system="http://cce.mitre.org">CCE-3410-8</ident>
@@ -1112,7 +1112,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.3.4" hidden="false">
           <title xml:lang="en">Restrict Execution of userhelper to Console Users </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If your environment has defined a group, usergroup containing all the human users of your system, restrict execution of the userhelper program to only that group: # chgrp usergroup /usr/sbin/userhelper # chmod 4710 /usr/sbin/userhelper The userhelper program provides authentication for graphical services which must run with root privileges, such as the system-config- family of graphical configuration utilities. Only human users logged into the system console are likely to ever have a legitimate need to run these utilities. This step provides some protection against possible flaws in userhelper’s implementation, and against further privilege escalation when system accounts are compromised. See Section 2.3.2.2 for more information on creating a group of human users. The userhelper program is configured by the files in /etc/security/console.apps/. Each file specifies, for some program, what user the program should run as, and what program should be executed after successful authentication. Note: The configuration in /etc/security/console.apps/ is applied in combination with the PAM configuration of the service defined in /etc/pam.d/. First, userhelper determines what user the service should run as. (Typically, this will be root.) Next, userhelper uses the PAM API to allow the user who ran the program to attempt to authenticate as the desired user. The PAM API exchange is wrapped in a GUI if the application’s configuration requests one. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-55" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-55" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Execution of userhelper to Console Users </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /usr/sbin/userhelper file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-4185-5</ident>
@@ -1120,7 +1120,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:56" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-56" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-56" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Execution of userhelper to Console Users </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /usr/sbin/userhelper should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-3952-9</ident>
@@ -1136,7 +1136,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.4.1" hidden="false">
           <title xml:lang="en">Ensure that No Dangerous Directories Exist in Roots Path '</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The active path of the root account can be obtained by starting a new root shell and running: # echo $PATH This will produce a colon-separated list of directories in the path. For each directory DIR in the path, ensure that DIR is not equal to a single . character. Also ensure that there are no “empty” elements in the path, such as in these examples: PATH=:/bin PATH=/bin: PATH=/bin::/sbin These empty elements have the same effect as a single . character. For each element in the path, run: # ls -ld DIR and ensure that write permissions are disabled for group and other. It is important to prevent root from executing unknown or untrusted programs, since such programs could contain malicious code. Therefore, root should not run programs installed by unprivileged users. Since root may often be working inside untrusted directories, the . character, which represents the current directory, should never be in the root path, nor should any directory which can be written to by an unprivileged or semi-privileged (system) user. It is a good practice for administrators to always execute privileged commands by typing the full path to the command. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-57" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-57" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure that No Dangerous Directories Exist in Root's Path </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The PATH variable should be set correctly for user root</description>
             <ident system="http://cce.mitre.org">CCE-3301-9</ident>
@@ -1148,7 +1148,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.4.2" hidden="false">
           <title xml:lang="en">Ensure that User Home Directories are not Group-Writable or World-Readable </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Sections 2.3.4.2–2.3.4.5 recommend modifying user home directories. Notify your user community, and solicit input if appropriate, before making this type of change. For each human user USER of the system, view the permissions of the user’s home directory: # ls -ld /home/USER Ensure that the directory is not group-writable and that it is not world-readable. If necessary, repair the permissions: # chmod g-w /home/USER # chmod o-rwx /home/USER User home directories contain many configuration files which affect the behavior of a user’s account. No user should ever have write permission to another user’s home directory. Group shared directories can be configured in subdirectories or elsewhere in the filesystem if they are needed. Typically, user home directories should not be world-readable. If a subset of users need read access to one another’s home directories, this can be provided using groups. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-58" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-58" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure that User Home Directories are not Group-Writable or World-Readable </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions should be set correctly for the home directories for all user accounts.</description>
             <ident system="http://cce.mitre.org">CCE-4090-7</ident>
@@ -1164,7 +1164,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.4.4" hidden="false">
           <title xml:lang="en">Ensure that Users Have Sensible Umask Values </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">1. Edit the global configuration files /etc/profile, /etc/bashrc, and /etc/csh.cshrc. Add or correct the line: umask 077 2. Edit the user definitions file /etc/login.defs. Add or correct the line: UMASK 077 3. View the additional configuration files /etc/csh.login and /etc/profile.d/*, and ensure that none of these files redefine the umask to a more permissive value unless there is a good reason for it. 4. Edit the root shell configuration files /root/.bashrc, /root/.bash profile, /root/.cshrc, and /root/.tcshrc. Add or correct the line: umask 077 With a default umask setting of 077, files and directories created by users will not be readable by any other user on the system. Users who wish to make specific files group- or world-readable can accomplish this using the chmod command. Additionally, users can make all their files readable to their group by default by setting a umask of 027 in their shell configuration files. If default per-user groups exist (that is, if every user has a default group whose name is the same as that user’s username and whose only member is the user), then it may even be safe for users to select a umask of 007, making it very easy to intentionally share files with group s of which the user is a member. In addition, it may be necessary to change root’s umask temporarily in order to install software or files which must be readable by other users, or to change the default umasks of certain service accounts such as the FTP user. However, setting a restrictive default protects the files of users who have not taken steps to make their files more available, and preventing files from being inadvertently shared. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-59" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-59" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure that Users Have Sensible Umask Values </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default umask for all users should be set correctly for the bash shell</description>
             <ident system="http://cce.mitre.org">CCE-3844-8</ident>
@@ -1172,7 +1172,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:60" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-60" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-60" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure that Users Have Sensible Umask Values </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default umask for all users should be set correctly for the csh shell</description>
             <ident system="http://cce.mitre.org">CCE-4227-5</ident>
@@ -1180,7 +1180,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:61" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-61" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-61" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure that Users Have Sensible Umask Values </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default umask for all users should be set correctly</description>
             <ident system="http://cce.mitre.org">CCE-3870-3</ident>
@@ -1204,7 +1204,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.5.2" hidden="false">
           <title xml:lang="en">Set Boot Loader Password </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">During the boot process, the boot loader is responsible for starting the execution of the kernel and passing options to it. The boot loader allows for the selection of different kernels – possibly on different partitions or media. Options it can pass to the kernel include “single-user mode,” which provides root access without any authentication, and the ability to disable SELinux. To prevent local users from modifying the boot parameters and endangering security, the boot loader configuration should be protected with a password. The default RHEL boot loader for x86 systems is called GRUB. To protect its configuration: 1. Select a password and then generate a hash from it by running: # grub-md5-crypt 2. Insert the following line into /etc/grub.conf immediately after the header comments. (Use the output from grub-md5-crypt as the value of password-hash ): password --md5 password-hash 3. Verify the permissions on /etc/grub.conf (which is a symlink to ../boot/grub/grub.conf): # chown root:root /etc/grub.conf # chmod 600 /etc/grub.conf Boot loaders for other platforms should offer a similar password protection feature. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-62" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-62" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Boot Loader Password </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/grub.conf file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-4144-2</ident>
@@ -1212,7 +1212,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:63" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-63" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-63" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Boot Loader Password </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/grub.conf should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-3923-0</ident>
@@ -1220,7 +1220,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:64" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-64" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-64" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Boot Loader Password </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The grub boot loader should have password protection enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3818-2</ident>
@@ -1228,7 +1228,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:65" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-65" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-65" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Boot Loader Password </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/grub.conf file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-4197-0</ident>
@@ -1240,7 +1240,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.5.3" hidden="false">
           <title xml:lang="en">Require Authentication for Single-User Mode </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Single-user mode is intended as a system recovery method, providing a single user root access to the system by providing a boot option at startup. By default, no authentication is performed if single-user mode is selected. This provides a trivial mechanism of bypassing security on the machine and gaining root access. To require entry of the root password even if the system is started in single-user mode, add the following line to the /etc/inittab file: ~~:S:wait:/sbin/sulogin </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-66" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-66" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Require Authentication for Single-User Mode </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The requirement for a password to boot into single-user mode should be configured correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4241-6</ident>
@@ -1252,7 +1252,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.5.4" hidden="false">
           <title xml:lang="en">Disable Interactive Boot</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/sysconfig/init. Add or correct the setting: PROMPT=no The PROMPT option allows the console user to perform an interactive system startup, in which it is possible to select the set of services which are started on boot. Using interactive boot, the console user could disable auditing, firewalls, or other services, weakening system security. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-67" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-67" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Interactive Boot</title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ability for users to perform interactive startups should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4245-7</ident>
@@ -1264,7 +1264,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.5.5" hidden="false">
           <title xml:lang="en">Implement Inactivity Time-out for Login Shells </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If the system does not run X Windows, then the login shells can be configured to automatically log users out after a period of inactivity. The following instructions are not practical for systems which run X Windows, as they will close terminal windows in the X environment. For information on how to automatically lock those systems, see Section 2.3.5.6. To implement a 10-minute idle time-out for the default /bin/bash shell, create a new file tmout.sh in the directory /etc/profile.d with the following lines: TMOUT=600 readonly TMOUT export TMOUT To implement a 10-minute idle time-out for the tcsh shell, create a new file autologout.csh in the directory /etc/profile.d with the following line: set -r autologout 10 Similar actions should be taken for any other login shells used. The example time-out here of 10 minutes should be adjusted to whatever your security policy requires. The readonly line for bash and the -r option for tcsh can be omitted if policy allows users to override the value. The automatic shell logout only occurs when the shell is the foreground process. If, for example, a vi session is left idle, then automatic logout would not occur. When logging in through a remote connection, as with SSH, it may be more effective to set the timeout value directly through that service. To learn how to set automatic timeout intervals for SSH, see Section 3.5.2.3. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-68" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-68" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Implement Inactivity Time-out for Login Shells </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The idle time-out value for the default /bin/tcsh shell should meet the minimum requirements.</description>
             <ident system="http://cce.mitre.org">CCE-3689-7</ident>
@@ -1272,7 +1272,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:69" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-69" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-69" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Implement Inactivity Time-out for Login Shells </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The idle time-out value for the default /bin/bash shell should meet the minimum requirements.</description>
             <ident system="http://cce.mitre.org">CCE-3707-7</ident>
@@ -1287,7 +1287,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.5.6.1" hidden="false">
             <title xml:lang="en">Configure GUI Screen Locking </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">In the default GNOME desktop, the screen can be locked by choosing Lock Screen from the System menu. The gconftool-2 program can be used to enforce mandatory screen locking settings for the default GNOME environment. Run the following commands to enforce idle activation of the screen saver, screen locking, a blank-screen screensaver, and 10-minute idle activation time: # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type bool \ --set /apps/gnome-screensaver/idle_activation_enabled true # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type bool \ --set /apps/gnome-screensaver/lock_enabled true # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type string \ --set /apps/gnome-screensaver/mode blank-only # gconftool-2 --direct \ --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \ --type int \ --set /apps/gnome-screensaver/idle_delay 10 The default setting of 10 minutes for idle activation is reasonable for many office environments, but the setting should conform to whatever policy is defined. The screensaver mode blank-only is selected to conceal the contents of the display from passersby. Because users should be trained to lock the screen when they step away from the computer, the automatic locking feature is only meant as a backup. The Lock Screen icon from the System menu can also be dragged to the taskbar in order to facilitate even more convenient screen-locking. The root account cannot be screen-locked, but this should have no practical effect as the root account should never be used to log into an X Windows environment, and should only be used to for direct login via console in emergency circumstances. For more information about configuring GNOME screensaver, see http://live.gnome.org/GnomeScreensaver. For more information about enforcing preferences in the GNOME environment using the GConf configuration system, see http://www.gnome.org/projects/gconf and the man page gconftool-2(1). </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-70" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-70" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Configure GUI Screen Locking </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The allowed period of inactivity gnome desktop lockout should be configured correctly.</description>
               <ident system="http://cce.mitre.org">CCE-3315-9</ident>
@@ -1295,7 +1295,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:71" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-71" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-71" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Configure GUI Screen Locking </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The vlock package should be installed or not as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-3910-7</ident>
@@ -1320,7 +1320,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.7.1" hidden="false">
           <title xml:lang="en">Modify the System Login Banner </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The contents of the file /etc/issue are displayed on the screen just above the login prompt for users logging directly into a terminal. Remote login programs such as SSH or FTP can be configured to display /etc/issue as well. Instructions for configuring each server daemon to show this file can be found in the relevant sections of Chapter 3. By default, the system will display the version of the OS, the kernel version, and the host name. Edit /etc/issue. Replace the default text with a message compliant with the local site policy or a legal disclaimer. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-72" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-72" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Modify the System Login Banner </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The system login banner text should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4060-0</ident>
@@ -1332,7 +1332,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.3.7.2" hidden="false">
           <title xml:lang="en">Implement a GUI Warning Banner </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">In the default graphical environment, users logging directly into the system are greeted with a login screen provided by the GNOME display manager. The warning banner should be displayed in this graphical environment for these users. The files for the default RHEL theme can be found in /usr/share/gdm/themes/RHEL. Add the following sample block of XML to /usr/share/gdm/themes/RHEL/RHEL.xml after the first two ”pixmap” entries: &lt;item type="rect"/&gt; &lt;pos anchor="n" x="50%" y="10" width="box" height="box"/&gt; &lt;box&gt; &lt;item type="label"/&gt; &lt;normal font="Sans 14" color="#ffffff"/&gt; &lt;text&gt; Insert the text of your warning banner here. &lt;/text&gt; &lt;/item&gt; &lt;/box&gt; &lt;/item&gt; The full syntax that GDM theme files expect is documented elsewhere, but the above XML will create a text box centered at the top of the screen. The font, text color, and exact positioning can all be easily modified by editing the appropriate values. The latest current GDM theme manual can be found at http://www.gnome.org/ projects/gdm/docs/thememanual.html. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-73" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-73" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Implement a GUI Warning Banner </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The direct gnome login warning banner should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4188-9</ident>
@@ -1353,7 +1353,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.4.2" hidden="false">
         <title xml:lang="en">Enable SELinux</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/selinux/config. Add or correct the following lines: SELINUX=enforcing SELINUXTYPE=targeted Edit the file /etc/grub.conf. Ensure that the following arguments DO NOT appear on any kernel command line in the file: selinux=0 enforcing=0 The directive SELINUX=enforcing enables SELinux at boot time. If SELinux is causing a lot of problems or preventing the system from booting, it is possible to boot into the warning-only mode SELINUX=permissive for debugging purposes. Make certain to change the mode back to enforcing after debugging, set the filesystems to be relabelled for consistency using the command touch /.autorelabel, and reboot. However, the RHEL5 default SELinux configuration should be sufficiently reasonable that most systems will boot without serious problems. Some applications that require deep or unusual system privileges, such as virtual machine software, may not be compatible with SELinux in its default configuration. However, this should be uncommon, and SELinux’s application support continues to improve. In other cases, SELinux may reveal unusual or insecure program behavior by design. The directive SELINUXTYPE=targeted configures SELinux to use the default targeted policy. See Section 2.4.6 if a stricter policy is appropriate for your site. The SELinux boot mode specified in /etc/selinux/config can be overridden by command-line arguments passed to the kernel. It is necessary to check grub.conf to ensure that this has not been done and to protect the bootloader as described in Section 2.3.5.2. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-74" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-74" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Enable SELinux</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SELinux should be enabled or disabled as appropriate</description>
           <ident system="http://cce.mitre.org">CCE-3977-6</ident>
@@ -1361,7 +1361,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:75" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-75" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-75" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Enable SELinux</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The SELinux state should be set appropriately.</description>
           <ident system="http://cce.mitre.org">CCE-3999-0</ident>
@@ -1369,7 +1369,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:76" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-76" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-76" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Enable SELinux</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The SELinux policy should be set appropriately.</description>
           <ident system="http://cce.mitre.org">CCE-3624-4</ident>
@@ -1384,7 +1384,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.4.3.1" hidden="false">
           <title xml:lang="en">Disable and Remove SETroubleshoot if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason to allow users to view SELinux denial information using the sealert GUI? If not, disable the service and remove the RPM: # chkconfig setroubleshoot off # yum erase setroubleshoot The setroubleshoot service is a facility for notifying the desktop user of SELinux denials in a user-friendly fashion. SELinux errors may provide important information about intrusion attempts in progress, or may give information about SELinux configuration problems which are preventing correct system operation. In order to maintain a secure and usable SELinux installation, error logging and notification is necessary. However, setroubleshoot is a service which has complex functionality, which runs a daemon and uses IPC to distribute information which may be sensitive, or even to allow users to modify SELinux settings, and which does not yet implement real authentication mechanisms. This guide recommends disabling setroubleshoot and using the kernel audit functionality to monitor SELinux’s behavior. In addition, since setroubleshoot automatically runs client-side code whenever a denial occurs, regardless of whether the setroubleshootd daemon is running, it is recommended that the program be removed entirely unless it is needed. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-77" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-77" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable and Remove SETroubleshoot if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The setroubleshoot service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4254-9</ident>
@@ -1392,7 +1392,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:78" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-78" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-78" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable and Remove SETroubleshoot if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The setroubleshoot package should be installed or uninstalled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4148-3</ident>
@@ -1404,7 +1404,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.4.3.2" hidden="false">
           <title xml:lang="en">Disable MCS Translation Service (mcstrans) if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Unless there is some overriding need for the convenience of category label translation, disable the MCS translation service: # chkconfig mcstrans off The mcstransd daemon provides the category label translation information defined in /etc/selinux/targeted/ setrans.conf to client processes which request this information. Category labelling is unlikely to be used except in sites with special requirements. Therefore, it should be disabled in order to reduce the amount of potentially vulnerable code running on the system. See Section 2.4.6 for more information about systems which use category labelling. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-79" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-79" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable MCS Translation Service (mcstrans) if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The mcstrans service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3668-1</ident>
@@ -1416,7 +1416,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.4.3.3" hidden="false">
           <title xml:lang="en">Restorecon Service (restorecond) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The restorecond daemon monitors a list of files which are frequently created or modified on running systems, and whose SELinux contexts are not set correctly. It looks for creation events related to files listed in /etc/ selinux/restorecond.conf, and sets the contexts of those files when they are discovered. The restorecond program is fairly simple, so it brings low risk, but, in its default configuration, does not add much value to a system. An automated program such as restorecond may be used to monitor problematic files for context problems, or system administrators may be trained to check file contexts of newly-created files using the command ls -lZ, and to repair contexts manually using the restorecon command. This guide makes no recommendation either for or against the use of restorecond. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-80" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-80" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restorecon Service (restorecond) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The restorecond service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4129-3</ident>
@@ -1460,7 +1460,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.5.1.1" hidden="false">
           <title xml:lang="en">Network Parameters for Hosts Only </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is this system going to be used as a firewall or gateway to pass IP traffic between different networks? If not, edit the file /etc/sysctl.conf and add or correct the following lines: net.ipv4.ip forward = 0 net.ipv4.conf.all.send redirects = 0 net.ipv4.conf.default.send redirects = 0 These settings disable hosts from performing network functionality which is only appropriate for routers. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-81" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-81" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts Only </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for sending ICMP redirects should be enabled or disabled for network interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4151-7</ident>
@@ -1468,7 +1468,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:82" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-82" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-82" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts Only </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Sending ICMP redirects should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4155-8</ident>
@@ -1476,7 +1476,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:83" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-83" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-83" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts Only </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">IP forwarding should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3561-8</ident>
@@ -1488,7 +1488,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.5.1.2" hidden="false">
           <title xml:lang="en">Network Parameters for Hosts and Routers </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/sysctl.conf and add or correct the following lines: net.ipv4.conf.all.accept_source_route = 0 net.ipv4.conf.all.accept_redirects = 0 net.ipv4.conf.all.secure_redirects = 0 net.ipv4.conf.all.log_martians = 1 net.ipv4.conf.default.accept_source_route = 0 net.ipv4.conf.default.accept_redirects = 0 net.ipv4.conf.default.secure_redirects = 0 net.ipv4.icmp_echo_ignore_broadcasts = 1 net.ipv4.icmp_ignore_bogus_error_messages = 1 net.ipv4.tcp_syncookies = 1 net.ipv4.conf.all.rp_filter = 1 net.ipv4.conf.default.rp_filter = 1 These options improve Linux’s ability to defend against certain types of IPv4 protocol attacks. The accept source route, accept redirects, and secure redirects options are turned off to disable IPv4 protocol features which are considered to have few legitimate uses and to be easy to abuse. The net.ipv4.conf.all.log martians option logs several types of suspicious packets, such as spoofed packets, source-routed packets, and redirects. The icmp echo ignore broadcasts icmp ignore bogus error messages options protect against ICMP attacks. The tcp syncookies option uses a cryptographic feature called SYN cookies to allow machines to continue to accept legitimate connections when faced with a SYN flood attack. See [12] for further information on this option. The rp filter option enables RFC-recommended source validation. It should not be used on machines which are routers for very complicated networks, but is helpful for end hosts and routers serving small networks. For more information on any of these, see the kernel source documentation file /Documentation/networking/ip-sysctl.txt.2 </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-84" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-84" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Accepting "secure" ICMP redirects (those from gateways listed in the default gateways list) should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3472-8</ident>
@@ -1496,7 +1496,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:85" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-85" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-85" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Accepting ICMP redirects should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4217-6</ident>
@@ -1504,7 +1504,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:86" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-86" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-86" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Ignoring bogus ICMP responses to broadcasts should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4133-5</ident>
@@ -1512,7 +1512,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:87" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-87" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-87" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Sending TCP syncookies should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4265-5</ident>
@@ -1520,7 +1520,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:88" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-88" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-88" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Ignoring ICMP echo requests (pings) sent to broadcast / multicast addresses should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3644-2</ident>
@@ -1528,7 +1528,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:89" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-89" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-89" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting ICMP redirects should be enabled or disabled for network interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4186-3</ident>
@@ -1536,7 +1536,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:90" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-90" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-90" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Performing source validation by reverse path should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4080-8</ident>
@@ -1544,7 +1544,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:91" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-91" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-91" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting "secure" ICMP redirects (those from gateways listed in the default gateways list) should be enabled or disabled for network interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3339-9</ident>
@@ -1552,7 +1552,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:92" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-92" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-92" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Logging of "martian" packets (those with impossible addresses) should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4320-8</ident>
@@ -1560,7 +1560,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:93" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-93" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-93" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for performing source validation by reverse path should be enabled or disabled for network interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3840-6</ident>
@@ -1568,7 +1568,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:94" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-94" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-94" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting source routed packets should be enabled or disabled for network interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4091-5</ident>
@@ -1576,7 +1576,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:95" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-95" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-95" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Network Parameters for Hosts and Routers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Accepting source routed packets should be enabled or disabled for all interfaces as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4236-6</ident>
@@ -1599,7 +1599,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.5.2.2.1" hidden="false">
             <title xml:lang="en">Disable Wireless in BIOS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Some laptops that include built-in wireless support offer the ability to disable the device through the BIOS. This is system-specific; consult your hardware manual or explore the BIOS setup during boot. 2A recent version of this file can be found online at http://lxr.linux.no/source/Documentation/networking/ip-sysctl.txt. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-96" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-96" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Wireless in BIOS </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All wireless devices should be enabled or disabled in the BIOS as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-3628-5</ident>
@@ -1611,7 +1611,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.5.2.2.2" hidden="false">
             <title xml:lang="en">Deactivate Wireless Interfaces </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Deactivating the wireless interfaces should prevent normal usage of the wireless capability. First, identify the interfaces available with the command: # ifconfig -a Additionally,the following command may also be used to determine whether wireless support (“extensions”) is included for a particular interface, though this may not always be a clear indicator: # iwconfig After identifying any wireless interfaces (which may have names like wlan0, ath0, wifi0, or eth0), deactivate the interface with the command: # ifdown interface These changes will only last until the next reboot. To disable the interface for future boots, remove the appropriate interface file from /etc/sysconfig/network-scripts: # rm /etc/sysconfig/network-scripts/ifcfg-interface </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-97" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-97" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Deactivate Wireless Interfaces </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All wireless interfaces should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4276-2</ident>
@@ -1623,7 +1623,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.5.2.2.3" hidden="false">
             <title xml:lang="en">Disable Wireless Drivers </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Removing the kernel drivers that provide support for wireless Ethernet devices will prevent users from easily activating the devices. To remove the wireless drivers from the system: # rm -r /lib/modules/kernelversion(s) /kernel/drivers/net/wireless This command must also be repeated every time the kernel is upgraded. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-98" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-98" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Wireless Drivers </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Device drivers for wireless devices should be included or excluded from the kernel as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4170-7</ident>
@@ -1643,7 +1643,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.5.3.1.1" hidden="false">
             <title xml:lang="en">Disable Automatic Loading of IPv6 Kernel Module </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To prevent the IPv6 kernel module (ipv6) from being loaded, add the following line to /etc/modprobe.conf: alias net-pf-10 off The unexpected name is a result of how the kernel requests modules for network protocol families; net-pf-10 is an alias for the ipv6 module. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-99" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-99" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Automatic Loading of IPv6 Kernel Module </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Automatic loading of the IPv6 kernel module should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-3562-6</ident>
@@ -1655,7 +1655,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.5.3.1.2" hidden="false">
             <title xml:lang="en">Disable Interface Usage of IPv6 </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To prevent configuration of IPv6 for all interfaces, add or correct the following lines in /etc/sysconfig/ network: NETWORKING_IPV6=no IPV6INIT=no For each network interface IFACE , add or correct the following lines in /etc/sysconfig/network-scripts/ ifcfg-IFACE as an additional prevention mechanism: IPV6INIT=no If it becomes necessary later to configure IPv6, only the interfaces requiring it should be enabled. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-100" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-100" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Interface Usage of IPv6 </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Global IPv6 initialization should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-3377-9</ident>
@@ -1663,7 +1663,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:101" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-101" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-101" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Interface Usage of IPv6 </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">IPv6 configuration should be enabled or disabled as appropriate for all interfaces.</description>
               <ident system="http://cce.mitre.org">CCE-4296-0</ident>
@@ -1671,7 +1671,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:102" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-102" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-102" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Interface Usage of IPv6 </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for IPv6 configuration should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-3381-1</ident>
@@ -1687,7 +1687,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.5.3.2.1" hidden="false">
             <title xml:lang="en">Disable Automatic Configuration </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Disable the system’s acceptance of router advertisements and redirects by adding or correcting the following line in /etc/sysconfig/network (note that this does not disable sending router solicitations): IPV6_AUTOCONF=no </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-103" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-103" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Automatic Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Accepting IPv6 router advertisements should be enabled or disabled as appropriate for all network interfaces.</description>
               <ident system="http://cce.mitre.org">CCE-4269-7</ident>
@@ -1695,7 +1695,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:104" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-104" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-104" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Automatic Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting IPv6 router advertisements should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4291-1</ident>
@@ -1703,7 +1703,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:105" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-105" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-105" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Automatic Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Accepting redirects from IPv6 routers should be enabled or disabled as appropriate for all network interfaces.</description>
               <ident system="http://cce.mitre.org">CCE-4313-3</ident>
@@ -1711,7 +1711,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:106" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-106" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-106" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Automatic Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting redirects from IPv6 routers should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4198-8</ident>
@@ -1727,7 +1727,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.5.3.2.3" hidden="false">
             <title xml:lang="en">Use Privacy Extensions for Address if Necessary </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To introduce randomness into the automatic generation of IPv6 addresses, add or correct the following line in /etc/sysconfig/network-scripts/ifcfg-IFACE: IPV6_PRIVACY=rfc3041 Automatically-generated IPv6 addresses are based on the underlying hardware (e.g. Ethernet) address, and so it becomes possible to track a piece of hardware over its lifetime using its traffic. If it is important for a system’s IP address to not trivially reveal its hardware address, this setting should be applied. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-107" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-107" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Use Privacy Extensions for Address if Necessary </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">IPv6 privacy extensions should be configured appropriately for all interfaces.</description>
               <ident system="http://cce.mitre.org">CCE-3842-2</ident>
@@ -1743,7 +1743,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.5.3.2.5" hidden="false">
             <title xml:lang="en">Limit Network-Transmitted Configuration </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Add the following lines to /etc/sysctl.conf to limit the configuration information requested from other systems, and accepted from the network: net.ipv6.conf.default.router_solicitations = 0 net.ipv6.conf.default.accept_ra_rtr_pref = 0 net.ipv6.conf.default.accept_ra_pinfo = 0 net.ipv6.conf.default.accept_ra_defrtr = 0 net.ipv6.conf.default.autoconf = 0 net.ipv6.conf.default.dad_transmits = 0 net.ipv6.conf.default.max_addresses = 1 The router solicitations setting determines how many router solicitations are sent when bringing up the interface. If addresses are statically assigned, there is no need to send any solicitations. The accept ra pinfo setting controls whether the system will accept prefix info from the router. The accept ra defrtr setting controls whether the system will accept Hop Limit settings from a router advertisement. Setting it to 0 prevents a router from changing your default IPv6 Hop Limit for outgoing packets. The autoconf setting controls whether router advertisements can cause the system to assign a global unicast address to an interface. The dad transmits setting determines how many neighbor solicitations to send out per address (global and link-local) when bringing up an interface to ensure the desired address is unique on the network. The max addresses setting determines how many global unicast IPv6 addresses can be assigned to each interface. The default is 16, but it should be set to exactly the number of statically configured global addresses required. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-108" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-108" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting router preference via IPv6 router advertisement should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4221-8</ident>
@@ -1751,7 +1751,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:109" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-109" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-109" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default number of global unicast IPv6 addresses allowed per network interface should be set appropriately. </description>
               <ident system="http://cce.mitre.org">CCE-4137-6</ident>
@@ -1759,7 +1759,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:110" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-110" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-110" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default number of IPv6 router solicitations for network interfaces to send should be set appropriately. </description>
               <ident system="http://cce.mitre.org">CCE-4159-0</ident>
@@ -1767,7 +1767,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:111" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-111" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-111" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default number of IPv6 duplicate address detection solicitations for network interfaces to send per configured address should be set appropriately. </description>
               <ident system="http://cce.mitre.org">CCE-3895-0</ident>
@@ -1775,7 +1775,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:112" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-112" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-112" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for autoconfiguring network interfaces using prefix information in IPv6 router advertisements should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4287-9</ident>
@@ -1783,7 +1783,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:113" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-113" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-113" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting prefix information via IPv6 router advertisement should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4058-4</ident>
@@ -1791,7 +1791,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:114" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-114" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-114" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Limit Network-Transmitted Configuration </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting for accepting a default router via IPv6 router advertisement should be enabled or disabled for network interfaces as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4128-5</ident>
@@ -1832,7 +1832,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.5.5.1" hidden="false">
           <title xml:lang="en">Inspect and Activate Default Rules </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">View the currently-enforced iptables rules by running the command: # iptables -nL --line-numbers The command is analogous for the ip6tables program. If the firewall does not appear to be active (i.e., no rules appear), activate it and ensure that it starts at boot by issuing the following commands (and analogously for ip6tables): # service iptables restart # chkconfig iptables on The default iptables rules are: Chain INPUT (policy ACCEPT) num target prot opt source destination 1 RH-Firewall-1-INPUT all -- 0.0.0.0/0 0.0.0.0/0 Chain FORWARD (policy ACCEPT) num target prot opt source destination 1 RH-Firewall-1-INPUT all -- 0.0.0.0/0 0.0.0.0/0 Chain OUTPUT (policy ACCEPT) num target prot opt source destination Chain RH-Firewall-1-INPUT (2 references) num target prot opt source destination 1 ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 2 ACCEPT icmp -- 0.0.0.0/0 0.0.0.0/0 icmp type 255 3 ACCEPT esp -- 0.0.0.0/0 0.0.0.0/0 4 ACCEPT ah -- 0.0.0.0/0 0.0.0.0/0 5 ACCEPT udp -- 0.0.0.0/0 224.0.0.251 udp dpt:5353 6 ACCEPT udp -- 0.0.0.0/0 0.0.0.0/0 udp dpt:631 7 ACCEPT tcp -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:631 8 ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 state RELATED,ESTABLISHED 9 ACCEPT tcp -- 0.0.0.0/0 0.0.0.0/0 state NEW tcp dpt:22 10 REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-host-prohibited The ip6tables default rules are similar, with its rules 2 and 10 reflecting protocol naming and addressing differences. Instead of rule 8, however, ip6tables includes two rules that accept all incoming udp and tcp packets with a particular destination port range. This is because the current Netfilter implementation for IPv6 lacks reliable connection-tracking functionality. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-115" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-115" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Inspect and Activate Default Rules </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ip6tables service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4167-3</ident>
@@ -1840,7 +1840,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:116" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-116" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-116" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Inspect and Activate Default Rules </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The iptables service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4189-7</ident>
@@ -1925,7 +1925,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.6.1" hidden="false">
         <title xml:lang="en">Configure Syslog</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Syslog has been the default Unix logging mechanism for many years. It has a number of downsides, including inconsistent log format, lack of authentication for received messages, and lack of authentication, encryption, or reliable transport for messages sent over a network. However, due to its long history, syslog is an accepted standard which is supported by almost all Unix applications. This section discusses how to configure syslog for best effect, and how to use tools provided with the system to maintain and monitor your logs. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-117" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-117" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Configure Syslog</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The syslog service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3679-8</ident>
@@ -1940,7 +1940,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.6.1.2" hidden="false">
           <title xml:lang="en">Confirm Existence and Permissions of System Log Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">For each log file LOGFILE referenced in /etc/syslog.conf, run the commands: # touch LOGFILE # chown root:root LOGFILE # chmod 0600 LOGFILE Syslog will refuse to log to a file which does not exist. All messages intended for that file will be silently discarded, so it is important to verify that all log files exist. Some logs may contain sensitive information, so it is better to restrict permissions so that only administrative users can read or write logfiles. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-118" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-118" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Confirm Existence and Permissions of System Log Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All syslog log files should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3701-0</ident>
@@ -1948,7 +1948,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:119" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-119" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-119" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Confirm Existence and Permissions of System Log Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for all syslog log files should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4233-3</ident>
@@ -1956,7 +1956,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:120" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-120" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-120" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Confirm Existence and Permissions of System Log Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">All syslog log files should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-4366-1</ident>
@@ -1968,7 +1968,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.6.1.3" hidden="false">
           <title xml:lang="en">Send Logs to a Remote Loghost </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/syslog.conf. Add or correct the line: *.* @loghost.example.com where loghost.example.com is the name of your central log server. If system logs are to be useful in detecting malicious activities, it is necessary to send logs to a remote server. An intruder who has compromised the root account on a machine may delete the log entries which indicate that the system was attacked before they are seen by an administrator. However, it is recommended that logs be stored on the local host in addition to being sent to the loghost, because syslog uses the UDP protocol to send messages over a network. UDP does not guarantee reliable delivery, and moderately busy sites will lose log messages occasionally, especially in periods of high traffic which may be the result of an attack. In addition, remote syslog messages are not authenticated in any way, so it is easy for an attacker to introduce spurious messages to the central log server. Also, some problems cause loss of network connectivity, which will prevent the sending of messages to the central server. For all of these reasons, it is better to store log messages both centrally and on each host, so that they can be correlated if necessary. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-121" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-121" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Send Logs to a Remote Loghost </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Syslog logs should be sent to a remote loghost or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4260-6</ident>
@@ -1980,7 +1980,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.6.1.4" hidden="false">
           <title xml:lang="en">Enable syslogd to Accept Remote Messages on Loghosts Only </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is this machine the central log server for your organization? If so, edit the file /etc/sysconfig/syslog. Add or correct the following line: SYSLOGD_OPTIONS="-m 0 -r -s example.com " where example.com is the name of your domain. If the machine is not a log server, edit /etc/sysconfig/syslog, and instead add or correct the line: SYSLOGD_OPTIONS="-m 0" By default, RHEL5’s syslog does not listen over the network for log messages. The -r flag enables syslogd to listen over a network, and should be used only if necessary. The -s example.com flag strips the domain name example.com from each sending machine’s hostname before logging messages from that host, to reduce the amount of redundant information placed in log files. See the syslogd(8) man page for further information. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-122" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-122" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable syslogd to Accept Remote Messages on Loghosts Only </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Syslogd should accept remote messages or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3382-9</ident>
@@ -1992,7 +1992,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.6.1.5" hidden="false">
           <title xml:lang="en">Ensure All Logs are Rotated by logrotate </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/logrotate.d/syslog. Find the first line, which should look like this (wrapped for clarity): /var/log/messages /var/log/secure /var/log/maillog /var/log/spooler \ /var/log/boot.log /var/log/cron { Edit this line so that it contains a one-space-separated listing of each log file referenced in /etc/syslog.conf. All logs in use on a system must be rotated regularly, or the log files will consume disk space over time, eventually interfering with system operation. The file /etc/logrotate.d/syslog is the configuration file used by the logrotate program to maintain all log files written by syslog. By default, it rotates logs weekly and stores four archival copies of each log. These settings can be modified by editing /etc/logrotate.conf, but the defaults are sufficient for purposes of this guide. Note that logrotate is run nightly by the cron job /etc/cron.daily/logrotate. If particularly active logs need to be rotated more often than once a day, some other mechanism must be used. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-123" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-123" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure All Logs are Rotated by logrotate </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The logrotate (syslog rotater) service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4182-2</ident>
@@ -2004,7 +2004,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.6.1.6" hidden="false">
           <title xml:lang="en">Monitor Suspicious Log Messages using Logwatch </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The system includes an extensible program called Logwatch for reporting on unusual items in syslog. Logwatch is valuable because it provides a parser for the syslog entry format and a number of signatures for types of lines which are considered to be mundane or noteworthy. Logwatch has a number of downsides: the signatures can be inaccurate and are not always categorized consistently, and you must be able to program in Perl in order to customize the signature database. However, it is recommended that all Linux sites which do not have time to deploy a third-party log monitoring application run Logwatch in its default configuration. This provides some useful information about system activity in exchange for very little administrator effort. This guide recommends that Logwatch be run only on the central logserver, if your site has one, in order to focus administrator attention by sending all daily logs in a single e-mail. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-124" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-124" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Monitor Suspicious Log Messages using Logwatch </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The logwatch service should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4323-2</ident>
@@ -2028,7 +2028,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-2.6.2.1" hidden="false">
           <title xml:lang="en">Enable the auditd Service </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Ensure that the auditd service is enabled (this is the default): # chkconfig auditd on By default, auditd logs only SELinux denials, which are helpful for debugging SELinux and discovering intrusion attempts, and certain types of security events, such as modifications to user accounts (useradd, passwd, etc), login events, and calls to sudo. Data is stored in /var/log/audit/audit.log. By default, auditd rotates 4 logs by size (5MB), retaining a maximum of 20MB of data in total, and refuses to write entries when the disk is too full. This minimizes the risk of audit data filling its partition and impacting other services. However, it is possible to lose audit data if the system is busy. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-125" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-125" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable the auditd Service </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The auditd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4292-9</ident>
@@ -2080,7 +2080,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.2.1" hidden="false">
         <title xml:lang="en">Inetd and Xinetd</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there an operational need to run the deprecated inetd or xinetd software packages? If not, ensure that they are removed from the system: # yum erase inetd xinetd Beginning with Red Hat Enterprise Linux 5, the xinetd service is no longer installed by default. This change represents increased awareness that the dedicated network listener model does not improve security or reliability of services, and that restriction of network listeners is better handled using a granular model such as SELinux than using xinetd’s limited security options. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-126" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-126" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Inetd and Xinetd</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The inetd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4234-1</ident>
@@ -2088,7 +2088,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:127" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-127" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-127" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Inetd and Xinetd</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The xinetd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4252-3</ident>
@@ -2096,7 +2096,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:128" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-128" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-128" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Inetd and Xinetd</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The inetd package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4023-8</ident>
@@ -2104,7 +2104,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:129" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-129" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-129" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Inetd and Xinetd</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The xifnetd package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4164-0</ident>
@@ -2116,7 +2116,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.2.2" hidden="false">
         <title xml:lang="en">Telnet</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for users to access the system via the insecure telnet protocol, rather than the more secure SSH protocol? If not, ensure that the telnet server is removed from the system: # yum erase telnet-server The telnet protocol uses unencrypted network communication, which means that data from the login session, including passwords and all other information transmitted during the session, can be stolen by eavesdroppers on the network, and also that outsiders can easily hijack the session to gain authenticated access to the telnet server. Organizations which use telnet should be actively working to migrate to a more secure protocol. See Section 3.5 for information about the SSH service. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-130" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-130" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Telnet</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The telnet service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3390-2</ident>
@@ -2124,7 +2124,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:131" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-131" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-131" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Telnet</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The telnet-server package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4330-7</ident>
@@ -2139,7 +2139,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.2.3.1" hidden="false">
           <title xml:lang="en">Remove the Rsh Server Commands from the System </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for users to access the system via the insecure rlogin, rsh, or rcp commands rather than the more secure ssh and scp? If not, ensure that the rsh server is removed from the system: # yum erase rsh-server SSH was designed to be a drop-in replacement for the r-commands, which suffer from the same hijacking and eavesdropping problems as telnet. There is unlikely to be a case in which these commands cannot be replaced with SSH. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-132" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-132" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove the Rsh Server Commands from the System </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rcp service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3974-3</ident>
@@ -2147,7 +2147,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:133" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-133" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-133" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove the Rsh Server Commands from the System </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rsh service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4141-8</ident>
@@ -2155,7 +2155,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:134" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-134" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-134" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove the Rsh Server Commands from the System </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rlogin service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3537-8</ident>
@@ -2163,7 +2163,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:135" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-135" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-135" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove the Rsh Server Commands from the System </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rsh packagee should be installed or uninstalled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4308-3</ident>
@@ -2180,7 +2180,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.2.4" hidden="false">
         <title xml:lang="en">NIS</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The NIS client service ypbind is not activated by default. In the event that it was activated at some point, disable it by executing the command: # chkconfig ypbind off The NIS server package is not installed by default. In the event that it was installed at some point, remove it from the system by executing the command: # yum erase ypserv The Network Information Service (NIS), also known as “Yellow Pages” (YP), and its successor NIS+ have been made obsolete by Kerberos, LDAP, and other modern centralized authentication services. NIS should not be used because it suffers from security problems inherent in its design, such as inadequate protection of important authentication information. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-136" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-136" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">NIS</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ypbind service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3705-1</ident>
@@ -2188,7 +2188,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:137" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-137" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-137" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">NIS</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ypserv package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4348-9</ident>
@@ -2200,7 +2200,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.2.5" hidden="false">
         <title xml:lang="en">TFTP Server</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there an operational need to run the deprecated TFTP server software? If not, ensure that it is removed from the system: # yum erase tftp-server TFTP is a lightweight version of the FTP protocol which has traditionally been used to configure networking equipment. However, TFTP provides little security, and modern versions of networking operating systems fre77 quently support configuration via SSH or other more secure protocols. A TFTP server should be run only if no more secure method of supporting existing equipment can be found. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-138" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-138" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">TFTP Server</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The tftp service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4273-9</ident>
@@ -2208,7 +2208,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:139" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-139" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-139" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">TFTP Server</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The tftp-server package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3916-4</ident>
@@ -2224,7 +2224,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.1" hidden="false">
         <title xml:lang="en">Installation Helper Service (firstboot)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Firstboot is a daemon specific to the Red Hat installation process. It handles “one-time” configuration following successful installation of the operating system. As such, there is no reason for this service to remain enabled. Disable firstboot by issuing the command: # chkconfig firstboot off </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-140" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-140" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Installation Helper Service (firstboot)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The firstboot service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3412-4</ident>
@@ -2236,7 +2236,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.2" hidden="false">
         <title xml:lang="en">Console Mouse Service (gpm)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">GPM is the service that controls the text console mouse pointer. (The X Windows mouse pointer is unaffected by this service.) If mouse functionality in the console is not required, disable this service: # chkconfig gpm off Although it is preferable to run as few services as possible, the console mouse pointer can be useful for preventing administrator mistakes in runlevel 3 by enabling copy-and-paste operations. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-141" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-141" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Console Mouse Service (gpm)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The gpm service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4229-1</ident>
@@ -2248,7 +2248,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.3" hidden="false">
         <title xml:lang="en">Interrupt Distribution on Multiprocessor Systems (irqbalance)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The goal of the irqbalance service is to optimize the balance between power savings and performance through distribution of hardware interrupts across multiple processors. In a server environment with multiple processors, this provides a useful service and should be left enabled. If a machine has only one processor, the service may be disabled: # chkconfig irqbalance off </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-142" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-142" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Interrupt Distribution on Multiprocessor Systems (irqbalance)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The irqbalance service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4123-6</ident>
@@ -2260,7 +2260,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.4" hidden="false">
         <title xml:lang="en">ISDN Support (isdn)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ISDN service facilitates Internet connectivity in the presence of an ISDN modem. If an ISDN modem is not being used, disable this service: # chkconfig isdn off </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-143" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-143" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">ISDN Support (isdn)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The isdn service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4286-1</ident>
@@ -2272,7 +2272,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.5" hidden="false">
         <title xml:lang="en">Kdump Kernel Crash Analyzer (kdump)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Kdump is a new kernel crash dump analyzer. It uses kexec to boot a secondary kernel (“capture” kernel) following a system crash. The kernel dump from the system crash is loaded into the capture kernel for analysis. Unless the system is used for kernel development or testing, disable the service: # chkconfig kdump off </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-144" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-144" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Kdump Kernel Crash Analyzer (kdump)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The kdump service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3425-6</ident>
@@ -2284,7 +2284,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.6" hidden="false">
         <title xml:lang="en">Kudzu Hardware Probing Utility (kudzu)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for console users to add new hardware to the system? If not: # chkconfig kudzu off Kudzu, Red Hat’s hardware detection program, represents an unnecessary security risk as it allows unprivileged users to perform hardware configuration without authorization. Unless this specific functionality is required, Kudzu should be disabled. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-145" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-145" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Kudzu Hardware Probing Utility (kudzu)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The kudzu service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4211-9</ident>
@@ -2296,7 +2296,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.7" hidden="false">
         <title xml:lang="en">Software RAID Monitor (mdmonitor)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The mdmonitor service is used for monitoring a software RAID (hardware RAID setups do not use this service). This service is extraneous unless software RAID is in use (which is not common). If software RAID monitoring is not required, disable this service: # chkconfig mdmonitor off </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-146" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-146" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Software RAID Monitor (mdmonitor)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The mdmonitor service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3854-7</ident>
@@ -2308,7 +2308,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.8" hidden="false">
         <title xml:lang="en">IA32 Microcode Utility(microcodectl)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">microcode ctl is a microcode utility for use with Intel IA32 processors (Pentium Pro, PII, Celeron, PIII, Xeon, Pentium 4, etc) If the system is not running an Intel IA32 processor, disable this service: # chkconfig microcode ctl off </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-147" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-147" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">IA32 Microcode Utility(microcodectl)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The microcode_ctl service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4356-2</ident>
@@ -2320,7 +2320,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.9" hidden="false">
         <title xml:lang="en">Network Service (network)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The network service allows associated network interfaces to access the network. This section contains general guidance for controlling the operation of the service. For kernel parameters which affect networking, see Section </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-148" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-148" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Network Service (network)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The network service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4369-5</ident>
@@ -2344,7 +2344,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.10" hidden="false">
         <title xml:lang="en">Smart Card Support (pcscd)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The pcscd service provides support for Smart Cards and Smart Card Readers. If Smart Cards are not in use on the system, disable this service: # chkconfig pcscd off </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-149" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-149" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Smart Card Support (pcscd)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The pcscd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4100-4</ident>
@@ -2356,7 +2356,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.11" hidden="false">
         <title xml:lang="en">SMART Disk Monitoring Support (smartd)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SMART (Self-Monitoring, Analysis, and Reporting Technology) is a feature of hard drives that allows them to detect symptoms of disk failure and relay an appropriate warning. This technology is considered to bring relatively low security risk, and can be useful. Leave this service running if the system’s hard drives are SMART-capable. Otherwise, disable it: # chkconfig smartd off </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-150" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-150" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">SMART Disk Monitoring Support (smartd)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The smartd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3455-3</ident>
@@ -2368,7 +2368,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.12" hidden="false">
         <title xml:lang="en">Boot Caching (readahead early/readahead later)</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The following services provide one-time caching of files belonging to some boot services, with the goal of allowing the system to boot faster. It is recommended that this service be disabled on most machines: # chkconfig readahead early off # chkconfig readahead later off The readahead services do not substantially increase a system’s risk exposure, but they also do not provide great benefit. Unless the system is running a specialized application for which the file caching substantially improves system boot time, this guide recommends disabling the services. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-151" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-151" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Boot Caching (readahead early/readahead later)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The readahead_early service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4421-4</ident>
@@ -2376,7 +2376,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:152" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-152" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-152" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Boot Caching (readahead early/readahead later)</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The readahead_later service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4302-6</ident>
@@ -2391,7 +2391,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.13.1" hidden="false">
           <title xml:lang="en">D-Bus IPC Service (messagebus) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">D-Bus is an IPC mechanism that provides a common channel for inter-process communication. If no services which require D-Bus are in use, disable this service: # chkconfig messagebus off A number of default services make use of D-Bus, including X Windows (Section 3.6), Bluetooth (Section 3.3.14) and Avahi (Section 3.7). This guide recommends that D-Bus and all its dependencies be disabled unless there is a mission-critical need for them. Stricter configuration of D-Bus is possible and documented in the man page dbus-daemon(1). D-Bus maintains two separate configuration files, located in /etc/dbus-1/, one for system-specific configuration and the other for session-specific configuration. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-153" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-153" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">D-Bus IPC Service (messagebus) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The messagebus service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3822-4</ident>
@@ -2403,7 +2403,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.13.2" hidden="false">
           <title xml:lang="en">HAL Daemon (haldaemon) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The haldaemon service provides a dynamic way of managing device interfaces. It automates device configuration and provides an API for making devices accessible to applications through the D-Bus interface. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-154" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-154" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">HAL Daemon (haldaemon) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The haldaemon service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4364-6</ident>
@@ -2427,7 +2427,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.14.1" hidden="false">
           <title xml:lang="en">Bluetooth Host Controller Interface Daemon (bluetooth) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The bluetooth service enables the system to use Bluetooth devices. If the system requires no Bluetooth devices, disable this service: # chkconfig bluetooth off </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-155" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-155" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Bluetooth Host Controller Interface Daemon (bluetooth) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The bluetooth service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4355-4</ident>
@@ -2439,7 +2439,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.14.2" hidden="false">
           <title xml:lang="en">Bluetooth Input Devices (hidd) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The hidd service provides support for Bluetooth input devices. If the system has no Bluetooth input devices (e.g. keyboard or mouse), disable this service: # chkconfig hidd off </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-156" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-156" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Bluetooth Input Devices (hidd) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The hidd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4377-8</ident>
@@ -2459,7 +2459,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.15.1" hidden="false">
           <title xml:lang="en">Advanced Power Management Subsystem (apmd) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The apmd service provides last generation power management support. If the system is capable of ACPI support, or if power management is not necessary, disable this service: # chkconfig apmd off APM is being replaced by ACPI and should be considered deprecated. As such, it can be disabled if ACPI is supported by your hardware and kernel. If the file /proc/acpi/info exists and contains ACPI version information, then APM can safely be disabled without loss of functionality. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-157" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-157" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Advanced Power Management Subsystem (apmd) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The apmd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4289-5</ident>
@@ -2471,7 +2471,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.15.2" hidden="false">
           <title xml:lang="en">Advanced Configuration and Power Interface (acpid) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The acpid service provides next generation power management support. Unless power management features are not necessary, leave this service enabled. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-158" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-158" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Advanced Configuration and Power Interface (acpid) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The acpid service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4298-6</ident>
@@ -2483,7 +2483,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.3.15.3" hidden="false">
           <title xml:lang="en">CPU Throttling (cpuspeed) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The cpuspeed service uses hardware support to throttle the CPU when the system is idle. Unless CPU power optimization is unnecessary, leave this service enabled. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-159" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-159" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">CPU Throttling (cpuspeed) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The cpuspeed service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4051-9</ident>
@@ -2497,7 +2497,7 @@
     <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.4" hidden="false">
       <title xml:lang="en">Cron and At Daemons</title>
       <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The cron and at services are used to allow commands to be executed at a later time. The cron service is required by almost all systems to perform necessary maintenance tasks, while at may or may not be required on a given system. Both daemons should be configured defensively. </description>
-      <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-160" selected="false" weight="10.000000">
+      <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-160" selected="false" weight="10.000000" role="full" severity="unknown">
         <title xml:lang="en">Cron and At Daemons</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The crond service should be enabled or disabled as appropriate.</description>
         <ident system="http://cce.mitre.org">CCE-4324-0</ident>
@@ -2508,7 +2508,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.4.1" hidden="false">
         <title xml:lang="en">Disable anacron if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is this a machine which is designed to run all the time, such as a server or a workstation which is left on at night? If so: # yum erase anacron The anacron subsystem is designed to provide cron functionality for machines which may be shut down during the normal times that system cron jobs run, frequently in the middle of the night. Laptops and workstations which are shut down at night should keep anacron enabled, so that standard system cron jobs will run when the machine boots. However, on machines which do not need this additional functionality, anacron represents another piece of privileged software which could contain vulnerabilities. Therefore, it should be removed when possible to reduce system risk. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-161" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-161" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable anacron if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The anacron service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4406-5</ident>
@@ -2516,7 +2516,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:162" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-162" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-162" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable anacron if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The anacron package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4428-9</ident>
@@ -2528,7 +2528,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.4.2" hidden="false">
         <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">1. Restrict the permissions on the primary system crontab file: # chown root:root /etc/crontab # chmod 600 /etc/crontab 2. If anacron has not been removed, restrict the permissions on its primary configuration file: # chown root:root /etc/anacrontab # chmod 600 /etc/anacrontab 3. Restrict the permission on all system crontab directories: # cd /etc # chown -R root:root cron.hourly cron.daily cron.weekly cron.monthly cron.d # chmod -R go-rwx cron.hourly cron.daily cron.weekly cron.monthly cron.d 4. Restrict the permissions on the spool directory for user crontab files: # chown root:root /var/spool/cron # chmod -R go-rwx /var/spool/cron Cron and anacron make use of a number of configuration files and directories. The system crontabs need only be edited by root, and user crontabs are edited using the setuid root crontab command. If unprivileged users can modify system cron configuration files, they may be able to gain elevated privileges, so all unnecessary access to these files should be disabled. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-163" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-163" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.monthly file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-4322-4</ident>
@@ -2536,7 +2536,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:164" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-164" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-164" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/cron.daily should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4450-3</ident>
@@ -2544,7 +2544,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:165" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-165" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-165" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.weekly file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-4331-5</ident>
@@ -2552,7 +2552,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:166" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-166" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-166" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/crontab file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-3851-3</ident>
@@ -2560,7 +2560,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:167" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-167" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-167" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/anacrontab file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-4379-4</ident>
@@ -2568,7 +2568,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:168" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-168" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-168" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/crontab should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4388-5</ident>
@@ -2576,7 +2576,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:169" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-169" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-169" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.hourly file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-4054-3</ident>
@@ -2584,7 +2584,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:170" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-170" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-170" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.monthly file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-4441-2</ident>
@@ -2592,7 +2592,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:171" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-171" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-171" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.d file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-4212-7</ident>
@@ -2600,7 +2600,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:172" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-172" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-172" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.d file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-4380-2</ident>
@@ -2608,7 +2608,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:173" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-173" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-173" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.weekly file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-3833-1</ident>
@@ -2616,7 +2616,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:174" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-174" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-174" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/anacrontab file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-3604-6</ident>
@@ -2624,7 +2624,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:175" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-175" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-175" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/cron.hourly should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4106-1</ident>
@@ -2632,7 +2632,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:176" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-176" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-176" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.hourly file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-3983-4</ident>
@@ -2640,7 +2640,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:177" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-177" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-177" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/crontab file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-3626-9</ident>
@@ -2648,7 +2648,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:178" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-178" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-178" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.daily file should be owned by the appropriate user.</description>
           <ident system="http://cce.mitre.org">CCE-4022-0</ident>
@@ -2656,7 +2656,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:179" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-179" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-179" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/anacrontab should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4304-2</ident>
@@ -2664,7 +2664,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:180" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-180" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-180" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/cron.weekly should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4203-6</ident>
@@ -2672,7 +2672,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:181" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-181" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-181" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/cron.monthly should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4251-5</ident>
@@ -2680,7 +2680,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:182" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-182" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-182" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/cron.daily file should be owned by the appropriate group.</description>
           <ident system="http://cce.mitre.org">CCE-3481-9</ident>
@@ -2688,7 +2688,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:183" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-183" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-183" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Restrict Permissions on Files Used by cron</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/cron.d should be set correctly.</description>
           <ident system="http://cce.mitre.org">CCE-4250-7</ident>
@@ -2711,7 +2711,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.5.1.1" hidden="false">
           <title xml:lang="en">Disable and Remove OpenSSH Software </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Disable and remove openssh-server with the commands: # chkconfig sshd off # yum erase openssh-server Users of the system will still be able to use the SSH client program /usr/bin/ssh to access SSH servers on other systems. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-184" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-184" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable and Remove OpenSSH Software </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The sshd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4268-9</ident>
@@ -2719,7 +2719,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:185" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-185" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-185" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable and Remove OpenSSH Software </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH should be installed or uninstalled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4272-1</ident>
@@ -2731,7 +2731,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.5.1.2" hidden="false">
           <title xml:lang="en">Remove SSH Server iptables Firewall Exception </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the files /etc/sysconfig/iptables and /etc/sysconfig/ip6tables (if IPv6 is in use). In each file, locate and delete the line: -A RH-Firewall-1-INPUT -m state --state NEW -m tcp -p tcp --dport 22 -j ACCEPT By default, inbound connections to SSH’s port are allowed. If the SSH server is not being used, this exception should be removed from the firewall configuration. See Section 2.5.5 for more information about Iptables. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-186" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-186" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove SSH Server iptables Firewall Exception </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Inbound connections to the ssh port should be allowed or denied as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4295-2</ident>
@@ -2747,7 +2747,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.5.2.1" hidden="false">
           <title xml:lang="en">Ensure Only Protocol 2 Connections Allowed </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Only SSH protocol version 2 connections should be permitted. Version 1 of the protocol contains security vulnerabilities. The default setting shipped in the configuration file is correct, but it is important enough to check. Verify that the following line appears: Protocol 2 </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-187" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-187" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Ensure Only Protocol 2 Connections Allowed </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH version 1 protocol support should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4325-7</ident>
@@ -2763,7 +2763,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.5.2.3" hidden="false">
           <title xml:lang="en">Set Idle Timeout Interval for User Logins </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH allows administrators to set an idle timeout interval. After this interval has passed, the idle user will be automatically logged out. Find and edit the following lines in /etc/ssh/sshd config as follows: ClientAliveInterval interval ClientAliveCountMax 0 The timeout interval is given in seconds. To have a timeout of 5 minutes, set interval to 300. If a shorter timeout has already been set for the login shell, as in Section 2.3.5.5, that value will prempt any SSH setting made here. Keep in mind that some processes may stop SSH from correctly detecting that the user is idle. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-188" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-188" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Set Idle Timeout Interval for User Logins </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The SSH idle timout interval should be set to an appropriate value</description>
             <ident system="http://cce.mitre.org">CCE-3845-5</ident>
@@ -2775,7 +2775,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.5.2.4" hidden="false">
           <title xml:lang="en">Disable .rhosts Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH can emulate the behavior of the obsolete rsh command in allowing users to enable insecure access to their accounts via .rhosts files. To ensure that this behavior is disabled, add or correct the following line: IgnoreRhosts yes </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-189" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-189" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable .rhosts Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Emulation of the rsh command through the ssh server should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4475-0</ident>
@@ -2787,7 +2787,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.5.2.5" hidden="false">
           <title xml:lang="en">Disable Host-Based Authentication </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH’s cryptographic host-based authentication is slightly more secure than .rhosts authentication, since hosts are cryptographically authenticated. However, it is not recommended that hosts unilaterally trust one another, even within an organization. To disable host-based authentication, add or correct the following line: HostbasedAuthentication no </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-190" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-190" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Host-Based Authentication </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH host-based authentication should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4370-3</ident>
@@ -2799,7 +2799,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.5.2.6" hidden="false">
           <title xml:lang="en">Disable root Login via SSH </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The root user should never be allowed to login directly over a network, as this both reduces auditable information about who ran privileged commands on the system and allows direct attack attempts on root’s password. To disable root login via SSH, add or correct the following line: PermitRootLogin no </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-191" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-191" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable root Login via SSH </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Root login via SSH should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4387-7</ident>
@@ -2811,7 +2811,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.5.2.7" hidden="false">
           <title xml:lang="en">Disable Empty Passwords</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To explicitly disallow remote login from accounts with empty passwords, add or correct the following line: PermitEmptyPasswords no Measures should also be taken to disable accounts with empty passwords system-wide, as described in Section 2.3.1.5. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-192" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-192" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Empty Passwords</title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Remote connections from accounts with empty passwords should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3660-8</ident>
@@ -2823,7 +2823,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.5.2.8" hidden="false">
           <title xml:lang="en">Enable a Warning Banner </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Section 2.3.7 contains information on how to create an appropriate warning banner. To enable a warning banner, add or correct the following line: Banner /etc/issue </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-193" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-193" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable a Warning Banner </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">SSH warning banner should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4431-3</ident>
@@ -2847,7 +2847,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.6.1.1" hidden="false">
           <title xml:lang="en">Disable X Windows at System Boot </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/inittab, and correct the line id:5:initdefault: to: id:3:initdefault: This action changes the default boot runlevel of the system from 5 to 3. These two runlevels should be identical except that runlevel 5 starts X on boot, while runlevel 3 does not. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-194" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-194" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable X Windows at System Boot </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">X Windows should be enabled or disabled at system boot as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4462-8</ident>
@@ -2859,7 +2859,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.6.1.2" hidden="false">
           <title xml:lang="en">Remove X Windows from the System if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Remove the X11 RPMs from the system: # yum groupremove "X Window System" As long as X.org remains installed on the system, users can still run X Windows by typing startx at the shell prompt. This may run X Windows using configuration settings which are less secure than the system defaults. Therefore, if the machine is a dedicated server which does not need to provide graphical logins at all, it is safest to remove the X.org software entirely. The command given here will remove over 100 packages. It should safely and effectively remove X from machines which do not need it. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-195" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-195" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Remove X Windows from the System if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">X Windows should be installed or removed as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4422-2</ident>
@@ -2899,7 +2899,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.7.1.1" hidden="false">
           <title xml:lang="en">Disable Avahi Server Software </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Issue the command: # chkconfig avahi-daemon off </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-196" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-196" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Avahi Server Software </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The avahi-daemon service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4365-3</ident>
@@ -2919,7 +2919,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.7.2.1" hidden="false">
           <title xml:lang="en">Serve Only via Required Protocol </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting in the configuration file allows Avahi to use both IPv4 and IPv6 sockets. If you are using only IPv4, edit /etc/avahi/avahi-daemon.conf and ensure the following line exists in the [server] section: use-ipv6=no Similarly, if you are using only IPv6, disable IPv4 sockets with the line: use-ipv4=no </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-197" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-197" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Serve Only via Required Protocol </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Avahi daemon should be configured to serve via Ipv6 or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4136-8</ident>
@@ -2927,7 +2927,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:202" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-198" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-198" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Serve Only via Required Protocol </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Avahi daemon should be configured to serve via Ipv4 or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4409-9</ident>
@@ -2939,7 +2939,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.7.2.2" hidden="false">
           <title xml:lang="en">Check Responses TTL Field '</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi can be set to ignore IP packets unless their TTL field is 255. To make Avahi ignore packets unless the TTL field is 255, edit /etc/avahi/avahi-daemon.conf and ensure the following line appears in the [server] section: check-response-ttl=yes This helps to ensure that only mDNS responses from the local network are processed, because the TTL field in a packet is decremented from its initial value of 255 whenever it is routed from one network to another. Although a properly-configured router or firewall should not allow mDNS packets into the local network at all, this option provides another check to ensure they are not trusted. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-199" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-199" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Check Responses' TTL Field </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi should be configured to accept packets with a TTL field not equal to 255 or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4426-3</ident>
@@ -2951,7 +2951,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.7.2.3" hidden="false">
           <title xml:lang="en">Prevent Other Programs from Using Avahis Port '</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi can stop other mDNS stacks from running on the host by preventing other processes from binding to port 5353. To prevent other mDNS stacks from running, edit /etc/avahi/avahi-daemon.conf and ensure the following line appears in the [server] section: disallow-other-stacks=yes This is designed to help ensure that only Avahi is responsible for mDNS traffic coming from that port on the system. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-200" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-200" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Prevent Other Programs from Using Avahi's Port </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi should be configured to allow other stacks from binding to port 5353 or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4193-9</ident>
@@ -2963,7 +2963,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.7.2.4" hidden="false">
           <title xml:lang="en">Disable Publishing if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default setting in the configuration file allows the avahi-daemon to send information about the local host, such as its address records and the services it offers, to the local network. To stop sending this information but still allow Avahi to query the network for services, ensure the configuration file includes the following line in the [publish] section: disable-publishing=yes This line may be particularly useful if Avahi is needed for printer discovery, but not to advertise services. This configuration is highly recommended for client systems that should not advertise their services (or existence). </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-201" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-201" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Publishing if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of local information should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4444-6</ident>
@@ -2975,7 +2975,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.7.2.5" hidden="false">
           <title xml:lang="en">Restrict Published Information </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If it is necessary to publish some information to the network, it should not be joined by any extraneous information, or by information supplied by a non-trusted source on the system. Prevent user applications from using Avahi to publish services by adding or correcting the following line in the [publish] section: disable-user-service-publishing=yes Implement as many of the following lines as possible, to restrict the information published by Avahi: publish-addresses=no publish-hinfo=no publish-workstation=no publish-domain=no Inspect the files in the directory /etc/avahi/services/. Unless there is an operational need to publish information about each of these services, delete the corresponding file. These options should be used even if publishing is disabled entirely via disable-publishing, since that option prevents publishing attempts from succeeding, while these options prevent the attempts from being made in the first place. Using both approaches is recommended for completeness. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-202" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-202" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Published Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of local information by user applications should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4352-1</ident>
@@ -2983,7 +2983,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:207" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-203" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-203" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Published Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of hardware information should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4433-9</ident>
@@ -2991,7 +2991,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:208" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-204" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-204" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Published Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of workstation name should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4451-1</ident>
@@ -2999,7 +2999,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:209" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-205" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-205" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Published Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of IP addresses should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4341-4</ident>
@@ -3007,7 +3007,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:210" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-206" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-206" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Published Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Avahi publishing of domain name should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4358-8</ident>
@@ -3024,7 +3024,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.8.1" hidden="false">
         <title xml:lang="en">Disable the CUPS Service if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Do you need the ability to print from this machine or to allow others to print to it? If not: # chkconfig cups off </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-207" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-207" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable the CUPS Service if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The cups service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4112-9</ident>
@@ -3036,7 +3036,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.8.2" hidden="false">
         <title xml:lang="en">Disable Firewall Access to Printing Service if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Does this system need to operate as a network print server? If not, edit the files /etc/sysconfig/iptables and /etc/sysconfig/ip6tables (if IPv6 is in use). In each file, locate and delete the lines: -A RH-Firewall-1-INPUT -p udp -m udp --dport 631 -j ACCEPT -A RH-Firewall-1-INPUT -p tcp -m tcp --dport 631 -j ACCEPT By default, inbound connections to the Internet Printing Protocol port are allowed. If the print server does not need to be accessed, either because the machine is not running the print service at all or because the machine is not providing a remote network printer to other machines, this exception should be removed from the firewall configuration. See Section 2.5.5 for more information about the Iptables firewall. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-208" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-208" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Firewall Access to Printing Service if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Firewall access to printing service should be enabled or disabled as appropriate</description>
           <ident system="http://cce.mitre.org">CCE-3649-1</ident>
@@ -3054,7 +3054,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.8.3.1.1" hidden="false">
             <title xml:lang="en">Disable Printer Browsing Entirely if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To disable printer browsing entirely, edit the CUPS configuration file, located at /etc/cups/cupsd.conf: Browsing Off BrowseAllow none The CUPS print service can be configured to broadcast a list of available printers to the network. Other machines on the network, also running the CUPS print service, can be configured to listen to these broadcasts and add and configure these printers for immediate use. By disabling this browsing capability, the machine will no longer generate or receive such broadcasts. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-209" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-209" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Printer Browsing Entirely if Possible </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Remote print browsing should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4420-6</ident>
@@ -3062,7 +3062,7 @@
                 <check-content-ref name="oval:gov.irs.rhel5:def:215" href="scap-rhel5-oval.xml"/>
               </check>
             </Rule>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-210" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-210" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Printer Browsing Entirely if Possible </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">CUPS should be allowed or denied the ability to listen for Incoming printer information as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4407-3</ident>
@@ -3095,7 +3095,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.8.4.1" hidden="false">
           <title xml:lang="en">Disable HPLIP Service if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Since the HPIJS driver will still function without the added HPLIP service, HPLIP should be disabled unless the specific higher level functions that HPLIP provides are needed by a non-PostScript HP printer on the system. # chkconfig hplip off Note: If installing the HPLIP package from scratch, it should be noted that HPIJS can be installed directly without HPLIP. Please see the FAQ at the HPLIP web site at http://hplip.sourceforge.net/faqs.html for more information on how to do this. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-211" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-211" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable HPLIP Service if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The hplip service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4425-5</ident>
@@ -3112,7 +3112,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.9.1" hidden="false">
         <title xml:lang="en">Disable DHCP Client if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">For each interface IFACE on the system (e.g. eth0), edit /etc/sysconfig/network-scripts/ifcfg-IFACE and make the following changes: 1. Correct the BOOTPROTO line to read: BOOTPROTO=static 2. Add or correct the following lines, substituting the appropriate values based on your site’s addressing scheme: NETMASK=255.255.255.0 IPADDR=192.168.1.2 GATEWAY=192.168.1.1 DHCP is the default network configuration method provided by the system installer, so it may be enabled on many systems. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-212" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-212" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable DHCP Client if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dhcp client service should be enabled or disabled as appropriate for each interface.</description>
           <ident system="http://cce.mitre.org">CCE-4191-3</ident>
@@ -3132,7 +3132,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.9.3" hidden="false">
         <title xml:lang="en">Disable DHCP Server if possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If the dhcp package has been installed on a machine which does not need to operate as a DHCP server, disable the daemon: # chkconfig dhcpd off If possible, remove the software as well: # yum erase dhcp The DHCP server dhcpd is not installed or activated by default. If the software was installed and activated, but the system does not need to act as a DHCP server, it should be disabled and removed. Unmanaged DHCP servers will provide faulty information to clients, interfering with the operation of a legitimate site DHCP server if there is one, or causing misconfigured machines to exhibit unpredictable behavior if there is not. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-213" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-213" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable DHCP Server if possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dhcpd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4336-4</ident>
@@ -3140,7 +3140,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:219" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-214" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-214" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable DHCP Server if possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dhcp package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4464-4</ident>
@@ -3155,7 +3155,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.9.4.1" hidden="false">
           <title xml:lang="en">Do Not Use Dynamic DNS </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To prevent the DHCP server from receiving DNS information from clients, edit /etc/dhcpd.conf, and add or correct the following global option: ddns-update-style none; The Dynamic DNS protocol is used to remotely update the data served by a DNS server. DHCP servers can use Dynamic DNS to publish information about their clients. This setup carries security risks, and its use is not recommended. If Dynamic DNS must be used despite the risks it poses, it is critical that Dynamic DNS transactions be protected using TSIG or some other cryptographic authentication mechanism. See Section 3.14 for more information about DNS servers, including further information about TSIG and Dynamic DNS. Also see dhcpd.conf(5) for more information about protecting the DHCP server from passing along malicious DNS data from its clients. Note: The ddns-update-style option controls only whether the DHCP server will attempt to act as a Dynamic DNS client. As long as the DNS server itself is correctly configured to reject DDNS attempts, an incorrect ddns-update-style setting on the client is harmless (but should be fixed as a best practice). </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-215" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-215" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Do Not Use Dynamic DNS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dynamic DNS feature of the DHCP server should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4257-2</ident>
@@ -3167,7 +3167,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.9.4.2" hidden="false">
           <title xml:lang="en">Deny Decline Messages </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/dhcpd.conf and add or correct the following global option to prevent the DHCP server from responding the DHCPDECLINE messages, if possible: deny declines; The DHCPDECLINE message can be sent by a DHCP client to indicate that it does not consider the lease offered by the server to be valid. By issuing many DHCPDECLINE messages, a malicious client can exhaust the DHCP server’s pool of IP addresses, causing the DHCP server to forget old address allocations. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-216" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-216" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Deny Decline Messages </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">DHCPDECLINE messages should be accepted or denied by the DHCP server as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4403-2</ident>
@@ -3179,7 +3179,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.9.4.3" hidden="false">
           <title xml:lang="en">Deny BOOTP Queries </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Unless your network needs to support older BOOTP clients, disable support for the bootp protocol by adding or correcting the global option: deny bootp; The bootp option tells dhcpd to respond to BOOTP queries. If support for this simpler protocol is not needed, it should be disabled to remove attack vectors against the DHCP server. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-217" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-217" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Deny BOOTP Queries </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">BOOTP queries should be accepted or denied by the DHCP server as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4345-5</ident>
@@ -3191,7 +3191,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.9.4.4" hidden="false">
           <title xml:lang="en">Minimize Served Information </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/dhcpd.conf. Examine each address range section within the file, and ensure that the following options are not defined unless there is an operational need to provide this information via DHCP: option domain-name option domain-name-servers option nis-domain option nis-servers option ntp-servers option routers option time-offset Because the configuration information provided by the DHCP server could be maliciously provided to clients by a rogue DHCP server, the amount of information provided via DHCP should be minimized. Remove these definitions from the DHCP server configuration to ensure that legitimate clients do not unnecessarily rely on DHCP for this information. Note: By default, the RHEL5 client installation uses DHCP to request much of the above information from the DHCP server. In particular, domain-name, domain-name-servers, and routers are configured via DHCP. These settings are typically necessary for proper network functionality, but are also usually static across machines at a given site. See Section 3.9.2.1 for a description of how to configure static site information within the DHCP client configuration. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-218" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-218" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Domain name server information should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3724-2</ident>
@@ -3199,7 +3199,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:224" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-219" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-219" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Default routers should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4243-2</ident>
@@ -3207,7 +3207,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:225" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-220" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-220" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Domain name should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4389-3</ident>
@@ -3215,7 +3215,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:226" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-221" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-221" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">NIS domain should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3913-1</ident>
@@ -3223,7 +3223,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:227" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-222" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-222" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">NIS servers should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4169-9</ident>
@@ -3231,7 +3231,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:228" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-223" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-223" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Time offset should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4318-2</ident>
@@ -3239,7 +3239,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:229" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-224" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-224" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Minimize Served Information </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">NTP servers should be sent or not sent by the DHCP server as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4319-0</ident>
@@ -3251,7 +3251,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.9.4.5" hidden="false">
           <title xml:lang="en">Configure Logging </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Ensure that the following line exists in /etc/syslog.conf: daemon.* /var/log/daemon.log Configure logwatch or other log monitoring tools to summarize error conditions reported by the dhcpd process. By default, dhcpd logs notices to the daemon facility. Sending all daemon messages to a dedicated log file is part of the syslog configuration outlined in Section 2.6.1.1. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-225" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-225" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure Logging </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">dhcpd logging should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3733-3</ident>
@@ -3290,7 +3290,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.10.2.2.1" hidden="false">
             <title xml:lang="en">Enable the NTP Daemon </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If this machine is an NTP server, ensure that ntpd is enabled at boot time: # chkconfig ntpd on </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-226" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-226" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Enable the NTP Daemon </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ntpd service should be enabled or disabled as appropriate.</description>
               <ident system="http://cce.mitre.org">CCE-4376-0</ident>
@@ -3302,7 +3302,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.10.2.2.2" hidden="false">
             <title xml:lang="en">Deny All Access to ntpd by Default </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/ntp.conf. Prepend or correct the following line: restrict default ignore Since ntpd is a complex software package which listens for network connections and runs as root, it must be protected from network access by unauthorized machines. This setting uses ntpd’s internal authorization to deny all access to any machine, server or client, which is not specifically authorized by other policy settings. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-227" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-227" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Deny All Access to ntpd by Default </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Network access to ntpd should be allowed or denied as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4134-3</ident>
@@ -3314,7 +3314,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.10.2.2.3" hidden="false">
             <title xml:lang="en">Specify a Remote NTP Server for Time Data </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Find the IP address, server-ip , of an appropriate remote NTP server. Edit the file /etc/ntp.conf, and add or correct the following lines: restrict server-ip mask 255.255.255.255 nomodify notrap noquery server server-ip If your site does not require time data to be accurate, but merely to be synchronized among local machines, this step can be omitted, and the NTP server will default to providing time data from the local clock. However, it is a good idea to periodically synchronize the clock to some source of accurate time, even if it is not appropriate to do so automatically. The previous step disabled all remote access to this NTP server’s state data. This NTP server must contact a remote server to obtain accurate data, so NTP’s configuration must allow that remote data to be used to modify the system clock. The restrict line changes the default access permissions for that remote server. The server line specifies the remote server as the preferred NTP server for time data. If you intend to synchronize to more than one server, specify restrict and server lines for each server. Note: It would be possible to specify a hostname, rather than an IP address, for the server field. However, the restrict setting applies only to network blocks of IP addresses, so it is considered more maintainable to use the IP address in both fields. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-228" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-228" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Specify a Remote NTP Server for Time Data </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">A remote NTP Server for time synchronization should be specified or not as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4385-1</ident>
@@ -3335,7 +3335,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.10.3.1" hidden="false">
           <title xml:lang="en">Obtain NTP Software </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If your site intends to use the OpenNTPD implementation, it is necessary to compile and install the software. (If your site intends to use the reference NTP implementation, no installation is necessary.) 1. Obtain the software by downloading an appropriate source version, openntpd-version .tar.gz, from http://www.openntpd.org/portable.html. 2. Unpack the source code: $ tar xzf openntpd-version .tar.gz 3. Configure and compile the source. (By default, the code will be compiled for installation into /usr/ local): $ cd openntpd-version $ ./configure --with-privsep-user=ntp $ make 4. As root, install the resulting program into /usr/local: # make install The configuration option --with-privsep-user=ntp tells OpenNTPD to use the existing system account ntp for the non-root portion of its operation. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-229" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-229" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Obtain NTP Software </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">OpenNTPD should be installed or uninstalled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4032-9</ident>
@@ -3350,7 +3350,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.10.3.2.1" hidden="false">
             <title xml:lang="en">Enable the NTP Daemon </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/rc.local. Add or correct the following line: /usr/local/sbin/ntpd -s </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-230" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-230" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Enable the NTP Daemon </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ntp daemon should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4424-8</ident>
@@ -3362,7 +3362,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.10.3.2.2" hidden="false">
             <title xml:lang="en">Configure the Client NTP Daemon to Use the Local Server</title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /usr/local/etc/ntpd.conf. Add or correct the following line: server local-server.example.com where local-server.example.com is the hostname of the site’s local NTP or SNTP server. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-231" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-231" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Configure the Client NTP Daemon to Use the Local Server</title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ntp daemon synchronization server should be set appropriately</description>
               <ident system="http://cce.mitre.org">CCE-3487-6</ident>
@@ -3397,7 +3397,7 @@
     <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.11" hidden="false">
       <title xml:lang="en">Mail Transfer Agent</title>
       <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Mail servers are used to send and receive mail over a network on behalf of site users. Mail is a very common service, and MTAs are frequent targets of network attack. Ensure that machines are not running MTAs unnecessarily, and configure needed MTAs as defensively as possible. </description>
-      <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-232" selected="false" weight="10.000000">
+      <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-232" selected="false" weight="10.000000" role="full" severity="unknown">
         <title xml:lang="en">Mail Transfer Agent</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The sendmail service should be enabled or disabled as appropriate.</description>
         <ident system="http://cce.mitre.org">CCE-4416-4</ident>
@@ -3415,7 +3415,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.11.2.1" hidden="false">
           <title xml:lang="en">Disable the Listening Sendmail Daemon </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/sysconfig/sendmail. Add or modify the line: DAEMON=no The MTA performs two functions: listening over a network for incoming SMTP e-mail requests, and sending mail from the local machine. Since outbound mail may be delayed due to network outages or other problems, the outbound MTA runs in a queue-only mode, in which it periodically attempts to resend any delayed mail. Setting DAEMON=no tells sendmail to execute only the queue runner on this machine, and never to receive SMTP mail requests. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-233" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-233" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable the Listening Sendmail Daemon </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The listening sendmail daemon should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4293-7</ident>
@@ -3571,7 +3571,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.12.3.1" hidden="false">
           <title xml:lang="en">Install OpenLDAP Server RPM </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is this machine the OpenLDAP server? If so: # yum install openldap-servers # chkconfig ldap on The openldap-servers RPM is not installed by default on RHEL5 machines. It is needed only by the OpenLDAP server, not by the clients which use LDAP for authentication. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-234" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-234" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Install OpenLDAP Server RPM </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ldap service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3501-4</ident>
@@ -3635,7 +3635,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.12.3.7" hidden="false">
           <title xml:lang="en">Correct Permissions on LDAP Server Files </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Correct the permissions on the ldap server’s files: # chown ldap:root /var/lib/ldap/* Some manual methods of inserting information into the LDAP database may leave these files with incorrect permissions. This will prevent slapd from starting correctly. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-235" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-235" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Correct Permissions on LDAP Server Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /var/lib/ldap/* files should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-4484-2</ident>
@@ -3643,7 +3643,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:253" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-236" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-236" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Correct Permissions on LDAP Server Files </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /var/lib/ldap/* files should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-4502-1</ident>
@@ -3671,7 +3671,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.13.1.1" hidden="false">
           <title xml:lang="en">Disable Services Used Only by NFS </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If NFS is not needed, perform the following steps to disable NFS client daemons: # chkconfig nfslock off # chkconfig rpcgssd off # chkconfig rpcidmapd off The nfslock, rpcgssd, and rpcidmapd daemons all perform NFS client functions. All of these daemons run with elevated privileges, and many listen for network connections. If they are not needed, they should be disabled to improve system security posture. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-237" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-237" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Services Used Only by NFS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nfslock service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4396-8</ident>
@@ -3679,7 +3679,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:255" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-238" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-238" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Services Used Only by NFS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rpcgssd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3535-2</ident>
@@ -3687,7 +3687,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:256" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-239" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-239" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Services Used Only by NFS </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rpcidmapd service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-3568-3</ident>
@@ -3699,7 +3699,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.13.1.2" hidden="false">
           <title xml:lang="en">Disable netfs if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Determine whether any network filesystems handled by netfs are mounted on this system: # mount -t nfs,nfs4,smbfs,cifs,ncpfs If this command returns no output, disable netfs to improve system security: # chkconfig netfs off The netfs script manages the boot-time mounting of several types of networked filesystems, of which NFS and Samba (see Section 3.18) are the most common. If these filesystem types are not in use, the script can be disabled, protecting the system somewhat against accidental or malicious changes to /etc/fstab and against flaws in the netfs script itself. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-240" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-240" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable netfs if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The netfs service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4533-6</ident>
@@ -3711,7 +3711,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.13.1.3" hidden="false">
           <title xml:lang="en">Disable RPC Portmapper if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If: * NFS is not needed * The site does not rely on NIS for authentication information, and * The machine does not run any other RPC-based service then disable the RPC portmapper service: # chkconfig portmap off By design, the RPC model does not require particular services to listen on fixed ports, but instead uses a daemon, portmap, to tell prospective clients which ports to use to contact the services they are trying to reach. This model weakens system security by introducing another privileged daemon which may be directly attacked, and is unnecessary because RPC was never adopted by enough services to risk using up all the ports on a system. Unfortunately, the portmapper is central to RPC design, so it cannot be disabled if your site is using any RPCbased services, including NFS, NIS (see Section 3.2.4 for information about NIS, which is not recommended), or any third-party or custom RPC-based program. If none of these programs are in use, however, portmap should be disabled to improve system security. In order to get more information about whether portmap may be disabled on a given host, query the local portmapper using the command: # rpcinfo -p If the only services listed are portmapper and status, it is safe to disable the portmapper. If other services are listed and your site is not running NFS or NIS, investigate these services and disable them if possible. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-241" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-241" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable RPC Portmapper if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The portmap service should be enabled or disabled as appropriate.</description>
             <ident system="http://cce.mitre.org">CCE-4550-0</ident>
@@ -3735,7 +3735,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.13.2.3" hidden="false">
           <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/sysconfig/nfs. Add or correct the following lines: LOCKD_TCPPORT=lockd-port LOCKD_UDPPORT=lockd-port MOUNTD_PORT=mountd-port RQUOTAD_PORT=rquotad-port STATD_PORT=statd-port STATD_OUTGOING_PORT=statd-outgoing-port where each X-port is a port which is not used by any other service on your network. Firewalling should be done at each host and at the border firewalls to protect the NFS daemons from remote access, since NFS servers should never be accessible from outside the organization. However, by default, the portmapper assigns each NFS service to a port dynamically at service startup time. Dynamic ports cannot be protected by port filtering firewalls such as iptables (Section 2.5.5). Therefore, restrict each service to always use a given port, so that firewalling can be done effectively. Note that, because of the way RPC is implemented, it is not possible to disable the portmapper even if ports are assigned statically to all RPC services. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-242" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-242" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The lockd service should be configured to use a static port or a dynamic portmapper port for TCP as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4559-1</ident>
@@ -3743,7 +3743,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:260" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-243" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-243" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The statd service should be configured to use an outgoing static port or an outgoing dynamic portmapper port as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4015-4</ident>
@@ -3751,7 +3751,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:261" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-244" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-244" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The statd service should be configured to use a static port or a dynamic portmapper port as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3667-3</ident>
@@ -3759,7 +3759,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:262" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-245" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-245" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The lockd service should be configured to use a static port or a dynamic portmapper port for UDP as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4310-9</ident>
@@ -3767,7 +3767,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:263" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-246" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-246" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The mountd service should be configured to use a static port or a dynamic portmapper port as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4438-8</ident>
@@ -3775,7 +3775,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:264" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-247" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-247" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Configure NFS Services to Use Fixed Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rquotad service should be configured to use a static port or a dynamic portmapper port as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3579-0</ident>
@@ -3791,7 +3791,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.13.3.1" hidden="false">
           <title xml:lang="en">Disable NFS Server Daemons </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en"># chkconfig nfs off # chkconfig rpcsvcgssd off There is no need to run the NFS server daemons except on a small number of properly secured machines designated as NFS servers. Ensure that these daemons are turned off on clients. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-248" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-248" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable NFS Server Daemons </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nfs service should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4473-5</ident>
@@ -3799,7 +3799,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:266" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-249" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-249" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable NFS Server Daemons </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The rpcsvcgssd service should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4491-7</ident>
@@ -3811,7 +3811,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.13.3.2" hidden="false">
           <title xml:lang="en">Mount Remote Filesystems with Restrictive Options </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the file /etc/fstab. For each filesystem whose type (column 3) is nfs or nfs4, add the text ,nodev,nosuid to the list of mount options in column 4. If appropriate, also add ,noexec. See Section 2.2.1.2 for a description of the effects of these options. In general, execution of files mounted via NFS should be considered risky because of the possibility that an adversary could intercept the request and substitute a malicious file. Allowing setuid files to be executed from remote servers is particularly risky, both for this reason and because it requires the clients to extend root-level trust to the NFS server. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-250" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-250" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Mount Remote Filesystems with Restrictive Options </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nodev option should be enabled or disabled for all NFS mounts as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4368-7</ident>
@@ -3819,7 +3819,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:268" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-251" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-251" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Mount Remote Filesystems with Restrictive Options </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The nosuid option should be enabled or disabled for all NFS mounts as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4024-6</ident>
@@ -3827,7 +3827,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:269" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-252" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-252" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Mount Remote Filesystems with Restrictive Options </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The noexec option should be enabled or disabled for all NFS mounts as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4526-0</ident>
@@ -3850,7 +3850,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.13.4.1.2" hidden="false">
             <title xml:lang="en">Use Root-Squashing on All Exports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/exports. Ensure that no line contains the option no root squash. If a filesystem is exported using root squashing, requests from root on the client are considered to be unprivileged (mapped to a user such as nobody). This provides some mild protection against remote abuse of an NFS server. Root squashing is enabled by default, and should not be disabled. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-253" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-253" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Use Root-Squashing on All Exports </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Root squashing should be enabled or disabled as appropriate for all NFS shares</description>
               <ident system="http://cce.mitre.org">CCE-4544-3</ident>
@@ -3862,7 +3862,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.13.4.1.3" hidden="false">
             <title xml:lang="en">Restrict NFS Clients to Privileged Ports </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/exports. Ensure that no line contains the option insecure. By default, Linux’s NFS implementation requires that all client requests be made from ports less than 1024. If your organization has control over machines connected to its network, and if NFS requests are prohibited at the border firewall, this offers some protection against malicious requests from unprivileged users. Therefore, the default should not be changed. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-254" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-254" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Restrict NFS Clients to Privileged Ports </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Restriction of NFS clients to privileged ports should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4465-1</ident>
@@ -3874,7 +3874,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.13.4.1.4" hidden="false">
             <title xml:lang="en">Export Filesystems Read-Only if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/exports. Ensure that every line contains the option ro and does not contain the option rw, unless there is an operational need for remote clients to modify that filesystem. If a filesystem is being exported so that users can view the files in a convenient fashion, but there is no need for users to edit those files, exporting the filesystem read-only removes an attack vector against the server. The default filesystem export mode is ro, so do not specify rw without a good reason. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-255" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-255" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Export Filesystems Read-Only if Possible </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Write access to NFS shares should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4350-5</ident>
@@ -3896,7 +3896,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.14.1" hidden="false">
         <title xml:lang="en">Disable DNS Server if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there an operational need for this machine to act as a DNS server for this site? If not, disable the software and remove it from the system: # chkconfig named off # yum erase bind DNS software should be disabled on any machine which does not need to be a nameserver. Note that the BIND DNS server software is not installed on RHEL5 by default. The remainder of this section discusses secure configuration of machines which must be nameservers. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-256" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-256" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable DNS Server if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The named service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3578-2</ident>
@@ -3904,7 +3904,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:274" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-257" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-257" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable DNS Server if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The bind package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4219-2</ident>
@@ -3927,7 +3927,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.14.3.2" hidden="false">
           <title xml:lang="en">Run DNS Software in a chroot Jail </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Install the bind-chroot package: # yum install bind-chroot Place a valid named.conf file inside the chroot jail: # cp /etc/named.conf /var/named/chroot/etc/named.conf # chown root:root /var/named/chroot/etc/named.conf # chmod 644 /var/named/chroot/etc/named.conf Create and populate an appropriate zone directory within the jail, based on the options directive. If your named.conf includes: options { directory "/path/to/DIRNAME "; ... } then copy that directory and its contents from the original zone directory: # cp -r /path/to/DIRNAME /var/named/chroot/DIRNAME Edit the file /etc/sysconfig/named. Add or correct the line: ROOTDIR=/var/named/chroot Chroot jails are not foolproof. However, they serve to make it more difficult for a compromised program to be used to attack the entire host. They do this by restricting a program’s ability to traverse the directory upward, so that files outside the jail are not visible to the chrooted process. Since RHEL5 supports a standard mechanism for placing BIND in a chroot jail, you should take advantage of this feature. Note: If you are running BIND in a chroot jail, then you should use the jailed named.conf as the primary nameserver configuration file. That is, when this guide recommends editing /etc/named.conf, you should instead edit /var/named/chroot/etc/named.conf. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-258" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-258" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Run DNS Software in a chroot Jail </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /var/named/chroot/etc/named.conf file should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3985-9</ident>
@@ -3935,7 +3935,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:276" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-259" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-259" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Run DNS Software in a chroot Jail </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /var/named/chroot/etc/named.conf should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4487-5</ident>
@@ -3943,7 +3943,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:277" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-260" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-260" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Run DNS Software in a chroot Jail </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /var/named/chroot/etc/named.conf file should be owned by the appropriate user.</description>
             <ident system="http://cce.mitre.org">CCE-4258-0</ident>
@@ -3979,7 +3979,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.14.4.5" hidden="false">
           <title xml:lang="en">Disable Dynamic Updates if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason to enable the risky dynamic update functionality? If not: Edit /etc/named.conf. For each zone specification, correct the following directive if necessary: zone "example.com " IN { allow-update { none; }; ... } Dynamic updates allow remote servers to add, delete, or modify any entries in your zone file. Therefore, they should be considered highly risky, and disabled unless there is a very good reason for their use. If dynamic updates must be allowed, IP-based ACLs are insufficient protection, since they are easily spoofed. Instead, use TSIG keys (see the previous section for an example), and consider using the update-policy directive to restrict changes to only the precise type of change needed. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-261" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-261" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable Dynamic Updates if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">LDAP's dynamic updates feature should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4399-2</ident>
@@ -3996,7 +3996,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.15.1" hidden="false">
         <title xml:lang="en">Disable vsftpd if Possible </title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for the machine to act as an FTP server? If not, disable vsftpd if it has been installed: # chkconfig vsftpd off </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-262" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-262" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable vsftpd if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The vsftpd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3919-8</ident>
@@ -4015,7 +4015,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.15.3.1" hidden="false">
           <title xml:lang="en">Enable Logging of All FTP Transactions </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the vsftpd configuration file. Add or correct the following configuration options: xferlog_std_format=NO log_ftp_protocol=YES The modifications above ensure that all commands sent to the ftp server are logged using the verbose vsftpd log format. The default vsftpd log file is /var/log/vsftpd.log. Note: If verbose logging to vsftpd.log is done, sparse logging of downloads to /var/log/xferlog will not also occur. However, the information about what files were downloaded is included in the information logged to vsftpd.log. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-263" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-263" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable Logging of All FTP Transactions </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Logging of vsftpd transactions should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4549-2</ident>
@@ -4027,7 +4027,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.15.3.2" hidden="false">
           <title xml:lang="en">Create Warning Banners for All FTP Users </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit the vsftpd configuration file. Add or correct the following configuration options: banner_file=/etc/issue See Section 2.3.7 for an explanation of banner file use. This setting will cause the system greeting banner to be used for FTP connections as well. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-264" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-264" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Create Warning Banners for All FTP Users </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">A warning banner for all FTP users should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4554-2</ident>
@@ -4042,7 +4042,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.15.3.3.1" hidden="false">
             <title xml:lang="en">Restrict Access to Anonymous Users if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for users to transfer files to/from their own accounts using FTP, rather than using a secure protocol like SCP/SFTP? If not: Edit the vsftpd configuration file. Add or correct the following configuration option: local_enable=NO If non-anonymous FTP logins are necessary, follow the guidance in the remainder of this section to secure these logins as much as possible. The use of non-anonymous FTP logins is strongly discouraged. Since SSH clients and servers are widely available, and since SSH provides support for a transfer mode which resembles FTP in user interface, there is no good reason to allow password-based FTP access. See Section 3.5 for more information about SSH. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-265" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-265" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Restrict Access to Anonymous Users if Possible </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Local user login to the vsftpd service should be enabled or disabled as appropriate</description>
               <ident system="http://cce.mitre.org">CCE-4443-8</ident>
@@ -4059,7 +4059,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.15.3.4" hidden="false">
           <title xml:lang="en">Disable FTP Uploads if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Is there a mission-critical reason for users to upload files via FTP? If not: Edit the vsftpd configuration file. Add or correct the following configuration options: write_enable=NO If FTP uploads are necessary, follow the guidance in the remainder of this section to secure these transactions as much as possible. Anonymous FTP can be a convenient way to make files available for universal download. However, it is less common to have a need to allow unauthenticated users to place files on the FTP server. If this must be done, it is necessary to ensure that files cannot be uploaded and downloaded from the same directory. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-266" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-266" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Disable FTP Uploads if Possible </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File uploads via vsftpd should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4461-0</ident>
@@ -4084,7 +4084,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.16.1" hidden="false">
         <title xml:lang="en">Disable Apache if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If Apache was installed and activated, but the system does not need to act as a web server, then it should be disabled and removed from the system: # chkconfig httpd off # yum erase httpd </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-267" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-267" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Apache if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The httpd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4338-0</ident>
@@ -4092,7 +4092,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:285" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-268" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-268" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Apache if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The httpd package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4514-6</ident>
@@ -4119,7 +4119,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.16.3.1" hidden="false">
           <title xml:lang="en">Restrict Information Leakage </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The ServerTokens and ServerSignature directives determine how much information the web server discloses about the configuration of the system. ServerTokens Prod restricts information in page headers, returning only the word “Apache.” ServerSignature Off keeps Apache from displaying the server version on error pages. It is a good security practice to limit the information provided to clients. Add or correct the following directives in /etc/httpd/conf/httpd.conf so that as little information as possible is released: ServerTokens Prod ServerSignature Off </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-269" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-269" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Information Leakage </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The apache2 server's ServerTokens value should be set appropriately</description>
             <ident system="http://cce.mitre.org">CCE-4474-3</ident>
@@ -4127,7 +4127,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:288" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-270" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-270" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict Information Leakage </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The apache2 server's ServerSignature value should be set appropriately</description>
             <ident system="http://cce.mitre.org">CCE-3756-4</ident>
@@ -4283,7 +4283,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.16.5.1" hidden="false">
           <title xml:lang="en">Restrict File and Directory Access </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Minimize access to critical Apache files and directories: # chmod 511 /usr/sbin/httpd # chmod 750 /var/log/httpd/ # chmod 750 /etc/httpd/conf/ # chmod 640 /etc/httpd/conf/* # chgrp -R apache /etc/httpd/conf </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-271" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-271" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict File and Directory Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/httpd/conf should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4509-6</ident>
@@ -4291,7 +4291,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:290" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-272" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-272" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict File and Directory Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /etc/httpd/conf/* should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4386-9</ident>
@@ -4299,7 +4299,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:291" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-273" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-273" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict File and Directory Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /usr/sbin/httpd should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4029-5</ident>
@@ -4307,7 +4307,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:292" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-274" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-274" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict File and Directory Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The /etc/httpd/conf/* files should be owned by the appropriate group.</description>
             <ident system="http://cce.mitre.org">CCE-3581-6</ident>
@@ -4315,7 +4315,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:293" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-275" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-275" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Restrict File and Directory Access </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">File permissions for /var/log/httpd should be set correctly.</description>
             <ident system="http://cce.mitre.org">CCE-4574-0</ident>
@@ -4344,7 +4344,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.17.1" hidden="false">
         <title xml:lang="en">Disable Dovecot if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If the system does not need to operate as an IMAP or POP3 server, disable and remove Dovecot if it was installed: # chkconfig dovecot off # yum erase dovecot </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-276" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-276" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Dovecot if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dovecot service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3847-1</ident>
@@ -4352,7 +4352,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:295" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-277" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-277" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Dovecot if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The dovecot package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4239-0</ident>
@@ -4367,7 +4367,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.17.2.1" hidden="false">
           <title xml:lang="en">Support Only the Necessary Protocols </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/dovecot.conf. Add or correct the following lines, replacing PROTOCOL with only the subset of protocols (imap, imaps, pop3, pop3s) required: protocols = PROTOCOL Dovecot supports the IMAP and POP3 protocols, as well as SSL-protected versions of those protocols. Configure the Dovecot server to support only the protocols needed by your site. If possible, require SSL protection for all transactions. The SSL protocol variants listen on alternate ports (995 instead of 110 for pop3s, and 993 instead of 143 for imaps), and require SSL-aware clients. An alternate approach is to listen on the standard port and require the client to use the STARTTLS command before authenticating. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-278" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-278" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Support Only the Necessary Protocols </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Dovecot should be configured to support the imaps protocol or not as necessary</description>
             <ident system="http://cce.mitre.org">CCE-4384-4</ident>
@@ -4375,7 +4375,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:297" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-279" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-279" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Support Only the Necessary Protocols </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Dovecot should be configured to support the pop3s protocol or not as necessary</description>
             <ident system="http://cce.mitre.org">CCE-3887-7</ident>
@@ -4383,7 +4383,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:298" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-280" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-280" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Support Only the Necessary Protocols </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Dovecot should be configured to support the pop3 protocol or not as necessary</description>
             <ident system="http://cce.mitre.org">CCE-4530-2</ident>
@@ -4391,7 +4391,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:299" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-281" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-281" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Support Only the Necessary Protocols </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Dovecot should be configured to support the imap protocol or not as necessary</description>
             <ident system="http://cce.mitre.org">CCE-4547-6</ident>
@@ -4418,7 +4418,7 @@
           <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.17.2.2.4" hidden="false">
             <title xml:lang="en">Disable Plaintext Authentication </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">To prevent Dovecot from attempting plaintext authentication of clients, edit /etc/dovecot.conf and add or correct the following line: disable_plaintext_auth = yes The disable plaintext auth command disallows login-related commands until an encrypted session has been negotiated using SSL. If client compatibility requires you to allow connections to the pop3 or imap ports, rather than the alternate SSL ports, you should use this command to require STARTTLS before authentication. </description>
-            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-282" selected="false" weight="10.000000">
+            <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-282" selected="false" weight="10.000000" role="full" severity="unknown">
               <title xml:lang="en">Disable Plaintext Authentication </title>
               <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Dovecot plaintext authentication of clients should be enabled or disabled as necessary</description>
               <ident system="http://cce.mitre.org">CCE-4552-6</ident>
@@ -4431,7 +4431,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.17.2.3" hidden="false">
           <title xml:lang="en">Enable Dovecot Options to Protect Against Code Flaws </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Edit /etc/dovecot.conf and add or correct the following line: login_process_per_connection = yes mail_drop_priv_before_exec = yes IMAP and POP3 are remote authenticated protocols, meaning that the server must accept remote connections from anyone, but provide substantial services only to clients who have successfully authenticated. To protect against security problems, Dovecot splits these functions into separate server processes. The imap-login and/or pop3-login processes accept connections from unauthenticated users, and only spawn imap or pop3 processes on successful authentication. However, the imap-login and pop3-login processes themselves may contain vulnerabilities. Since each of these processes operates as a daemon, handling multiple sequential client connections from different users, bugs in the code could allow unauthenticated users to steal credential data. If the login process per connection option is enabled, then a separate imap-login or pop3-login process is created for each new connection, protecting against this class of problems. This option has an efficiency cost, but is strongly recommended. If the mail drop priv before exec option is on, the imap-login or pop3-login process will drop privileges to the user’s ID after authentication and before executing the imap or pop3 process itself. Under some very limited circumstances, this could protect against privilege escalation by authenticated users. However, if the mail executable option is used to run code before starting each user’s session, it is important to drop privileges to prevent the custom code from running as root. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-283" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-283" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable Dovecot Options to Protect Against Code Flaws </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Dovecot option to drop privileges to user before executing mail process should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4371-1</ident>
@@ -4439,7 +4439,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:302" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-284" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-284" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Enable Dovecot Options to Protect Against Code Flaws </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Dovecot option to spawn a new login process per connection should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4410-7</ident>
@@ -4460,7 +4460,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.18.1" hidden="false">
         <title xml:lang="en">Disable Samba if Possible </title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If the Samba service has been enabled and will not be used, disable it: # chkconfig smb off Even after the Samba server package has been installed, it will remain disabled. Do not enable this service unless it is absolutely necessary to provide Microsoft Windows file and print sharing functionality. </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-285" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-285" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Samba if Possible </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The smb service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4551-8</ident>
@@ -4536,7 +4536,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.19.1" hidden="false">
         <title xml:lang="en">Disable Squid if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">If Squid was installed and activated, but the system does not need to act as a proxy server, then it should be disabled and removed: # chkconfig squid off # yum erase squid </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-286" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-286" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Squid if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The squid service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4556-7</ident>
@@ -4544,7 +4544,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:305" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-287" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-287" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable Squid if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The squid package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4076-6</ident>
@@ -4563,7 +4563,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.19.2.2" hidden="false">
           <title xml:lang="en">Verify Default Secure Settings </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Several security-enhancing settings in the Squid configuration file are enabled by default, but appear as comments in the configuration file (as mentioned in Section 3.19.2). In these instances, the explicit directive is not present, which means it is implicitly enabled. If you are operating with a default configuration file, this section can be ignored. Ensure that the following security settings are NOT explicitly changed from their default values: ftp_passive on ftp_sanitycheck on check_hostnames on request_header_max_size 20 KB reply_header_max_size 20 KB cache_effective_user squid cache_effective_group squid ignore_unknown_nameservers on ftp passive forces FTP passive connections. ftp sanitycheck performs additional sanity checks on FTP data connections. check hostnames ensures that hostnames meet RFC compliance. request header max size and reply header max size place an upper limit on HTTP header length, precautions against denial-of-service and buffer overflow vulnerabilities. cache effective user and cache effective group designate the EUID and EGID of Squid following initialization (it is essential that the EUID/EGID be set to an unprivileged sandbox account). ignore unknown nameservers checks to make sure that DNS responses come from the same IP the request was sent to. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-288" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-288" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to force FTP passive connections should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4454-5</ident>
@@ -4571,7 +4571,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:307" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-289" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-289" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid max request HTTP header length should be set to an appropriate value</description>
             <ident system="http://cce.mitre.org">CCE-4353-9</ident>
@@ -4579,7 +4579,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:308" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-290" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-290" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to check for RFC compliant hostnames should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4503-9</ident>
@@ -4587,7 +4587,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:309" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-291" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-291" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to ignore unknown nameservers should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3585-7</ident>
@@ -4595,7 +4595,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:310" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-292" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-292" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid max reply HTTP header length should be set to an appropriate value</description>
             <ident system="http://cce.mitre.org">CCE-4419-8</ident>
@@ -4603,7 +4603,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:311" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-293" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-293" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid EUID should be set to an appropriate user</description>
             <ident system="http://cce.mitre.org">CCE-3692-1</ident>
@@ -4611,7 +4611,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:312" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-294" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-294" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to perform FTP sanity checks should be enabled or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4459-4</ident>
@@ -4619,7 +4619,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:313" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-295" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-295" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Verify Default Secure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid GUID should be set to an appropriate group</description>
             <ident system="http://cce.mitre.org">CCE-4476-8</ident>
@@ -4631,7 +4631,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.19.2.3" hidden="false">
           <title xml:lang="en">Change Default Insecure Settings </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The default configuration settings for the following tags are considered to be weak security and NOT recommended. Add or modify the configuration file to include the following lines: allow_underscore off httpd_suppress_version_string on forwarded_for off log_mime_hdrs on allow underscore enforces RFC 1034 compliance on hostnames by disallowing the use of underscores. httpd suppress version string prevents Squid from revealing version information in web headers and error pages. forwarded for reveals proxy client IP addresses in HTTP headers and should be disabled to prevent the leakage of internal network configuration details. log mime hdrs enables logging of HTTP response/request headers. </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-296" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-296" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Change Default Insecure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to show proxy client IP addresses in HTTP headers should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4181-4</ident>
@@ -4639,7 +4639,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:315" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-297" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-297" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Change Default Insecure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to log HTTP MIME headers should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4577-3</ident>
@@ -4647,7 +4647,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:316" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-298" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-298" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Change Default Insecure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to allow underscores in hostnames should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4344-8</ident>
@@ -4655,7 +4655,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:317" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-299" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-299" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Change Default Insecure Settings </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The Squid option to suppress the httpd version string should be enabled or disabled as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4494-1</ident>
@@ -4671,7 +4671,7 @@
         <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.19.2.5" hidden="false">
           <title xml:lang="en">Access Control Lists (ACL) </title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Be very careful with the order of access control tags. Access control is handled top-down. The first rule that matches is the only rule adhered to. The last rule on the list defines the default behavior in the case of no rule match. The acl and http access tags are used in combination to allow filtering based on a series of access control lists. Squid has a list of default ACLs for localhost, SSL ports, and “safe” ports. Following the definition of these ACLs, a series of http access directives establish the following default filtering policy: * Allow cachemgr access only from localhost * Allow access to only ports in the “safe” access control list * Limit CONNECT method to SSL ports only * Allow access from localhost * Deny all other requests The default ACL policies are reasonable from a security standpoint. However, the number of ports listed as “safe” could be significantly trimmed depending on the needs of your network. Out of the box, ports 21, 70, 80, 210, 280, 443, 488, 591, 777, and 1025 through 65535 are all considered safe. Some of these ports are associated with deprecated or rarely used protocols. As such, this list could be trimmed to further tighten filtering. The following actions should be taken to tighten the ACL policies: 1. There is a filter line in the configuration file that is recommended but commented out. This line should be uncommented or added to prevent access to localhost from the proxy: http access deny to_localhost 2. An access list should be setup for the specific network or networks that the proxy is intended to serve. Only this subset of IP addresses should be allowed access. Add these lines where the following comment appears: # INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS acl your-network-acl-name src ip-range http_access allow your-network-acl-name Note: ip-range is of the format xxx.xxx.xxx.xxx/xx 3. Ensure that the final http access line to appear in the document is the following: http access deny all This guarantees that all traffic not meeting an explicit filtering rule is denied. Further filters should be established to meet the specific needs of a network, explicitly allowing access only where necessary. 4. Consult the chart below. Corresponding acl entries for unused protocols should be commented out and thus denied. Port Service Summary Recommendation 21 ftp File Transfer Protocol(FTP) is a widely used file transfer protocol. ALLOW 70 gopher The gopher protocol is a deprecated search and retrieval protocol that is almost extinct, with as few as 100 gopher servers present worldwide. Support for gopher is disabled in most modern browsers. DENY 80 http A web proxy needs to allow access to HTTP traffic. ALLOW 210 wais The Wide Area Information Server port is similar to gopher, serving as a text searching system to scour indexes on remote machines. Today, it is deprecated and nearly non-existent on the Internet. DENY 280 http-mgmt No documentation of any kind could be found on the obscure service that resides on this port. DENY 443 https SSL traffic is likely (and recommended) for any proxy and should be allowed. ALLOW 488 gss-http No documentation of any kind could be found on the obscure service that resides on this port. DENY 591 filemaker Filemaker is a database application originally offered by Apple in the 1980s. Although development continues and it remains in use today, it should be disabled if your network does not require such traffic. DENY the obscure service that resides on this port. DENY Port Service Summary Recommendation 1025-65535 unregistered ports Random high ports are used by a variety of applications and should be allowed. ALLOW </description>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-300" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-300" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow gss-http traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4511-2</ident>
@@ -4679,7 +4679,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:319" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-301" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-301" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow https traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4529-4</ident>
@@ -4687,7 +4687,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:320" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-302" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-302" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow wais traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-3610-3</ident>
@@ -4695,7 +4695,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:321" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-303" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-303" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow multiling http traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4466-9</ident>
@@ -4703,7 +4703,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:322" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-304" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-304" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow http traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4607-8</ident>
@@ -4711,7 +4711,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:323" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-305" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-305" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow ftp traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4255-6</ident>
@@ -4719,7 +4719,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:324" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-306" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-306" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow gopher traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4127-7</ident>
@@ -4727,7 +4727,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:325" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-307" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-307" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow filemaker traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4519-5</ident>
@@ -4735,7 +4735,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:326" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-308" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-308" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid proxy access to localhost should be allowed or denied as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4413-1</ident>
@@ -4743,7 +4743,7 @@
               <check-content-ref name="oval:gov.irs.rhel5:def:327" href="scap-rhel5-oval.xml"/>
             </check>
           </Rule>
-          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-309" selected="false" weight="10.000000">
+          <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-309" selected="false" weight="10.000000" role="full" severity="unknown">
             <title xml:lang="en">Access Control Lists (ACL) </title>
             <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">Squid should be configured to allow http-mgmt traffic or not as appropriate</description>
             <ident system="http://cce.mitre.org">CCE-4373-7</ident>
@@ -4784,7 +4784,7 @@
       <Group id="xccdf_org.open-scap_group_scap-rhel5-group-3.20.1" hidden="false">
         <title xml:lang="en">Disable SNMP Server if Possible</title>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The system includes an SNMP daemon that allows for its remote monitoring, though it not installed by default. If it was installed and activated, it is important that the software be disabled and removed. If there is not a mission-critical need for hosts at this site to be remotely monitored by a SNMP tool, then disable and remove SNMP as follows: # chkconfig snmpd off # yum erase net-snmpd </description>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-310" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-310" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable SNMP Server if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The snmpd service should be enabled or disabled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-3765-5</ident>
@@ -4792,7 +4792,7 @@
             <check-content-ref name="oval:gov.irs.rhel5:def:329" href="scap-rhel5-oval.xml"/>
           </check>
         </Rule>
-        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-311" selected="false" weight="10.000000">
+        <Rule id="xccdf_org.open-scap_rule_scap-rhel5-rule-311" selected="false" weight="10.000000" role="full" severity="unknown">
           <title xml:lang="en">Disable SNMP Server if Possible</title>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en">The net-smtp package should be installed or uninstalled as appropriate.</description>
           <ident system="http://cce.mitre.org">CCE-4404-0</ident>

--- a/tests/DS/test_sds_eval.sh
+++ b/tests/DS/test_sds_eval.sh
@@ -95,6 +95,9 @@ function test_eval_complex()
 	local result="$arf"
 	assert_exists 1 '//rule-result'
 	assert_exists 1 '//rule-result[@idref="xccdf_moc.elpmaxe.www_rule_second"]'
+	assert_exists 1 '//rule-result[@idref="xccdf_moc.elpmaxe.www_rule_second" and @role="full"]'
+	assert_exists 1 '//rule-result[@idref="xccdf_moc.elpmaxe.www_rule_second" and @severity="unknown"]'
+	assert_exists 1 '//rule-result[@idref="xccdf_moc.elpmaxe.www_rule_second" and @weight]'
 	assert_exists 1 '//rule-result/result'
 	assert_exists 1 '//rule-result/result[text()="pass"]'
 	rm $arf


### PR DESCRIPTION
Adds severity and role attributes to rule-result elements in XCCDF
results. These attributes are optional in XCCDF 1.2 specification but if
the XCCDF is used in ARF the attributes are mandatory.  See SCAP 1.3
specification Section 4.5 item 10. We didn't create these attributes if
the input XCCDF didn't contain them. We can fix it by assuming the
default values. According to XCCDF 1.2 specification, the default value
of role element is "full" and the default value of severity element is
"unknown". The presence of role, weight and severity attributes is
checked by SCAPVAL. We had weight attribute but missing role and
severity caused error RES-392.

Fixes: #1630