### PR TITLE
Add a simple test for SOURCE_DATE_EPOCH

### DIFF
--- a/tests/DS/test_ds_misc.sh
+++ b/tests/DS/test_ds_misc.sh
@@ -250,6 +250,16 @@ function test_ds_continue_without_remote_resources() {
 	rm -f "$result" "$oval_result"
 }
 
+function test_source_date_epoch() {
+	local xccdf="$srcdir/sds_multiple_oval/multiple-oval-xccdf.xml"
+	local result="$(mktemp)"
+	local timestamp="2020-03-05T13:09:37"
+	export SOURCE_DATE_EPOCH="1583410177"
+	$OSCAP ds sds-compose "$xccdf" "$result"
+	assert_exists 3 '//ds:component[@timestamp="'$timestamp'"]'
+	rm -f "$result"
+}
+
 
 # Testing.
 test_init
@@ -276,6 +286,7 @@ test_run "test_eval_complex" test_eval_complex
 test_run "sds_add_multiple_oval_twice_in_row" sds_add_multiple_twice
 test_run "test_ds_1_2_continue_without_remote_resources" test_ds_continue_without_remote_resources ds_continue_without_remote_resources/remote_content_1.2.ds.xml xccdf_com.example.www_profile_test_remote_res
 test_run "test_ds_1_3_continue_without_remote_resources" test_ds_continue_without_remote_resources ds_continue_without_remote_resources/remote_content_1.3.ds.xml xccdf_com.example.www_profile_test_remote_res
+test_run "test_source_date_epoch"test_source_date_epoch
 
 test_exit
 


### PR DESCRIPTION
This test checks if the SOURCE_DATE_EPOCH is used in the
oscap ds sds-compose command as a datastream component timestamp.

Related to https://github.com/OpenSCAP/openscap/pull/1699/