### PR TITLE
Fix how oval_probe_ext_eval checks absence of the response from the probe

### DIFF
--- a/src/OVAL/oval_probe_ext.c
+++ b/src/OVAL/oval_probe_ext.c
@@ -993,7 +993,7 @@ int oval_probe_ext_eval(SEAP_CTX_t *ctx, oval_pd_t *pd, oval_pext_t *pext, struc
 	}
 
 	if (flags & OVAL_PDFLAG_NOREPLY) {
-		if (s_sys != NULL) {
+		if (SEXP_typeof(s_sys) != SEXP_TYPE_LIST || SEXP_list_length(s_sys) != 0) {
                         /*
                          * The no-reply flag is set and oval_probe_comm returned some
                          * data. This is considered a non-fatal error.


### PR DESCRIPTION
The code was updated in accordance with how empty messages (with sexp == NULL) are encoded in:
https://github.com/OpenSCAP/openscap/blob/d05a0e8f382f758820c7623deabdd0ea2dd28b03/src/OVAL/probes/SEAP/seap-packet.c#L256

Fixes annoying warning `Obtrusive data from probe!`.

Fixes: #1632.