### PR TITLE
Fix oval_debian_evr_string_cmp

### DIFF
--- a/src/OVAL/results/oval_cmp_evr_string.c
+++ b/src/OVAL/results/oval_cmp_evr_string.c
@@ -434,13 +434,13 @@ oval_result_t oval_debian_evr_string_cmp(const char *state, const char *sys, ova
 	case OVAL_OPERATION_NOT_EQUAL:
 		return ((result != 0) ? OVAL_RESULT_TRUE : OVAL_RESULT_FALSE);
 	case OVAL_OPERATION_GREATER_THAN:
-		return ((result == 1) ? OVAL_RESULT_TRUE : OVAL_RESULT_FALSE);
+		return ((result > 0) ? OVAL_RESULT_TRUE : OVAL_RESULT_FALSE);
 	case OVAL_OPERATION_GREATER_THAN_OR_EQUAL:
-		return ((result != -1) ? OVAL_RESULT_TRUE : OVAL_RESULT_FALSE);
+		return ((result >= 0) ? OVAL_RESULT_TRUE : OVAL_RESULT_FALSE);
 	case OVAL_OPERATION_LESS_THAN:
-		return ((result == -1) ? OVAL_RESULT_TRUE : OVAL_RESULT_FALSE);
+		return ((result < 0) ? OVAL_RESULT_TRUE : OVAL_RESULT_FALSE);
 	case OVAL_OPERATION_LESS_THAN_OR_EQUAL:
-		return ((result != 1) ? OVAL_RESULT_TRUE : OVAL_RESULT_FALSE);
+		return ((result <= 0) ? OVAL_RESULT_TRUE : OVAL_RESULT_FALSE);
 	}
 
 	oscap_seterr(OSCAP_EFAMILY_OVAL, "Invalid type of operation in rpm version comparison: %d.", operation);


### PR DESCRIPTION
The function verrevcmp can return any positive or negative number as a comparison result, not just 1 or -1.
@dodys LMK if there's an issue.