### PR TITLE
Fix multiple segfaults and broken test in --stig-viewer feature

### DIFF
--- a/src/XCCDF/result.c
+++ b/src/XCCDF/result.c
@@ -1159,8 +1159,9 @@ void xccdf_result_to_dom(struct xccdf_result *result, xmlNode *result_node, xmlD
 			struct oscap_reference_iterator *references = xccdf_item_get_references(item);
 			while (oscap_reference_iterator_has_more(references)) {
 				struct oscap_reference *ref = oscap_reference_iterator_next(references);
-				if (strcmp(oscap_reference_get_href(ref), DISA_STIG_VIEWER_HREF[0]) == 0 ||
-				    strcmp(oscap_reference_get_href(ref), DISA_STIG_VIEWER_HREF[1]) == 0) {
+				const char *href = oscap_reference_get_href(ref);
+				if (href && (strcmp(href, DISA_STIG_VIEWER_HREF[0]) == 0 ||
+							strcmp(href, DISA_STIG_VIEWER_HREF[1]) == 0)) {
 					const char *stig_rule_id = oscap_reference_get_title(ref);
 
 					xccdf_test_result_type_t other_res = (xccdf_test_result_type_t)oscap_htable_detach(nodes_by_rule_id, stig_rule_id);
@@ -1367,8 +1368,9 @@ void xccdf_rule_result_to_dom(struct xccdf_rule_result *result, xmlDoc *doc, xml
 		struct oscap_reference_iterator *references = xccdf_item_get_references(item);
 		while (oscap_reference_iterator_has_more(references)) {
 			struct oscap_reference *ref = oscap_reference_iterator_next(references);
-			if (strcmp(oscap_reference_get_href(ref), DISA_STIG_VIEWER_HREF[0]) == 0 ||
-			    strcmp(oscap_reference_get_href(ref), DISA_STIG_VIEWER_HREF[1]) == 0) {
+			const char *href = oscap_reference_get_href(ref);
+			if (href && (strcmp(href, DISA_STIG_VIEWER_HREF[0]) == 0 ||
+					strcmp(href, DISA_STIG_VIEWER_HREF[1]) == 0)) {
 				const char *stig_rule_id = oscap_reference_get_title(ref);
 
 				xccdf_test_result_type_t expected_res = (xccdf_test_result_type_t)oscap_htable_get(nodes_by_rule_id, stig_rule_id);

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1393,9 +1393,12 @@ static int _build_xccdf_result_source(struct xccdf_session *session)
 		}
 
 		if (session->export.xccdf_stig_viewer_file != NULL) {
+			struct xccdf_benchmark *cloned_benchmark = xccdf_benchmark_clone(benchmark);
 			struct xccdf_result *cloned_result = xccdf_result_clone(session->xccdf.result);
+			xccdf_benchmark_add_result(cloned_benchmark, cloned_result);
 			struct oscap_source * stig_result = xccdf_result_stig_viewer_export_source(cloned_result, session->export.xccdf_stig_viewer_file);
-			xccdf_result_free(cloned_result);
+			// cloned_result is freed during xccdf_benchmark_free
+			xccdf_benchmark_free(cloned_benchmark);
 			if (oscap_source_save_as(stig_result, NULL) != 0) {
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not save file: %s",
 						oscap_source_readable_origin(stig_result));

--- a/tests/API/XCCDF/unittests/test_single_rule.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_single_rule.xccdf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_com.example.www_benchmark_dummy" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="false" xml:lang="en-US">
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" id="xccdf_com.example.www_benchmark_dummy" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="false" xml:lang="en-US">
   <status>accepted</status>
   <version>1.0</version>
 
@@ -26,6 +26,14 @@
   </Value>
   <Rule selected="true" id="xccdf_com.example.www_rule_test-pass">
     <title>This rule always pass</title>
+    <reference>Clever book, page 18, section 3</reference>
+    <reference>
+      <dc:title>Test reference without href attribute</dc:title>
+      <dc:publisher>OpenSCAP Project</dc:publisher>
+      <dc:type>Dummy reference</dc:type>
+      <dc:subject>Random subject</dc:subject>
+      <dc:identifier>12345</dc:identifier>
+    </reference>
     <reference href="http://iase.disa.mil/stigs/os/unix-linux/Pages/index.aspx">RHEL-07-040800</reference>
     <reference href="http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx">SV-86937r1_rule</reference>
     <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">

--- a/tests/API/XCCDF/unittests/test_single_rule_stigw.sh
+++ b/tests/API/XCCDF/unittests/test_single_rule_stigw.sh
@@ -24,5 +24,5 @@ $OSCAP xccdf eval --stig-viewer "$result" "$srcdir/${name}.xccdf.xml" 2> "$stder
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 [ -s "$result" ]
 
-"${PYTHON:-python}" "$srcdir/stig-viewer-equivalence.py" "$result" "$srcdir/correct_stigw_result.xml" 2> "$stderr"
+"$PREFERRED_PYTHON" "$srcdir/stig-viewer-equivalence.py" "$result" "$srcdir/correct_stigw_result.xml" 2> "$stderr"
 rm "$result"

--- a/tests/API/XCCDF/unittests/test_single_rule_stigw.sh
+++ b/tests/API/XCCDF/unittests/test_single_rule_stigw.sh
@@ -19,8 +19,10 @@ echo "Result file = $result"
 # evaluated when '--rule' option is not specified.
 
 # One of the rules is supposed to fail, so the return code of this line has to be 0 so the test can continue
-$OSCAP xccdf eval --stig-viewer "$result" "$srcdir/${name}.xccdf.xml" 2> "$stderr" || true
+$OSCAP xccdf eval --stig-viewer "$result" "$srcdir/${name}.xccdf.xml" 2> "$stderr" || ret=$?
+[ $ret == 2 ]
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
+[ -s "$result" ]
 
-"${PYTHON:-python}" "$srcdir/stig-viewer-equivalence.py" "$result" "$srcdir/correct_stigw_result.xml" 2> "$stderr" || ret=$?
+"${PYTHON:-python}" "$srcdir/stig-viewer-equivalence.py" "$result" "$srcdir/correct_stigw_result.xml" 2> "$stderr"
 rm "$result"


### PR DESCRIPTION
This PR aims to fix 2 segfaults in the code creating the XML output for DISA STIG Viewer.

The first segmentation fault is a new problem. It has been caused by a mistake in 9b40767967e533bdb340ca4c91f2fd1192694820. This segmentation fault occurs any time an user uses `--stig-viewer`. For example: `oscap xccdf eval --profile ospp --stig-viewer /tmp/xxx /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml`. 

Unfortunately, the problem hasn't been discovered by CI, because the test https://github.com/OpenSCAP/openscap/blob/maint-1.3/tests/API/XCCDF/unittests/test_single_rule_stigw.sh is wrong. https://github.com/OpenSCAP/openscap/blob/1ccdd3bb31b2f1d4da5c7e9b6018597454e879cd/tests/API/XCCDF/unittests/test_single_rule_stigw.sh#L22
This condition ignores any fail in the `oscap` command. A similar mistake is repeated also when the comparison script is executed, therefore the test also didn't ensure that the generated file is correct.


The second segmentation fault has been reported in https://bugzilla.redhat.com/show_bug.cgi?id=1911999 and https://bugzilla.redhat.com/show_bug.cgi?id=1912000. Shortly, the problem is that our code expects that every `xccdf:reference` element has a `href` attribute. But, according to XCCDF 1.2 specification section 6.2.6, the `href` attribute is optional. We don't expect no `href` and we crash.  Some SCAP content uses `xccdf:reference` without `href` attribute, for example DISA STIG for RHEL 7 V3R1. Moreover, his STIG uses Dublin Core elements within `xccdf:reference`. We will extend the aforementioned test case to cover these elements.