### PR TITLE
Fix CentOS 8 CPE

### DIFF
--- a/cpe/openscap-cpe-dict.xml
+++ b/cpe/openscap-cpe-dict.xml
@@ -51,7 +51,7 @@
       </cpe-item>
       <cpe-item name="cpe:/o:centos:centos:8">
             <title xml:lang="en-us">Community Enterprise Operating System 8</title>
-            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.rhel:def:1008</check>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.centos:def:8</check>
       </cpe-item>
       <cpe-item name="cpe:/o:scientificlinux:scientificlinux:5">
             <title xml:lang="en-us">Scientific Linux 5</title>

--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -172,7 +172,7 @@
                         <criterion comment="Community Enterprise Operating System 7 is installed" test_ref="oval:org.open-scap.cpe.rhel:tst:1007"/>
                   </criteria>
             </definition>
-            <definition class="inventory" id="oval:org.open-scap.cpe.rhel:def:1008" version="1">
+            <definition class="inventory" id="oval:org.open-scap.cpe.centos:def:8" version="1">
                   <metadata>
                         <title>Community Enterprise Operating System 8</title>
                         <affected family="unix">
@@ -182,7 +182,8 @@
                         <description>The operating system installed on the system is Community Enterprise Operating System 8</description>
                   </metadata>
                   <criteria>
-                        <criterion comment="Community Enterprise Operating System 8 is installed" test_ref="oval:org.open-scap.cpe.rhel:tst:1008"/>
+                        <criterion comment="Community Enterprise Operating System is installed" test_ref="oval:org.open-scap.cpe.centos:tst:8" />
+                        <criterion comment="Community Enterprise Operating System version is 8" test_ref="oval:org.open-scap.cpe.centos:tst:8000" />
                   </criteria>
             </definition>
             <definition class="inventory" id="oval:org.open-scap.cpe.scientific:def:5" version="1">
@@ -856,11 +857,14 @@
                   <object object_ref="oval:org.open-scap.cpe.redhat-release:obj:3"/>
                   <state state_ref="oval:org.open-scap.cpe.rhel:ste:1007"/>
             </rpmverifyfile_test>
-            <rpmverifyfile_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.rhel:tst:1008" version="1" check="at least one" comment="centos-release is version 8"
-                  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-                  <object object_ref="oval:org.open-scap.cpe.redhat-release:obj:3"/>
-                  <state state_ref="oval:org.open-scap.cpe.rhel:ste:1008"/>
-            </rpmverifyfile_test>
+            <textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check /etc/os-release ID is centos" id="oval:org.open-scap.cpe.centos:tst:8" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                  <object object_ref="oval:org.open-scap.cpe.centos:obj:8"/>
+                  <state state_ref="oval:org.open-scap.cpe.centos:ste:8"/>
+            </textfilecontent54_test>
+            <textfilecontent54_test check="all" comment="Check /etc/os-release VERSION_ID is 8" id="oval:org.open-scap.cpe.centos:tst:8000" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                  <object object_ref="oval:org.open-scap.cpe.centos:obj:8000"/>
+                  <state state_ref="oval:org.open-scap.cpe.centos:ste:8000"/>
+            </textfilecontent54_test>
             <rpmverifyfile_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.scientific:tst:5" version="1" check="at least one" comment="sl-release is version 5"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <object object_ref="oval:org.open-scap.cpe.redhat-release:obj:3"/>
@@ -1188,6 +1192,16 @@
                   <key>SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
                   <name>ProductName</name>
             </registry_object>
+            <textfilecontent54_object id="oval:org.open-scap.cpe.centos:obj:8" version="1" comment="Check os-release ID" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                  <filepath>/etc/os-release</filepath>
+                  <pattern operation="pattern match">^ID=&quot;(\w+)&quot;$</pattern>
+                  <instance datatype="int">1</instance>
+            </textfilecontent54_object>
+            <textfilecontent54_object id="oval:org.open-scap.cpe.centos:obj:8000" version="1" comment="Check os-release VERSION_ID" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                  <filepath>/etc/os-release</filepath>
+                  <pattern operation="pattern match">^VERSION_ID=&quot;(\d)&quot;$</pattern>
+                  <instance datatype="int">1</instance>
+            </textfilecontent54_object>
       </objects>
       <states>
             <family_state id="oval:org.open-scap.cpe.unix:ste:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
@@ -1223,10 +1237,12 @@
                   <name operation="pattern match">^centos-release</name>
                   <version operation="pattern match">^7</version>
             </rpmverifyfile_state>
-            <rpmverifyfile_state id="oval:org.open-scap.cpe.rhel:ste:1008" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-                  <name operation="pattern match">^centos-release</name>
-                  <version operation="pattern match">^8</version>
-            </rpmverifyfile_state>
+            <textfilecontent54_state id="oval:org.open-scap.cpe.centos:ste:8" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                  <subexpression>centos</subexpression>
+            </textfilecontent54_state>
+            <textfilecontent54_state id="oval:org.open-scap.cpe.centos:ste:8000" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent">
+                  <subexpression>8</subexpression>
+            </textfilecontent54_state>
             <rpmverifyfile_state id="oval:org.open-scap.cpe.scientific:ste:5" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <name operation="pattern match">^sl-release</name>
                   <version operation="pattern match">^5</version>


### PR DESCRIPTION
With the CentOS stream effort, the centos-relase RPM package is no
longer available. While CentOS 8.2.2004 features centos-release RPM
package, the CentOS 8.3.2011 features centos-linux-release RPM and
CentOS Stream features centos-stream-release RPM package. We have
decided to parse /etc/os-release file instead which is often present and
doesn't require librpm to be present.

Fixes: #1661