### PR TITLE
Allow oscap-podman to run rootless

### DIFF
--- a/utils/oscap-podman
+++ b/utils/oscap-podman
@@ -34,10 +34,10 @@ function usage()
     echo "oscap-podman -- Tool for SCAP evaluation of Podman images and containers."
     echo
     echo "Compliance scan of Podman image:"
-    echo "$ sudo oscap-podman [--oscap=<OSCAP_BINARY>] IMAGE_NAME OSCAP_ARGUMENT [OSCAP_ARGUMENT...]"
+    echo "$ oscap-podman [--oscap=<OSCAP_BINARY>] IMAGE_NAME OSCAP_ARGUMENT [OSCAP_ARGUMENT...]"
     echo
     echo "Compliance scan of Podman container:"
-    echo "$ sudo oscap-podman [--oscap=<OSCAP_BINARY>] CONTAINER_NAME OSCAP_ARGUMENT [OSCAP_ARGUMENT...]"
+    echo "$ oscap-podman [--oscap=<OSCAP_BINARY>] CONTAINER_NAME OSCAP_ARGUMENT [OSCAP_ARGUMENT...]"
     echo
     echo "See \`man oscap\` to learn more about semantics of OSCAP_ARGUMENT options."
 }
@@ -58,8 +58,9 @@ else
     invalid "Invalid arguments provided."
 fi
 
+# rootless requires unshare prior to running certain commands
 if [ "$(id -u)" -ne 0 ]; then
-    die "This script cannot run in rootless mode."
+	ROOTLESS_CMD="podman unshare --"
 fi
 if grep -q "\-\-remediate" <<< "$@"; then
     die "This script does not support '--remediate' option."
@@ -92,29 +93,26 @@ fi
 # podman init creates required files such as: /run/.containerenv - we don't care about output and exit code
 podman init $ID &> /dev/null || true
 
-DIR=$(podman mount $ID) || die "Failed to mount."
+DIR=$($ROOTLESS_CMD podman mount $ID) || die "Failed to mount."
 
 if [ ! -f "$DIR/run/.containerenv" ]; then
     # ubi8-init image does not create .containerenv when running podman init, but we need to make sure that the file is there
-    touch "$DIR/run/.containerenv"
+    $ROOTLESS_CMD touch "$DIR/run/.containerenv"
 fi
 
 export OSCAP_CONTAINER_VARS
 OSCAP_CONTAINER_VARS=`podman inspect $ID --format '{{join .Config.Env "\n"}}'`
 
 export OSCAP_PROBE_ROOT
-OSCAP_PROBE_ROOT="$(cd "$DIR" && pwd)" || die "Unable to change current directory to OSCAP_PROBE_ROOT (DIR)."
+OSCAP_PROBE_ROOT="$($ROOTLESS_CMD cd "$DIR" && $ROOTLESS_CMD pwd)" || die "Unable to change current directory to OSCAP_PROBE_ROOT (DIR)."
 export OSCAP_EVALUATION_TARGET="$TARGET"
 shift 1
 
-$OSCAP_BINARY "$@"
+$ROOTLESS_CMD $OSCAP_BINARY "$@"
 EXIT_CODE=$?
 
+$ROOTLESS_CMD podman umount $ID > /dev/null || die "Failed to unmount."
 if [ $CLEANUP -eq 1 ]; then
-    # podman-rm should handle also unmounting of the container filesystem.
-    podman rm -f $ID > /dev/null || die "Failed to clean up."
-else
-    # If a running container is target of the scan just unmount its filesystem.
-    podman umount $ID > /dev/null || die "Failed to unmount."
+    podman rm $ID > /dev/null || die "Failed to clean up."
 fi
 exit $EXIT_CODE


### PR DESCRIPTION
Running oscap-podman as rootless only requires that we run
"podman unshare" at key points to change the namespace.  Check if we're
rootless, and if so, prepend with unshare.

This appears to work with both rootless and root modes without issues:
```
$ wget -O - https://www.redhat.com/security/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2 | bzip2 --decompress > rhel-8.oval.xml

$ podman images
REPOSITORY                                  TAG     IMAGE ID      CREATED       SIZE
registry.redhat.io/ubi8                     latest  33df2983b061  5 weeks ago   208 MB

$ /usr/bin/oscap-podman-rootless 33df2983b061 oval eval --report vulnerability.html rhel-8.oval.xml
Definition oval:com.redhat.rhsa:def:20205237: false
Definition oval:com.redhat.rhsa:def:20205236: false
Definition oval:com.redhat.rhsa:def:20205146: false
Definition oval:com.redhat.rhsa:def:20205100: false
Definition oval:com.redhat.rhsa:def:20205085: false
Definition oval:com.redhat.rhsa:def:20204952: false
- - - - 8< - - - -
Definition oval:com.redhat.rhba:def:20194268: false
Definition oval:com.redhat.rhba:def:20193674: false
Definition oval:com.redhat.rhba:def:20193384: false
Evaluation done.

$ head vulnerability.html; echo "- - - - 8< - - - -"; tail vulnerability.html
<?xml version="1.0"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

<!--
				Color mapping
				Result enumeration
		Class       |t|f|u|e|na|ne|
		compliance  |G|R|B|Y|- |- |
		inventory   |-|-|B|Y|- |- |
		misc        |-|-|B|Y|- |- |
- - - - 8< - - - -
	  <tr class="resultgoodB">
		<td class="Text" align="center">oval:com.redhat.rhba:def:20193384</td>
		<td class="Text" align="center">false</td>
		<td class="Text" align="center">patch</td>
		<td class="Text" align="center">[<a class="Hover" target="_blank" href="https://access.redhat.com/errata/RHBA-2019:3384">RHBA-2019:3384</a>], [<a class="Hover" target="_blank" href="https://access.redhat.com/security/cve/CVE-2019-8320">CVE-2019-8320</a>], [<a class="Hover" target="_blank" href="https://access.redhat.com/security/cve/CVE-2019-8321">CVE-2019-8321</a>], [<a class="Hover" target="_blank" href="https://access.redhat.com/security/cve/CVE-2019-8322">CVE-2019-8322</a>], [<a class="Hover" target="_blank" href="https://access.redhat.com/security/cve/CVE-2019-8323">CVE-2019-8323</a>], [<a class="Hover" target="_blank" href="https://access.redhat.com/security/cve/CVE-2019-8325">CVE-2019-8325</a>]</td>
		<td class="Text">RHBA-2019:3384: ruby:2.5 bug fix and enhancement update (Moderate)</td>
	  </tr>
	</table>
  </body>
</html>
```
