### PR TITLE
Refresh OpenSCAP user manual

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -4,6 +4,7 @@
 :sce_web:       https://www.open-scap.org/features/other-standards/sce/
 :openscap_web: https://open-scap.org/
 :oscap_git:     https://github.com/OpenSCAP/openscap
+:devel_manual:  https://github.com/OpenSCAP/openscap/blob/maint-1.3/docs/developer/developer.adoc
 :ssg_git:       https://github.com/OpenSCAP/scap-security-guide
 :xmlsec:        https://www.aleksey.com/xmlsec/
 :xslt:          http://www.w3.org/TR/xslt
@@ -19,11 +20,13 @@
 :pci_dss: https://www.pcisecuritystandards.org/security_standards/
 :usgcb: http://usgcb.nist.gov/
 :stig:    http://iase.disa.mil/stigs/Pages/index.aspx
-:scap_1-2:  http://scap.nist.gov/revision/1.2/
-:scap_1-1:  http://scap.nist.gov/revision/1.1/index.html
-:scap_1-0:  http://scap.nist.gov/revision/1.0/
+:scap_1-3: https://csrc.nist.gov/Projects/Security-Content-Automation-Protocol/SCAP-Releases/scap-1-3
+:scap_1-2: https://csrc.nist.gov/Projects/Security-Content-Automation-Protocol/SCAP-Releases/SCAP-1-2
+:scap_1-1: https://csrc.nist.gov/Projects/Security-Content-Automation-Protocol/SCAP-Releases/SCAP-1-1
+:scap_1-0: https://csrc.nist.gov/Projects/Security-Content-Automation-Protocol/SCAP-Releases/SCAP-1-0
 :nvd:       https://web.nvd.nist.gov/view/ncp/repository
 :toc:
+:toclevels: 4
 :toc-placement: preamble
 :numbered:
 
@@ -33,278 +36,364 @@ toc::[]
 
 == Introduction
 
-This documentation provides information about a command-line tool called
- `oscap` and its most common operations.  With `oscap` you can check
-security configuration settings of a system, and examine the system for signs of
-a compromise by using rules based on standards and specifications. The
- `oscap` uses {scap}[SCAP] which is a line of specifications maintained by
-the {nist}[NIST] which was created to provide a standardized approach for
+This documentation provides information about OpenSCAP and its most common
+operations. With OpenSCAP, you can check security configuration settings of a
+system, and examine the system for signs of a compromise by using rules based on
+standards and specifications. 
+
+OpenSCAP uses {scap}[SCAP] which is a line of specifications maintained by the
+{nist}[NIST]. SCAP was created to provide a standardized approach for
 maintaining system security. New specifications are governed by NIST's SCAP
 http://scap.nist.gov/timeline.html[Release cycle] in order to provide a
-consistent and repeatable revision workflow. The `oscap` mainly processes
-the {xccdf}[XCCDF] which is a standard way of expressing a checklist content and
+consistent and repeatable revision workflow. OpenSCAP mainly processes the
+{xccdf}[XCCDF] which is a standard way of expressing a checklist content and
 defines security checklists. It also combines with other specifications such as
-{cpe}[CPE], {cce}[CCE] and {oval}[OVAL] to create a SCAP-expressed checklist that
-can be processed by SCAP-validated products.  For more information about the
+{cpe}[CPE], {cce}[CCE] and {oval}[OVAL] to create a SCAP-expressed checklist
+that can be processed by SCAP-validated products. For more information about the
 SCAP please refer to http://open-scap.org/features/standards/[SCAP Standards].
 
-The `oscap` tool is a part of the {openscap_web}[OpenSCAP] project.  If you're
-interested in a graphical alternative to this tool please visit
-{workbench_url}[SCAP Workbench] page.
-
-
-We will use the {ssg}[SCAP Security Guide] project to provide us the SCAP
-content. It provides security policies written in a form of SCAP documents
-covering many areas of computer security, and it implements security guidances
-recommended by respected authorities, namely {pci_dss}[PCI DSS], {stig}[STIG], and
-{usgcb}[USGCB].
-
-You can also generate your own SCAP content if you have an understanding of at least
-XCCDF or OVAL. XCCDF content is also frequently published online under open
-source licenses, and you can customize this content to suit your needs instead.
-SCAP Workbench is a great tool to do the customization.
-
-The Basic oscap usage section of the manual presents how to install the tool
-and SCAP content and how to use those to examine a SCAP content, perform a
-configuration scan or how to automatically remediate your machines.
-
-Third section provides cover advanced topic like validation, signing and
-transformation of SCAP content, generating reports and guides and also some
-information about CPE applicability.
-
-== Basic oscap Usage
+OpenSCAP supports SCAP {scap_1-3}[1.3] and is backward compatible with SCAP
+{scap_1-2}[1.2], SCAP {scap_1-1}[1.1] and SCAP {scap_1-0}[1.0]. No special
+treatment is required to import and process earlier versions of the SCAP
+content.
 
 If you want to perform configuration or vulnerability scans of a local system
 then the following must be available:
 
- . A tool (`oscap` or SCAP Workbench)
- . SCAP content (XCCDF, OVAL...)
+. A tool (`oscap` or SCAP Workbench)
+. SCAP content (SCAP source data stream, XCCDF, OVAL...)
 
-=== Installation
+The `oscap` tool is a part of the {openscap_web}[OpenSCAP] project. If you're
+interested in a graphical alternative to this tool please visit
+{workbench_url}[SCAP Workbench] page.
 
-You can either build the OpenSCAP library and the `oscap` tool from
-{oscap_git}[source] (for details please refer to the <<../developer/developer.adoc#,Developer Documentation>>),
-or you can use an existing build for your Linux distribution. Use the
-following yum command if you want to install the oscap tool on your
-Fedora or Red Hat Enterprise Linux distribution:
+We will use the {ssg}[SCAP Security Guide] project to provide us the SCAP
+content. It provides security policies written in a form of SCAP documents
+covering many areas of security compliance, and it implements security guidances
+recommended by respected authorities, namely {pci_dss}[PCI DSS], {stig}[STIG],
+and {usgcb}[USGCB].
 
-----------------------------
+You can also generate your own SCAP content if you have an understanding of at
+least XCCDF or OVAL. XCCDF content is also frequently published online under
+open source licenses, and you can customize this content to suit your needs
+instead. SCAP Workbench is a great tool to do the customization.
+
+== Installing OpenSCAP
+
+You can either build OpenSCAP from {oscap_git}[source code] or you can use an
+existing build for your Linux distribution. 
+
+For instructions about building from source code, please refer to
+{devel_manual}[OpenSCAP Developer Manual].
+
+To install OpenSCAP on Red Hat Enterprise Linux 8 and newer, on CentOS 8 and
+newer or on Fedora use the following command:
+
+----
+# dnf install openscap-scanner
+----
+
+To install OpenSCAP on Red Hat Enterprise Linux 7 or CentOS 7 or older use the
+following command:
+
+----
 # yum install openscap-scanner
-----------------------------
+----
 
-NOTE: If the `openscap-scanner` is not available install
- `openscap-utils` instead.
+To install OpenSCAP on Debian or Ubuntu use the following command:
 
-Before you can start using the `oscap` tool you must have some SCAP content
-on your system.  You can download it from the respective web site but we
-will use the SSG project in the following sections. You can build it from the
-{ssg_git}[source] or you can install it using a package management system:
+----
+# apt install libopenscap8
+----
 
-----------------------------
-# yum install scap-security-guide
-----------------------------
+After the installation is completed you can start using the `oscap` command line
+tool.
 
-The SCAP content will be installed in *__/usr/share/xml/scap/ssg/content/__*.
-
-When the SCAP content is imported or installed on your system, `oscap` can
-process the content by specifying the file path to the content. The `oscap`
-supports SCAP {scap_1-2}[1.2] and is backward compatible with SCAP
-{scap_1-1}[1.1] and SCAP {scap_1-0}[1.0]. No special treatment is required in
-order to import and process earlier versions of the SCAP content.
-
-To display the version of oscap, supported specifications, built-in CPE
+To display the version of OpenSCAP, supported specifications, built-in CPE
 names, and supported OVAL objects, type the following command:
 
-----------
-$ oscap -V
-----------
+----
+$ oscap --version
+----
 
-=== Displaying Information about SCAP Content
-One of the capabilities of `oscap` is to display information about the SCAP
-contents within a file. Running the `oscap info` command allows the
-examination of the internal structure of a SCAP document and displays
-information such as the document type, specification version, status, the date
-the document was published (**Generated**) and the date the document was copied to
-file system (**Imported**). When examining an XCCDF document or a SCAP data stream,
-generally, the most useful information is about profiles, checklists, and
-streams.
+=== Getting SCAP content
 
-The following example demonstrates usage and sample output of the
-command when target is SCAP data stream:
+To perform any task with OpenSCAP you also need to have security policies in
+SCAP format. We call them *SCAP content*. There are many providers of SCAP
+content.
+
+In this document we will use SCAP content provided by *SCAP Security Guide*
+(SSG). Many Linux distributions ship it in the `scap-security-guide` package.
+
+To install `scap-security-guide` on Red Hat Enterprise Linux 8 and newer, on
+CentOS 8 and newer or on Fedora use the following command:
 
 ----
-$ oscap info /usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
+# yum install scap-security-guide
+----
+
+To install `scap-security-guide`  on Red Hat Enterprise Linux 7 or CentOS 7 or
+older use the following command:
+
+----
+# yum install scap-security-guide
+----
+
+The SCAP content will be installed in the `/usr/share/xml/scap/ssg/content/`
+directory.
+
+On other platforms, you can download the upstream release from
+https://github.com/ComplianceAsCode/content/releases/[GitHub].
+
+When the SCAP content is installed on your system, `oscap` can
+process the content by specifying the file path to the content.
+
+You can also use any other SCAP content with OpenSCAP.
+
+== Displaying information about SCAP content
+
+Information about an SCAP file can be displayed using the `oscap info` command.
+
+=== Displaying information about SCAP source data streams
+
+The most common SCAP file type is an SCAP source data stream. In the following
+example, we will display information about SCAP source data stream
+`/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml` from the
+`scap-security-guide` package.
+
+----
+$ oscap info /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml
 Document type: Source Data Stream
-Imported: 2016-08-10T20:49:16
+Imported: 2021-01-12T04:50:11
 
-Stream: scap_org.open-scap_datastream_from_xccdf_ssg-rhel7-xccdf-1.2.xml
+Stream: scap_org.open-scap_datastream_from_xccdf_ssg-rhel8-xccdf-1.2.xml
 Generated: (null)
-Version: 1.2
+Version: 1.3
 Checklists:
-        Ref-Id: scap_org.open-scap_cref_ssg-rhel7-xccdf-1.2.xml
-                Status: draft
-                Generated: 2016-08-10
-                Resolved: true
-                Profiles:
-                        xccdf_org.ssgproject.content_profile_standard
-                        xccdf_org.ssgproject.content_profile_pci-dss
-                        xccdf_org.ssgproject.content_profile_C2S
-                        xccdf_org.ssgproject.content_profile_rht-ccp
-                        xccdf_org.ssgproject.content_profile_common
-                        xccdf_org.ssgproject.content_profile_stig-rhel7-workstation-upstream
-                        xccdf_org.ssgproject.content_profile_stig-rhel7-server-gui-upstream
-                        xccdf_org.ssgproject.content_profile_stig-rhel7-server-upstream
-                        xccdf_org.ssgproject.content_profile_ospp-rhel7-server
-                        xccdf_org.ssgproject.content_profile_nist-cl-il-al
-                        xccdf_org.ssgproject.content_profile_cjis-rhel7-server
-                Referenced check files:
-                        ssg-rhel7-oval.xml
-                                system: http://oval.mitre.org/XMLSchema/oval-definitions-5
-                        ssg-rhel7-ocil.xml
-                                system: http://scap.nist.gov/schema/ocil/2
-                        http://www.redhat.com/security/data/oval/Red_Hat_Enterprise_Linux_7.xml
-                                system: http://oval.mitre.org/XMLSchema/oval-definitions-5
+	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-xccdf-1.2.xml
+		Status: draft
+		Generated: 2021-01-12
+		Resolved: true
+		Profiles:
+			Title: CIS Red Hat Enterprise Linux 8 Benchmark
+				Id: xccdf_org.ssgproject.content_profile_cis
+			Title: Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)
+				Id: xccdf_org.ssgproject.content_profile_cui
+			Title: Australian Cyber Security Centre (ACSC) Essential Eight
+				Id: xccdf_org.ssgproject.content_profile_e8
+			Title: Health Insurance Portability and Accountability Act (HIPAA)
+				Id: xccdf_org.ssgproject.content_profile_hipaa
+			Title: PCI-DSS v3.2.1 Control Baseline for Red Hat Enterprise Linux 8
+				Id: xccdf_org.ssgproject.content_profile_pci-dss
+			Title: [DRAFT] DISA STIG for Red Hat Enterprise Linux 8
+				Id: xccdf_org.ssgproject.content_profile_stig
+			Title: Protection Profile for General Purpose Operating Systems
+				Id: xccdf_org.ssgproject.content_profile_ospp
+		Referenced check files:
+			ssg-rhel8-oval.xml
+				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
+			ssg-rhel8-ocil.xml
+				system: http://scap.nist.gov/schema/ocil/2
+			security-data-oval-com.redhat.rhsa-RHEL8.xml
+				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
 Checks:
-        Ref-Id: scap_org.open-scap_cref_ssg-rhel7-oval.xml
-        Ref-Id: scap_org.open-scap_cref_ssg-rhel7-ocil.xml
-        Ref-Id: scap_org.open-scap_cref_output--ssg-rhel7-cpe-oval.xml
-        Ref-Id: scap_org.open-scap_cref_output--ssg-rhel7-oval.xml
+	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-oval.xml
+	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-ocil.xml
+	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-cpe-oval.xml
+	Ref-Id: scap_org.open-scap_cref_security-data-oval-com.redhat.rhsa-RHEL8.xml
 Dictionaries:
-        Ref-Id: scap_org.open-scap_cref_output--ssg-rhel7-cpe-dictionary.xml
+	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-cpe-dictionary.xml
 ----
 
-and when XCCDF document is examined:
-
-----
-$ oscap info /usr/share/xml/scap/ssg/content/ssg-rhel7-xccdf.xml
-Document type: XCCDF Checklist
-Checklist version: 1.1
-Imported: 2016-08-10T20:49:16
-Status: draft
-Generated: 2016-08-10
-Resolved: true
-Profiles:
-        standard
-        pci-dss
-        C2S
-        rht-ccp
-        common
-        stig-rhel7-workstation-upstream
-        stig-rhel7-server-gui-upstream
-        stig-rhel7-server-upstream
-        ospp-rhel7-server
-        nist-cl-il-al
-        cjis-rhel7-server
-Referenced check files:
-        ssg-rhel7-oval.xml
-                system: http://oval.mitre.org/XMLSchema/oval-definitions-5
-        ssg-rhel7-ocil.xml
-                system: http://scap.nist.gov/schema/ocil/2
-        http://www.redhat.com/security/data/oval/Red_Hat_Enterprise_Linux_7.xml
-                system: http://oval.mitre.org/XMLSchema/oval-definitions-5
-----
-
-**Document type** describes what format the file is in. Common types include
-XCCDF, OVAL, Source Data Stream and Result Data Stream.
-
-**Checklist version** is the XCCDF version only shown for XCCDF files. Common
-values are 1.1 and 1.2.
-
-**Imported** is the date the file was imported for use with OpenSCAP. Since
+* **Document type** describes what format the file is in. Common types include
+XCCDF, OVAL, source data stream and result data stream.
+* **Imported** is the date the file was imported for use with OpenSCAP. Since
 OpenSCAP uses the local filesystem and has no proprietary database format
 the imported date is the same as file modification date.
-
-**Status** is the XCCDF Benchmark status. Common values include "accepted",
-"draft", "deprecated" and "incomplete". Please refer to the XCCDF specification
-for details. This is only shown for XCCDF files.
-
-**Generated** date is the date the file was created / generated. This date
-is shown for XCCDF files and Checklists and is sourced from the XCCDF **Status**
-element.
-
-**Checklists** lists available checklists incorporated in the Data Stream that
+* **Stream** is the data stream ID.
+* **Version** is the version of the SCAP standard.
+* **Checklists** lists available checklists incorporated in the data stream that
 you can use for the `--benchmark-id` command line attribute with `oscap xccdf
 eval`. Also each checklist has the detailed information printed.
+* **Status** is the XCCDF Benchmark status. Common values include "accepted",
+"draft", "deprecated" and "incomplete". Please refer to the XCCDF specification
+for details.
+* **Generated** date is the date the file was created or generated. This date is
+shown for XCCDF files and Checklists and is sourced from the XCCDF **Status**
+element.
+* **Profiles** lists available profiles, their titles and IDs that you can use for
+the `--profile` command line attribute.
+* **Checks** and **Dictionaries** lists OVAL checks components and CPE
+dictionaries components in the given data stream.
 
-**Profiles** lists available profile IDs that you can use for the `--profile`
-command line attribute with `oscap xccdf eval`.
-
-==== More Information about Result Files (XCCDF and ARF)
-
-`oscap info` is less helpful with XCCDF results and ARF files. Two important
-dates that are commonly requested are the evaluation start and end dates.
-
-To look them up in the XCCDF result file, open the file and look for the
-TestResult element. The **start-time** and **end-time** attributes contain the evaluation
-times and dates.
-
-----
-<TestResult id="xccdf_org.open-scap_testresult_common"
-  start-time="2017-01-21T19:16:28" end-time="2017-01-21T19:17:35">
-----
-
-To look up the dates in ARF file open the file and again look for the TestResult
-elements. The elements will be located in the arf:report elements.
+To display more detailed information about a profile including the profile
+description, use the `--profile` option followed by the profile ID.
 
 ----
-<arf:reports>
-  <arf:report id="xccdf1">
-    <arf:content>
-      <TestResult xmlns="http://checklists.nist.gov/xccdf/1.2"
-        id="xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_stig-rhel7-server-upstream"
-        start-time="2017-01-20T14:30:18" end-time="2017-01-20T14:36:32">
+$ oscap info --profile xccdf_org.ssgproject.content_profile_ospp /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml
 ----
 
-You can also find both dates in a HTML report, table **Evaluation
-characteristics**. To generate HTML report from XCCDF result or ARF, use
-`oscap xccdf generate report` command.
+=== Displaying information about SCAP result data streams
 
-=== Scanning with OSCAP
-The main goal of the `oscap` tool is to perform configuration and
-vulnerability scans of a local system. Oscap is able to evaluate both
-XCCDF benchmarks and OVAL definitions and generate the appropriate
-results. Please note that SCAP content can be provided either in a
-single file (as an OVAL file or SCAP Data Stream), or as multiple
-separate XML files. The following examples distinguish between these
-approaches.
+The `oscap info` command is also helpful with other SCAP file types such as
+SCAP result data stream (ARF) files.
 
-==== OVAL
-The SCAP document can have a form of a single OVAL file (an OVAL
-Definition file). The `oscap` tool processes the OVAL Definition file
-during evaluation of OVAL definitions. It collects system
-information, evaluates it and generates an OVAL Result file. The result
-of evaluation of each OVAL definition is printed to standard output
-stream. The following examples describe the most common scenarios
-involving an OVAL Definition file.
+OpenSCAP can display the evaluation start and end dates when given ARF file.
 
-* To evaluate all definitions within the given OVAL Definition file, run
-the following command:
-----------------------------------------------------------
-$ oscap oval eval --results oval-results.xml scap-oval.xml
-----------------------------------------------------------
-Where *scap-oval.xml* is the OVAL Definition file and *oval-results.xml*
-is the OVAL Result file.
+In this example, we will display information about the ARF file `arf.xml`.
 
-* The following is an example of evaluating one particular definition
-within the given OVAL Definition file:
-----------------------------------------------------------------------------------
-$ oscap oval eval --id oval:rhel:def:1000 --results oval-results.xml scap-oval.xml
-----------------------------------------------------------------------------------
-Where the OVAL definition being evaluated is defined by the
-*oval:rhel:def:1000* string, *scap-oval.xml* is the OVAL Definition file
-and *oval-results.xml* is the OVAL Result file.
+----
+$ oscap info arf.xml 
+Document type: Result Data Stream
+Imported: 2021-02-11T11:04:51
 
-* To evaluate all definitions from the OVAL component that are part of a
-particular data stream within a SCAP data stream collection, run the
+Asset: asset0
+	ARF report: xccdf1
+		Report request: collection1
+		Result ID: xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_ospp
+		Source benchmark: /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml
+		Source profile: xccdf_org.ssgproject.content_profile_ospp
+		Evaluation started: 2021-02-11T11:03:06+01:00
+		Evaluation finished: 2021-02-11T11:04:51+01:00
+		Platform CPEs:
+			cpe:/o:fedoraproject:fedora:25
+			cpe:/o:fedoraproject:fedora:26
+			cpe:/o:fedoraproject:fedora:27
+----
+
+== Scanning
+
+The main goal of OpenSCAP is to perform configuration and vulnerability scans of
+a local system. OpenSCAP is able to evaluate SCAP source data streams, XCCDF
+benchmarks and OVAL definitions and generate the appropriate results.
+
+SCAP content can be provided either in a single file (as an SCAP source data
+stream), or as multiple separate XML files.
+
+=== Scanning using SCAP source data streams
+
+Commonly, all required input files are bundled together in an SCAP source data
+stream. Scanning using an SCAP source data stream can be performed by the
+`oscap xccdf eval` command, with some additional parameters available.
+The basic syntax of the `oscap xccdf eval` command is the following:
+
+----
+# oscap xccdf eval --profile PROFILE_ID --results-arf ARF_FILE --report REPORT_FILE SOURCE_DATA_STREAM_FILE
+----
+
+Where:
+
+* `PROFILE_ID` is the ID of an XCCDF profile
+* `ARF_FILE` is the file path where the results in SCAP results data stream
+format (ARF) will be generated
+* `REPORT_FILE` is the file path where a report in HTML format will be generated
+* `SOURCE_DATA_STREAM_FILE` is the file path of the evaluated SCAP source data
+stream
+
+For example, to evaluate the `xccdf_org.ssgproject.content_profile_ospp` profile
+from the `/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml` SCAP source
+data stream run this command:
+
+----
+# oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_ospp --results-arf results.xml --report report.html /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml
+----
+
+The progress and results will be shown in the terminal. Full results are
+generated in `results.xml` as an SCAP result data stream. Detailed results can
+be found in the HTML report `report.html`.
+
+----
+$ firefox report.html
+----
+
+TIP: Instead of the complete profile ID you can provide only a suffix of the
+profile ID. For example, instead of `--profile
+xccdf_org.ssgproject.content_profile_ospp` you can use just `--profile ospp`.
+
+=== Selecting SCAP source data stream components
+
+To evaluate a specific XCCDF benchmark that is part of a specific SCAP source
+data stream, use the following command:
+
+----
+$ oscap xccdf eval --datastream-id DS_ID --xccdf-id CREF --results-arf ARF_FILE SOURCE_DATA_STREAM_FILE
+----
+
+Where:
+
+* `DS_ID` is the ID of `<ds:data-stream>` element to be evaluated
+* `XCCDF_ID` is ID of the `<ds:component-ref>` element pointing to the
+desired XCCDF document
+* `ARF_FILE` is a file containing the scan results in a form of an SCAP
+result data stream
+* `SOURCE_DATA_STREAM_FILE` is the SCAP source data stream file
+
+NOTE: If you omit `--datastream-id` on the command line, the first data
+stream from the collection will be used. If you omit `--xccdf-id`, the
+first component from the checklists element will be used. If you omit
+both, the first data stream that has a component in the checklists
+element will be used - the first component in its checklists element
+will be used.
+
+To evaluate a specific XCCDF benchmark that is part of an SCAP source data
+stream use the following options:
+
+----
+$ oscap xccdf eval --benchmark-id BENCHMARK_ID --results-arf ARF_XML SOURCE_DATA_STREAM_FILE
+----
+
+Where:
+
+* `SOURCE_DATA_STREAM_FILE` is a file representing the SCAP source data stream
+* `BENCHMARK_ID` is the value of the "id" attribute of `<xccdf:Benchmark>` 
+containing component
+* `ARF_FILE` is a file containing the scan results in a form of an SCAP
+result data stream
+
+
+=== Evaluating Standalone OVAL Definitions
+
+The SCAP document can have a form of a single OVAL file (an OVAL Definition
+file). The `oscap` tool processes the OVAL Definition file during evaluation of
+OVAL definitions. It collects system information, evaluates it and generates an
+OVAL Result file. The result of evaluation of each OVAL definition is printed to
+standard output stream. The following examples describe the most common
+scenarios involving an OVAL Definition file.
+
+To evaluate OVAL definitions within the given OVAL Definition file the
+`oscap oval eval` command can be used. Its basic form is the following:
+
+----
+$ oscap oval eval --results RESULTS_FILE OVAL_FILE
+----
+
+Where:
+
+* `OVAL_FILE` is the OVAL Definition file
+* `RESULTS_FILE` is the path where OVAL Results file will be stored
+
+It's possible to select and evaluate one particular definition
+within the given OVAL Definition file using `--id` option:
+
+----
+$ oscap oval eval --id oval:rhel:def:1000 --results oval-results.xml oval.xml
+----
+
+Where the OVAL definition being evaluated has ID `oval:rhel:def:1000`,
+`oval.xml` is the OVAL Definition file and `oval-results.xml` is the
+OVAL Result file.
+
+To evaluate all definitions from the OVAL component that are part of a
+particular data stream component within a SCAP source data stream, run the
 following command:
----------------------------------------------------------------------------------------------------
-$ oscap oval eval --datastream-id ds.xml --oval-id xccdf.xml --results oval-results.xml scap-ds.xml
----------------------------------------------------------------------------------------------------
-Where *ds.xml* is the given data stream, *xccdf.xml* is an XCCDF file
-specifying the OVAL component, *oval-results.xml* is the OVAL Result
-file, and *scap-ds.xml* is a file representing the SCAP data stream
-collection.
 
+----
+$ oscap oval eval --datastream-id ds.xml --oval-id xccdf.xml --results oval-results.xml scap-ds.xml
+----
+
+Where `ds.xml` is the ID of a specific data stream, `xccdf.xml` is an XCCDF file
+specifying the OVAL component, `oval-results.xml` is the OVAL Result file, and
+`scap-ds.xml` is the SCAP source data stream collection.
 
 When the SCAP content is represented by multiple XML files, the OVAL
 Definition file can be distributed along with the XCCDF file. In such a
@@ -320,6 +409,7 @@ $ oscap xccdf export-oval-variables \
 --profile united_states_government_configuration_baseline \
 usgcb-rhel5desktop-xccdf.xml
 ----
+
 ----
 $ oscap oval eval \
 --variables usgcb-rhel5desktop-oval.xml-0.variables-0.xml \
@@ -368,25 +458,25 @@ full results:
 ----
 
 If your use-case requires thin OVAL results you most likely also want
-to omit system characteristics. You can use the *--without-syschar*
+to omit system characteristics. You can use the `--without-syschar`
 option to that effect.
 
 Usage of OVAL directives file when scanning a plain OVAL file:
 
----------------------------------------------------------------------------------------------------
+----
 $ oscap oval eval --directives directives.xml --without-syschar --results oval-results.xml oval.xml
----------------------------------------------------------------------------------------------------
+----
 
-Usage of OVAL directives file when scanning OVAL component from a Source DataStream:
+Usage of OVAL directives file when scanning OVAL component from a source data stream:
 
----------------------------------------------------------------------------------------------------
+----
 $ oscap oval eval --directives directives.xml --without-syschar --datastream-id ds.xml --oval-id oval.xml --results oval-results.xml scap-ds.xml
----------------------------------------------------------------------------------------------------
+----
 
 It is not always clear which OVAL file will be used when multiple files
 are distributed. In case you are evaluating an XCCDF file you can use:
 
----------------------------------------------------------------------------------------------------
+----
 $ oscap info ssg-rhel7-xccdf.xml
 Document type: XCCDF Checklist
 Checklist version: 1.1
@@ -416,17 +506,18 @@ Referenced check files:
                 system: http://scap.nist.gov/schema/ocil/2
         https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2
                 system: http://oval.mitre.org/XMLSchema/oval-definitions-5
----------------------------------------------------------------------------------------------------
+----
 
 In the output you can see all referenced check files. In this case we see
 that `ssg-rhel7-oval.xml` is referenced. To see contents of this file you
 can open it in a text editor.
 
-You can use `oscap info` with Source DataStream files as well. Source
-DataStream will often reference OVAL files that are bundled in it.
-It is also possible to extract OVAL files from Source DataStream through `oscap ds sds-split`.
+You can use `oscap info` with source data stream files as well. Source
+data stream will often reference OVAL files that are bundled in it.
+It is also possible to extract OVAL files from source data stream using
+`oscap ds sds-split`.
 
----------------------------------------------------------------------------------------------------
+----
 $ oscap ds sds-split ssg-rhel7-ds.xml extracted/
 $ ls -1 extracted/
 scap_org.open-scap_cref_output--ssg-rhel7-cpe-dictionary.xml
@@ -434,15 +525,17 @@ scap_org.open-scap_cref_ssg-rhel7-xccdf-1.2.xml
 ssg-rhel7-cpe-oval.xml
 ssg-rhel7-ocil.xml
 ssg-rhel7-oval.xml
----------------------------------------------------------------------------------------------------
+----
 
-After splitting the Source DataStream you can inspect OVAL and XCCDF files
-individually using a text editor. Keep in mind that this is only an example
-and filenames depend on contents of the DataStream you are splitting and that
-you can also inspect XCCDF and OVAL content directly in Source DataStream
-or Result DataStream.
+After splitting the source data stream you can inspect OVAL and XCCDF files
+individually using a text editor. Keep in mind that this is only an example and
+file names depend on contents of the source data stream you are splitting and
+that you can also inspect XCCDF and OVAL content directly in a source data
+stream or a result data stream.
 
-==== XCCDF
+
+=== Evaluating XCCDF
+
 When evaluating an XCCDF benchmark, `oscap` usually processes an XCCDF
 file, an OVAL file and the CPE dictionary. It performs system
 analysis and produces XCCDF results based on this analysis. The results
@@ -517,70 +610,29 @@ evaluation:
 $ oscap xccdf eval --profile Desktop --results xccdf-results.xml --cpe cpe-dictionary.xml scap-xccdf.xml
 ----
 
-Where *scap-xccdf.xml* is the XCCDF document, *Desktop* is the selected
-profile from the XCCDF document, *xccdf-results.xml* is a file storing
-the scan results, and *cpe-dictionary.xml* is the CPE dictionary.
+Where `scap-xccdf.xml` is the XCCDF document, `Desktop` is the selected
+profile from the XCCDF document, `xccdf-results.xml` is a file storing
+the scan results, and `cpe-dictionary.xml` is the CPE dictionary.
 
-* You can additionaly add `--rule` option to the above command to evaluate
+* You can additionally add `--rule` option to the above command to evaluate
 a specific rule:
 
 ----
 $ oscap xccdf eval --profile Desktop --rule ensure_gpgcheck_globally_activated  --results xccdf-results.xml --cpe cpe-dictionary.xml scap-xccdf.xml
 ----
 
-Where *ensure_gpgcheck_globally_activated* is the only rule from the *Desktop*
+Where `ensure_gpgcheck_globally_activated` is the only rule from the `Desktop`
 profile which will be evaluated.
 
-==== Source DataStream
-Commonly, all required input files are bundled together in Source DataStream.
-Scanning using Source DataStream is also handled by `oscap xccdf eval` command,
-with some additional parameters available to determine which of the bundled
-benchmarks should be performed.
-
-* To evaluate a specific XCCDF benchmark that is part of a DataStream
-within a SCAP DataStream collection, run the following command:
-
-----
-$ oscap xccdf eval --datastream-id ds.xml --xccdf-id xccdf.xml --results xccdf-results.xml scap-ds.xml
-----
-
-Where *scap-ds.xml* is a file representing the SCAP DataStream
-collection, *ds.xml* is the particular DataStream, *xccdf.xml* is ID of
-the component-ref pointing to the desired XCCDF document, and
-*xccdf-results.xml* is a file containing the scan results.
-
-NOTE: If you omit `--datastream-id` on the command line, the first data
-stream from the collection will be used. If you omit `--xccdf-id`, the
-first component from the checklists element will be used. If you omit
-both, the first DataStream that has a component in the checklists
-element will be used - the first component in its checklists element
-will be used.
-
-
-* (Alternative, not recommended) To evaluate a specific XCCDF benchmark
-that is part of a DataStream within a SCAP DataStream collection run
-the following command:
-
---------------------------------------------------------------------------------------
-$ oscap xccdf eval --benchmark-id benchmark_id --results xccdf-results.xml scap-ds.xml
---------------------------------------------------------------------------------------
-
-Where *scap-ds.xml* is a file representing the SCAP DataStream
-collection, *benchmark_id* is a string matching the "id" attribute of
-xccdf:Benchmark containing in a component, and *xccdf-results.xml* is a
-file containing the scan results.
-
-==== Result DataStream (ARF)
-
 In the examples above we are generating XCCDF result files using the `--results`
-command-line argument. You can use `--results-arf` to generate a Result DataStream
-(also called ARF - Asset Reporting Format) XML instead.
+command-line argument. You can use `--results-arf` to generate an SCAP result
+data stream (also called ARF - Asset Reporting Format) XML instead.
 
---------------------------------------------------------------------------------------
+----
 $ oscap xccdf eval --benchmark-id benchmark_id --results-arf arf-results.xml scap-ds.xml
---------------------------------------------------------------------------------------
+----
 
-==== Generating results compatible with STIG Viewer
+=== Generating results compatible with STIG Viewer
 
 DISA STIG Viewer is a graphical user interface (GUI) application that enables
 easy viewing of SCAP-formatted Security Technical Implementation Guides
@@ -639,43 +691,49 @@ STIG by DISA. When evaluating a STIG provided by DISA using `oscap`, use the
 `scap-security-guide` content in STIG Viewer and evaluating
 `scap-security-guide` by oscap, use `--results` instead of `--stig-viewer`.
 
-=== Remediate System
+
+== Remediating system
+
 OpenSCAP allows to automatically remediate systems that have been found in a
-non-compliant state. For system remediation, an XCCDF file with instructions is
-required. The _scap-security-guide_ package contains certain remediation
-instructions.
+non-compliant state. For system remediation the rules in SCAP content need to
+have a remediation script attached. For example, the SCAP source data streams in
+the `scap-security-guide` package contain rules with remediation fix scripts.
 
 System remediation consists of the following steps:
 
- . `oscap` performs a regular XCCDF evaluation.
+ . The `oscap` command performs a regular XCCDF evaluation.
  . An assessment of the results is performed by evaluating the OVAL definitions.
  Each rule that has failed is marked as a candidate for remediation.
- . `oscap` searches for an appropriate fix element, resolves it, prepares the
- environment, and executes the fix script.
+ . The `oscap` program searches for an appropriate `<xccdf:fix>` element,
+ resolves it, prepares the environment, and executes the fix script.
  . Any output of the fix script is captured by `oscap` and stored within the
- *rule-result* element. The return value of the fix script is stored as well.
+ `<xccdf:rule-result>` element. The return value of the fix script is stored as
+ well.
  . Whenever `oscap` executes a fix script, it immediately evaluates the OVAL
  definition again (to verify that the fix script has been applied correctly).
  During this second run, if the OVAL evaluation returns success, the result of
  the rule is *fixed*, otherwise it is an *error*.
  . Detailed results of the remediation are stored in an output XCCDF file. It
- contains two *TestResult* elements. The first *TestResult* element represents the
- scan prior to the remediation. The second *TestResult* is derived from the first
- one and contains remediation results.
+ contains two `<xccdf:TestResult>` elements. The first `<xccdf:TestResult>`
+ element represents the scan prior to the remediation. The second
+ `<xccdf:TestResult>` is derived from the first one and contains remediation
+ results.
 
 There are three modes of operation of `oscap` with regard to remediation:
 online, offline, and review.
 
-==== Online Remediation
-Online remediation executes fix elements at the time of scanning. Evaluation and
+=== Remediation during scanning
+
+The remediation scripts can be executed at the time of scanning. Evaluation and
 remediation are performed as a part of a single command.
 
-To enable online remediation, use the `--remediate` command-line option. For
-example, to execute online remediation using the _scap-security-guide_ package,
-run:
+To enable remediation during scanning, use the `oscap xccdf eval` command with
+the `--remediate` command-line option.
+
+In this example we will execute remediation during evaluation of the OSPP profile:
 
 ----
-$ oscap xccdf eval --remediate --profile xccdf_org.ssgproject.content_profile_rht-ccp --results scan-xccdf-results.xml /usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
+# oscap xccdf eval --remediate --profile xccdf_org.ssgproject.content_profile_ospp --results-arf results.xml /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml
 ----
 
 The output of this command consists of two sections. The first section shows the
@@ -685,48 +743,310 @@ only *fixed* and *error* results. The *fixed* result indicates that the scan per
 after the remediation passed. The *error* result indicates that even after
 applying the remediation, the evaluation still does not pass.
 
-==== Offline Remediation
-Offline remediation allows you to postpone fix execution. In first step, the
-system is only evaluated, and the results are stored in a *TestResult* element in
-an XCCDF file.
+=== Remediation after scanning
+
+This feature allows you to postpone fix execution. 
+
+In first step, the system is only evaluated, and the results are stored in the
+`<xccdf:TestResult>` element in an XCCDF results file.
 
 In the second step, `oscap` executes the fix scripts and verifies the result. It
 is safe to store the results into the input file, no data will be lost. During
-offline remediation, a new *TestResult* element is created that is based
-on the input one and inherits all the data. The newly created *TestResult*
-differs only in the *rule-result* elements that have failed. For those,
-remediation is executed.
+offline remediation, a new `<xccdf:TestResult>` element is created that is based
+on the input one and inherits all the data. The newly created
+`<xccdf:TestResult>` differs only in the `<xccdf:rule-result>` elements that
+have failed. For those, remediation is executed.
 
-To perform offline remediation using the _scap-security-guide_ package, run:
 
+For example:
 ----
-$ oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_rht-ccp --results scan-xccdf-results.xml /usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
-----
-----
-$ oscap xccdf remediate --results scan-xccdf-results.xml scan-xccdf-results.xml
+# oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_ospp --results results.xml /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml
 ----
 
-==== Remediation Review
+----
+# oscap xccdf remediate --results remediation-results.xml results.xml
+----
+
+=== Reviewing remediations
+
 The review mode allows users to store remediation instructions to a file for
 further review. The remediation content is not executed during this operation.
 To generate remediation instructions in the form of a shell script, run:
 
+. Run a scan and generate XCCDF results file using the `--results` option.
++
 ----
-$ oscap xccdf generate fix \
---fix-type bash \
---profile xccdf_org.ssgproject.content_profile_rht-ccp \
---output my-remediation-script.sh \
-/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
+# oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_ospp --results results.xml /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml
+----
++
+. Obtain the results ID.
++
+----
+$ oscap info results.xml
+----
++
+. Generate the fix based on the scan results.
++
+----
+# oscap xccdf generate fix --fix-type bash --output my-remediation-script.sh --result-id xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_ospp results.xml 
 ----
 
+
+== Tailoring
+
+This section describes tailoring of content using a tailoring file. This allows
+you to change behavior of content without its direct modification.
+
+. Create a tailoring file
++
+Tailoring file can be easily created using {workbench_url}[SCAP Workbench].
++
+. List profiles in the tailoring file
++
+----
+$ oscap info ssg-rhel8-ds-tailoring.xml
+Document type: XCCDF Tailoring
+Imported: 2016-08-31T11:08:16
+Benchmark Hint: /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml
+Profiles:
+	xccdf_org.ssgproject.content_profile_C2S_customized
+----
++
+. Run a scan. The command evaluates tailored data stream by
+`ssg-rhel8-ds-tailoring.xml` tailoring file. XCCDF results can be found in
+`results.xml` file.
++
+----
+$ oscap xccdf eval \
+--profile xccdf_org.ssgproject.content_profile_C2S_customized \
+--tailoring-file ssg-rhel8-ds-tailoring.xml \
+--results results.xml
+/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml
+----
+
+WARNING: Use the ID of the customized profile (from the tailoring file), do not
+use the ID of the original profile.
+
+
+Instead of external tailoring file, you can also use tailoring component
+integrated to data stream.
+
+----
+$ oscap info simple-ds.xml
+
+Document type: Source Data Stream
+Imported: 2016-02-02T14:06:14
+
+Stream: scap_org.open-scap_datastream_from_xccdf_simple-xccdf.xml
+Generated: (null)
+Version: 1.2
+Checklists:
+	Ref-Id: scap_org.open-scap_cref_simple-xccdf.xml
+		Status: incomplete
+		Resolved: false
+		Profiles:
+			xccdf_org.open-scap_profile_override
+		Referenced check files:
+			simple-oval.xml
+				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
+	Ref-Id: scap_org.open-scap_cref_simple-tailoring.xml
+		Benchmark Hint: (null)
+		Profiles:
+			xccdf_org.open-scap_profile_default
+			xccdf_org.open-scap_profile_unselecting
+			xccdf_org.open-scap_profile_override
+Checks:
+	Ref-Id: scap_org.open-scap_cref_simple-oval.xml
+No dictionaries.
+----
+
+To choose tailoring component `scap_org.open-scap_cref_simple-tailoring.xml`,
+the command below can be used.
+
+----
+$ oscap xccdf eval \
+--tailoring-id scap_org.open-scap_cref_simple-tailoring.xml \
+--profile xccdf_org.open-scap_profile_default \
+--results results.xml simple-ds.xml
+----
+
+The command above evaluates content using tailoring component
+`scap_org.open-scap_cref_simple-tailoring.xml` from source data stream. Scan
+results are stored in `results.xml` file.
+
+
+== Scanning with Script Check Engine (SCE)
+
+The Script Check Engine (SCE) is an alternative check engine for XCCDF checklist
+evaluation.  SCE allows you to call shell scripts out of the XCCDF document.
+This approach might be suitable for various use cases, mostly when OVAL checks
+are not required. More information about SCE usage is available on this page:
+{sce_web}[Using SCE].
+
+WARNING: SCE is not part of any SCAP specification.
+
+
+== Validating SCAP Content
+
+The `oscap` tool can be used to validate the security content
+against standard SCAP XML schemas. The validation results are printed to the
+standard error stream (stderr). The general syntax of the validation command
+is the following:
+
+----
+$ oscap module validate [module_options_and_arguments] FILE
+----
+
+where `FILE` is the full path to the file being validated. As a `module` you
+can use:
+
+  * xccdf,
+  * oval,
+  * cpe or
+  * cve.
+
+The only exception is the data stream module (ds), which uses the sds-validate
+operation instead of validate. So for example, it would be like:
+
+----
+$ oscap ds sds-validate scap-ds.xml
+----
+
+NOTE: Note that all SCAP components within the given data stream are validated
+automatically and none of the components is specified separately.
+
+You can also enable extra Schematron-based validation if you validate OVAL
+specification. This validation method is slower but it provides deeper analysis.
+Run the following command to validate an OVAL document using Schematron:
+
+----
+$ oscap oval validate --schematron oval-file.xml
+----
+
+The results of validation are printed to standard error stream (stderr).
+
+NOTE: Please note that for the rest of `oscap` functionality, unless you specify
+--skip-validation (--skip-valid), validation will automatically occur before
+files are used. Therefore, you do not need to explicitly validate a datastream
+before use.
+
+=== Validating digital signature in SCAP source data stream
+
+When evaluating a digitally signed SCAP source data stream OpenSCAP validates
+the digital signature of the data stream. The signature validation is performed
+automatically while loading the file. Data streams with invalid signatures would
+be rejected and would not be evaluated. OpenSCAP uses
+https://www.aleksey.com/xmlsec/[XML Security Library] with OpenSSL backend to
+validate the digital signature.
+
+The signature validation only checks that the datastream hasn't been altered
+since its latest signature. OpenSCAP doesn't address trustworthiness of
+certificates or public keys that are part of the `KeyInfo` signature element and
+that are used to verify the signature. You should verify those keys yourself to
+prevent evaluation of datastreams that have been modified and signed by bad
+actors.
+
+The signature validation can be skipped by adding the
+`--skip-signature-validation` option to the `oscap xccdf eval` command.
+
+== Generating reports, guides and scripts
+
+Another useful features of `oscap` is the ability to generate documents in a
+human-readable format. It allows you to transform an XML file into HTML or
+plain-text format. This feature is used to generate security guides and
+checklists, which serve as a source of information, as well as guidance for
+secure system configuration. The results of system scans can also be transformed
+to well-readable result reports. Moreover, remediation scripts and Ansible
+playbooks can be generated if the SCAP content contains these data.
+
+The general command syntax is the following:
+
+----
+oscap module generate sub-module [specific_module/sub-module_options_and_arguments] file
+----
+
+Where module is either `xccdf` or `oval`, `sub-module` is a type of
+the generated document, and file represents an XCCDF or OVAL file. A sub-module
+can be either `report`, `guide`, `custom` or `fix`. Please see
+ `man oscap` for more details.
+
+
+=== Generating HTML guides
+
+To generate a HTML guide from an SCAP source data stream or an XCCDF file use the `oscap xccdf generate guide` command.
+
+Generating a guide with profile checklist (see an
+https://static.open-scap.org/examples/guide-checklist.html[example]):
+
+----
+$ oscap xccdf generate guide --profile xccdf_org.ssgproject.content_profile_ospp /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml > guide.html
+----
+
+=== Generating HTML reports
+
+To generate HTML scan reports after scan from the scan results in ARF or XCCDF
+format the `oscap xccdf generate report` command can be used.
+
+Generating the HTML report with information about checks (see an
+https://static.open-scap.org/examples/report-xccdf-oval.html[example]):
+
+----
+$ oscap xccdf generate report arf.xml > report.html
+----
+
+TIP: The HTML report can be generated also during scan by adding the `--report`
+option to the `oscap xccdf eval` command.
+
+=== Generating bash scripts
+
+To generate a bash remediation script from an XCCDF profile, use the `oscap
+xccdf generate fix` command. OpenSCAP will extract remediation scripts for all
+rules in the given profile to a file.
+
+For example, to generate a bash remediation script for RHEL 8 OSPP profile, run:
+
+----
+$ oscap xccdf generate fix --profile ospp /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml > fix.sh
+----
+
+The output contains fixes for all rules in the given profile including those
+rules that would pass. It's because system isn't scanned during this command. If
+you want to generate remediation only for the failed rules based on scan
+results, refer to <<_reviewing_remediations,Reviewing remediations>>.
+
+=== Generating Ansible Playbooks
+
+Similar to generating bash scripts, OpenSCAP is able to extract Ansible tasks
+associated with XCCDF rules and generate an Ansible Playbook that can be used to
+configure the operating system according to the given profile. To generate
+Anisble Playbook use the `oscap xccdf generate fix` command with `--fix-type
+ansible` option.
+
+For example, to generate Ansible Playbook from RHEL 8 OSPP profile, run:
+
+----
+$ oscap xccdf generate fix --profile ospp --fix-type ansible /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml > playbook.yml
+----
+
+The generated Ansible Playbook is generated from an OpenSCAP profile without
+preliminary evaluation. It attempts to fix every selected rule, even if the
+system is already compliant. The output contains fixes for all rules in the
+given profile including those rules that would pass. It's because system isn't
+scanned during this command. If you want to generate remediation only for the
+failed rules based on scan results, refer to <<_reviewing_remediations,Reviewing
+remediations>>.
+
+== Details on SCAP conformance
+
 === Check Engines
+
 Most XCCDF content uses the OVAL check engine. This is when OVAL
 Definitions are being evaluated in order to assess a system. Complete
 information of an evaluation is recorded in OVAL Results files, as
 defined by the OVAL specification. By examining these files it's
 possible check what definitions were used for the evaluation and why the
 results are as they are. Please note these files are not generated
-unless *--oval-results* is used.
+unless `--oval-results` is used.
 
 Some content may use alternative check engines, for example the
 {sce_web}[SCE] check engine.
@@ -737,7 +1057,7 @@ read or interpreted in any way unless the check system is known and
 supported. Following is an evaluation output of an XCCDF with unknown
 check system:
 
---------------------------------------------------------
+----
 $ oscap xccdf eval sds-datastream.xml
 
 Title   Check group file contents
@@ -753,22 +1073,23 @@ Rule    xccdf_org.example_rule_system_authcontent-shadow
 Result  notchecked
 
 ...
---------------------------------------------------------
+----
 
 NOTE: The *notchecked* result is also reported for rules that have no
 check implemented. *notchecked* means that there was no check in that
 particular rule that could be evaluated.
 
 
-==== CVE, CCE, CPE and other identifiers
-Each XCCDF Rule can have xccdf:ident elements inside. These elements
+=== CVE, CCE, CPE and other identifiers
+
+Each XCCDF Rule can have `<xccdf:ident>` elements inside. These elements
 allow the content creator to reference various external identifiers like
 CVE, CCE, CPE and others.
 
-When scanning, oscap output identifiers of scanned rules regardless of
+When scanning, `oscap` outputs identifiers of scanned rules regardless of
 their results. For example:
 
-------------------------------------------------------------------------
+----
 Title   Ensure Repodata Signature Checking is Not Disabled For Any Repos
 Rule    rule-2.1.2.3.6.a
 Result  pass
@@ -782,7 +1103,7 @@ Title   Verify group who owns 'shadow' file
 Rule    rule-2.2.3.1.b
 Ident   CCE-3988-3
 Result  pass
-------------------------------------------------------------------------
+----
 
 All identifiers (if any) are printed to stdout for each rule. Since
 standard output doesn't allow for compact identifier metadata to be
@@ -793,8 +1114,9 @@ is a CVE you can click it to display its metadata from the official NVD
 database (requires internet connection). OpenSCAP doesn't provide
 metadata for other types of identifiers.
 
-Another place where these identifiers can be found are machine-readable Result Datastream files.
-This file can be generated during the scan by adding *--results-arf* option.
+Another place where these identifiers can be found are machine-readable SCAP
+result data stream (ARF) files. This file can be generated during the scan by
+adding `--results-arf` option.
 
 ----
 $ oscap xccdf eval \
@@ -803,7 +1125,7 @@ $ oscap xccdf eval \
 /usr/share/xml/scap/ssg/content/ssg-rhel6-ds.xml
 ----
 
-Result data stream file **results.xml** contains these identifiers in <rule-result>
+Result data stream file `results.xml` contains these identifiers in `<xccdf:rule-result>`
 elements.
 
 ----
@@ -838,160 +1160,26 @@ by grouping by NIST SP 800-53 ID, you can see all NIST 800-53 IDs
 related to the searched CCE ID.
 
 
-==== Bundled CCE data
+=== Bundled CCE data
+
 OpenSCAP does not provide any static or product bundled CCE data. Thus
 it has no way of displaying the last generated, updated and officially
 published dates of static or product bundled CCE data because the dates
 are not defined.
 
-==== Scanning with Script Check Engine (SCE)
-The Script Check Engine (SCE) is an alternative check engine for XCCDF checklist
-evaluation.  SCE allows you to call shell scripts out of the XCCDF document.
-This approach might be suitable for various use cases, mostly when OVAL checks
-are not required. More information about SCE usage is available on this page:
-{sce_web}[Using SCE].
-
-WARNING: SCE is not part of any SCAP specification.
-
-
-== Advanced oscap usage
-
-=== Validating SCAP Content
-Before you start using a security policy on your systems, you should first
-verify the policy in order to avoid any possible syntax or semantic errors in
-the policy. The `oscap` tool can be used to validate the security content
-against standard SCAP XML schemas. The validation results are printed to the
-standard error stream (stderr). The general syntax of such a validation command
-is the following:
-
-----
-$ oscap module validate [module_options_and_arguments] file
-----
-
-where file is the full path to the file being validated. As a `module` you
-can use:
-
-  * xccdf,
-  * oval,
-  * cpe or
-  * cve.
-
-The only exception is the data stream module (ds), which uses the sds-validate
-operation instead of validate. So for example, it would be like:
-
-----
-$ oscap ds sds-validate scap-ds.xml
-----
-
-NOTE: Note that all SCAP components within the given data stream are validated
-automatically and none of the components is specified separately.
-
-You can also enable extra Schematron-based validation if you validate OVAL
-specification. This validation method is slower but it provides deeper analysis.
-Run the following command to validate an OVAL document using Schematron:
-
-----
-$ oscap oval validate --schematron oval-file.xml
-----
-
-The results of validation are printed to standard error stream (stderr).
-
-NOTE: Please note that for the rest of `oscap` functionality, unless you specify
---skip-validation (--skip-valid), validation will automatically occur before files are used.
-Therefore, you do not need to explicitly validate a datastream before
-use.
-
-=== Validating digital signature in SCAP source data stream
-
-When evaluating a digitally signed SCAP source data stream OpenSCAP validates
-the digital signature of the data stream. The signature validation is performed
-automatically while loading the file. Data streams with invalid signatures would
-be rejected and would not be evaluated. OpenSCAP uses
-https://www.aleksey.com/xmlsec/[XML Security Library] with OpenSSL backend to
-validate the digital signature.
-
-The signature validation only checks that the datastream hasn't been altered
-since its latest signature. OpenSCAP doesn't address trustworthiness of
-certificates or public keys that are part of the `KeyInfo` signature element and
-that are used to verify the signature. You should verify those keys yourself to
-prevent evaluation of datastreams that have been modified and signed by bad
-actors.
-
-The signature validation can be skipped by adding the
-`--skip-signature-validation` option to the `oscap xccdf eval` command.
-
-
-=== Generating Reports and Guides
-Another useful features of `oscap` is the ability to generate SCAP content in a
-human-readable format. It allows you to transform an XML file
-into HTML or plain-text format. This feature is used to generate security
-guides and checklists, which serve as a source of information, as well as
-guidance for secure system configuration. The results of system scans can also
-be transformed to well-readable result reports. The general command syntax is
-the following:
-
-----
-oscap module generate sub-module [specific_module/sub-module_options_and_arguments] file
-----
-
-where module is either `xccdf` or `oval`, `sub-module` is a type of
-the generated document, and file represents an XCCDF or OVAL file. A sub-module
-can be either `report`, `guide`, `custom` or `fix`. Please see
- `man oscap` for more details.
-
-
-=== Content Transformation
-The oscap tool is also capable of using the {xslt}[XSLT] (Extensible Stylesheet
-Language Transformations) language, which allows transformation of a SCAP
-content XML file into another XML, HTML, plain text or {xsl}[XSL] document.
-This feature is very useful when you need the SCAP document in a
-human-readable form. The following commands represent the most common
-cases:
-
-* Creating a guide (see an
-https://static.open-scap.org/examples/guide.html[example]):
---------------------------------------------------------
-$ oscap xccdf generate guide scap-xccdf.xml > guide.html
---------------------------------------------------------
-
-* Creating a guide with profile checklist (see an
-https://static.open-scap.org/examples/guide-checklist.html[example]):
-------------------------------------------------------------------------------------
-$ oscap xccdf generate guide --profile Desktop scap-xccdf.xml > guide-checklist.html
-------------------------------------------------------------------------------------
-
-* Generating the XCCDF scan report (see an
-https://static.open-scap.org/examples/report-xccdf.html[example]):
--------------------------------------------------------------------
-$ oscap xccdf generate report xccdf-results.xml > report-xccdf.html
--------------------------------------------------------------------
-
-* Generating the OVAL scan report (see an
-https://static.open-scap.org/examples/report-oval.html[example]):
-----------------------------------------------------------------
-$ oscap oval generate report oval-results.xml > report-oval.html
-----------------------------------------------------------------
-
-* Generating the XCCDF report with additional information from failed
-OVAL tests (see an
-https://static.open-scap.org/examples/report-xccdf-oval.html[example]):
-----
-$ oscap xccdf generate report \
---oval-template oval-results.xml xccdf-results.xml > report-xccdf-oval.html
-----
-
 
 === CPE applicability
+
 XCCDF rules in the content may target only specific platforms and hold
 no meaning on other platforms. Such an XCCDF rule contains an
-*<xccdf:platform>* element in its body. This element references a CPE
-name or CPE2 platform (defined using **cpe2:platform-specification**)
+`<xccdf:platform>`` element in its body. This element references a CPE
+name or CPE2 platform (defined using `<cpe2:platform-specification>`)
 that could be defined in a CPE dictionary file or a CPE language file
 or it can also be embedded directly in the XCCDF document.
 
-An XCCDF rule can contain multiple *<xccdf:platform>* elements. It is
+An XCCDF rule can contain multiple `<xccdf:platform>` elements. It is
 deemed applicable if at least one of the listed platforms is applicable.
-If an XCCDF rule contains no *<xccdf:platform>* elements it is considered
+If an XCCDF rule contains no `<xccdf:platform>` elements it is considered
 always applicable.
 
 If the CPE name or CPE2 platform is defined in an external file, use the
@@ -999,12 +1187,12 @@ If the CPE name or CPE2 platform is defined in an external file, use the
 command is an example of the XCCDF content evaluation using CPE name
 from an external file:
 
------------------------------------------------------------------------------------------
+----
 $ oscap xccdf eval --results xccdf-results.xml --cpe external-cpe-file.xml xccdf-file.xml
------------------------------------------------------------------------------------------
+----
 
-Where *xccdf-file.xml* is the XCCDF document, *xccdf-results.xml* is a file
-containing the scan results, and *external-cpe-file.xml* is the CPE
+Where `xccdf-file.xml` is the XCCDF document, `xccdf-results.xml` is a file
+containing the scan results, and `external-cpe-file.xml` is the CPE
 dictionary or a language file.
 
 If you are evaluating a source data stream, `oscap` automatically
@@ -1016,23 +1204,23 @@ shown by the command below:
 $ oscap xccdf eval --datastream-id ds.xml --xccdf-id xccdf.xml --results xccdf-results.xml --cpe additional-external-cpe.xml scap-ds.xml
 ----
 
-Where *scap-ds.xml* is a file representing the SCAP data stream
-collection, *ds.xml* is the particular data stream, *xccdf.xml* is the
-XCCDF document, *xccdf-results.xml* is a file containing the scan
-results, and *additional-external-cpe.xml* is the additional CPE
+Where `scap-ds.xml` is a file representing the SCAP data stream
+collection, `ds.xml` is the particular data stream, `xccdf.xml` is the
+XCCDF document, `xccdf-results.xml` is a file containing the scan
+results, and `additional-external-cpe.xml` is the additional CPE
 dictionary or language file.
 
 The `oscap` tool will use an OVAL file attached to the CPE dictionary to
 determine applicability of any CPE name in the dictionary.
 
 Apart from the instructions above, no extra steps have to be taken for
-content using *cpe:fact-ref* or **cpe2:fact-ref**. See the following
+content using `<cpe:fact-ref>` or `<cpe2:fact-ref>`. See the following
 sections for details on resolving.
 
 ==== xccdf:platform applicability resolution
 
 When a CPE name or language model platform is referenced via
-*<xccdf:platform>* elements, resolution happens in the following order:
+`<xccdf:platform>` elements, resolution happens in the following order:
 
  . Look into embedded CPE2 language model if name is found and applicable deem
  it applicable
@@ -1048,7 +1236,7 @@ look for it elsewhere.
 
 ==== cpe:fact-ref and cpe2:fact-ref resolution
 
-CPE name referenced from within fact-ref is resolved in the following
+CPE name referenced from within `fact-ref` is resolved in the following
 order:
 
 .  Look into embedded CPE dictionary, if name is found and applicable
@@ -1065,17 +1253,14 @@ is used as a fall-back option when there is no other CPE source found.
 
 The list of inbuilt CPE names can be found in the output of
 
------------------
+----
 $ oscap --version
------------------
+----
 
-You can file a request to include any additional product in the built-in
-dictionary via https://www.redhat.com/mailman/listinfo/open-scap-list[open-scap
-mailing list] or
-https://bugzilla.redhat.com/enter_bug.cgi?product=Fedora[bugzilla].
-
+The built-in CPE dictionary will be deprecated in OpenSCAP 1.4.0.
 
 === Notes on the Concept of Multiple OVAL Values
+
 This section describes advanced concepts of OVAL Variables and their
 implementation in `oscap`. The SCAP specification allows for an OVAL
 variable to have multiple values during a single assessment run. There
@@ -1108,6 +1293,7 @@ use XCCDF to bridge that gap).
 TIP: `oscap` supports both variable modes as described below.
 
 ==== Sources of Variable Values
+
 First we need to understand how a single value can be bound to a
 variable in the OVAL checking engine. There are three ways to do this:
 
@@ -1116,6 +1302,7 @@ defined in an external file. Such a file is called an OVAL Variable File
 and can be recognized by using the following command: `oscap info
 file.xml`. The OVAL Variables file can be passed to the evaluation by
  `--variables` argument such as:
+ 
 ----
 $ oscap oval eval \
 --variables usgcb-rhel5desktop-oval.xml-0.variables-0.xml \
@@ -1124,50 +1311,55 @@ usgcb-rhel5desktop-oval.xml
 ----
 
 2)  XCCDF Bindings -- The values of external variables can be given from
-an XCCDF file. In the XCCDF file within each *<xccdf:check>* element,
-there might be *<xccdf:check-export>* elements. These elements allow
-transition of *<xccdf:value>* elements to *<oval:variables>* elements. The
+an XCCDF file. In the XCCDF file within each `<xccdf:check>` element,
+there might be `<xccdf:check-export>` elements. These elements allow
+transition of `<xccdf:value>` elements to `<oval:variables>` elements. The
 following command allows users to export variable bindings from XCCDF to
 an OVAL Variables file:
+
 ----
 $ oscap xccdf export-oval-variables --profile united_states_government_configuration_baseline usgcb-rhel5desktop-xccdf.xml
 ----
 
 3)  Values within an OVAL Definition File -- Variables' values defined
-directly in the OVAL definitions file *<constant_variable>* and
-*<local_variable>* elements.
+directly in the OVAL definitions file `<constant_variable>` and
+`<local_variable>` elements.
 
 ==== Evaluation of Multiple OVAL Values
+
 With `oscap`, there are two possible ways how two or more values can be
 specified for a variable used by one OVAL definition. The approach you choose
 depends on what mode you want to use, multival or multiset.
 
 The `oscap` handles multiple OVAL values seamlessly. Users don't need to do
 anything differently than for a normal scan.
-The command below demonstrates evaluation of DataStream, which may include
-multiset, multival, or both concepts combined, or none of them.
+The command below demonstrates evaluation of an SCAP source data stream, which
+may include multiset, multival, or both concepts combined, or none of them.
+
 ----
 $ oscap xccdf eval --profile my_baseline --results-arf scap-arf.xml --cpe additional-external-cpe.xml scap-ds.xml
 ----
 
 ==== Multival
+
 Multival can pass multiple values to a single OVAL definition
 evaluation. This can be accomplished by all three ways as described in
 previous section.
 
 1)  OVAL Variables file -- This option is straight forward. The file
-format (XSD schema) allows for multiple *<value>* elements within each
-*<variable>* element.
+format (XSD schema) allows for multiple `<value>` elements within each
+`<variable>` element.
 
---------------------------------------------------------------------------------
+----
 <variable id="oval:com.example.www:var:1" datatype="string" comment="Unknown">
   <value>600</value>
   <value>400</value>
 </variable>
---------------------------------------------------------------------------------
+----
 
-2)  XCCDF Bindings -- Use multiple *<xccdf:check-export>* referring to the
+2)  XCCDF Bindings -- Use multiple `<xccdf:check-export>` referring to the
 very same OVAL variable binding with multiple different XCCDF values.
+
 ----
 <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
   <check-export value-id="xccdf_com.example.www_value_1"
@@ -1179,17 +1371,18 @@ very same OVAL variable binding with multiple different XCCDF values.
 ----
 
 3)  Values within OVAL Definitions file -- This is similar to using a
-Variables file, there are multiple *<value>* elements allowed within
-*<constant_variable>* or *<local_variable>* elements.
+Variables file, there are multiple `<value>` elements allowed within
+`<constant_variable>` or `<local_variable>` elements.
 
 ==== Multiset
+
 Multiset allows for the very same OVAL definition to be evaluated
 multiple times using different values assigned to the variables for each
 evaluation. In OpenSCAP, this is only possible by option (2) XCCDF
 Bindings. The following XCCDF snippet evaluates twice the very same OVAL
 Definition, each time it binds a different value to the OVAL variable.
 
--------------------------------------------------------------------------------------------------------
+----
 <Rule id="xccdf_moc.elpmaxe.www_rule_1" selected="true">
   <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
     <check-export value-id="xccdf_moc.elpmaxe.www_value_1" export-name="oval:com.example.www:var:1"/>
@@ -1202,7 +1395,7 @@ Definition, each time it binds a different value to the OVAL variable.
     <check-content-ref href="my-test-oval.xml" name="oval:com.example.www:def:1"/>
   </check>
 </Rule>
--------------------------------------------------------------------------------------------------------
+----
 
 After the evaluation, the OVAL results file will contain multiple
 result-definitions and multiple result-tests and multiple
@@ -1225,42 +1418,6 @@ multiset evaluation.
     <tested_variable variable_id="oval:com.example.www:var:1">400</tested_variable>
   </test>
 </tests>
-----
-
-
-
-=== External or remote resources
-Some SCAP content references external resources. For example SCAP Security Guide
-uses external OVAL file to check that the system is up to date and has no known
-security vulnerabilities. However, other content can use external resources for
-other purposes.
-
-When you are evaluating SCAP content with external resources the `oscap` tool
-will warn you:
-
-----
-$ oscap xccdf eval \
---profile xccdf_org.ssgproject.content_profile_common \
-/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
-
-WARNING: This content points out to the remote resources. Use `--fetch-remote-resources' option to download them.
-WARNING: Skipping https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2 file which is referenced from XCCDF content
-----
-
-By default the `oscap` tool will not blindly download and execute remote content.
-If you trust your local content and the remote content it references, you can use
-the `--fetch-remote-resources` option to automatically download it using the
-`oscap` tool.
-
-----
-$ oscap xccdf eval \
---fetch-remote-resources \
---profile xccdf_org.ssgproject.content_profile_common \
-/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
-Downloading: https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2 ... ok
-Title   Ensure /var/log Located On Separate Partition
-Rule    xccdf_org.ssgproject.content_rule_partition_for_var_log
-...
 ----
 
 
@@ -1302,21 +1459,21 @@ $ xsltproc --stringparam reverse_DNS com.example.www /usr/share/openscap/xsl/xcc
 And then patch the content using a text editor, adding `multi-check` as
 shown in the example Rule snippet above.
 
-To create a source DataStream from the patched content, the following command can be used:
+To create a source data stream from the patched content, the following command can be used:
 
 ----
 $ oscap ds sds-compose xccdf-1.2.xml source_ds.xml
 ----
 
 If the original XCCDF file referenced a custom CPE dictionary, you also have to inject
-the CPE dictionary into the DataStream in order to create a valid source DataStream.
-To add a CPE dictionary component into your DataStream in place, use this command:
+the CPE dictionary into the source data stream in order to create a valid source data stream.
+To add a CPE dictionary component into your data stream in place, use this command:
 
 ----
 $ oscap ds sds-add cpe_dictionary.xml source_ds.xml
 ----
 
-Now the `source_ds.xml` DataStream can be evaluated as usual.
+Now the `source_ds.xml` data stream can be evaluated as usual.
 
 === Identifying SWID tags
 
@@ -1341,7 +1498,8 @@ part of an SCAP source data stream.
 
 For example, the following command can be used to evaluate an SCAP source data
 stream that contains OVAL inventory class definitions that search for the
-presence of a matching SWID tag (referenced XML files can be obtained from the [SCAP 1.3 validation test suite](https://csrc.nist.gov/CSRC/media/Projects/scap-validation-program/documents/SCAP1.3ValidationTestContent_1-3.0.0.0.zip)):
+presence of a matching SWID tag (referenced XML files can be obtained from the
+https://csrc.nist.gov/CSRC/media/Projects/scap-validation-program/documents/SCAP1.3ValidationTestContent_1-3.0.0.0.zip[SCAP 1.3 validation test suite]).
 
 ----
 $ oscap xccdf eval --results-arf arf.xml --profile xccdf_gov.nist.validation_profile_r2850-rhel r2850-rhel-datastream.xml
@@ -1354,6 +1512,43 @@ the presence of a matching SWID tag:
 ----
 $ oscap oval eval --results results.xml r2860-rhel-oval.xml
 ----
+
+
+== Using external or remote resources
+
+Some SCAP content references external resources. For example SCAP Security Guide
+uses external OVAL file to check that the system is up to date and has no known
+security vulnerabilities. However, other content can use external resources for
+other purposes.
+
+When you are evaluating SCAP content with external resources the `oscap` tool
+will warn you:
+
+----
+$ oscap xccdf eval \
+--profile xccdf_org.ssgproject.content_profile_common \
+/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
+
+WARNING: This content points out to the remote resources. Use `--fetch-remote-resources' option to download them.
+WARNING: Skipping https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2 file which is referenced from XCCDF content
+----
+
+By default the `oscap` tool will not blindly download and execute remote content.
+If you trust your local content and the remote content it references, you can use
+the `--fetch-remote-resources` option to automatically download it using the
+`oscap` tool.
+
+----
+$ oscap xccdf eval \
+--fetch-remote-resources \
+--profile xccdf_org.ssgproject.content_profile_common \
+/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
+Downloading: https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2 ... ok
+Title   Ensure /var/log Located On Separate Partition
+Rule    xccdf_org.ssgproject.content_rule_partition_for_var_log
+...
+----
+
 
 == Practical Examples
 This section demonstrates practical usage of certain security content provided
@@ -1396,9 +1591,9 @@ $ oscap xccdf eval \
 === Auditing Security Vulnerabilities of Red Hat Products
 The Red Hat Security Response Team provides OVAL definitions for all
 vulnerabilities (identified by CVE name) that affect Red Hat Enterprise
-Linux 3, 4, 5, 6 and 7. This enable users to perform a vulnerability scan
+Linux 3, 4, 5, 6, 7 and 8. This enable users to perform a vulnerability scan
 and diagnose whether system is vulnerable or not. The data is provided in
-three ways -- OVAL file, OVAL + XCCDF and a Source DataStream.
+three ways -- OVAL file, OVAL + XCCDF and an SCAP source data stream.
 
 ==== OVAL + XCCDF
 
@@ -1463,8 +1658,8 @@ database where additional information like CVE description, CVSS score, CVSS
 vector etc. are stored.
 
 
-==== Source DataStream
-The Source DataStream use-case is very similar to OVAL+XCCDF. The only
+==== Source data stream
+The Source data stream use-case is very similar to OVAL+XCCDF. The only
 difference is that you don't have to download two separate files.
 
 1)  Download the content
@@ -1495,10 +1690,10 @@ $ wget https://www.redhat.com/security/data/oval/Red_Hat_Enterprise_Linux_7.xml
 ----
 
 You can get a list of all the plain OVAL files by visiting
-https://www.redhat.com/security/data/oval/
+https://www.redhat.com/security/data/oval/v2/
 
-The list of available datastream files is available at
-https://www.redhat.com/security/data/metrics/ds/
+The list of available data stream files is available at
+https://www.redhat.com/security/data/metrics/ds/v2/
 
 
 ==== Disclaimer
@@ -1542,55 +1737,42 @@ $ oscap xccdf generate report --output report.html results.xml
 ----
 
 === How to Evaluate DISA STIG
+
 This section describes how to evaluate the Defense Information Systems Agency
 (DISA) Security Technical Implementation Guide (STIG) on Red Hat Eneterprise
-Linux 6.
+Linux 7.
 
-1) Download the DISA STIG content.
+. Download the DISA STIG content.
++
 ----
-$ wget http://iasecontent.disa.mil/stigs/zip/July2015/U_RedHat_6_V1R8_STIG_SCAP_1-1_Benchmark.zip
+$ wget https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_RHEL_7_V3R2_STIG_SCAP_1-2_Benchmark.zip
 ----
-
-2) Unpack the content.
----------------------------------------------------
-$ unzip U_RedHat_6_V1R8_STIG.zip
----------------------------------------------------
-
-3)  Fix the content using a sed substitution.
----------------------------------------------------------------------------------------------------
-$ sed -i 's/<Group\ \(.*\)/<Group\ selected="false"\ \1/g' U_RedHat_6_V1R8_STIG_SCAP_1-1_Benchmark-xccdf.xml
----------------------------------------------------------------------------------------------------
-
-NOTE: Why is the substitution needed? According to the {xccdf_1-2}[XCCDF
-specification 1.2] the `selected` attribute for *Rule* or *Group* is *true* by default.
-It means that if you create a new profile even with only one rule selected, all
-rules within the benchmark will be evaluated because they are set to true by default. The
-substitution will set all Groups as unselected by default which means all
-descendants will also be unselected by default.
-
-4) Display a list of available profiles.
++
+. Unpack the content.
++
 ----
-$ oscap info U_RedHat_6_V1R8_STIG_SCAP_1-1_Benchmark-xccdf.xml
+$ unzip U_RHEL_7_V3R2_STIG_SCAP_1-2_Benchmark.zip
 ----
-
-5)  Evaluate your favorite profile, for example *MAC-1_Public*, and write
-XCCDF results into the results.xml file.
++
+. Display a list of available profiles.
++
 ----
-$ oscap xccdf eval \
---profile MAC-1_Public \
---results results.xml \
---cpe U_RedHat_6_V1R8_STIG_SCAP_1-1_Benchmark-cpe-dictionary.xml \
-U_RedHat_6_V1R8_STIG_SCAP_1-1_Benchmark-xccdf.xml
+$ oscap info U_RHEL_7_V3R2_STIG_SCAP_1-2_Benchmark.xml
+----
++
+. Evaluate your favorite profile, for example *MAC-1_Public*, and write
+ARF results into the results.xml file.
++
+----
+# oscap xccdf eval \
+--profile xccdf_mil.disa.stig_profile_MAC-1_Public \
+--results-arf results.xml \
+--report report.html \
+U_RHEL_7_V3R2_STIG_SCAP_1-2_Benchmark.xml
 ----
 
-6) Generate a scan report that is readable in a web browser.
------
-$ oscap xccdf generate report --output report.html results.xml
------
-
-If you are interested in DISA STIG content for RHEL5 or RHEL7 please visit
-{nvd}[National Vulnerability Database] and look for *Red Hat Enterprise Linux 6*
-or *Red Hat Enterprise Linux 7* as a target product.
+If you are interested in DISA STIG content for other systems please refer to
+https://public.cyber.mil/stigs/downloads/[DoD Cyber Exchange].
 
 === How to Evaluate United States Government Configuration Baseline (USGCB)
 NOTE: NIST offers no official USGCB for RHEL6 as of September 2014 but you can
@@ -1693,27 +1875,6 @@ files available on the filesystem. That is possible because the SCAP
 standard files are native file formats of the OpenSCAP.
 
 
-
-=== How to evaluate guidances for Red Hat Enterprise Linux 6 or 7
-Guidances for Red Hat Enterprise Linux 6 and 7 can be acquired from
-{ssg_git}[SCAP Security Guide
-project] (SSG). SSG holds currently the most evolved and elaborate SCAP
-policy for Linux systems. The project provides practical security
-hardening advice for Red Hat products and also links it to compliance
-requirements in order to ease deployment activities, such as
-certification and accreditation.
-
-The project started in 2011 as open collaboration of U.S. Government
-bodies to develop next generation of United States Government Baseline
-(USGCB) available for Red Hat Enterprise Linux 6. There are multiple
-parties contributing to the project from the public sector and private
-sector.
-
-The SSG project contains baselines for both desktops and servers. See
-https://github.com/OpenSCAP/scap-security-guide
-
-
-
 === How to check that patches are up-to-date on Red Hat Enterprise Linux 6 or 7
 This section describes how to check that software patches are up-to-date using
 external OVAL content.
@@ -1747,101 +1908,11 @@ $ oscap xccdf eval \
 This command evaluates common profile for Red Hat Enterprise Linux 6 or 7. Part of
 the profile is a rule to check that patches are up-to-date. To evaluate the rule
 correctly, oscap tool needs to download an up-to-date OVAL file from Red Hat servers. This can be
-allowed using *--fetch-remote-resources* option. Result of this scan will be saved
-in **results.xml** using ARF format.
+allowed using `--fetch-remote-resources` option. Result of this scan will be saved
+in `results.xml` using ARF format.
 
 
-
-=== How to tailor Source data stream
-This section describes tailoring of content using Tailoring file. This allows
-you to change behavior of content without its direct modification.
-
-1) Obtain tailoring file
-
-Tailoring file can be easily generated using {workbench_url}[SCAP Workbench].
-
-2) List profiles of tailoring file
-
-----
-$ oscap info ssg-rhel6-ds-tailoring.xml
-Document type: XCCDF Tailoring
-Imported: 2016-08-31T11:08:16
-Benchmark Hint: /usr/share/xml/scap/ssg/content/ssg-rhel6-ds.xml
-Profiles:
-	xccdf_org.ssgproject.content_profile_C2S_customized
-----
-
-3) Evaluate
-
-----
-$ oscap xccdf eval \
---profile xccdf_org.ssgproject.content_profile_C2S_customized \
---tailoring-file ssg-rhel6-ds-tailoring.xml \
---results results.xml
-/usr/share/xml/scap/ssg/content/ssg-rhel6-ds.xml
-----
-
-The command above evaluates tailored data stream by **ssg-rhel6-ds-tailoring.xml** tailoring file.
-XCCDF results can be found in **results.xml** file.
-
-Instead of external tailoring file, you can also use tailoring component integrated to data stream.
-
-----
-$ oscap info simple-ds.xml
-
-Document type: Source Data Stream
-Imported: 2016-02-02T14:06:14
-
-Stream: scap_org.open-scap_datastream_from_xccdf_simple-xccdf.xml
-Generated: (null)
-Version: 1.2
-Checklists:
-	Ref-Id: scap_org.open-scap_cref_simple-xccdf.xml
-		Status: incomplete
-		Resolved: false
-		Profiles:
-			xccdf_org.open-scap_profile_override
-		Referenced check files:
-			simple-oval.xml
-				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
-	Ref-Id: scap_org.open-scap_cref_simple-tailoring.xml
-		Benchmark Hint: (null)
-		Profiles:
-			xccdf_org.open-scap_profile_default
-			xccdf_org.open-scap_profile_unselecting
-			xccdf_org.open-scap_profile_override
-Checks:
-	Ref-Id: scap_org.open-scap_cref_simple-oval.xml
-No dictionaries.
-----
-
-To choose tailoring component "scap_org.open-scap_cref_simple-tailoring.xml", the command below can be used.
-
-----
-$ oscap xccdf eval \
---tailoring-id scap_org.open-scap_cref_simple-tailoring.xml \
---profile xccdf_org.open-scap_profile_default \
---results results.xml simple-ds.xml
-----
-
-The command above evaluates content using tailoring component *scap_org.open-scap_cref_simple-tailoring.xml* from source data stream.
-Scan results are stored in *results.xml* file.
-
-
-=== Evaluation of content
-Specified XCCDF or data stream content can contain zero or more profiles.
-
-Scan can be evaluated without specific profile, otherwise profile can be selected using
-*--profile* option.
-
-----
-$ oscap xccdf eval --results results.xml /usr/share/xml/scap/ssg/content/ssg-rhel6-ds.xml
-----
-
-The command above evaluates rules without specific profile. XCCDF results are stored in *results.xml* file.
-
-
-== Other utilities
+== Scanning remote and virtual machines or containers
 
 Apart from the `oscap` command, OpenSCAP provides also other utilities for
 special purposes. Those utilities use `oscap` under the hood, but they
@@ -1849,16 +1920,22 @@ enable users to perform advanced tasks in a single command.
 This manual gives a quick overview of and shows basic usage of these tools.
 Each of the tools have its own manual page that gives more detailed information.
 
-=== Scanning remote machines using oscap-ssh
+To install these tools install the `openscap-utils` package.
 
-The `oscap-ssh` is a simple tool for scanning remote machines with OpenSCAP
-over network and collecting results.
+----
+# dnf install openscap-utils
+----
+
+=== Scanning remote machines
+
+The `oscap-ssh` command is a simple tool for scanning remote machines with
+OpenSCAP over network and collecting results.
 
 The tool uses SSH connection to copy the SCAP content to a remote machine, then
 it runs an evaluation of the target system and downloads the results back.
 The remote machine needs to have OpenSCAP installed.
 
-The tool can evaluate source DataStreams and OVAL files.
+The tool can evaluate source data streams and OVAL files.
 Usage of the tool mimics usage and options of `oscap` tool.
 
 In the following example, we will scan a remote Fedora server located on IP address
@@ -1874,6 +1951,31 @@ $ oscap-ssh root@192.168.1.13 22 xccdf eval \
 /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml
 ----
 
+=== Scanning containers and containers images using oscap-podman
+
+The `oscap-podman` tool can be used to scan Linux containers and container images.
+Usage of the tool mimics usage and options of `oscap` tool.
+
+NOTE: `oscap-podman` is available only on Fedora and Red Hat Enterprise Linux 8
+or newer. On other systems use `oscap-docker` instead.
+
+
+. Get the ID of a container or a container image, for example:
++
+----
+# podman images
+REPOSITORY                       TAG     IMAGE ID      CREATED       SIZE
+registry.access.redhat.com/ubi8  latest  3269c37eae33  2 months ago  208 MB
+----
++
+. Evaluate the SCAP content, for example:
++
+----
+# oscap-podman 3269c37eae33 xccdf eval --report report.html --profile ospp /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml 
+----
+
+Note that the `oscap-podman` command requires root privileges.
+
 === Scanning of Docker containers and images using oscap-docker
 
 The `oscap-docker` is used to scan Docker containers and images. It can
@@ -1881,15 +1983,14 @@ assess vulnerabilities in the container or image and check their compliance
 with security policies. Usage of the tool mimics usage and options
 of `oscap` tool.
 
+NOTE: `oscap-docker` isn't available on Fedora and on Red Hat Enterprise Linux 8
+or newer. On other systems use `oscap-podman` instead.
+
 The `oscap-docker` tool uses a technique called offline scanning.
 That means that the filesystem of the container is mounted to a directory
 on the host. The mounted filesystem is read-only. OpenSCAP then assess
 the container from the host. Therefore no agent is installed
 in the container and container is not touched or changed in any way.
-
-However, `oscap-docker` requires http://www.projectatomic.io/[Atomic]
-installed on the host. Atomic is advanced container management solution and
-it enables `oscap-docker` to access the containers.
 
 In the first example, we will perform a vulnerability assessment
 of an Docker image of Red Hat Enterprise Linux 7 (named *rhel7*). The command

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1951,7 +1951,7 @@ $ oscap-ssh root@192.168.1.13 22 xccdf eval \
 /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml
 ----
 
-=== Scanning containers and containers images using oscap-podman
+=== Scanning containers and container images using oscap-podman
 
 The `oscap-podman` tool can be used to scan Linux containers and container images.
 Usage of the tool mimics usage and options of `oscap` tool.

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -592,7 +592,7 @@ This table lists the possible results of a single rule:
 |
 
 |fixed
-|The rule had failed, but was then fixed by automated remediation.
+|The rule had initially evaluated to "fail", but was then fixed by automated remediation and therefore it now evaluates as "pass".
 |
 |===
 


### PR DESCRIPTION
This commit wants to improve OpenSCAP user manual, make it
up-to-date and more understandable for the readers.
- update for SCAP 1.3
- fix broken links
- improve document structure
- remove duplicate information
- remove outdated information
- document oscap-podman
- promote using data streams over separate XCCDF and OVAL files
- fix adoc syntax
- fix style
- fix some grammar
- use more real or currently used examples
- fixed misleading information about oscap xccdf generate fix
- added generating Ansible Playbooks

Reviewers, please, I know it's tempting to check just for typos and grammar. But try to change your mind and focus on the content instead. Check on the documented facts. It's really important to avoid misleading information and make sure that there aren't wrong or not working commands or mistakes in command line options. Also, try to pretend that you are an user.

Fixes: #1644 