### PR TITLE
Improve documentation about --stig-viewer option

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -629,10 +629,14 @@ STIG in `STIGs` panel on the left side. Click on `Checklists` and then on
 Results File`. Locate the `results-stig.xml` from step 1. The results will be
 shown in STIG Viewer.
 
-NOTE: The `--stig-viewer` option is intended for evaluating SCAP content in
-which the XCCDF Rule IDs aren't the same as STIG IDs, mainly
-`scap-security-guide`. When using SCAP content provided by DISA, use
-`--results` instead.
+NOTE: The `--stig-viewer` option is intended for evaluating SCAP source
+datastream other than STIG provided by DISA, in which the XCCDF Rule IDs aren't
+the same as STIG IDs, for example `scap-security-guide` content, and then
+loading the generated file in STIG Viewer into checklist created from STIG
+provided by DISA.  When evaluating STIG provided by DISA using `oscap`, use
+`--results` instead. Similarly, when creating checklists based on
+`scap-security-guide` content in STIG Viewer and evaluating
+`scap-security-guide` by `oscap`, use `--results` instead.
 
 === Remediate System
 OpenSCAP allows to automatically remediate systems that have been found in a

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -580,30 +580,59 @@ command-line argument. You can use `--results-arf` to generate a Result DataStre
 $ oscap xccdf eval --benchmark-id benchmark_id --results-arf arf-results.xml scap-ds.xml
 --------------------------------------------------------------------------------------
 
-==== Result STIG Viewer
+==== Results for STIG Viewer
 
-If you want to import the XCCDF scan results to DISA STIG Viewer but your Rule IDs don't
-match the DISA's ones, you can use the `--stig-viewer` command-line argument along with
-a special reference in your Rules to generate XCCDF result files that can be imported by
-DISA STIG Viewer.
+DISA STIG Viewer is a graphical user interface (GUI) application that enables
+easy viewing of SCAP formatted Security Technical Implementation Guides
+(STIGs).  For more information on DISA STIG Viewer go to
+https://public.cyber.mil/stigs/srg-stig-tools/[SRG / STIG Tools].
 
---------------------------------------------------------------------------------------
-$ oscap xccdf eval --profile stig-rhel7-disa --stig-viewer results-stig.xml ssg-rhel7-ds.xml
---------------------------------------------------------------------------------------
+OpenSCAP can generate results compatible with DISA STIG Viewer when evaluating
+SCAP content not provided by DISA that uses different Rule IDs than official
+DISA STIG, for example `scap-security-guide` or third party content.
 
-Each rule in the input XCCDF must contain a reference to its STIG Rule ID, and its 
-href attribute must be exactly `http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx`.
+To be able to produce results compatible with DISA STIG Viewer, each rule in
+the input SCAP source data stream must contain a reference to a STIG Rule ID,
+and its `href` attribute must be either
+`http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx` or
+`https://public.cyber.mil/stigs/srg-stig-tools/`.
 
 For example:
 ----
 <Rule id="rpm_verify_permissions">
   ...
-  <reference href="http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx">SV-86473r2_rule</reference>
+  <reference href="https://public.cyber.mil/stigs/srg-stig-tools/">SV-86473r2_rule</reference>
   ...
 </Rule>
 ----
 
-For more information on DISA STIG Viewer click link:http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx[here].
+A good example of SCAP source data stream that meets this assumption is the
+`/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml` provided by
+`scap-security-guide` RPM package. We will use this file to demonstrate its
+usage with DISA STIG Viewer.
+
+1) Scan your system using `oscap` with `--stig-viewer` option.
+
+----
+$ oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_stig --stig-viewer results-stig.xml /usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
+----
+
+2) Get the STIG, eg. from https://public.cyber.mil/stigs/downloads/[STIGs
+document library] and extract it.  The version of STIG must conform to the
+version of `xccdf_org.ssgproject.content_profile_stig` profile.
+
+3) In STIG Viewer, click on `File` and then on `Import STIG`. Then, select the
+STIG in `STIGs` panel on the left side. Click on `Checklists` and then on
+`Create Checklists - Check Marked STIG(s)`.
+
+4) Import the OpenSCAP scan results by clicking on `Import` and then on `XCCDF
+Results File`. Locate the `results-stig.xml` from step 1. The results will be
+shown in STIG Viewer.
+
+NOTE: The `--stig-viewer` option is intended for evaluating SCAP content in
+which the XCCDF Rule IDs aren't the same as STIG IDs, mainly
+`scap-security-guide`. When using SCAP content provided by DISA, use
+`--results` instead.
 
 === Remediate System
 OpenSCAP allows to automatically remediate systems that have been found in a

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -592,7 +592,7 @@ SCAP content that uses different rule IDs than the official DISA STIG format,
 for example, content from the `scap-security-guide` package or third-party
 content.
 
-To produce results compatible with STIG Viewer, each rule in a SCAP source data
+To produce results compatible with STIG Viewer, each rule in an SCAP source data
 stream must contain a reference to a STIG Rule ID, and the value of the `href`
 attribute must be either
 `http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx` or
@@ -631,7 +631,7 @@ STIG in `STIGs` panel on the left side. Click on `Checklists` and then on
 Results File`. Locate the `results-stig.xml` file obtained in step 1. STIG
 Viewer shows the results subsequently.
 
-NOTE: The `--stig-viewer` option serves for evaluating a SCAP source data stream
+NOTE: The `--stig-viewer` option serves for evaluating an SCAP source data stream
 other than a STIG provided by DISA, for example, `scap-security-guide` content
 and loading the generated file in STIG Viewer into a checklist created from a
 STIG by DISA. When evaluating a STIG provided by DISA using `oscap`, use the

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -580,20 +580,21 @@ command-line argument. You can use `--results-arf` to generate a Result DataStre
 $ oscap xccdf eval --benchmark-id benchmark_id --results-arf arf-results.xml scap-ds.xml
 --------------------------------------------------------------------------------------
 
-==== Results for STIG Viewer
+==== Generating results compatible with STIG Viewer
 
 DISA STIG Viewer is a graphical user interface (GUI) application that enables
-easy viewing of SCAP formatted Security Technical Implementation Guides
-(STIGs).  For more information on DISA STIG Viewer go to
-https://public.cyber.mil/stigs/srg-stig-tools/[SRG / STIG Tools].
+easy viewing of SCAP-formatted Security Technical Implementation Guides
+(STIGs). For more information on DISA STIG Viewer see the
+https://public.cyber.mil/stigs/srg-stig-tools/[SRG / STIG Tools] website.
 
-OpenSCAP can generate results compatible with DISA STIG Viewer when evaluating
-SCAP content not provided by DISA that uses different Rule IDs than official
-DISA STIG, for example `scap-security-guide` or third party content.
+OpenSCAP can generate results compatible with STIG Viewer even when evaluating
+SCAP content that uses different rule IDs than the official DISA STIG format,
+for example, content from the `scap-security-guide` package or third-party
+content.
 
-To be able to produce results compatible with DISA STIG Viewer, each rule in
-the input SCAP source data stream must contain a reference to a STIG Rule ID,
-and its `href` attribute must be either
+To produce results compatible with STIG Viewer, each rule in a SCAP source data
+stream must contain a reference to a STIG Rule ID, and the value of the `href`
+attribute must be either
 `http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx` or
 `https://public.cyber.mil/stigs/srg-stig-tools/`.
 
@@ -606,37 +607,37 @@ For example:
 </Rule>
 ----
 
-A good example of SCAP source data stream that meets this assumption is the
-`/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml` provided by
-`scap-security-guide` RPM package. We will use this file to demonstrate its
-usage with DISA STIG Viewer.
+In the following example, we use the
+`/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml` file provided by the
+`scap-security-guide` RPM package. This data stream file meets both
+prerequisites for rules.
 
-1) Scan your system using `oscap` with `--stig-viewer` option.
+1) Scan your system using the `oscap` command with the `--stig-viewer` option.
 
 ----
 $ oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_stig --stig-viewer results-stig.xml /usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
 ----
 
-2) Get the STIG, eg. from https://public.cyber.mil/stigs/downloads/[STIGs
-document library] and extract it.  The version of STIG must conform to the
-version of `xccdf_org.ssgproject.content_profile_stig` profile.
+2) Download a STIG file of your choice, for example, from the
+https://public.cyber.mil/stigs/downloads/[STIGs Document Library], and extract
+it. The version of the STIG must conform to the version of the
+`xccdf_org.ssgproject.content_profile_stig` profile.
 
 3) In STIG Viewer, click on `File` and then on `Import STIG`. Then, select the
 STIG in `STIGs` panel on the left side. Click on `Checklists` and then on
 `Create Checklists - Check Marked STIG(s)`.
 
 4) Import the OpenSCAP scan results by clicking on `Import` and then on `XCCDF
-Results File`. Locate the `results-stig.xml` from step 1. The results will be
-shown in STIG Viewer.
+Results File`. Locate the `results-stig.xml` file obtained in step 1. STIG
+Viewer shows the results subsequently.
 
-NOTE: The `--stig-viewer` option is intended for evaluating SCAP source
-datastream other than STIG provided by DISA, in which the XCCDF Rule IDs aren't
-the same as STIG IDs, for example `scap-security-guide` content, and then
-loading the generated file in STIG Viewer into checklist created from STIG
-provided by DISA.  When evaluating STIG provided by DISA using `oscap`, use
-`--results` instead. Similarly, when creating checklists based on
+NOTE: The `--stig-viewer` option serves for evaluating a SCAP source data stream
+other than a STIG provided by DISA, for example, `scap-security-guide` content
+and loading the generated file in STIG Viewer into a checklist created from a
+STIG by DISA. When evaluating a STIG provided by DISA using `oscap`, use the
+`--results` option instead. Similarly, when creating checklists based on
 `scap-security-guide` content in STIG Viewer and evaluating
-`scap-security-guide` by `oscap`, use `--results` instead.
+`scap-security-guide` by oscap, use `--results` instead of `--stig-viewer`.
 
 === Remediate System
 OpenSCAP allows to automatically remediate systems that have been found in a

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -131,8 +131,7 @@ Writes results to a given FILE in Asset Reporting Format. It is recommended to u
 .TP
 \fB\-\-stig-viewer FILE\fR
 .RS
-Writes XCCDF results into FILE in a format readable by DISA STIG Viewer. See \fIhttp://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx\fR.
-This option should be used to generate results for DISA STIG Viewer older than 2.6. To use DISA STIG Viewer 2.6 or newer, use \fB\-\-results\fR instead.
+Writes XCCDF results into FILE. The rule result IDs in FILE are modified according to STIG references in evaluated content. The FILE can be simply imported into DISA STIG Viewer. See \fIhttps://public.cyber.mil/stigs/srg-stig-tools/\fR for information about DISA STIG Viewer.
 .RE
 .TP
 \fB\-\-thin-results\fR
@@ -232,8 +231,7 @@ Writes results to a given FILE in Asset Reporting Format. It is recommended to u
 .TP
 \fB\-\-stig-viewer FILE\fR
 .RS
-Writes XCCDF results into FILE in a format readable by DISA STIG Viewer. See \fIhttp://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx\fR.
-This option should be used to generate results for DISA STIG Viewer older than 2.6. To use DISA STIG Viewer 2.6 or newer, use \fB\-\-results\fR instead.
+Writes XCCDF results into FILE. The rule result IDs in FILE are modified according to STIG references in evaluated content. The FILE can be simply imported into DISA STIG Viewer. See \fIhttps://public.cyber.mil/stigs/srg-stig-tools/\fR for information about DISA STIG Viewer.
 .RE
 .TP
 \fB\-\-report FILE\fR


### PR DESCRIPTION
The documentation of --stig-viewer option wasn't sufficient and
confused multiple users, for example RHBZ#1896957.

This change tries to describe the use case in which --stig-viewer
option is used in a greater detail.

The commit removes the information about --stig-viewer not working
with DISA STIG Viewer newer than 2.6 because it works fine with
version 2.11. The source of this information is unclear, probably
a confusion due to difference between using DISA benchmark and SSG.

Fixes: RHBZ#1918759