### PR TITLE
Silence some compiler warnings found with LLVM/clang

### DIFF
--- a/src/OVAL/results/oval_cmp_evr_string.c
+++ b/src/OVAL/results/oval_cmp_evr_string.c
@@ -368,7 +368,7 @@ static int verrevcmp(const char *a, const char *b)
  * @retval <0 If a is smaller than b.
  * @retval >0 If a is greater than b.
  */
-int dpkg_version_compare(struct dpkg_version *a, struct dpkg_version *b)
+static int dpkg_version_compare(struct dpkg_version *a, struct dpkg_version *b)
 {
 	int rc;
 

--- a/src/OVAL/results/oval_cmp_evr_string.c
+++ b/src/OVAL/results/oval_cmp_evr_string.c
@@ -441,9 +441,10 @@ oval_result_t oval_debian_evr_string_cmp(const char *state, const char *sys, ova
 		return ((result < 0) ? OVAL_RESULT_TRUE : OVAL_RESULT_FALSE);
 	case OVAL_OPERATION_LESS_THAN_OR_EQUAL:
 		return ((result <= 0) ? OVAL_RESULT_TRUE : OVAL_RESULT_FALSE);
+	default:
+		oscap_seterr(OSCAP_EFAMILY_OVAL, "Invalid type of operation in rpm version comparison: %d.", operation);
 	}
 
-	oscap_seterr(OSCAP_EFAMILY_OVAL, "Invalid type of operation in rpm version comparison: %d.", operation);
 	return OVAL_RESULT_ERROR;
 }
 


### PR DESCRIPTION
This pull request fixes some new warnings found by building with LLVM/clang on FreeBSD. I do not believe these changes fix real bugs, however I think it is good to silence compiler warnings whenever possible as it increases the visibility of future warnings that could be actual problems.

**Changes:**

1. Fix a missing prototype warning by making ``dpkg_version_compare()`` static. The function is not called outside of its file as its only caller is ``oval_debian_evr_string_cmp()``. 

2. Silence an un-handled enumeration value warning in ``oval_debian_evr_string_cmp()`` by adding a default case in the switch statement, and explicitly calling ``oscap_seterr()`` there. Previously the function would set an error for unhandled values immediately after leaving the switch statement, so the behavior should be identical.