### PR TITLE
Add SCAP 1.3 source data stream schematron

### DIFF
--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -114,6 +114,9 @@
       <sch:assert id="scap-general-xccdf-status-rule-value-date-1" test="text()='draft' or text()= 'accepted'">SRC-5-1</sch:assert>
       <sch:assert id="scap-general-xccdf-status-rule-value-date-2" test="@date!=''">SRC-5-2</sch:assert>
     </sch:rule>
+    <sch:rule id="scap-cce-check-rule-1" context="xccdf:ident">
+      <sch:assert flag="WARNING" test="not(@system='http://cce.mitre.org' or @system='CCE') or text() != ''" id="scap-cce-check-assert-1">A-16-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule/@id"/></sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -100,6 +100,7 @@
     </sch:rule>
     <sch:rule id="scap-general-oval-generator" context="oval-def:generator/oval-com:schema_version">
       <sch:assert id="scap-general-oval-version" test="@platform or text()='5.3' or text()='5.4' or text()='5.5' or text()='5.6' or text()='5.7' or text()='5.8' or text()='5.9' or text()='5.10' or text()='5.10.1' or text()='5.11' or text()='5.11.1' or text()='5.11.2'">SRC-216-1</sch:assert>
+      <sch:assert id="scap-general-oval-platform-version" test="not(@platform) or text()='5.11.1:1.0' or text()='5.11.1:1.1' or text()='5.11.1:1.2' or text()='5.11.2:1.0' or text()='5.11.2:1.1' or text()='5.11.2:1.2'">SRC-216-2</sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -83,6 +83,7 @@
     </sch:rule>
     <sch:rule id="scap-general-xccdf-check" context="xccdf:Rule/xccdf:check">
       <sch:assert id="scap-general-xccdf-check-sys-req" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule[1]/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-check-patches-ref-oval-only" test="not(current()/parent::xccdf:Rule[substring(@id, string-length(@id) - string-length('security_patches_up_to_date') + 1) = 'security_patches_up_to_date']) or current()/@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5'">SRC-169-2|xccdf:Rule <sch:value-of select="parent::xccdf:Rule/@id"/></sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -110,6 +110,10 @@
       <sch:assert id="scap-general-signature-sig-third-ref-manifest" test="dsig:Object/dsig:Manifest[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[3]/@URI]">SRC-288-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
       <sch:assert id="scap-general-signature-sig-key-info" test="dsig:KeyInfo">SRC-290-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
     </sch:rule>
+    <sch:rule id="scap-general-xccdf-status-rule-value-date" context="xccdf:status">
+      <sch:assert id="scap-general-xccdf-status-rule-value-date-1" test="text()='draft' or text()= 'accepted'">SRC-5-1</sch:assert>
+      <sch:assert id="scap-general-xccdf-status-rule-value-date-2" test="@date!=''">SRC-5-2</sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -108,6 +108,7 @@
       <sch:assert id="scap-general-signature-sig-first-ref-ds" test="ancestor::ds:data-stream-collection[1]/ds:data-stream[concat('#',@id) = current()/dsig:SignedInfo/dsig:Reference[1]/@URI]">SRC-286-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
       <sch:assert id="scap-general-signature-sig-ref-sig-prop" test="dsig:Object/dsig:SignatureProperties[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[2]/@URI]">SRC-287-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
       <sch:assert id="scap-general-signature-sig-third-ref-manifest" test="dsig:Object/dsig:Manifest[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[3]/@URI]">SRC-288-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-key-info" test="dsig:KeyInfo">SRC-290-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -33,6 +33,7 @@
       <sch:assert id="scap-general-xccdf-benchmark-description" test="xccdf:description">SRC-10-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-lang-required" test="@xml:lang">SRC-2-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-no-check-content-check" test="not(.//xccdf:check-content)">SRC-25-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-val-forbid" test="not(.//xccdf:Value//xccdf:source) and not(.//xccdf:Value//xccdf:complex-value) and not(.//xccdf:Value//xccdf:complex-default) and not(.//xccdf:Value//xccdf:choices//xccdf:complex-choice)">SRC-276-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -30,101 +30,101 @@
 
   <sch:pattern id="scap-general">
     <sch:rule id="scap-general-xccdf-benchmark" context="xccdf:Benchmark">
-      <sch:assert id="scap-general-xccdf-benchmark-description" test="xccdf:description">SRC-10-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-lang-required" test="@xml:lang">SRC-2-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-no-check-content-check" test="not(.//xccdf:check-content)">SRC-25-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-val-forbid" test="not(.//xccdf:Value//xccdf:source) and not(.//xccdf:Value//xccdf:complex-value) and not(.//xccdf:Value//xccdf:complex-default) and not(.//xccdf:Value//xccdf:choices//xccdf:complex-choice)">SRC-276-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-version-time-attribute-req" test="xccdf:version/@time">SRC-3-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-no-xinclude" test="not(.//xinclude:include)">SRC-339-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-version-update-req" test=".//xccdf:version[string(@update)]">SRC-341-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-no-set-complex-value" test="not(.//xccdf:set-complex-value)">SRC-343-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-style" test="@style = 'SCAP_1.3'">SRC-4-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-metadata-missing" test="xccdf:metadata">SRC-8-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-title-1" test="xccdf:title">SRC-9-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-description" test="xccdf:description">Error: SRC-10-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-lang-required" test="@xml:lang">Error: SRC-2-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-no-check-content-check" test="not(.//xccdf:check-content)">Error: SRC-25-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-val-forbid" test="not(.//xccdf:Value//xccdf:source) and not(.//xccdf:Value//xccdf:complex-value) and not(.//xccdf:Value//xccdf:complex-default) and not(.//xccdf:Value//xccdf:choices//xccdf:complex-choice)">Error: SRC-276-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-version-time-attribute-req" test="xccdf:version/@time">Warning: SRC-3-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-no-xinclude" test="not(.//xinclude:include)">Error: SRC-339-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-version-update-req" test=".//xccdf:version[string(@update)]">Warning: SRC-341-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-no-set-complex-value" test="not(.//xccdf:set-complex-value)">Error: SRC-343-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-style" test="@style = 'SCAP_1.3'">Warning: SRC-4-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-missing" test="xccdf:metadata">Error: SRC-8-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-title-1" test="xccdf:title">Error: SRC-9-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">Error: SRC-9-3|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">Error: SRC-9-3|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
-      <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-profile-title-1" test="xccdf:title">SRC-9-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-profile-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-profile-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">Error: SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-profile-title-1" test="xccdf:title">Error: SRC-9-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-profile-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">Error: SRC-9-3|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-profile-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">Error: SRC-9-3|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-value" context="xccdf:Value">
-      <sch:assert id="scap-general-xccdf-value-description" test="xccdf:description">SRC-10-1|xccdf:Value <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-value-title-1" test="xccdf:title">SRC-9-1|xccdf:Value <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-value-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Value <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-value-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Value <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-value-description" test="xccdf:description">Error: SRC-10-1|xccdf:Value <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-value-title-1" test="xccdf:title">Error: SRC-9-1|xccdf:Value <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-value-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">Error: SRC-9-3|xccdf:Value <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-value-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">Error: SRC-9-3|xccdf:Value <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-group" context="xccdf:Group">
-      <sch:assert id="scap-general-xccdf-group-description" test="xccdf:description">SRC-10-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-group-description" test="xccdf:description">Error: SRC-10-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-group-extension" test="not(@extends)">SRC-354-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-group-title-1" test="xccdf:title">SRC-9-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-group-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Group <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-group-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Group <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-group-title-1" test="xccdf:title">Error: SRC-9-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-group-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">Error: SRC-9-3|xccdf:Group <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-group-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">Error: SRC-9-3|xccdf:Group <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-rule" context="xccdf:Rule">
-      <sch:assert id="scap-general-xccdf-rule-description" test="xccdf:description">SRC-10-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-rule-title-1" test="xccdf:title">SRC-9-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-rule-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-rule-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-rule-cve-cce-cpe" test="xccdf:ident[@system = 'http://cce.mitre.org' or @system = 'http://cve.mitre.org' or @system = 'http://cpe.mitre.org']">SRC-251-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-rule-attributes-exists" test="@selected and @weight and @role and @severity">A-26-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-description" test="xccdf:description">Error: SRC-10-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-title-1" test="xccdf:title">Error: SRC-9-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">Error: SRC-9-3|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">Error: SRC-9-3|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-cve-cce-cpe" test="xccdf:ident[@system = 'http://cce.mitre.org' or @system = 'http://cve.mitre.org' or @system = 'http://cpe.mitre.org']">Warning: SRC-251-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-attributes-exists" test="@selected and @weight and @role and @severity">Warning: A-26-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-metadata" context="xccdf:Benchmark/xccdf:metadata">
-      <sch:assert id="scap-general-xccdf-metadata-populated-creator" test="dc:creator/text()">SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-metadata-populated-publisher" test="dc:publisher/text()">SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-metadata-populated-contributor" test="dc:contributor/text()">SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-metadata-populated-source" test="dc:source/text()">SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated-creator" test="dc:creator/text()">Error: SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated-publisher" test="dc:publisher/text()">Error: SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated-contributor" test="dc:contributor/text()">Error: SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated-source" test="dc:source/text()">Error: SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-system-cpe-dict-check" context="cpe-dict:check">
-      <sch:assert id="scap-general-system-cpe-dict-check2" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-2|cpe-dict:cpe-item <sch:value-of select="ancestor::cpe-dict:cpe-item[1]/@name"/></sch:assert>
+      <sch:assert id="scap-general-system-cpe-dict-check2" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">Error: SRC-118-2|cpe-dict:cpe-item <sch:value-of select="ancestor::cpe-dict:cpe-item[1]/@name"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-system-cpe-lang-check" context="cpe-lang:check-fact-ref">
-      <sch:assert id="scap-general-system-cpe-lang-check2" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-3|cpe-lang:platform <sch:value-of select="ancestor::cpe-lang:platform[1]/@id"/></sch:assert>
+      <sch:assert id="scap-general-system-cpe-lang-check2" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">Error: SRC-118-3|cpe-lang:platform <sch:value-of select="ancestor::cpe-lang:platform[1]/@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-check" context="xccdf:Rule/xccdf:check">
-      <sch:assert id="scap-general-xccdf-check-sys-req" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule[1]/@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-check-patches-ref-oval-only" test="not(current()/parent::xccdf:Rule[substring(@id, string-length(@id) - string-length('security_patches_up_to_date') + 1) = 'security_patches_up_to_date']) or current()/@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5'">SRC-169-2|xccdf:Rule <sch:value-of select="parent::xccdf:Rule/@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-rule-check-content-ref-req" test="xccdf:check-content-ref">SRC-175-1|xccdf:Rule <sch:value-of select="parent::xccdf:Rule/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-check-sys-req" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">Error: SRC-118-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule[1]/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-check-patches-ref-oval-only" test="not(current()/parent::xccdf:Rule[substring(@id, string-length(@id) - string-length('security_patches_up_to_date') + 1) = 'security_patches_up_to_date']) or current()/@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5'">Error: SRC-169-2|xccdf:Rule <sch:value-of select="parent::xccdf:Rule/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-check-content-ref-req" test="xccdf:check-content-ref">Error: SRC-175-1|xccdf:Rule <sch:value-of select="parent::xccdf:Rule/@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-scap-data-stream-collection" context="scap:data-stream-collection ">
-      <sch:assert id="scap-general-latest-schematron-rules" test="current()[@schematron-version='1.3']">SRC-330-2|scap:data-stream-collection</sch:assert>
+      <sch:assert id="scap-general-latest-schematron-rules" test="current()[@schematron-version='1.3']">Error: SRC-330-2|scap:data-stream-collection</sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-scap-content" context="scap:data-stream">
-      <sch:assert id="scap-general-scap-content-use-case" test="@use-case = 'CONFIGURATION' or @use-case = 'VULNERABILITY' or @use-case = 'INVENTORY' or @use-case = 'OTHER'" >SRC-324-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-use-case" test="@use-case = 'CONFIGURATION' or @use-case = 'VULNERABILITY' or @use-case = 'INVENTORY' or @use-case = 'OTHER'">Error: SRC-324-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-oval-def" context="oval-def:definition">
-      <sch:assert id="scap-general-oval-def-rule-compliance-cce" test="@class != 'compliance' or oval-def:metadata/oval-def:reference[@source='http://cce.mitre.org' or @source='CCE']">SRC-207-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-oval-def-vulnerability-cve-ref" test="@class != 'vulnerability' or oval-def:metadata/oval-def:reference[@source='http://cve.mitre.org' or @source='CVE']">SRC-214-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-oval-def-rule-compliance-cce" test="@class != 'compliance' or oval-def:metadata/oval-def:reference[@source='http://cce.mitre.org' or @source='CCE']">Warning: SRC-207-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-oval-def-vulnerability-cve-ref" test="@class != 'vulnerability' or oval-def:metadata/oval-def:reference[@source='http://cve.mitre.org' or @source='CVE']">Warning: SRC-214-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-oval-generator" context="oval-def:generator/oval-com:schema_version">
-      <sch:assert id="scap-general-oval-version" test="@platform or text()='5.3' or text()='5.4' or text()='5.5' or text()='5.6' or text()='5.7' or text()='5.8' or text()='5.9' or text()='5.10' or text()='5.10.1' or text()='5.11' or text()='5.11.1' or text()='5.11.2'">SRC-216-1</sch:assert>
-      <sch:assert id="scap-general-oval-platform-version" test="not(@platform) or text()='5.11.1:1.0' or text()='5.11.1:1.1' or text()='5.11.1:1.2' or text()='5.11.2:1.0' or text()='5.11.2:1.1' or text()='5.11.2:1.2'">SRC-216-2</sch:assert>
+      <sch:assert id="scap-general-oval-version" test="@platform or text()='5.3' or text()='5.4' or text()='5.5' or text()='5.6' or text()='5.7' or text()='5.8' or text()='5.9' or text()='5.10' or text()='5.10.1' or text()='5.11' or text()='5.11.1' or text()='5.11.2'">Error: SRC-216-1</sch:assert>
+      <sch:assert id="scap-general-oval-platform-version" test="not(@platform) or text()='5.11.1:1.0' or text()='5.11.1:1.1' or text()='5.11.1:1.2' or text()='5.11.2:1.0' or text()='5.11.2:1.1' or text()='5.11.2:1.2'">Error: SRC-216-2</sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-signature-sig" context="dsig:Signature">
-      <sch:assert id="scap-general-signature-sig-manifest-req" test="dsig:Object/dsig:Manifest">SRC-284-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
-      <sch:assert id="scap-general-signature-sig-tmsad" test="dsig:Object/dsig:SignatureProperties/dsig:SignatureProperty/tmsad:signature-info">SRC-285-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
-      <sch:assert id="scap-general-signature-sig-first-ref-ds" test="ancestor::ds:data-stream-collection[1]/ds:data-stream[concat('#',@id) = current()/dsig:SignedInfo/dsig:Reference[1]/@URI]">SRC-286-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
-      <sch:assert id="scap-general-signature-sig-ref-sig-prop" test="dsig:Object/dsig:SignatureProperties[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[2]/@URI]">SRC-287-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
-      <sch:assert id="scap-general-signature-sig-third-ref-manifest" test="dsig:Object/dsig:Manifest[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[3]/@URI]">SRC-288-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
-      <sch:assert id="scap-general-signature-sig-key-info" test="dsig:KeyInfo">SRC-290-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-manifest-req" test="dsig:Object/dsig:Manifest">Error: SRC-284-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-tmsad" test="dsig:Object/dsig:SignatureProperties/dsig:SignatureProperty/tmsad:signature-info">Error: SRC-285-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-first-ref-ds" test="ancestor::ds:data-stream-collection[1]/ds:data-stream[concat('#',@id) = current()/dsig:SignedInfo/dsig:Reference[1]/@URI]">Error: SRC-286-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-ref-sig-prop" test="dsig:Object/dsig:SignatureProperties[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[2]/@URI]">Error: SRC-287-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-third-ref-manifest" test="dsig:Object/dsig:Manifest[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[3]/@URI]">Error: SRC-288-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-key-info" test="dsig:KeyInfo">Warning: SRC-290-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-status-rule-value-date" context="xccdf:status">
-      <sch:assert id="scap-general-xccdf-status-rule-value-date-1" test="text()='draft' or text()= 'accepted'">SRC-5-1</sch:assert>
-      <sch:assert id="scap-general-xccdf-status-rule-value-date-2" test="@date!=''">SRC-5-2</sch:assert>
+      <sch:assert id="scap-general-xccdf-status-rule-value-date-1" test="text()='draft' or text()= 'accepted'">Error: SRC-5-1</sch:assert>
+      <sch:assert id="scap-general-xccdf-status-rule-value-date-2" test="@date!=''">Error: SRC-5-2</sch:assert>
     </sch:rule>
     <sch:rule id="scap-cce-check-rule-1" context="xccdf:ident">
-      <sch:assert flag="WARNING" test="not(@system='http://cce.mitre.org' or @system='CCE') or text() != ''" id="scap-cce-check-assert-1">A-16-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule/@id"/></sch:assert>
-      <sch:assert flag="ERROR" test="not(@system='http://cce.mitre.org' or @system='CCE') or starts-with(text(), 'CCE-')" id="scap-cce-check-assert-2">A-17-1|<sch:value-of select="."/></sch:assert>
+      <sch:assert flag="WARNING" test="not(@system='http://cce.mitre.org' or @system='CCE') or text() != ''" id="scap-cce-check-assert-1">Warning: A-16-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule/@id"/></sch:assert>
+      <sch:assert flag="ERROR" test="not(@system='http://cce.mitre.org' or @system='CCE') or starts-with(text(), 'CCE-')" id="scap-cce-check-assert-2">Error: A-17-1|<sch:value-of select="."/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-cce-check-rule-2" context="oval-def:reference">
-      <sch:assert flag="WARNING" test="not(@source='http://cce.mitre.org' or @source='CCE') or @ref_id!=''" id="scap-cce-check-assert-5">A-16-1|oval-def:definition <sch:value-of select="ancestor::oval-def:definition/@id"/></sch:assert>
-      <sch:assert flag="ERROR" test="not(@source='http://cce.mitre.org' or @source='CCE') or starts-with(@ref_id, 'CCE-')" id="scap-cce-check-assert-6">A-17-1|<sch:value-of select="@ref_id"/></sch:assert>
+      <sch:assert flag="WARNING" test="not(@source='http://cce.mitre.org' or @source='CCE') or @ref_id!=''" id="scap-cce-check-assert-5">Warning: A-16-1|oval-def:definition <sch:value-of select="ancestor::oval-def:definition/@id"/></sch:assert>
+      <sch:assert flag="ERROR" test="not(@source='http://cce.mitre.org' or @source='CCE') or starts-with(@ref_id, 'CCE-')" id="scap-cce-check-assert-6">Error: A-17-1|<sch:value-of select="@ref_id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-check-system-content-match-rule" context="scap:check-system-content">
-      <sch:assert flag="ERROR" test="not(@content-type='OVAL_COMPLIANCE' or @content-type='OVAL_PATCH' or @content-type='CPE_INVENTORY' or @content-type='OVAL_VULNERABILITY') or oval-def:oval_definitions" id="scap-check-system-content-match-assert-1">A-18-1</sch:assert>
-      <sch:assert flag="ERROR" test="@content-type != 'OCIL_QUESTIONS' or ocil:ocil" id="scap-check-system-content-match-assert-2">A-18-1</sch:assert>
+      <sch:assert flag="ERROR" test="not(@content-type='OVAL_COMPLIANCE' or @content-type='OVAL_PATCH' or @content-type='CPE_INVENTORY' or @content-type='OVAL_VULNERABILITY') or oval-def:oval_definitions" id="scap-check-system-content-match-assert-1">Error: A-18-1</sch:assert>
+      <sch:assert flag="ERROR" test="@content-type != 'OCIL_QUESTIONS' or ocil:ocil" id="scap-check-system-content-match-assert-2">Error: A-18-1</sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -54,6 +54,12 @@
     <sch:rule id="scap-general-xccdf-rule" context="xccdf:Rule">
       <sch:assert id="scap-general-xccdf-rule-description" test="xccdf:description">SRC-10-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
+    <sch:rule id="scap-general-xccdf-metadata" context="xccdf:Benchmark/xccdf:metadata">
+      <sch:assert id="scap-general-xccdf-metadata-populated-creator" test="dc:creator/text()">SRC-8-1</sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated-publisher" test="dc:publisher/text()">SRC-8-1</sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated-contributor" test="dc:contributor/text()">SRC-8-1</sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated-source" test="dc:source/text()">SRC-8-1</sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -39,6 +39,7 @@
       <sch:assert id="scap-general-xccdf-benchmark-version-update-req" test=".//xccdf:version[string(@update)]">SRC-341-1</sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-set-complex-value" test="not(.//xccdf:set-complex-value)">SRC-343-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-style" test="@style = 'SCAP_1.3'">SRC-4-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-missing" test="xccdf:metadata">SRC-8-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -34,7 +34,7 @@
       <sch:assert id="scap-general-xccdf-benchmark-lang-required" test="@xml:lang">SRC-2-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-no-check-content-check" test="not(.//xccdf:check-content)">SRC-25-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-val-forbid" test="not(.//xccdf:Value//xccdf:source) and not(.//xccdf:Value//xccdf:complex-value) and not(.//xccdf:Value//xccdf:complex-default) and not(.//xccdf:Value//xccdf:choices//xccdf:complex-choice)">SRC-276-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-version-time-attribute-req" test="xccdf:version/@time">SRC-3-|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-version-time-attribute-req" test="xccdf:version/@time">SRC-3-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-xinclude" test="not(.//xinclude:include)">SRC-339-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-version-update-req" test=".//xccdf:version[string(@update)]">SRC-341-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-set-complex-value" test="not(.//xccdf:set-complex-value)">SRC-343-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -36,6 +36,7 @@
       <sch:assert id="scap-general-xccdf-benchmark-val-forbid" test="not(.//xccdf:Value//xccdf:source) and not(.//xccdf:Value//xccdf:complex-value) and not(.//xccdf:Value//xccdf:complex-default) and not(.//xccdf:Value//xccdf:choices//xccdf:complex-choice)">SRC-276-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-version-time-attribute-req" test="xccdf:version/@time">SRC-3-2</sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-xinclude" test="not(.//xinclude:include)">SRC-339-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-version-update-req" test=".//xccdf:version[string(@update)]">SRC-341-1</sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -78,6 +78,9 @@
     <sch:rule id="scap-general-system-cpe-dict-check" context="cpe-dict:check">
       <sch:assert id="scap-general-system-cpe-dict-check2" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-2|cpe-dict:cpe-item <sch:value-of select="ancestor::cpe-dict:cpe-item[1]/@name"/></sch:assert>
     </sch:rule>
+    <sch:rule id="scap-general-system-cpe-lang-check" context="cpe-lang:check-fact-ref">
+      <sch:assert id="scap-general-system-cpe-lang-check2" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-3|cpe-lang:platform <sch:value-of select="ancestor::cpe-lang:platform[1]/@id"/></sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -34,9 +34,9 @@
       <sch:assert id="scap-general-xccdf-benchmark-lang-required" test="@xml:lang">SRC-2-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-no-check-content-check" test="not(.//xccdf:check-content)">SRC-25-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-val-forbid" test="not(.//xccdf:Value//xccdf:source) and not(.//xccdf:Value//xccdf:complex-value) and not(.//xccdf:Value//xccdf:complex-default) and not(.//xccdf:Value//xccdf:choices//xccdf:complex-choice)">SRC-276-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-version-time-attribute-req" test="xccdf:version/@time">SRC-3-2</sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-version-time-attribute-req" test="xccdf:version/@time">SRC-3-|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-xinclude" test="not(.//xinclude:include)">SRC-339-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-version-update-req" test=".//xccdf:version[string(@update)]">SRC-341-1</sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-version-update-req" test=".//xccdf:version[string(@update)]">SRC-341-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-set-complex-value" test="not(.//xccdf:set-complex-value)">SRC-343-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-style" test="@style = 'SCAP_1.3'">SRC-4-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-metadata-missing" test="xccdf:metadata">SRC-8-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
@@ -58,7 +58,7 @@
     </sch:rule>
     <sch:rule id="scap-general-xccdf-group" context="xccdf:Group">
       <sch:assert id="scap-general-xccdf-group-description" test="xccdf:description">SRC-10-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-xccdf-benchmark-no-group-extension" test="not(@extends)">SRC-354-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-no-group-extension" test="not(@extends)">SRC-354-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-group-title-1" test="xccdf:title">SRC-9-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-group-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Group <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-group-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Group <sch:value-of select="@id"/></sch:assert>
@@ -72,10 +72,10 @@
       <sch:assert id="scap-general-xccdf-rule-attributes-exists" test="@selected and @weight and @role and @severity">A-26-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-metadata" context="xccdf:Benchmark/xccdf:metadata">
-      <sch:assert id="scap-general-xccdf-metadata-populated-creator" test="dc:creator/text()">SRC-8-1</sch:assert>
-      <sch:assert id="scap-general-xccdf-metadata-populated-publisher" test="dc:publisher/text()">SRC-8-1</sch:assert>
-      <sch:assert id="scap-general-xccdf-metadata-populated-contributor" test="dc:contributor/text()">SRC-8-1</sch:assert>
-      <sch:assert id="scap-general-xccdf-metadata-populated-source" test="dc:source/text()">SRC-8-1</sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated-creator" test="dc:creator/text()">SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated-publisher" test="dc:publisher/text()">SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated-contributor" test="dc:contributor/text()">SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated-source" test="dc:source/text()">SRC-8-1|xccdf:Benchmark <sch:value-of select="parent::xccdf:Benchmark/@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-system-cpe-dict-check" context="cpe-dict:check">
       <sch:assert id="scap-general-system-cpe-dict-check2" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-2|cpe-dict:cpe-item <sch:value-of select="ancestor::cpe-dict:cpe-item[1]/@name"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -37,6 +37,7 @@
       <sch:assert id="scap-general-xccdf-benchmark-version-time-attribute-req" test="xccdf:version/@time">SRC-3-2</sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-xinclude" test="not(.//xinclude:include)">SRC-339-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-version-update-req" test=".//xccdf:version[string(@update)]">SRC-341-1</sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-no-set-complex-value" test="not(.//xccdf:set-complex-value)">SRC-343-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -104,6 +104,7 @@
     </sch:rule>
     <sch:rule id="scap-general-signature-sig" context="dsig:Signature">
       <sch:assert id="scap-general-signature-sig-manifest-req" test="dsig:Object/dsig:Manifest">SRC-284-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-tmsad" test="dsig:Object/dsig:SignatureProperties/dsig:SignatureProperty/tmsad:signature-info">SRC-285-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -98,6 +98,9 @@
       <sch:assert id="scap-general-oval-def-rule-compliance-cce" test="@class != 'compliance' or oval-def:metadata/oval-def:reference[@source='http://cce.mitre.org' or @source='CCE']">SRC-207-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-oval-def-vulnerability-cve-ref" test="@class != 'vulnerability' or oval-def:metadata/oval-def:reference[@source='http://cve.mitre.org' or source='CVE']">SRC-214-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
+    <sch:rule id="scap-general-oval-generator" context="oval-def:generator/oval-com:schema_version">
+      <sch:assert id="scap-general-oval-version" test="@platform or text()='5.3' or text()='5.4' or text()='5.5' or text()='5.6' or text()='5.7' or text()='5.8' or text()='5.9' or text()='5.10' or text()='5.10.1' or text()='5.11' or text()='5.11.1' or text()='5.11.2'">SRC-216-1</sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -124,6 +124,7 @@
     </sch:rule>
     <sch:rule id="scap-check-system-content-match-rule" context="scap:check-system-content">
       <sch:assert flag="ERROR" test="not(@content-type='OVAL_COMPLIANCE' or @content-type='OVAL_PATCH' or @content-type='CPE_INVENTORY' or @content-type='OVAL_VULNERABILITY') or oval-def:oval_definitions" id="scap-check-system-content-match-assert-1">A-18-1</sch:assert>
+      <sch:assert flag="ERROR" test="@content-type != 'OCIL_QUESTIONS' or ocil:ocil" id="scap-check-system-content-match-assert-2">A-18-1</sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -85,6 +85,9 @@
       <sch:assert id="scap-general-xccdf-check-sys-req" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule[1]/@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-check-patches-ref-oval-only" test="not(current()/parent::xccdf:Rule[substring(@id, string-length(@id) - string-length('security_patches_up_to_date') + 1) = 'security_patches_up_to_date']) or current()/@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5'">SRC-169-2|xccdf:Rule <sch:value-of select="parent::xccdf:Rule/@id"/></sch:assert>
     </sch:rule>
+    <sch:rule id="scap-general-scap-data-stream-collection" context="scap:data-stream-collection ">
+      <sch:assert id="scap-general-latest-schematron-rules" test="current()[@schematron-version='1.3']">SRC-330-2|scap:data-stream-collection</sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -81,6 +81,9 @@
     <sch:rule id="scap-general-system-cpe-lang-check" context="cpe-lang:check-fact-ref">
       <sch:assert id="scap-general-system-cpe-lang-check2" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-3|cpe-lang:platform <sch:value-of select="ancestor::cpe-lang:platform[1]/@id"/></sch:assert>
     </sch:rule>
+    <sch:rule id="scap-general-xccdf-check" context="xccdf:Rule/xccdf:check">
+      <sch:assert id="scap-general-xccdf-check-sys-req" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule[1]/@id"/></sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -118,6 +118,9 @@
       <sch:assert flag="WARNING" test="not(@system='http://cce.mitre.org' or @system='CCE') or text() != ''" id="scap-cce-check-assert-1">A-16-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule/@id"/></sch:assert>
       <sch:assert flag="ERROR" test="not(@system='http://cce.mitre.org' or @system='CCE') or startswith(text(), 'CCE-')" id="scap-cce-check-assert-2">A-17-1|<sch:value-of select="."/></sch:assert>
     </sch:rule>
+    <sch:rule id="scap-cce-check-rule-2" context="oval-def:reference">
+      <sch:assert flag="WARNING" test="not(@source='http://cce.mitre.org' or @source='CCE') or @ref_id!=''" id="scap-cce-check-assert-5">A-16-1|oval-def:definition <sch:value-of select="ancestor::oval-def:definition/@id"/></sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -31,6 +31,7 @@
   <sch:pattern id="scap-general">
     <sch:rule id="scap-general-xccdf-benchmark" context="xccdf:Benchmark">
       <sch:assert id="scap-general-xccdf-benchmark-description" test="xccdf:description">SRC-10-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-lang-required" test="@xml:lang">SRC-2-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -94,6 +94,9 @@
     <sch:rule id="scap-general-scap-content" context="scap:data-stream">
       <sch:assert id="scap-general-scap-content-use-case" test="@use-case = 'CONFIGURATION' or @use-case = 'VULNERABILITY' or @use-case = 'INVENTORY' or @use-case = 'OTHER'" >SRC-324-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
+    <sch:rule id="scap-general-oval-def" context="oval-def:definition">
+      <sch:assert id="scap-general-oval-def-rule-compliance-cce" test="@class != 'compliance' or oval-def:metadata/oval-def:reference[@source='http://cce.mitre.org' or @source='CCE']">SRC-207-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -105,6 +105,7 @@
     <sch:rule id="scap-general-signature-sig" context="dsig:Signature">
       <sch:assert id="scap-general-signature-sig-manifest-req" test="dsig:Object/dsig:Manifest">SRC-284-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
       <sch:assert id="scap-general-signature-sig-tmsad" test="dsig:Object/dsig:SignatureProperties/dsig:SignatureProperty/tmsad:signature-info">SRC-285-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-first-ref-ds" test="ancestor::ds:data-stream-collection[1]/ds:data-stream[concat('#',@id) = current()/dsig:SignedInfo/dsig:Reference[1]/@URI]">SRC-286-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -47,6 +47,7 @@
     </sch:rule>
     <sch:rule id="scap-general-xccdf-group" context="xccdf:Group">
       <sch:assert id="scap-general-xccdf-group-description" test="xccdf:description">SRC-10-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-no-group-extension" test="not(@extends)">SRC-354-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-rule" context="xccdf:Rule">
       <sch:assert id="scap-general-xccdf-rule-description" test="xccdf:description">SRC-10-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -84,6 +84,7 @@
     <sch:rule id="scap-general-xccdf-check" context="xccdf:Rule/xccdf:check">
       <sch:assert id="scap-general-xccdf-check-sys-req" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule[1]/@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-check-patches-ref-oval-only" test="not(current()/parent::xccdf:Rule[substring(@id, string-length(@id) - string-length('security_patches_up_to_date') + 1) = 'security_patches_up_to_date']) or current()/@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5'">SRC-169-2|xccdf:Rule <sch:value-of select="parent::xccdf:Rule/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-check-content-ref-req" test="xccdf:check-content-ref">SRC-175-1|xccdf:Rule <sch:value-of select="parent::xccdf:Rule/@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-scap-data-stream-collection" context="scap:data-stream-collection ">
       <sch:assert id="scap-general-latest-schematron-rules" test="current()[@schematron-version='1.3']">SRC-330-2|scap:data-stream-collection</sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -88,6 +88,9 @@
     <sch:rule id="scap-general-scap-data-stream-collection" context="scap:data-stream-collection ">
       <sch:assert id="scap-general-latest-schematron-rules" test="current()[@schematron-version='1.3']">SRC-330-2|scap:data-stream-collection</sch:assert>
     </sch:rule>
+    <sch:rule id="scap-general-scap-content" context="scap:data-stream">
+      <sch:assert id="scap-general-scap-content-use-case" test="@use-case = 'CONFIGURATION' or @use-case = 'VULNERABILITY' or @use-case = 'INVENTORY' or @use-case = 'OTHER'" >SRC-324-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This schematron has been created based on the original SCAP 1.3 schematron from NIST -->
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt">
+  <sch:ns prefix="ai" uri="http://scap.nist.gov/schema/asset-identification/1.1"/>
+  <sch:ns prefix="arf" uri="http://scap.nist.gov/schema/asset-reporting-format/1.1"/>
+  <sch:ns prefix="cat" uri="urn:oasis:names:tc:entity:xmlns:xml:catalog"/>
+  <sch:ns prefix="cpe-dict" uri="http://cpe.mitre.org/dictionary/2.0"/>
+  <sch:ns prefix="cpe-lang" uri="http://cpe.mitre.org/language/2.0"/>
+  <sch:ns prefix="dc" uri="http://purl.org/dc/elements/1.1/"/>
+  <sch:ns prefix="ds" uri="http://scap.nist.gov/schema/scap/source/1.2"/>
+  <sch:ns prefix="dsig" uri="http://www.w3.org/2000/09/xmldsig#"/>
+  <sch:ns prefix="java" uri="java:gov.nist.secauto.scap.validation.schematron"/>
+  <sch:ns prefix="nvd-config" uri="http://scap.nist.gov/schema/feed/configuration/0.1"/>
+  <sch:ns prefix="ocil" uri="http://scap.nist.gov/schema/ocil/2.0"/>
+  <sch:ns prefix="oval-com" uri="http://oval.mitre.org/XMLSchema/oval-common-5"/>
+  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+  <sch:ns prefix="oval-res" uri="http://oval.mitre.org/XMLSchema/oval-results-5"/>
+  <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
+  <sch:ns prefix="rc" uri="http://scap.nist.gov/schema/reporting-core/1.1"/>
+  <sch:ns prefix="scap" uri="http://scap.nist.gov/schema/scap/source/1.2"/>
+  <sch:ns prefix="scap-con" uri="http://scap.nist.gov/schema/scap/constructs/1.2"/>
+  <sch:ns prefix="tmsad" uri="http://scap.nist.gov/schema/xml-dsig/1.0"/>
+  <sch:ns prefix="xccdf" uri="http://checklists.nist.gov/xccdf/1.2"/>
+  <sch:ns prefix="xcf" uri="nist:scap:xslt:function"/>
+  <sch:ns prefix="xinclude" uri="http://www.w3.org/2001/XInclude"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="xml" uri="http://www.w3.org/XML/1998/namespace"/>
+  <sch:ns prefix="xsd" uri="http://www.w3.org/2001/XMLSchema"/>
+
+  <sch:pattern id="scap-general">
+    <sch:rule id="scap-general-xccdf-benchmark" context="xccdf:Benchmark">
+      <sch:assert id="scap-general-xccdf-benchmark-description" test="xccdf:description">SRC-10-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
+      <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-xccdf-value" context="xccdf:Value">
+      <sch:assert id="scap-general-xccdf-value-description" test="xccdf:description">SRC-10-1|xccdf:Value <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-xccdf-group" context="xccdf:Group">
+      <sch:assert id="scap-general-xccdf-group-description" test="xccdf:description">SRC-10-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-xccdf-rule" context="xccdf:Rule">
+      <sch:assert id="scap-general-xccdf-rule-description" test="xccdf:description">SRC-10-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
+  </sch:pattern>
+
+</sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -116,6 +116,7 @@
     </sch:rule>
     <sch:rule id="scap-cce-check-rule-1" context="xccdf:ident">
       <sch:assert flag="WARNING" test="not(@system='http://cce.mitre.org' or @system='CCE') or text() != ''" id="scap-cce-check-assert-1">A-16-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule/@id"/></sch:assert>
+      <sch:assert flag="ERROR" test="not(@system='http://cce.mitre.org' or @system='CCE') or startswith(text(), 'CCE-')" id="scap-cce-check-assert-2">A-17-1|<sch:value-of select="."/></sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -35,6 +35,7 @@
       <sch:assert id="scap-general-xccdf-no-check-content-check" test="not(.//xccdf:check-content)">SRC-25-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-val-forbid" test="not(.//xccdf:Value//xccdf:source) and not(.//xccdf:Value//xccdf:complex-value) and not(.//xccdf:Value//xccdf:complex-default) and not(.//xccdf:Value//xccdf:choices//xccdf:complex-choice)">SRC-276-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-version-time-attribute-req" test="xccdf:version/@time">SRC-3-2</sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-no-xinclude" test="not(.//xinclude:include)">SRC-339-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -40,19 +40,24 @@
       <sch:assert id="scap-general-xccdf-benchmark-no-set-complex-value" test="not(.//xccdf:set-complex-value)">SRC-343-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-style" test="@style = 'SCAP_1.3'">SRC-4-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-metadata-missing" test="xccdf:metadata">SRC-8-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-title-1" test="xccdf:title">SRC-9-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-profile-title-1" test="xccdf:title">SRC-9-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-value" context="xccdf:Value">
       <sch:assert id="scap-general-xccdf-value-description" test="xccdf:description">SRC-10-1|xccdf:Value <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-value-title-1" test="xccdf:title">SRC-9-1|xccdf:Value <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-group" context="xccdf:Group">
       <sch:assert id="scap-general-xccdf-group-description" test="xccdf:description">SRC-10-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-group-extension" test="not(@extends)">SRC-354-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-group-title-1" test="xccdf:title">SRC-9-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-rule" context="xccdf:Rule">
       <sch:assert id="scap-general-xccdf-rule-description" test="xccdf:description">SRC-10-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-title-1" test="xccdf:title">SRC-9-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-metadata" context="xccdf:Benchmark/xccdf:metadata">
       <sch:assert id="scap-general-xccdf-metadata-populated-creator" test="dc:creator/text()">SRC-8-1</sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -41,23 +41,28 @@
       <sch:assert id="scap-general-xccdf-style" test="@style = 'SCAP_1.3'">SRC-4-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-metadata-missing" test="xccdf:metadata">SRC-8-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-title-1" test="xccdf:title">SRC-9-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-profile-title-1" test="xccdf:title">SRC-9-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-profile-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-value" context="xccdf:Value">
       <sch:assert id="scap-general-xccdf-value-description" test="xccdf:description">SRC-10-1|xccdf:Value <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-value-title-1" test="xccdf:title">SRC-9-1|xccdf:Value <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-value-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Value <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-group" context="xccdf:Group">
       <sch:assert id="scap-general-xccdf-group-description" test="xccdf:description">SRC-10-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-group-extension" test="not(@extends)">SRC-354-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-group-title-1" test="xccdf:title">SRC-9-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-group-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Group <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-rule" context="xccdf:Rule">
       <sch:assert id="scap-general-xccdf-rule-description" test="xccdf:description">SRC-10-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-rule-title-1" test="xccdf:title">SRC-9-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-metadata" context="xccdf:Benchmark/xccdf:metadata">
       <sch:assert id="scap-general-xccdf-metadata-populated-creator" test="dc:creator/text()">SRC-8-1</sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -38,6 +38,7 @@
       <sch:assert id="scap-general-xccdf-benchmark-no-xinclude" test="not(.//xinclude:include)">SRC-339-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-version-update-req" test=".//xccdf:version[string(@update)]">SRC-341-1</sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-set-complex-value" test="not(.//xccdf:set-complex-value)">SRC-343-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-style" test="@style = 'SCAP_1.3'">SRC-4-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -75,6 +75,9 @@
       <sch:assert id="scap-general-xccdf-metadata-populated-contributor" test="dc:contributor/text()">SRC-8-1</sch:assert>
       <sch:assert id="scap-general-xccdf-metadata-populated-source" test="dc:source/text()">SRC-8-1</sch:assert>
     </sch:rule>
+    <sch:rule id="scap-general-system-cpe-dict-check" context="cpe-dict:check">
+      <sch:assert id="scap-general-system-cpe-dict-check2" test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'">SRC-118-2|cpe-dict:cpe-item <sch:value-of select="ancestor::cpe-dict:cpe-item[1]/@name"/></sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -96,6 +96,7 @@
     </sch:rule>
     <sch:rule id="scap-general-oval-def" context="oval-def:definition">
       <sch:assert id="scap-general-oval-def-rule-compliance-cce" test="@class != 'compliance' or oval-def:metadata/oval-def:reference[@source='http://cce.mitre.org' or @source='CCE']">SRC-207-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-oval-def-vulnerability-cve-ref" test="@class != 'vulnerability' or oval-def:metadata/oval-def:reference[@source='http://cve.mitre.org' or source='CVE']">SRC-214-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -96,7 +96,7 @@
     </sch:rule>
     <sch:rule id="scap-general-oval-def" context="oval-def:definition">
       <sch:assert id="scap-general-oval-def-rule-compliance-cce" test="@class != 'compliance' or oval-def:metadata/oval-def:reference[@source='http://cce.mitre.org' or @source='CCE']">SRC-207-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
-      <sch:assert id="scap-general-oval-def-vulnerability-cve-ref" test="@class != 'vulnerability' or oval-def:metadata/oval-def:reference[@source='http://cve.mitre.org' or source='CVE']">SRC-214-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-oval-def-vulnerability-cve-ref" test="@class != 'vulnerability' or oval-def:metadata/oval-def:reference[@source='http://cve.mitre.org' or @source='CVE']">SRC-214-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-oval-generator" context="oval-def:generator/oval-com:schema_version">
       <sch:assert id="scap-general-oval-version" test="@platform or text()='5.3' or text()='5.4' or text()='5.5' or text()='5.6' or text()='5.7' or text()='5.8' or text()='5.9' or text()='5.10' or text()='5.10.1' or text()='5.11' or text()='5.11.1' or text()='5.11.2'">SRC-216-1</sch:assert>
@@ -116,11 +116,11 @@
     </sch:rule>
     <sch:rule id="scap-cce-check-rule-1" context="xccdf:ident">
       <sch:assert flag="WARNING" test="not(@system='http://cce.mitre.org' or @system='CCE') or text() != ''" id="scap-cce-check-assert-1">A-16-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule/@id"/></sch:assert>
-      <sch:assert flag="ERROR" test="not(@system='http://cce.mitre.org' or @system='CCE') or startswith(text(), 'CCE-')" id="scap-cce-check-assert-2">A-17-1|<sch:value-of select="."/></sch:assert>
+      <sch:assert flag="ERROR" test="not(@system='http://cce.mitre.org' or @system='CCE') or starts-with(text(), 'CCE-')" id="scap-cce-check-assert-2">A-17-1|<sch:value-of select="."/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-cce-check-rule-2" context="oval-def:reference">
       <sch:assert flag="WARNING" test="not(@source='http://cce.mitre.org' or @source='CCE') or @ref_id!=''" id="scap-cce-check-assert-5">A-16-1|oval-def:definition <sch:value-of select="ancestor::oval-def:definition/@id"/></sch:assert>
-      <sch:assert flag="ERROR" test="not(@source='http://cce.mitre.org' or @source='CCE') or startswith(@ref_id, 'CCE-')" id="scap-cce-check-assert-6">A-17-1|<sch:value-of select="@ref_id"/></sch:assert>
+      <sch:assert flag="ERROR" test="not(@source='http://cce.mitre.org' or @source='CCE') or starts-with(@ref_id, 'CCE-')" id="scap-cce-check-assert-6">A-17-1|<sch:value-of select="@ref_id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-check-system-content-match-rule" context="scap:check-system-content">
       <sch:assert flag="ERROR" test="not(@content-type='OVAL_COMPLIANCE' or @content-type='OVAL_PATCH' or @content-type='CPE_INVENTORY' or @content-type='OVAL_VULNERABILITY') or oval-def:oval_definitions" id="scap-check-system-content-match-assert-1">A-18-1</sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -106,6 +106,7 @@
       <sch:assert id="scap-general-signature-sig-manifest-req" test="dsig:Object/dsig:Manifest">SRC-284-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
       <sch:assert id="scap-general-signature-sig-tmsad" test="dsig:Object/dsig:SignatureProperties/dsig:SignatureProperty/tmsad:signature-info">SRC-285-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
       <sch:assert id="scap-general-signature-sig-first-ref-ds" test="ancestor::ds:data-stream-collection[1]/ds:data-stream[concat('#',@id) = current()/dsig:SignedInfo/dsig:Reference[1]/@URI]">SRC-286-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-ref-sig-prop" test="dsig:Object/dsig:SignatureProperties[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[2]/@URI]">SRC-287-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -122,6 +122,9 @@
       <sch:assert flag="WARNING" test="not(@source='http://cce.mitre.org' or @source='CCE') or @ref_id!=''" id="scap-cce-check-assert-5">A-16-1|oval-def:definition <sch:value-of select="ancestor::oval-def:definition/@id"/></sch:assert>
       <sch:assert flag="ERROR" test="not(@source='http://cce.mitre.org' or @source='CCE') or startswith(@ref_id, 'CCE-')" id="scap-cce-check-assert-6">A-17-1|<sch:value-of select="@ref_id"/></sch:assert>
     </sch:rule>
+    <sch:rule id="scap-check-system-content-match-rule" context="scap:check-system-content">
+      <sch:assert flag="ERROR" test="not(@content-type='OVAL_COMPLIANCE' or @content-type='OVAL_PATCH' or @content-type='CPE_INVENTORY' or @content-type='OVAL_VULNERABILITY') or oval-def:oval_definitions" id="scap-check-system-content-match-assert-1">A-18-1</sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -102,6 +102,9 @@
       <sch:assert id="scap-general-oval-version" test="@platform or text()='5.3' or text()='5.4' or text()='5.5' or text()='5.6' or text()='5.7' or text()='5.8' or text()='5.9' or text()='5.10' or text()='5.10.1' or text()='5.11' or text()='5.11.1' or text()='5.11.2'">SRC-216-1</sch:assert>
       <sch:assert id="scap-general-oval-platform-version" test="not(@platform) or text()='5.11.1:1.0' or text()='5.11.1:1.1' or text()='5.11.1:1.2' or text()='5.11.2:1.0' or text()='5.11.2:1.1' or text()='5.11.2:1.2'">SRC-216-2</sch:assert>
     </sch:rule>
+    <sch:rule id="scap-general-signature-sig" context="dsig:Signature">
+      <sch:assert id="scap-general-signature-sig-manifest-req" test="dsig:Object/dsig:Manifest">SRC-284-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+    </sch:rule>
   </sch:pattern>
 
 </sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -107,6 +107,7 @@
       <sch:assert id="scap-general-signature-sig-tmsad" test="dsig:Object/dsig:SignatureProperties/dsig:SignatureProperty/tmsad:signature-info">SRC-285-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
       <sch:assert id="scap-general-signature-sig-first-ref-ds" test="ancestor::ds:data-stream-collection[1]/ds:data-stream[concat('#',@id) = current()/dsig:SignedInfo/dsig:Reference[1]/@URI]">SRC-286-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
       <sch:assert id="scap-general-signature-sig-ref-sig-prop" test="dsig:Object/dsig:SignatureProperties[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[2]/@URI]">SRC-287-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-third-ref-manifest" test="dsig:Object/dsig:Manifest[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[3]/@URI]">SRC-288-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -68,6 +68,7 @@
       <sch:assert id="scap-general-xccdf-rule-title-1" test="xccdf:title">SRC-9-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-rule-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-rule-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-cve-cce-cpe" test="xccdf:ident[@system = 'http://cce.mitre.org' or @system = 'http://cve.mitre.org' or @system = 'http://cpe.mitre.org']">SRC-251-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-metadata" context="xccdf:Benchmark/xccdf:metadata">
       <sch:assert id="scap-general-xccdf-metadata-populated-creator" test="dc:creator/text()">SRC-8-1</sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -34,6 +34,7 @@
       <sch:assert id="scap-general-xccdf-benchmark-lang-required" test="@xml:lang">SRC-2-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-no-check-content-check" test="not(.//xccdf:check-content)">SRC-25-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-val-forbid" test="not(.//xccdf:Value//xccdf:source) and not(.//xccdf:Value//xccdf:complex-value) and not(.//xccdf:Value//xccdf:complex-default) and not(.//xccdf:Value//xccdf:choices//xccdf:complex-choice)">SRC-276-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-version-time-attribute-req" test="xccdf:version/@time">SRC-3-2</sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -32,6 +32,7 @@
     <sch:rule id="scap-general-xccdf-benchmark" context="xccdf:Benchmark">
       <sch:assert id="scap-general-xccdf-benchmark-description" test="xccdf:description">SRC-10-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-lang-required" test="@xml:lang">SRC-2-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-no-check-content-check" test="not(.//xccdf:check-content)">SRC-25-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -42,27 +42,32 @@
       <sch:assert id="scap-general-xccdf-metadata-missing" test="xccdf:metadata">SRC-8-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-title-1" test="xccdf:title">SRC-9-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
       <sch:assert id="scap-general-xccdf-profile-description" test="xccdf:description">SRC-10-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-profile-title-1" test="xccdf:title">SRC-9-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-profile-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-profile-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-value" context="xccdf:Value">
       <sch:assert id="scap-general-xccdf-value-description" test="xccdf:description">SRC-10-1|xccdf:Value <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-value-title-1" test="xccdf:title">SRC-9-1|xccdf:Value <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-value-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Value <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-value-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Value <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-group" context="xccdf:Group">
       <sch:assert id="scap-general-xccdf-group-description" test="xccdf:description">SRC-10-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-benchmark-no-group-extension" test="not(@extends)">SRC-354-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-group-title-1" test="xccdf:title">SRC-9-1|xccdf:Group <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-group-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Group <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-group-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Group <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-rule" context="xccdf:Rule">
       <sch:assert id="scap-general-xccdf-rule-description" test="xccdf:description">SRC-10-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-rule-title-1" test="xccdf:title">SRC-9-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-rule-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-metadata" context="xccdf:Benchmark/xccdf:metadata">
       <sch:assert id="scap-general-xccdf-metadata-populated-creator" test="dc:creator/text()">SRC-8-1</sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -69,6 +69,7 @@
       <sch:assert id="scap-general-xccdf-rule-title-3" test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']">SRC-9-3|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-rule-title-2" test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))">SRC-9-3|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
       <sch:assert id="scap-general-xccdf-rule-cve-cce-cpe" test="xccdf:ident[@system = 'http://cce.mitre.org' or @system = 'http://cve.mitre.org' or @system = 'http://cpe.mitre.org']">SRC-251-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-attributes-exists" test="@selected and @weight and @role and @severity">A-26-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
     </sch:rule>
     <sch:rule id="scap-general-xccdf-metadata" context="xccdf:Benchmark/xccdf:metadata">
       <sch:assert id="scap-general-xccdf-metadata-populated-creator" test="dc:creator/text()">SRC-8-1</sch:assert>

--- a/schemas/sds/1.3/source-data-stream-1.3.sch
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch
@@ -120,6 +120,7 @@
     </sch:rule>
     <sch:rule id="scap-cce-check-rule-2" context="oval-def:reference">
       <sch:assert flag="WARNING" test="not(@source='http://cce.mitre.org' or @source='CCE') or @ref_id!=''" id="scap-cce-check-assert-5">A-16-1|oval-def:definition <sch:value-of select="ancestor::oval-def:definition/@id"/></sch:assert>
+      <sch:assert flag="ERROR" test="not(@source='http://cce.mitre.org' or @source='CCE') or startswith(@ref_id, 'CCE-')" id="scap-cce-check-assert-6">A-17-1|<sch:value-of select="@ref_id"/></sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/sds/1.3/source-data-stream-1.3.sch.original
+++ b/schemas/sds/1.3/source-data-stream-1.3.sch.original
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--These rules are for informational purposes only and DO NOT supersede the requirements in NIST SP 800-126 Rev 3.-->
+<!--These rules may be revised at anytime. Comments/feedback on these rules are welcome.-->
+<!--Private comments may be sent to scap@nist.gov.  Public comments may be sent to scap-dev@nist.gov.-->
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" queryBinding="xslt2">
+  <sch:ns prefix="ai" uri="http://scap.nist.gov/schema/asset-identification/1.1"/>
+  <sch:ns prefix="arf" uri="http://scap.nist.gov/schema/asset-reporting-format/1.1"/>
+  <sch:ns prefix="cat" uri="urn:oasis:names:tc:entity:xmlns:xml:catalog"/>
+  <sch:ns prefix="cpe-dict" uri="http://cpe.mitre.org/dictionary/2.0"/>
+  <sch:ns prefix="cpe-lang" uri="http://cpe.mitre.org/language/2.0"/>
+  <sch:ns prefix="dc" uri="http://purl.org/dc/elements/1.1/"/>
+  <sch:ns prefix="ds" uri="http://scap.nist.gov/schema/scap/source/1.2"/>
+  <sch:ns prefix="dsig" uri="http://www.w3.org/2000/09/xmldsig#"/>
+  <sch:ns prefix="java" uri="java:gov.nist.secauto.scap.validation.schematron"/>
+  <sch:ns prefix="nvd-config" uri="http://scap.nist.gov/schema/feed/configuration/0.1"/>
+  <sch:ns prefix="ocil" uri="http://scap.nist.gov/schema/ocil/2.0"/>
+  <sch:ns prefix="oval-com" uri="http://oval.mitre.org/XMLSchema/oval-common-5"/>
+  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+  <sch:ns prefix="oval-res" uri="http://oval.mitre.org/XMLSchema/oval-results-5"/>
+  <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
+  <sch:ns prefix="rc" uri="http://scap.nist.gov/schema/reporting-core/1.1"/>
+  <sch:ns prefix="scap" uri="http://scap.nist.gov/schema/scap/source/1.2"/>
+  <sch:ns prefix="scap-con" uri="http://scap.nist.gov/schema/scap/constructs/1.2"/>
+  <sch:ns prefix="tmsad" uri="http://scap.nist.gov/schema/xml-dsig/1.0"/>
+  <sch:ns prefix="xccdf" uri="http://checklists.nist.gov/xccdf/1.2"/>
+  <sch:ns prefix="xcf" uri="nist:scap:xslt:function"/>
+  <sch:ns prefix="xinclude" uri="http://www.w3.org/2001/XInclude"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="xml" uri="http://www.w3.org/XML/1998/namespace"/>
+  <sch:ns prefix="xsd" uri="http://www.w3.org/2001/XMLSchema"/>
+  
+  <sch:let name="datafiles_directory" value="'datafiles'"/>
+
+  <sch:pattern id="scap-general">
+    <sch:rule id="scap-general-xccdf-benchmark" context="xccdf:Benchmark">
+      <sch:assert id="scap-general-xccdf-description" test="every $m in (. union .//xccdf:Profile union .//xccdf:Value union .//xccdf:Group union .//xccdf:Rule) satisfies exists($m/xccdf:description)">SRC-10-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-lang-required" test="exists(@xml:lang)">SRC-2-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-no-check-content-check" test="not(exists(.//xccdf:check-content))">SRC-25-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-val-forbid" test="not(exists(.//xccdf:Value//xccdf:source)) and not(exists(.//xccdf:Value//xccdf:complex-value)) and not(exists(.//xccdf:Value//xccdf:complex-default)) and not(exists(.//xccdf:Value//xccdf:choices//xccdf:complex-choice))">SRC-276-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-version-time-attribute-req" test="exists(xccdf:version/@time)">SRC-3-2</sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-no-xinclude" test="not(exists(.//xinclude:include))">SRC-339-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-version-update-req" test="exists(//xccdf:version[string(@update)])">SRC-341-1</sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-no-set-complex-value" test="not(exists(.//xccdf:set-complex-value))">SRC-343-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-no-group-extension" test="every $m in .//xccdf:Group satisfies not(exists($m/@extends))">SRC-354-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-style" test="@style eq 'SCAP_1.3'">SRC-4-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-missing" test="exists(xccdf:metadata)">SRC-8-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-metadata-populated" test="if( exists(xccdf:metadata) ) then exists(xccdf:metadata/dc:creator/text()) and exists(xccdf:metadata/dc:publisher/text()) and exists(xccdf:metadata/dc:contributor/text()) and exists(xccdf:metadata/dc:source/text()) else false()">SRC-8-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-title-1" test="every $m in (. union .//xccdf:Profile union .//xccdf:Value union .//xccdf:Group union .//xccdf:Rule) satisfies exists($m/xccdf:title)">SRC-9-1|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-title-3" test="every $m in (. union .//xccdf:Profile union .//xccdf:Value union .//xccdf:Group union .//xccdf:Rule) satisfies if( count($m/xccdf:title) gt 1 ) then exists($m/xccdf:title[@xml:lang eq 'en-US']) else true()">SRC-9-3|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-title-2" test="every $m in (. union .//xccdf:Profile union .//xccdf:Value union .//xccdf:Group union .//xccdf:Rule) satisfies (if( count($m/xccdf:title) gt 1 ) then count($m/xccdf:title) eq count($m/xccdf:title[@xml:lang]) else true())">SRC-9-2|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-benchmark-unique" test="every $m in ancestor::scap:data-stream-collection//xccdf:Benchmark[@id eq current()/@id] satisfies (generate-id($m) eq generate-id(current()) or $m/xccdf:version[1] ne current()/xccdf:version[1])">SRC-3-3|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert></sch:rule>
+    <sch:rule id="scap-general-xccdf-profile" context="xccdf:Profile">
+      <sch:assert id="scap-general-xccdf-profile-unique" test="if (count(ancestor::scap:data-stream-collection//xccdf:Benchmark/xccdf:Profile[@id eq current()/@id]) gt 1) then false() else true()">A-25-1|xccdf:Profile <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-system-cpe-dict-check" context="cpe-dict:check">
+      <sch:assert id="scap-general-system-cpe-dict-check2" test="@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system eq 'http://scap.nist.gov/schema/ocil/2'">SRC-118-2|cpe-dict:cpe-item <sch:value-of select="ancestor::cpe-dict:cpe-item[1]/@name"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-system-cpe-lang-check" context="cpe-lang:check-fact-ref">
+      <sch:assert id="scap-general-system-cpe-lang-check2" test="@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system eq 'http://scap.nist.gov/schema/ocil/2'">SRC-118-3|cpe-lang:platform <sch:value-of select="ancestor::cpe-lang:platform[1]/@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-cpe-ref-check-fact" test="some $m in current()/ancestor::scap:data-stream-collection//ds:checklists/ds:component-ref satisfies(exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, current()/@href))//oval-def:definition[@id eq current()/@id-ref]) or exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, current()/@href))//ocil:questionnaire[@id eq current()/@id-ref]))">A-27-1|cpe-lang:check-fact-ref <sch:value-of select="@id-ref"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-xccdf-check" context="xccdf:Rule/xccdf:check">
+      <sch:assert id="scap-general-xccdf-check-sys-req" test="@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system eq 'http://scap.nist.gov/schema/ocil/2'">SRC-118-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule[1]/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-check-patches-ref-oval-only" test="if(current()/parent::xccdf:Rule[ends-with(@id,'security_patches_up_to_date')]) then current()/@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' else true()">SRC-169-2|xccdf:Rule <sch:value-of select="parent::xccdf:Rule/@id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-scap-data-stream-collection" context="scap:data-stream-collection ">
+      <sch:assert id="scap-general-latest-schematron-rules" test="exists(current()[@schematron-version='1.3'])">SRC-330-2|scap:data-stream-collection</sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-scap-content" context="scap:data-stream">
+      <sch:assert id="scap-general-scap-content-every-cpe-equal-subset2" test="if( function-available('java:isEqualOrSuperset') ) then (every $m in ds:checklists/ds:component-ref satisfies ((every $n in xcf:get-component($m)//xccdf:platform[not(starts-with(@idref,'#'))] satisfies some $o in ds:dictionaries/ds:component-ref satisfies some $p in xcf:get-component($o)//cpe-dict:cpe-item satisfies java:isEqualOrSuperset($n/@idref,$p/@name)) and (every $q in xcf:get-component($m)//cpe-lang:fact-ref satisfies some $r in ds:dictionaries/ds:component-ref satisfies some $s in xcf:get-component($r)//cpe-dict:cpe-item satisfies java:isEqualOrSuperset($q/@name,$s/@name)))) else true()">SRC-15-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-check-content-ref-multiple-patch-id-req" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:Rule[starts-with(@id,'xccdf_') and ends-with(@id,'_rule_security_patches_up_to_date')]//xccdf:check-content-ref[not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)] satisfies if ($n/parent::node()[@multi-check eq 'true']) then count(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//oval-def:definition[@class eq 'patch']) gt 0 else true()">SRC-169-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-check-content-ref-multiple-patch-name-omit" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:Rule[starts-with(@id,'xccdf_') and ends-with(@id,'_rule_security_patches_up_to_date')]//xccdf:check-content-ref satisfies if ($n/parent::node()[@multi-check eq 'true']) then not(exists($n[@name])) else true()">SRC-171-1|xccdf:Rule <value-of select="ancestor::xccdf:Rule/@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-check-content-ref-single-patch-id-req" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:Rule[starts-with(@id,'xccdf_') and ends-with(@id,'_rule_security_patches_up_to_date')]//xccdf:check-content-ref[not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)] satisfies if ($n/parent::node()[@multi-check eq 'false' or not(exists(@multi-check))]) then ((not(exists($n/preceding-sibling::*:check-content-ref)) and not(exists($n/following-sibling::*:check-content-ref))) and count(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//oval-def:definition[@id eq $n/@name and @class eq 'patch']) eq 1) else true()">SRC-377-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-check-content-ref-single-patch-name-req" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:Rule[starts-with(@id,'xccdf_') and ends-with(@id,'_rule_security_patches_up_to_date')]//xccdf:check-content-ref satisfies if ($n/parent::node()[@multi-check eq 'false' or not(exists(@multi-check))]) then exists($n[@name]) else true()">SRC-379-1|xccdf:Rule <value-of select="ancestor::xccdf:Rule/@id"/></sch:assert>
+      <sch:assert id="scap-use-case-conf-verification-rule-ref-oval" test="if( @use-case eq 'CONFIGURATION' ) then every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:Rule satisfies (if(exists($n/xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system eq 'http://scap.nist.gov/schema/ocil/2']/xccdf:check-content-ref[exists(@name) and not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)])) then some $o in $n/xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system eq 'http://scap.nist.gov/schema/ocil/2']/xccdf:check-content-ref[exists(@name) and not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)] satisfies (exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//oval-def:definition[@id eq $o/@name and matches(@class,'^(compliance|patch)$')]) or exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//ocil:questionnaire[@id eq $o/@name])) else true()) else true()">SRC-236-2|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-use-case-conf-verification-content-xccdf-req" test="if( @use-case eq 'CONFIGURATION' ) then (count(//*:checklists/ds:component-ref) gt 0 and (some $m in ds:checklists/ds:component-ref satisfies exists(xcf:get-component($m)/xccdf:Benchmark))) else true()">SRC-236-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-use-case-vul-assess-xccdf-oval-content-xccdf-req" test="if( @use-case eq 'VULNERABILITY' ) then (count(//*:checklists/ds:component-ref) gt 0 and (some $m in ds:checklists/ds:component-ref satisfies exists(xcf:get-component($m)/xccdf:Benchmark))) else true()">SRC-242-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-use-case-vul-assess-xccdf-oval-rule-xccdf-oval-ref-req" test="if( @use-case eq 'VULNERABILITY' ) then every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:Rule satisfies some $o in $n/xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system eq 'http://scap.nist.gov/schema/ocil/2']/xccdf:check-content-ref[exists(@name) and not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)] satisfies (exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//oval-def:definition[@id eq $o/@name and matches(@class,'^(vulnerability|patch)$')]) or exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//ocil:questionnaire[@id eq $o/@name])) else true()">SRC-242-2|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-use-case-inventory-collection-content-xccdf-req" test="if( @use-case eq 'INVENTORY' ) then (count(//*:checklists/ds:component-ref) gt 0 and (some $m in ds:checklists/ds:component-ref satisfies exists(xcf:get-component($m)/xccdf:Benchmark))) else true()">SRC-248-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-use-case-inventory-collection-xccdf-rule-ref-oval-def-req" test="if( @use-case eq 'INVENTORY' ) then every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:Rule satisfies some $o in $n/xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system eq 'http://scap.nist.gov/schema/ocil/2']/xccdf:check-content-ref[exists(@name) and not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)] satisfies (exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//oval-def:definition[@id eq $o/@name and matches(@class,'^(inventory)$')]) or exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//ocil:questionnaire[@id eq $o/@name])) else true()">SRC-248-2|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-xccdf-oval-ref-match" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:ident[matches(@system,'^(http://cce.mitre.org|http://cve.mitre.org|http://cpe.mitre.org)$')] satisfies every $o in $n/ancestor::xccdf:Rule[1]/xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5']/xccdf:check-content-ref[exists(@name)] satisfies exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//oval-def:definition[@id eq $o/@name]//oval-def:reference[matches(@source,xcf:ident-mapping($n/@system)) and $n eq @ref_id])">SRC-251-2|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-use-case-conf-verification-benchmark-one-rule-ref-oval-ocil" test="if( @use-case eq 'CONFIGURATION' ) then ( every $m in ds:checklists/ds:component-ref satisfies if( exists(xcf:get-component($m)/xccdf:Benchmark)) then (some $n in xcf:get-component($m)//xccdf:check[matches(@system,'^(http://oval\.mitre\.org/XMLSchema/oval-definitions-5|http://scap\.nist\.gov/schema/ocil/2)$')]/xccdf:check-content-ref[not(xcf:is-external-ref($m/cat:catalog,@href) cast as xsd:boolean)] satisfies (exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//ocil:questionnaire[@id eq $n/@name]) or exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//oval-def:definition[@id eq $n/@name and @class eq 'compliance']))) else true()) else true()">SRC-262-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-use-case-vul-assess-xccdf-benchmark-one-rule-ref-oval-ocil" test="if( @use-case eq 'VULNERABILITY' ) then( every $m in ds:checklists/ds:component-ref satisfies if( exists(xcf:get-component($m)/xccdf:Benchmark)) then( some $n in xcf:get-component($m)//xccdf:check[matches(@system,'^(http://oval\.mitre\.org/XMLSchema/oval-definitions-5|http://scap\.nist\.gov/schema/ocil/2)$')]/xccdf:check-content-ref[not(xcf:is-external-ref($m/cat:catalog,@href) cast as xsd:boolean)] satisfies (exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//ocil:questionnaire[@id eq $n/@name]) or exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//oval-def:definition[@id eq $n/@name and @class eq 'vulnerability']))) else true()) else true()">SRC-265-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-dict-and-oval-req" test="if( @use-case eq 'CONFIGURATION' ) then every $m in ds:checklists/ds:component-ref satisfies( if( exists(xcf:get-component($m)//xccdf:platform)  or exists(xcf:get-component($m)//cpe-dict:cpe-item)  ) then (exists(ds:dictionaries/ds:component-ref) and (some $n in ds:checks/ds:component-ref satisfies exists(xcf:get-component($n)//oval-def:definition[@class eq 'inventory'])) )else true()) else true()">SRC-30-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-resolve-to-comp-ref" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:check//xccdf:check-content-ref satisfies exists(xcf:get-component-ref($m/cat:catalog, $n/@href))">SRC-31-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-use-case" test="matches(@use-case,'^(CONFIGURATION|VULNERABILITY|INVENTORY|OTHER)$')">SRC-324-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-vuln-cpe-inv-req" test="if( @use-case eq 'VULNERABILITY' ) then every $m in ds:checklists/ds:component-ref satisfies (if( exists(xcf:get-component($m)//xccdf:platform) or exists(xcf:get-component($m)//cpe-dict:cpe-item) ) then (exists(ds:dictionaries/ds:component-ref) and (some $n in ds:checks/ds:component-ref satisfies exists(xcf:get-component($n)//oval-def:definition[@class eq 'inventory'])) ) else true()) else true()">SRC-33-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-indent-match-to-oval-def-inv" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:Rule[exists(xccdf:ident[@system eq 'http://cpe.mitre.org'])]/xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5']//xccdf:check-content-ref[not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean) and exists(@name)] satisfies exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//oval-def:definition[@id eq $n/@name and @class eq 'inventory'])">SRC-331-3|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-indent-match-to-oval-def-comp" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:Rule[exists(xccdf:ident[@system eq 'http://cce.mitre.org'])]/xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5']//xccdf:check-content-ref[not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean) and exists(@name)] satisfies exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//oval-def:definition[@id eq $n/@name and @class eq 'compliance'])">SRC-331-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-indent-match-to-oval-def-vuln" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:Rule[exists(xccdf:ident[@system eq 'http://cve.mitre.org'])]/xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5']//xccdf:check-content-ref[not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean) and exists(@name)] satisfies exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//oval-def:definition[@id eq $n/@name and @class eq 'vulnerability'])">SRC-331-2|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-ref-comp-once" test="every $m in .//scap:component-ref satisfies count($m/ancestor::scap:data-stream//scap:component-ref[@xlink:href eq $m/@xlink:href]) eq 1">SRC-333-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-oval-ref-check-content-ref-oval" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5']//xccdf:check-content-ref[not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)] satisfies exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//oval-def:oval_definitions)">SRC-345-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-xccdf-check-content-ref-name-not-req" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5']//xccdf:check-content-ref[not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)] satisfies (not(exists($n/@name)) or exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//oval-def:definition[@id eq $n/@name]))">SRC-346-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-ocil-check-content-ref-ocil" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:check[@system eq 'http://scap.nist.gov/schema/ocil/2']//xccdf:check-content-ref[not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)] satisfies exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//ocil:ocil)">SRC-348-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-scap-content-ocil-check-content-ref-with-without-name" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:check[@system eq 'http://scap.nist.gov/schema/ocil/2']//xccdf:check-content-ref[not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)] satisfies (not(exists($n/@name)) or exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//ocil:questionnaire[@id eq $n/@name]))">SRC-349-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-value-oval-binding-type-1" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5']/xccdf:check-export satisfies ( not(matches($n/ancestor::xccdf:Benchmark//xccdf:Value[@id eq $n/@value-id]/@type, '^number$')) or (every $o in $n/following-sibling::xccdf:check-content-ref satisfies matches(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//*[@id eq $n/@export-name]/@datatype, '^(int|float)$')))">SRC-38-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-value-oval-binding-type-2" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5']/xccdf:check-export satisfies ( not(matches($n/ancestor::xccdf:Benchmark//xccdf:Value[@id eq $n/@value-id]/@type, '^boolean$')) or (every $o in $n/following-sibling::xccdf:check-content-ref satisfies matches(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//*[@id eq $n/@export-name]/@datatype, '^boolean$')))">SRC-38-2|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-value-oval-binding-type-3" test="every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5']/xccdf:check-export satisfies ( not(matches($n/ancestor::xccdf:Benchmark//xccdf:Value[@id eq $n/@value-id]/@type, '^string$')) or (every $o in $n/following-sibling::xccdf:check-content-ref satisfies matches(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//*[@id eq $n/@export-name]/@datatype, '^(string|evr_string|version|ios_version|fileset_revision|binary)$')))">SRC-38-3|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-oval-cpe-inventory" test="every $m in ds:dictionaries/ds:component-ref satisfies every $n in xcf:get-component($m)//cpe-dict:cpe-list/cpe-dict:cpe-item/cpe-dict:check satisfies ($n/@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' and exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $n/@href))//oval-def:definition[@id = $n]))">SRC-72-1|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-xccdf-rule" context="xccdf:Rule">
+      <sch:assert id="scap-general-xccdf-rule-check-content-ref-req" test="every $m in .//xccdf:check satisfies exists($m/xccdf:check-content-ref)">SRC-175-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-cve-cce-cpe" test="exists(xccdf:ident[matches(@system,'^(http://cce.mitre.org|http://cve.mitre.org|http://cpe.mitre.org)$')])">SRC-251-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-ident-cve-cce-cpe-order" test="every $m in xccdf:ident satisfies matches($m/@system,'^(http://cpe.mitre.org|http://cve.mitre.org|http://cce.mitre.org)$') or not(exists($m/following-sibling::xccdf:ident[matches(@system,'^(http://cpe.mitre.org|http://cve.mitre.org|http://cce.mitre.org)$')]))">SRC-257-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-cce-exists" test="every $m in xccdf:ident[matches(@system, '^(http://cce.mitre.org)$')] satisfies exists(document(concat($datafiles_directory,'/nvdcce-0.1-feed.xml'))/nvd-config:nvd/nvd-config:entry[@id eq $m])">SRC-74-1|xccdf:Rule <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-xccdf-rule-attributes-exists" test="exists(@selected) and exists(@weight) and exists(@role) and exists(@severity)">A-26-1</sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-oval-def" context="oval-def:definition">
+      <sch:assert id="scap-general-oval-def-rule-compliance-cce" test="if(@class eq 'compliance') then exists(oval-def:metadata/oval-def:reference[matches(@source,'^(http://cce.mitre.org|CCE)$')]) else true()">SRC-207-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-oval-def-compliance-extension" test="if(@class eq 'compliance') then every $m in xcf:get-all-parents(ancestor::oval-def:definitions,.) satisfies matches($m/@class,'^(compliance|inventory)$') else true()">SRC-208-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-oval-def-ref-cpe-inventory" test="if(@class eq 'inventory') then exists(oval-def:metadata/oval-def:reference[matches(@source,'^(http://cpe.mitre.org|CPE)$') and (matches(@ref_id,'^[c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6}$') or matches(@ref_id,'^cpe:2\.3:[aho\*-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!&quot;#$$%&amp;\(\)\+,/:;&lt;=&gt;@\[\]\^`\{{\|}}~]))+(\?*|\*?))|[\*-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!&quot;#$$%&amp;\(\)\+,/:;&lt;=&gt;@\[\]\^`\{{\|}}~]))+(\?*|\*?))|[\*-])){4}$'))]) else true()">SRC-209-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-oval-def-inventory-extension" test="if(@class eq 'inventory') then every $m in xcf:get-all-parents(ancestor::oval-def:definitions,.) satisfies matches($m/@class,'^(inventory)$') else true()">SRC-210-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-oval-def-patch-extensions" test="if(@class eq 'patch') then every $m in xcf:get-all-parents(ancestor::oval-def:definitions,.) satisfies matches($m/@class,'^(patch|inventory)$') else true()">SRC-213-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-oval-def-vulnerability-cve-ref" test="if(@class eq 'vulnerability') then exists(oval-def:metadata/oval-def:reference[matches(@source,'^(http://cve.mitre.org|CVE)$')]) else true()">SRC-214-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+      <sch:assert id="scap-general-oval-def-vulnerability-extension" test="if(@class eq 'vulnerability') then every $m in xcf:get-all-parents(ancestor::oval-def:definitions,.) satisfies (if( generate-id(current()) ne generate-id($m) ) then matches($m/@class,'^(inventory|vulnerability)$') else true() ) else true()">SRC-215-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-oval-generator" context="oval-def:generator">
+      <sch:assert id="scap-general-oval-version" test="every $m in oval-com:schema_version satisfies if (not(exists($m/@platform))) then matches($m,'^5\.(3|4|5|6|7|8|9|10(\.1)?|11(\.1|\.2)?)$') else true()">SRC-216-1</sch:assert>
+      <sch:assert id="scap-general-oval-platform-version" test="every $m in oval-com:schema_version satisfies if (exists($m/@platform)) then matches($m,'^5\.11(\.1|\.2):1(\.0|\.1|\.2)$') else true()">SRC-216-2</sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-signature-sig" context="dsig:Signature">
+      <sch:assert id="scap-general-signature-sig-one-ds-ref" test="every $m in dsig:SignedInfo/dsig:Reference satisfies ((not(exists(ancestor::ds:data-stream-collection[1]/ds:data-stream[concat('#',@id) eq $m/@URI]))) or (every $n in $m/preceding-sibling::dsig:Reference satisfies not(exists(ancestor::ds:data-stream-collection[1]/ds:data-stream[concat('#',@id) eq $n/@URI]))))">SRC-282-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-local-refs-req" test="every $m in ancestor::ds:data-stream-collection[1]/ds:data-stream[concat('#',@id) eq current()/dsig:SignedInfo/dsig:Reference[1]/@URI]//ds:component-ref[starts-with(@xlink:href,'#')] satisfies exists(dsig:Object/dsig:Manifest/dsig:Reference[@URI eq $m/@xlink:href])">SRC-284-2|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-manifest-req" test="exists(dsig:Object/dsig:Manifest)">SRC-284-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-tmsad" test="exists(dsig:Object/dsig:SignatureProperties/dsig:SignatureProperty/tmsad:signature-info)">SRC-285-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-first-ref-ds" test="exists(ancestor::ds:data-stream-collection[1]/ds:data-stream[concat('#',@id) eq current()/dsig:SignedInfo/dsig:Reference[1]/@URI])">SRC-286-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-ref-sig-prop" test="exists(dsig:Object/dsig:SignatureProperties[concat('#',@Id) eq current()/dsig:SignedInfo/dsig:Reference[2]/@URI])">SRC-287-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-third-ref-manifest" test="exists(dsig:Object/dsig:Manifest[concat('#',@Id) eq current()/dsig:SignedInfo/dsig:Reference[3]/@URI])">SRC-288-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+      <sch:assert id="scap-general-signature-sig-key-info" test="exists(dsig:KeyInfo)">SRC-290-1|dsig:Signature <sch:value-of select="@Id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-general-xccdf-status-rule-value-date" context="xccdf:status">
+      <sch:assert id="scap-general-xccdf-status-rule-value-date-1" test=". eq 'draft' or . eq 'accepted'">SRC-5-1</sch:assert>
+      <sch:assert id="scap-general-xccdf-status-rule-value-date-2" test="@date ne ''">SRC-5-2</sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <sch:pattern id="scap-additional-rules">
+    <sch:rule id="scap-unused-oval-rule" context="oval-def:definition">
+      <sch:assert flag="WARNING" test="if(exists(//scap:xccdf-content)) then exists(ancestor::scap:check-system-content[@content-type eq 'OVAL_PATCH']) or exists(//xccdf:check-content-ref[@href eq current()/ancestor::scap:check-system-content/@id and (not(@name) or @name eq current()/@id)]) or exists(current()/ancestor::oval-def:oval_definitions//oval-def:extend_definition[@definition_ref eq current()/@id]) or exists(//cpe-dict:check[@href eq current()/ancestor::scap:check-system-content/@id and . eq current()/@id]) else true()" id="scap-unused-oval-assert">A-15-1|oval-def:definition <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-cce-check-rule-1" context="xccdf:ident">
+      <sch:assert flag="WARNING" test="if(@system eq 'http://cce.mitre.org' or @system eq 'CCE') then . ne '' else true()" id="scap-cce-check-assert-1">A-16-1|xccdf:Rule <sch:value-of select="ancestor::xccdf:Rule/@id"/></sch:assert>
+      <sch:assert flag="ERROR" test="if(@system eq 'http://cce.mitre.org' or @system eq 'CCE') then matches(., '^CCE-\d+-\d$') else true()" id="scap-cce-check-assert-2">A-17-1|<sch:value-of select="."/></sch:assert>
+      <sch:assert flag="ERROR" test="if((@system eq 'http://cce.mitre.org' or @system eq 'CCE') and matches(., '^CCE-\d+-\d$')) then (sum(for $j in (for $i in reverse(string-to-codepoints(concat(substring(.,5,string-length(.)-6),substring(.,string-length(.),1))))[position() mod 2 = 0] return ($i - 48) * 2, for $i in reverse(string-to-codepoints(concat(substring(.,5,string-length(.)-6),substring(.,string-length(.),1))))[position() mod 2 = 1] return ($i - 48)) return ($j mod 10, $j idiv 10)) mod 10) eq 0 else true()" id="scap-cce-check-assert-3">A-17-1|<sch:value-of select="."/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-cce-check-rule-2" context="oval-def:reference">
+      <sch:assert flag="WARNING" test="if(@source eq 'http://cce.mitre.org' or @source eq 'CCE') then @ref_id ne '' else true()" id="scap-cce-check-assert-5">A-16-1|oval-def:definition <sch:value-of select="ancestor::oval-def:definition/@id"/></sch:assert>
+      <sch:assert flag="ERROR" test="if(@source eq 'http://cce.mitre.org' or @source eq 'CCE') then matches(@ref_id, '^CCE-\d+-\d$') else true()" id="scap-cce-check-assert-6">A-17-1|<sch:value-of select="@ref_id"/></sch:assert>
+      <sch:assert flag="ERROR" test="if((@source eq 'http://cce.mitre.org' or @source eq 'CCE') and matches(@ref_id, '^CCE-\d+-\d$')) then (sum(for $j in (for $i in reverse(string-to-codepoints(concat(substring(@ref_id,5,string-length(@ref_id)-6),substring(@ref_id,string-length(@ref_id),1))))[position() mod 2 = 0] return ($i - 48) * 2, for $i in reverse(string-to-codepoints(concat(substring(@ref_id,5,string-length(@ref_id)-6),substring(@ref_id,string-length(@ref_id),1))))[position() mod 2 = 1] return ($i - 48)) return ($j mod 10, $j idiv 10)) mod 10) eq 0 else true()" id="scap-cce-check-assert-7">A-17-1|<sch:value-of select="@ref_id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-check-system-content-match-rule" context="scap:check-system-content">
+      <sch:assert flag="ERROR" test="if(matches(@content-type,'^(OVAL_COMPLIANCE|OVAL_PATCH|CPE_INVENTORY|OVAL_VULNERABILITY)$')) then exists(oval-def:oval_definitions) else true()" id="scap-check-system-content-match-assert-1">A-18-1</sch:assert>
+      <sch:assert flag="ERROR" test="if(matches(@content-type,'^(OCIL_QUESTIONS)$')) then exists(ocil:ocil) else true()" id="scap-check-system-content-match-assert-2">A-18-1</sch:assert>
+    </sch:rule>
+    <!--        
+        <sch:rule id="scap-xccdf-profile-check-rule" context="xccdf:Benchmark">
+        <sch:assert flag="ERROR"
+        test="if($profile ne '') then exists(current()//xccdf:Profile[@id eq $profile]) else true()"
+        id="scap-xccdf-profile-check-asset">A-20|xccdf:Benchmark <sch:value-of select="@id"/></sch:assert>
+        </sch:rule>
+    -->
+    <sch:rule id="scap-oval-tests" context="oval-def:tests/*">
+      <sch:assert flag="INFO" test="exists(document(concat($datafiles_directory,'/validation_program_oval_test_types.xml'))/test-types-collection/test_types[@style='SCAP_1.3']/test_type[@namespace eq namespace-uri(current()) and @name eq local-name(current())])" id="scap-oval-tests-validation-program-test-types">A-21-1|OVAL test <sch:value-of select="@id"/></sch:assert>
+    </sch:rule>
+    <sch:rule id="scap-collection" context="scap:data-stream-collection">
+      <sch:assert flag="WARNING" test="function-available('java:isEqualOrSuperset')" id="scap-collection-java-functions">A-22-1</sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:get-all-profile-parents">
+    <xsl:param name="doc"/>
+    <xsl:param name="node"/>
+    <xsl:sequence select="$node"/>
+    <xsl:if test="exists($node/@extends)">
+      <xsl:sequence select="xcf:get-all-profile-parents($doc,$doc//xccdf:Benchmark//xccdf:Profile[@id eq $node/@extends])"/>
+    </xsl:if>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:get-component">
+    <xsl:param name="component-ref"/>
+    <xsl:sequence select="$component-ref/ancestor::ds:data-stream-collection//ds:component[@id eq substring($component-ref/@xlink:href,2)]"/>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/XSL/Transform" name="xcf:get-all-def-children">
+    <xsl:param name="doc"/>
+    <xsl:param name="node"/>
+    <xsl:sequence select="$node"/>
+    <xsl:for-each select="$doc//oval-def:extend_definition[@definition_ref eq $node/@id]/ancestor::oval-def:definition">
+      <xsl:sequence select="xcf:get-all-def-children($doc,current())"/>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:ident-mapping">
+    <xsl:param name="in-string"/>
+    <xsl:choose>
+      <xsl:when test="$in-string eq 'http://cce.mitre.org'">
+        <xsl:value-of select="string('^(CCE|http://cce.mitre.org)$')"/>
+      </xsl:when>
+      <xsl:when test="$in-string eq 'http://cve.mitre.org'">
+        <xsl:value-of select="string('^(CVE|http://cve.mitre.org)$')"/>
+      </xsl:when>
+      <xsl:when test="$in-string eq 'http://cpe.mitre.org'">
+        <xsl:value-of select="string('^(CPE|http://cpe.mitre.org)$')"/>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:get-all-parents">
+    <xsl:param name="doc"/>
+    <xsl:param name="node"/>
+    <xsl:sequence select="$node"/>
+    <xsl:for-each select="$node//oval-def:extend_definition">
+      <xsl:sequence select="xcf:get-all-parents($doc,ancestor::oval-def:oval_definitions//*[@id eq current()/@definition_ref])"/>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:get-ocil-var-ref">
+    <xsl:param name="ocil_questionnaire"/>
+    <xsl:variable name="initialSet">
+      <xsl:for-each select="$ocil_questionnaire/ocil:actions/ocil:test_action_ref">
+        <xsl:sequence select="ancestor::ocil:ocil/ocil:test_actions/ocil:numeric_question_test_action[@id eq current()]/ocil:when_equals[@var_ref]"/>
+        <xsl:sequence select="ancestor::ocil:ocil/ocil:test_actions/ocil:string_question_test_action[@id eq current()]/ocil:when_pattern/ocil:pattern[@var_ref]"/>
+        <xsl:sequence select="ancestor::ocil:ocil/ocil:test_actions/ocil:numeric_question_test_action[@id eq current()]/ocil:when_range/ocil:range/ocil:min[@var_ref]"/>
+        <xsl:sequence select="ancestor::ocil:ocil/ocil:test_actions/ocil:numeric_question_test_action[@id eq current()]/ocil:when_range/ocil:range/ocil:max[@var_ref]"/>
+        <xsl:for-each select="ancestor::ocil:ocil/ocil:test_actions/*[@id eq current()]">
+          <xsl:sequence select="ancestor::ocil:ocil/ocil:questions/ocil:choice_question[@id eq current()/@question_ref]/ocil:choice[@var_ref]"/>
+          <xsl:for-each select="ancestor::ocil:ocil/ocil:questions/ocil:choice_question[@id eq current()/@question_ref]/ocil:choice_group_ref">
+            <xsl:sequence select="ancestor::ocil:questions/ocil:choice_group[@id eq current()]/ocil:choice[@var_ref]"/>
+          </xsl:for-each>
+        </xsl:for-each>
+      </xsl:for-each>
+    </xsl:variable>
+    <xsl:for-each select="$initialSet/*">
+      <xsl:sequence select="xcf:pass-ocil-var-ref($ocil_questionnaire,current())"/>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:get-component-ref">
+    <xsl:param name="catalog"/>
+    <xsl:param name="uri"/>
+    <xsl:variable name="component-ref-uri" select="xcf:resolve-in-catalog($catalog/*[1],$uri)"/>
+    <xsl:if test="$component-ref-uri ne ''">
+      <xsl:sequence select="$catalog/ancestor::ds:data-stream//ds:component-ref[@id eq substring($component-ref-uri,2)]"/>
+    </xsl:if>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:pass-ocil-var-ref">
+    <xsl:param name="ocil_questionnaire"/>
+    <xsl:param name="var_ref"/>
+    <xsl:sequence select="$var_ref"/>
+    <xsl:for-each select="$ocil_questionnaire/ancestor::ocil:ocil/ocil:variables/ocil:local_variable[@id eq $var_ref/@var_ref]/ocil:set/ocil:when_range/ocil:min[@var_ref]">
+      <xsl:sequence select="xcf:pass-ocil-var-ref($ocil_questionnaire,current())"/>
+    </xsl:for-each>
+    <xsl:for-each select="$ocil_questionnaire/ancestor::ocil:ocil/ocil:variables/ocil:local_variable[@id eq $var_ref/@var_ref]/ocil:set/ocil:when_range/ocil:max[@var_ref]">
+      <xsl:sequence select="xcf:pass-ocil-var-ref($ocil_questionnaire,current())"/>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:resolve-in-catalog">
+    <xsl:param name="resolver-node"/>
+    <xsl:param name="uri"/>
+    <xsl:choose>
+      <xsl:when test="starts-with($uri,'#')">
+        <xsl:value-of select="$uri"/>
+      </xsl:when>
+      <xsl:when test="exists($resolver-node)">
+        <xsl:choose>
+          <xsl:when test="$resolver-node/local-name() eq 'uri'">
+            <xsl:choose>
+              <xsl:when test="$resolver-node/@name eq $uri">
+                <xsl:value-of select="$resolver-node/@uri"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="xcf:resolve-in-catalog($resolver-node/following-sibling::*[1], $uri)"/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:when>
+          <xsl:when test="$resolver-node/local-name() eq 'rewriteURI'">
+            <xsl:choose>
+              <xsl:when test="starts-with($uri,$resolver-node/@uriStartString)">
+                <xsl:value-of select="concat($resolver-node/@rewritePrefix,substring($uri,string-length($resolver-node/@uriStartString)+1))"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="xcf:resolve-in-catalog($resolver-node/following-sibling::*[1], $uri)"/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:when>
+        </xsl:choose>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/XSL/Transform" name="xcf:get-all-external-vars">
+    <xsl:param name="doc"/>
+    <xsl:param name="node"/>
+    <xsl:sequence select="$doc//oval-def:external_variable[@id eq $node/@var_ref]"/>
+    <xsl:for-each select="$doc//*[@id eq $node/@var_ref]//*[@var_ref]">
+      <xsl:sequence select="xcf:get-all-external-vars($doc,current())"/>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:is-external-ref">
+    <xsl:param name="catalog"/>
+    <xsl:param name="uri"/>
+    <xsl:variable name="comp-ref" select="xcf:get-component-ref($catalog,$uri)"/>
+    <xsl:choose>
+      <xsl:when test="exists($comp-ref)">
+        <xsl:value-of select="not(starts-with($comp-ref/@xlink:href,'#'))"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="false()"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:get-all-group-parents">
+    <xsl:param name="doc"/>
+    <xsl:param name="node"/>
+    <xsl:sequence select="$node"/>
+    <xsl:if test="exists($node/@extends)">
+      <xsl:sequence select="xcf:get-all-group-parents($doc,$doc//xccdf:Benchmark//xccdf:Group[@id eq $node/@extends])"/>
+    </xsl:if>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:get-locator-prefix">
+    <xsl:param name="name"/>
+    <xsl:variable name="subName" select="substring($name,1,string-length($name) - string-length(tokenize($name,'-')[last()]) - 1)"/>
+    <xsl:choose>
+      <xsl:when test="ends-with($subName,'cpe')">
+        <xsl:value-of select="xcf:get-locator-prefix($subName)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="tokenize($subName,'/')[last()]"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function xmlns:xcf="nist:scap:xslt:function" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" name="xcf:get-locator-prefix-res">
+    <xsl:param name="name"/>
+    <xsl:variable name="subName" select="substring($name,1,string-length($name) - string-length(tokenize($name,'-')[last()]) - 1)"/>
+    <xsl:value-of select="xcf:get-locator-prefix($subName)"/>
+  </xsl:function>
+</sch:schema>

--- a/schemas/sds/1.3/source-data-stream-1.3.xsl
+++ b/schemas/sds/1.3/source-data-stream-1.3.xsl
@@ -1,0 +1,283 @@
+<?xml version="1.0" standalone="yes"?>
+<axsl:stylesheet xmlns:axsl="http://www.w3.org/1999/XSL/Transform" xmlns:sch="http://www.ascc.net/xml/schematron" xmlns:iso="http://purl.oclc.org/dsdl/schematron" xmlns:ai="http://scap.nist.gov/schema/asset-identification/1.1" xmlns:arf="http://scap.nist.gov/schema/asset-reporting-format/1.1" xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" xmlns:cpe-dict="http://cpe.mitre.org/dictionary/2.0" xmlns:cpe-lang="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:java="java:gov.nist.secauto.scap.validation.schematron" xmlns:nvd-config="http://scap.nist.gov/schema/feed/configuration/0.1" xmlns:ocil="http://scap.nist.gov/schema/ocil/2.0" xmlns:oval-com="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval-res="http://oval.mitre.org/XMLSchema/oval-results-5" xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" xmlns:rc="http://scap.nist.gov/schema/reporting-core/1.1" xmlns:scap="http://scap.nist.gov/schema/scap/source/1.2" xmlns:scap-con="http://scap.nist.gov/schema/scap/constructs/1.2" xmlns:tmsad="http://scap.nist.gov/schema/xml-dsig/1.0" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:xcf="nist:scap:xslt:function" xmlns:xinclude="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1.0"><!--Implementers: please note that overriding process-prolog or process-root is 
+    the preferred method for meta-stylesheets to use where possible. -->
+<axsl:param name="archiveDirParameter"/><axsl:param name="archiveNameParameter"/><axsl:param name="fileNameParameter"/><axsl:param name="fileDirParameter"/>
+
+<!--PHASES-->
+
+
+<!--PROLOG-->
+
+
+<!--KEYS-->
+
+
+<!--DEFAULT RULES-->
+
+
+<!--MODE: SCHEMATRON-SELECT-FULL-PATH-->
+<!--This mode can be used to generate an ugly though full XPath for locators-->
+<axsl:template match="*" mode="schematron-select-full-path"><axsl:apply-templates select="." mode="schematron-get-full-path"/></axsl:template>
+
+<!--MODE: SCHEMATRON-FULL-PATH-->
+<!--This mode can be used to generate an ugly though full XPath for locators-->
+<axsl:template match="*" mode="schematron-get-full-path"><axsl:apply-templates select="parent::*" mode="schematron-get-full-path"/><axsl:text>/</axsl:text><axsl:choose><axsl:when test="namespace-uri()=''"><axsl:value-of select="name()"/><axsl:variable name="p_1" select="1+    count(preceding-sibling::*[name()=name(current())])"/><axsl:if test="$p_1&gt;1 or following-sibling::*[name()=name(current())]">[<axsl:value-of select="$p_1"/>]</axsl:if></axsl:when><axsl:otherwise><axsl:text>*[local-name()='</axsl:text><axsl:value-of select="local-name()"/><axsl:text>' and namespace-uri()='</axsl:text><axsl:value-of select="namespace-uri()"/><axsl:text>']</axsl:text><axsl:variable name="p_2" select="1+   count(preceding-sibling::*[local-name()=local-name(current())])"/><axsl:if test="$p_2&gt;1 or following-sibling::*[local-name()=local-name(current())]">[<axsl:value-of select="$p_2"/>]</axsl:if></axsl:otherwise></axsl:choose></axsl:template><axsl:template match="@*" mode="schematron-get-full-path"><axsl:text>/</axsl:text><axsl:choose><axsl:when test="namespace-uri()=''">@<axsl:value-of select="name()"/></axsl:when><axsl:otherwise><axsl:text>@*[local-name()='</axsl:text><axsl:value-of select="local-name()"/><axsl:text>' and namespace-uri()='</axsl:text><axsl:value-of select="namespace-uri()"/><axsl:text>']</axsl:text></axsl:otherwise></axsl:choose></axsl:template>
+
+<!--MODE: SCHEMATRON-FULL-PATH-2-->
+<!--This mode can be used to generate prefixed XPath for humans-->
+<axsl:template match="node() | @*" mode="schematron-get-full-path-2"><axsl:for-each select="ancestor-or-self::*"><axsl:text>/</axsl:text><axsl:value-of select="name(.)"/><axsl:if test="preceding-sibling::*[name(.)=name(current())]"><axsl:text>[</axsl:text><axsl:value-of select="count(preceding-sibling::*[name(.)=name(current())])+1"/><axsl:text>]</axsl:text></axsl:if></axsl:for-each><axsl:if test="not(self::*)"><axsl:text/>/@<axsl:value-of select="name(.)"/></axsl:if></axsl:template>
+
+<!--MODE: GENERATE-ID-FROM-PATH -->
+<axsl:template match="/" mode="generate-id-from-path"/><axsl:template match="text()" mode="generate-id-from-path"><axsl:apply-templates select="parent::*" mode="generate-id-from-path"/><axsl:value-of select="concat('.text-', 1+count(preceding-sibling::text()), '-')"/></axsl:template><axsl:template match="comment()" mode="generate-id-from-path"><axsl:apply-templates select="parent::*" mode="generate-id-from-path"/><axsl:value-of select="concat('.comment-', 1+count(preceding-sibling::comment()), '-')"/></axsl:template><axsl:template match="processing-instruction()" mode="generate-id-from-path"><axsl:apply-templates select="parent::*" mode="generate-id-from-path"/><axsl:value-of select="concat('.processing-instruction-', 1+count(preceding-sibling::processing-instruction()), '-')"/></axsl:template><axsl:template match="@*" mode="generate-id-from-path"><axsl:apply-templates select="parent::*" mode="generate-id-from-path"/><axsl:value-of select="concat('.@', name())"/></axsl:template><axsl:template match="*" mode="generate-id-from-path" priority="-0.5"><axsl:apply-templates select="parent::*" mode="generate-id-from-path"/><axsl:text>.</axsl:text><axsl:value-of select="concat('.',name(),'-',1+count(preceding-sibling::*[name()=name(current())]),'-')"/></axsl:template><!--MODE: SCHEMATRON-FULL-PATH-3-->
+<!--This mode can be used to generate prefixed XPath for humans 
+	(Top-level element has index)-->
+<axsl:template match="node() | @*" mode="schematron-get-full-path-3"><axsl:for-each select="ancestor-or-self::*"><axsl:text>/</axsl:text><axsl:value-of select="name(.)"/><axsl:if test="parent::*"><axsl:text>[</axsl:text><axsl:value-of select="count(preceding-sibling::*[name(.)=name(current())])+1"/><axsl:text>]</axsl:text></axsl:if></axsl:for-each><axsl:if test="not(self::*)"><axsl:text/>/@<axsl:value-of select="name(.)"/></axsl:if></axsl:template>
+
+<!--MODE: GENERATE-ID-2 -->
+<axsl:template match="/" mode="generate-id-2">U</axsl:template><axsl:template match="*" mode="generate-id-2" priority="2"><axsl:text>U</axsl:text><axsl:number level="multiple" count="*"/></axsl:template><axsl:template match="node()" mode="generate-id-2"><axsl:text>U.</axsl:text><axsl:number level="multiple" count="*"/><axsl:text>n</axsl:text><axsl:number count="node()"/></axsl:template><axsl:template match="@*" mode="generate-id-2"><axsl:text>U.</axsl:text><axsl:number level="multiple" count="*"/><axsl:text>_</axsl:text><axsl:value-of select="string-length(local-name(.))"/><axsl:text>_</axsl:text><axsl:value-of select="translate(name(),':','.')"/></axsl:template><!--Strip characters--><axsl:template match="text()" priority="-1"/>
+
+<!--SCHEMA METADATA-->
+<axsl:template match="/"><axsl:apply-templates select="/" mode="M25"/></axsl:template>
+
+<!--SCHEMATRON PATTERNS-->
+
+
+<!--PATTERN scap-general-->
+
+
+	<!--RULE scap-general-xccdf-benchmark-->
+<axsl:template match="xccdf:Benchmark" priority="1017" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:description"/><axsl:otherwise>Error: SRC-10-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@xml:lang"/><axsl:otherwise>Error: SRC-2-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(.//xccdf:check-content)"/><axsl:otherwise>Error: SRC-25-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(.//xccdf:Value//xccdf:source) and not(.//xccdf:Value//xccdf:complex-value) and not(.//xccdf:Value//xccdf:complex-default) and not(.//xccdf:Value//xccdf:choices//xccdf:complex-choice)"/><axsl:otherwise>Error: SRC-276-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:version/@time"/><axsl:otherwise>Warning: SRC-3-2|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(.//xinclude:include)"/><axsl:otherwise>Error: SRC-339-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test=".//xccdf:version[string(@update)]"/><axsl:otherwise>Warning: SRC-341-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(.//xccdf:set-complex-value)"/><axsl:otherwise>Error: SRC-343-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@style = 'SCAP_1.3'"/><axsl:otherwise>Warning: SRC-4-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:metadata"/><axsl:otherwise>Error: SRC-8-2|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:title"/><axsl:otherwise>Error: SRC-9-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']"/><axsl:otherwise>Error: SRC-9-3|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))"/><axsl:otherwise>Error: SRC-9-3|xccdf:Benchmark <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-xccdf-profile-->
+<axsl:template match="xccdf:Profile" priority="1016" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:description"/><axsl:otherwise>Error: SRC-10-1|xccdf:Profile <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:title"/><axsl:otherwise>Error: SRC-9-1|xccdf:Profile <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']"/><axsl:otherwise>Error: SRC-9-3|xccdf:Profile <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))"/><axsl:otherwise>Error: SRC-9-3|xccdf:Profile <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-xccdf-value-->
+<axsl:template match="xccdf:Value" priority="1015" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:description"/><axsl:otherwise>Error: SRC-10-1|xccdf:Value <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:title"/><axsl:otherwise>Error: SRC-9-1|xccdf:Value <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']"/><axsl:otherwise>Error: SRC-9-3|xccdf:Value <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))"/><axsl:otherwise>Error: SRC-9-3|xccdf:Value <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-xccdf-group-->
+<axsl:template match="xccdf:Group" priority="1014" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:description"/><axsl:otherwise>Error: SRC-10-1|xccdf:Group <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(@extends)"/><axsl:otherwise>SRC-354-1|xccdf:Group <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:title"/><axsl:otherwise>Error: SRC-9-1|xccdf:Group <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']"/><axsl:otherwise>Error: SRC-9-3|xccdf:Group <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))"/><axsl:otherwise>Error: SRC-9-3|xccdf:Group <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-xccdf-rule-->
+<axsl:template match="xccdf:Rule" priority="1013" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:description"/><axsl:otherwise>Error: SRC-10-1|xccdf:Rule <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:title"/><axsl:otherwise>Error: SRC-9-1|xccdf:Rule <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="count(xccdf:title) &lt;= 1 or xccdf:title[@xml:lang = 'en-US']"/><axsl:otherwise>Error: SRC-9-3|xccdf:Rule <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="count(xccdf:title) &lt;= 1 or (count(xccdf:title) = count(xccdf:title[@xml:lang]))"/><axsl:otherwise>Error: SRC-9-3|xccdf:Rule <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:ident[@system = 'http://cce.mitre.org' or @system = 'http://cve.mitre.org' or @system = 'http://cpe.mitre.org']"/><axsl:otherwise>Warning: SRC-251-1|xccdf:Rule <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@selected and @weight and @role and @severity"/><axsl:otherwise>Warning: A-26-1|xccdf:Rule <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-xccdf-metadata-->
+<axsl:template match="xccdf:Benchmark/xccdf:metadata" priority="1012" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="dc:creator/text()"/><axsl:otherwise>Error: SRC-8-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="parent::xccdf:Benchmark/@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="dc:publisher/text()"/><axsl:otherwise>Error: SRC-8-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="parent::xccdf:Benchmark/@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="dc:contributor/text()"/><axsl:otherwise>Error: SRC-8-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="parent::xccdf:Benchmark/@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="dc:source/text()"/><axsl:otherwise>Error: SRC-8-1|xccdf:Benchmark <axsl:text/><axsl:value-of select="parent::xccdf:Benchmark/@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-system-cpe-dict-check-->
+<axsl:template match="cpe-dict:check" priority="1011" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'"/><axsl:otherwise>Error: SRC-118-2|cpe-dict:cpe-item <axsl:text/><axsl:value-of select="ancestor::cpe-dict:cpe-item[1]/@name"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-system-cpe-lang-check-->
+<axsl:template match="cpe-lang:check-fact-ref" priority="1010" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'"/><axsl:otherwise>Error: SRC-118-3|cpe-lang:platform <axsl:text/><axsl:value-of select="ancestor::cpe-lang:platform[1]/@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-xccdf-check-->
+<axsl:template match="xccdf:Rule/xccdf:check" priority="1009" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system = 'http://scap.nist.gov/schema/ocil/2'"/><axsl:otherwise>Error: SRC-118-1|xccdf:Rule <axsl:text/><axsl:value-of select="ancestor::xccdf:Rule[1]/@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(current()/parent::xccdf:Rule[substring(@id, string-length(@id) - string-length('security_patches_up_to_date') + 1) = 'security_patches_up_to_date']) or current()/@system = 'http://oval.mitre.org/XMLSchema/oval-definitions-5'"/><axsl:otherwise>Error: SRC-169-2|xccdf:Rule <axsl:text/><axsl:value-of select="parent::xccdf:Rule/@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="xccdf:check-content-ref"/><axsl:otherwise>Error: SRC-175-1|xccdf:Rule <axsl:text/><axsl:value-of select="parent::xccdf:Rule/@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-scap-data-stream-collection-->
+<axsl:template match="scap:data-stream-collection " priority="1008" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="current()[@schematron-version='1.3']"/><axsl:otherwise>Error: SRC-330-2|scap:data-stream-collection<axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-scap-content-->
+<axsl:template match="scap:data-stream" priority="1007" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@use-case = 'CONFIGURATION' or @use-case = 'VULNERABILITY' or @use-case = 'INVENTORY' or @use-case = 'OTHER'"/><axsl:otherwise>Error: SRC-324-1|scap:data-stream <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-oval-def-->
+<axsl:template match="oval-def:definition" priority="1006" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@class != 'compliance' or oval-def:metadata/oval-def:reference[@source='http://cce.mitre.org' or @source='CCE']"/><axsl:otherwise>Warning: SRC-207-1|oval-def:definition <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@class != 'vulnerability' or oval-def:metadata/oval-def:reference[@source='http://cve.mitre.org' or @source='CVE']"/><axsl:otherwise>Warning: SRC-214-1|oval-def:definition <axsl:text/><axsl:value-of select="@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-oval-generator-->
+<axsl:template match="oval-def:generator/oval-com:schema_version" priority="1005" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@platform or text()='5.3' or text()='5.4' or text()='5.5' or text()='5.6' or text()='5.7' or text()='5.8' or text()='5.9' or text()='5.10' or text()='5.10.1' or text()='5.11' or text()='5.11.1' or text()='5.11.2'"/><axsl:otherwise>Error: SRC-216-1<axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(@platform) or text()='5.11.1:1.0' or text()='5.11.1:1.1' or text()='5.11.1:1.2' or text()='5.11.2:1.0' or text()='5.11.2:1.1' or text()='5.11.2:1.2'"/><axsl:otherwise>Error: SRC-216-2<axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-signature-sig-->
+<axsl:template match="dsig:Signature" priority="1004" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="dsig:Object/dsig:Manifest"/><axsl:otherwise>Error: SRC-284-1|dsig:Signature <axsl:text/><axsl:value-of select="@Id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="dsig:Object/dsig:SignatureProperties/dsig:SignatureProperty/tmsad:signature-info"/><axsl:otherwise>Error: SRC-285-1|dsig:Signature <axsl:text/><axsl:value-of select="@Id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="ancestor::ds:data-stream-collection[1]/ds:data-stream[concat('#',@id) = current()/dsig:SignedInfo/dsig:Reference[1]/@URI]"/><axsl:otherwise>Error: SRC-286-1|dsig:Signature <axsl:text/><axsl:value-of select="@Id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="dsig:Object/dsig:SignatureProperties[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[2]/@URI]"/><axsl:otherwise>Error: SRC-287-1|dsig:Signature <axsl:text/><axsl:value-of select="@Id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="dsig:Object/dsig:Manifest[concat('#',@Id) = current()/dsig:SignedInfo/dsig:Reference[3]/@URI]"/><axsl:otherwise>Error: SRC-288-1|dsig:Signature <axsl:text/><axsl:value-of select="@Id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="dsig:KeyInfo"/><axsl:otherwise>Warning: SRC-290-1|dsig:Signature <axsl:text/><axsl:value-of select="@Id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-general-xccdf-status-rule-value-date-->
+<axsl:template match="xccdf:status" priority="1003" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="text()='draft' or text()= 'accepted'"/><axsl:otherwise>Error: SRC-5-1<axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@date!=''"/><axsl:otherwise>Error: SRC-5-2<axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-cce-check-rule-1-->
+<axsl:template match="xccdf:ident" priority="1002" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(@system='http://cce.mitre.org' or @system='CCE') or text() != ''"/><axsl:otherwise>Warning: A-16-1|xccdf:Rule <axsl:text/><axsl:value-of select="ancestor::xccdf:Rule/@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(@system='http://cce.mitre.org' or @system='CCE') or starts-with(text(), 'CCE-')"/><axsl:otherwise>Error: A-17-1|<axsl:text/><axsl:value-of select="."/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-cce-check-rule-2-->
+<axsl:template match="oval-def:reference" priority="1001" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(@source='http://cce.mitre.org' or @source='CCE') or @ref_id!=''"/><axsl:otherwise>Warning: A-16-1|oval-def:definition <axsl:text/><axsl:value-of select="ancestor::oval-def:definition/@id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(@source='http://cce.mitre.org' or @source='CCE') or starts-with(@ref_id, 'CCE-')"/><axsl:otherwise>Error: A-17-1|<axsl:text/><axsl:value-of select="@ref_id"/><axsl:text/><axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template>
+
+	<!--RULE scap-check-system-content-match-rule-->
+<axsl:template match="scap:check-system-content" priority="1000" mode="M25">
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="not(@content-type='OVAL_COMPLIANCE' or @content-type='OVAL_PATCH' or @content-type='CPE_INVENTORY' or @content-type='OVAL_VULNERABILITY') or oval-def:oval_definitions"/><axsl:otherwise>Error: A-18-1<axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose>
+
+		<!--ASSERT -->
+<axsl:choose><axsl:when test="@content-type != 'OCIL_QUESTIONS' or ocil:ocil"/><axsl:otherwise>Error: A-18-1<axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template><axsl:template match="text()" priority="-1" mode="M25"/><axsl:template match="@*|node()" priority="-2" mode="M25"><axsl:apply-templates select="*|comment()|processing-instruction()" mode="M25"/></axsl:template></axsl:stylesheet>

--- a/schemas/xccdf/1.2/xccdf_1.2-schematron.xsl
+++ b/schemas/xccdf/1.2/xccdf_1.2-schematron.xsl
@@ -310,7 +310,7 @@
 <axsl:template match="xccdf:Benchmark[not(xccdf:platform)]" priority="1000" mode="M38">
 
 		<!--ASSERT -->
-<axsl:choose><axsl:when test="false()"/><axsl:otherwise>Warning: The 'Benchmark' element has no platform specified, which implies the benchmark applies to all platforms. Applicable platforms should be indicate if possible. See the XCCDF 1.2.1 specification, Section 6.2.5.<axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="@*|*" mode="M38"/></axsl:template><axsl:template match="text()" priority="-1" mode="M38"/><axsl:template match="@*|node()" priority="-2" mode="M38"><axsl:apply-templates select="@*|*" mode="M38"/></axsl:template>
+<axsl:choose><axsl:when test="false()"/><axsl:otherwise>Warning: The 'Benchmark' element has no platform specified, which implies the benchmark applies to all platforms. Applicable platforms should be indicated if possible. See the XCCDF 1.2.1 specification, Section 6.2.5.<axsl:value-of select="string('&#10;')"/></axsl:otherwise></axsl:choose><axsl:apply-templates select="@*|*" mode="M38"/></axsl:template><axsl:template match="text()" priority="-1" mode="M38"/><axsl:template match="@*|node()" priority="-2" mode="M38"><axsl:apply-templates select="@*|*" mode="M38"/></axsl:template>
 
 <!--PATTERN benchmark_description_exists-->
 

--- a/src/common/oscapxml.c
+++ b/src/common/oscapxml.c
@@ -164,6 +164,8 @@ const char *oscap_document_type_to_string(oscap_document_type_t type)
 		return "CVE NVD Feed";
 	case OSCAP_DOCUMENT_CVRF_FEED:
 		return "CVRF Feed";
+	case OSCAP_DOCUMENT_OCIL:
+		return "OCIL Questionnaire";
 	default:
 		return NULL;
 	}

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -359,10 +359,13 @@ int oscap_source_validate(struct oscap_source *source, xml_reporter reporter, vo
 int oscap_source_validate_schematron(struct oscap_source *source, const char *outfile)
 {
 	FILE *outfile_fd = stdout;
-	if (outfile == NULL)
-		outfile_fd = stdout;
-	else
+	if (outfile != NULL) {
 		outfile_fd = fopen(outfile, "w");
+		if (outfile_fd == NULL) {
+			dE("Can't open %s: %s", outfile, strerror(errno));
+			return -1;
+		}
+	}
 	int ret = oscap_source_validate_schematron_priv(source, oscap_source_get_scap_type(source),
 			oscap_source_get_schema_version(source), outfile_fd);
 	if (outfile != NULL)

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -403,6 +403,9 @@ const char *oscap_source_get_schema_version(struct oscap_source *source)
 			case OSCAP_DOCUMENT_SCE_RESULT:
 				source->origin.version = oscap_strdup("1.0");
 				break;
+			case OSCAP_DOCUMENT_OCIL:
+				source->origin.version = oscap_strdup("2.0");
+				break;
 			default:
 				oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not determine origin.version for document %s: Unknown type: %s",
 					oscap_source_readable_origin(source),

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -358,8 +358,16 @@ int oscap_source_validate(struct oscap_source *source, xml_reporter reporter, vo
 
 int oscap_source_validate_schematron(struct oscap_source *source, const char *outfile)
 {
-	return oscap_source_validate_schematron_priv(source, oscap_source_get_scap_type(source),
-			oscap_source_get_schema_version(source), outfile);
+	FILE *outfile_fd = stdout;
+	if (outfile == NULL)
+		outfile_fd = stdout;
+	else
+		outfile_fd = fopen(outfile, "w");
+	int ret = oscap_source_validate_schematron_priv(source, oscap_source_get_scap_type(source),
+			oscap_source_get_schema_version(source), outfile_fd);
+	if (outfile != NULL)
+		fclose(outfile_fd);
+	return ret;
 }
 
 const char *oscap_source_get_schema_version(struct oscap_source *source)

--- a/src/source/schematron.c
+++ b/src/source/schematron.c
@@ -29,12 +29,16 @@
 #include <unistd.h>
 #endif
 
+#include <libxml/xpath.h>
+#include <libxml/xpathInternals.h>
 #include "common/_error.h"
+#include "common/debug_priv.h"
 #include "common/list.h"
 #include "common/util.h"
 #include "ds_sds_session.h"
 #include "DS/ds_sds_session_priv.h"
 #include "oscap.h"
+#include "oscap_helpers.h"
 #include "oscap_source.h"
 #include "source/oscap_source_priv.h"
 #include "source/schematron_priv.h"
@@ -130,6 +134,316 @@ static int _validate_sds_components(struct oscap_source *source)
 	return ret;
 }
 
+static char *_xcf_resolve_in_catalog(xmlNodePtr resolver_node, const char *uri, xmlXPathContextPtr context)
+{
+	if (*uri == '#') {
+		return oscap_strdup(uri);
+	}
+	if (resolver_node == NULL) {
+		return NULL;
+	}
+	if (strcmp((char *)resolver_node->name, "uri") == 0) {
+		char *name = (char *) xmlGetProp(resolver_node, BAD_CAST "name");
+		if (name != NULL && strcmp(name, uri) == 0) {
+			char *resolver_node_uri = (char *) xmlGetProp(resolver_node, BAD_CAST "uri");
+			free(name);
+			return resolver_node_uri;
+		} else {
+			free(name);
+			return _xcf_resolve_in_catalog(resolver_node->next, uri, context);
+		}
+	} else if (strcmp((char *)resolver_node->name, "rewriteURI") == 0) {
+		char *uri_start_string = (char *) xmlGetProp(resolver_node, BAD_CAST "uriStartString");
+		if (oscap_str_startswith(uri, uri_start_string)) {
+			char *rewrite_prefix = (char *) xmlGetProp(resolver_node, BAD_CAST "rewritePrefix");
+			char *concat = oscap_sprintf("%s%s", rewrite_prefix, uri + strlen(uri_start_string) + 1);
+			free(rewrite_prefix);
+			free(uri_start_string);
+			return concat;
+		} else {
+			free(uri_start_string);
+			return _xcf_resolve_in_catalog(resolver_node->next, uri, context);
+		}
+	}
+	return NULL;
+}
+
+static xmlNodePtr _xcf_get_component_ref(xmlNodePtr catalog, const char *uri, xmlXPathContextPtr context)
+{
+	char *component_ref_uri = _xcf_resolve_in_catalog(catalog->children->next, uri, context);
+	if (component_ref_uri == NULL) {
+		dD("Can't get component_ref URI using check-content-ref href='%s'", uri);
+		return NULL;
+	}
+	char *cref = component_ref_uri + 1;
+	xmlNodePtr component_ref_node = NULL;
+	char *xpath = oscap_sprintf("ancestor::ds:data-stream//ds:component-ref[@id='%s']", cref);
+	xmlXPathObjectPtr component_refs = xmlXPathNodeEval(catalog, BAD_CAST xpath, context);
+	if (component_refs->nodesetval->nodeNr == 1) {
+		component_ref_node = component_refs->nodesetval->nodeTab[0];
+	}
+	if (component_ref_node == NULL) {
+		dD("component-ref '%s' not found", cref);
+	}
+	xmlXPathFreeObject(component_refs);
+	free(xpath);
+	free(component_ref_uri);
+
+	return component_ref_node;
+}
+
+static xmlNodePtr _xcf_get_component(xmlNodePtr component_ref_node, xmlXPathContextPtr context)
+{
+	char *xlink_href = (char *) xmlGetNsProp(component_ref_node, BAD_CAST "href", BAD_CAST "http://www.w3.org/1999/xlink");
+	char *xpath = oscap_sprintf("ancestor::ds:data-stream-collection//ds:component[@id='%s']", xlink_href + 1);
+	free(xlink_href);
+	xmlXPathObjectPtr components = xmlXPathNodeEval(component_ref_node, BAD_CAST xpath, context);
+	xmlNodePtr component = NULL;
+	if (components->nodesetval->nodeNr == 1) {
+		component = components->nodesetval->nodeTab[0];
+	}
+	free(xpath);
+	xmlXPathFreeObject(components);
+	return component;
+}
+
+static xmlNodePtr _find_catalog(xmlNodePtr component_ref_node)
+{
+	/* find $m/catalog */
+	xmlNodePtr catalog = NULL;
+	xmlNodePtr cur = component_ref_node->children;
+	while (cur != NULL) {
+		if (!xmlStrcmp(cur->name, BAD_CAST "catalog")) {
+			catalog = cur;
+			break;
+		}
+		cur = cur->next;
+	}
+	return catalog;
+}
+
+static bool _xcf_is_external_ref(xmlNodePtr catalog, const char *uri, xmlXPathContextPtr context)
+{
+	xmlNodePtr comp_ref = _xcf_get_component_ref(catalog, uri, context);
+	bool res = false;
+	if (comp_ref != NULL) {
+		char *xlink_href = (char *) xmlGetNsProp(comp_ref, BAD_CAST "href", BAD_CAST "http://www.w3.org/1999/xlink");
+		if (!oscap_str_startswith(xlink_href, "#"))
+			res = true;
+		free(xlink_href);
+	}
+	return res;
+}
+
+static bool _req_src_236_2_sub6(xmlNodePtr component, xmlXPathContextPtr context, const char *name, const char *rule_id)
+{
+	bool exists_ocil = false;
+	char *ocil_xpath = oscap_sprintf(".//ocil:questionnaire[@id='%s']", name);
+	xmlXPathObjectPtr ocil_questionnaires = xmlXPathNodeEval(component, BAD_CAST ocil_xpath, context);
+	for (int m = 0; m < ocil_questionnaires->nodesetval->nodeNr; m++) {
+		xmlNodePtr ocil_questionnaire = ocil_questionnaires->nodesetval->nodeTab[m];
+		char *ocil_questionnaire_id = (char *) xmlGetProp(ocil_questionnaire, BAD_CAST "id");
+		dD("Found OCIL questionnaire id='%s' for rule id='%s'", ocil_questionnaire_id, rule_id);
+		free(ocil_questionnaire_id);
+		exists_ocil = true;
+	}
+	free(ocil_xpath);
+	xmlXPathFreeObject(ocil_questionnaires);
+	return exists_ocil;
+}
+
+static bool _req_src_236_2_sub5(xmlNodePtr component, xmlXPathContextPtr context, const char *name, const char *rule_id)
+{
+	/* exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//oval-def:definition[@id eq $o/@name and matches(@class, '^(compliance|patch)$')]) */
+	bool exists_oval = false;
+	char *oval_xpath = oscap_sprintf(".//oval-def:definition[@id='%s' and (@class='compliance' or @class='patch')]", name);
+	xmlXPathObjectPtr oval_definitions = xmlXPathNodeEval(component, BAD_CAST oval_xpath, context);
+	for (int m = 0; m < oval_definitions->nodesetval->nodeNr; m++) {
+		xmlNodePtr oval_definition = oval_definitions->nodesetval->nodeTab[m];
+		char *oval_def_id = (char *) xmlGetProp(oval_definition, BAD_CAST "id");
+		dD("Found OVAL definition id='%s' for rule id='%s'", oval_def_id, rule_id);
+		free(oval_def_id);
+		exists_oval = true;
+	}
+	free(oval_xpath);
+	xmlXPathFreeObject(oval_definitions);
+	return exists_oval;
+}
+
+static bool _req_src_236_2_sub4(xmlNodePtr check_content_ref_node, xmlNodePtr catalog, xmlXPathContextPtr context, const char *rule_id)
+{
+	char *href = (char *) xmlGetProp(check_content_ref_node, BAD_CAST "href");
+	/* xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href) */
+	xmlNodePtr component_ref =  _xcf_get_component_ref(catalog, href, context);
+	free(href);
+	if (component_ref == NULL) {
+		dD("component_ref not found");
+		return false;
+	}
+	xmlNodePtr component = _xcf_get_component(component_ref, context);
+	if (component == NULL) {
+		dD("component not found\n");
+		return false;
+	}
+
+	char *name = (char *) xmlGetProp(check_content_ref_node, BAD_CAST "name");
+
+	/* exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//oval-def:definition[@id eq $o/@name and matches(@class, '^(compliance|patch)$')]) or exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//ocil:questionnaire[@id eq $o/@name])) */
+	bool res = (_req_src_236_2_sub5(component, context, name, rule_id) || _req_src_236_2_sub6(component, context, name, rule_id));
+
+	free(name);
+	return res;
+}
+
+static bool _req_src_236_2_sub3(xmlNodePtr rule_node, xmlNodePtr catalog, xmlXPathContextPtr context)
+{
+	bool res = true;
+	char *rule_id = (char *) xmlGetProp(rule_node, BAD_CAST "id");
+
+	/* note: $n is an xccdf:Rule */
+	/* if(exists($n/xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system eq 'http://scap.nist.gov/schema/ocil/2']/xccdf:check-content-ref[exists(@name) and not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)])) then ... else true() */
+	xmlXPathObjectPtr check_content_refs = xmlXPathNodeEval(rule_node, BAD_CAST "xccdf:check[@system='http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system='http://scap.nist.gov/schema/ocil/2']/xccdf:check-content-ref[@name]", context);
+	/* TODO: external refs check */
+	if (check_content_refs == NULL) {
+		dD("Rule '%s' has no suitable check-content-refs", rule_id);
+		free(rule_id);
+		return true;
+	}
+
+	/* ... then some $o in $n/xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system eq 'http://scap.nist.gov/schema/ocil/2']/xccdf:check-content-ref[exists(@name) and not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)] satisfies ... */
+	bool found = false;
+	for (int l = 0; l < check_content_refs->nodesetval->nodeNr; l++) {
+		xmlNodePtr check_content_ref_node = check_content_refs->nodesetval->nodeTab[l];
+		char *href = (char *) xmlGetProp(check_content_ref_node, BAD_CAST "href");
+		if (_xcf_is_external_ref(catalog, href, context)) {
+			free(href);
+			continue;
+		}
+		free(href);
+		if (_req_src_236_2_sub4(check_content_ref_node, catalog, context, rule_id)) {
+			found = true;
+			break;
+		}
+	}
+	if (!found) {
+		res = false;
+	}
+	free(rule_id);
+	xmlXPathFreeObject(check_content_refs);
+	return res;
+}
+
+static bool _req_src_236_2_sub2(xmlNodePtr component_ref_node, xmlNodePtr catalog, xmlXPathContextPtr context)
+{
+	bool res = true;
+	/* every $n in xcf:get-component($m)//xccdf:Rule satisfies ... */
+	xmlNodePtr component_node = _xcf_get_component(component_ref_node, context);
+	if (component_node == NULL) {
+		char *xlink_href = (char *) xmlGetNsProp(component_ref_node, BAD_CAST "href", BAD_CAST "http://www.w3.org/1999/xlink");
+		dD("Can't find component using component-ref '%s'", xlink_href);
+		free(xlink_href);
+		return false;
+	}
+	xmlXPathObjectPtr rules = xmlXPathNodeEval(component_node, BAD_CAST ".//xccdf:Rule", context);
+	for (int i = 0; i < rules->nodesetval->nodeNr; i++) {
+		xmlNodePtr rule_node = rules->nodesetval->nodeTab[i];
+		char *rule_id = (char *) xmlGetProp(rule_node, BAD_CAST "id");
+		dD("Checking xccdf:Rule id='%s'", rule_id);
+		free(rule_id);
+		if (!_req_src_236_2_sub3(rule_node, catalog, context)) {
+			res = false;
+			break;
+		}
+	}
+	xmlXPathFreeObject(rules);
+	return res;
+}
+
+static bool _req_src_236_2_sub1(xmlNodePtr data_stream_node, xmlXPathContextPtr context)
+{
+	int res = true;
+	/* every $m in ds:checklists/ds:component-ref satisfies ... */
+	xmlXPathObjectPtr component_refs = xmlXPathNodeEval(data_stream_node, BAD_CAST "ds:checklists/ds:component-ref", context);
+	for (int i = 0; i < component_refs->nodesetval->nodeNr; i++) {
+		xmlNodePtr component_ref_node = component_refs->nodesetval->nodeTab[i];
+		char *component_ref_id = (char *) xmlGetProp(component_ref_node, BAD_CAST "id");
+		dD("Checking ds:component-ref id='%s'", component_ref_id);
+		free(component_ref_id);
+
+		/* find $m/catalog */
+		xmlNodePtr catalog = _find_catalog(component_ref_node);
+		if (catalog == NULL) {
+			res = false;
+			break;
+		}
+
+		if (!_req_src_236_2_sub2(component_ref_node, catalog, context)) {
+			res = false;
+			break;
+		}
+	}
+	xmlXPathFreeObject(component_refs);
+	return res;
+}
+
+static bool _req_src_236_2(xmlXPathContextPtr context)
+{
+	/*
+	 * This function implements the check for SCAPVAL requirement SRC-236-2
+	 * which is implemented in XML Schematron file 'source-data-stream-1.3.sch'
+	 * assert scap-use-case-conf-verification-rule-ref-oval.
+	 *
+	 * <sch:assert id="scap-use-case-conf-verification-rule-ref-oval" test="if( @use-case eq 'CONFIGURATION' ) then every $m in ds:checklists/ds:component-ref satisfies every $n in xcf:get-component($m)//xccdf:Rule satisfies (if(exists($n/ xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system eq 'http://scap.nist.gov/schema/ocil/2']/xccdf:check-content-ref[exists(@name) and not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)])) then some $o in $n/xccdf:check[@system eq 'http://oval.mitre.org/XMLSchema/oval-definitions-5' or @system eq 'http://scap.nist.gov/schema/ocil/2']/xccdf:check-content-ref[exists(@name) and not(xcf:is-external-ref($m/cat:catalog, @href) cast as xsd:boolean)] satisfies (exists(xcf:get-component(xcf:get-component-ref($m/cat:catalog, $o/@href))//oval-def:definition[@id eq $o/@name and matches(@class,'^(compliance|patch)$')]) or exists(xcf:get-component(xcf:  get-component-ref($m/cat:catalog, $o/@href))//ocil:questionnaire[@id eq $o/@name])) else true()) else true()">SRC-236-2|scap:data-stream <sch:value-of select="@id"/></sch:assert>
+	 */
+
+	bool res = true;
+	/* The parent rule element in the schematron matches all scap:data-stream elements */
+	xmlXPathObjectPtr data_streams = xmlXPathEval(BAD_CAST "//scap:data-stream", context);
+	for (int i = 0; i < data_streams->nodesetval->nodeNr; i++) {
+		xmlNodePtr data_stream_node = data_streams->nodesetval->nodeTab[i];
+		/* The assert applies only to configuration use cases */
+		/* if(@use-case eq 'CONFIGURATION') then ...  else true() */
+		char *use_case = (char *) xmlGetProp(data_stream_node, BAD_CAST "use-case");
+		if (use_case == NULL || strcmp(use_case, "CONFIGURATION") != 0) {
+			continue;
+		}
+		free(use_case);
+		if (!_req_src_236_2_sub1(data_stream_node, context)) {
+			char *data_stream_id = (char *) xmlGetProp(data_stream_node, BAD_CAST "id");
+			printf("SRC-236-2|scap:data-stream %s\n", data_stream_id);
+			free(data_stream_id);
+			res = false;
+			break;
+		}
+	}
+	xmlXPathFreeObject(data_streams);
+	return res;
+}
+
+static int _additional_schematron_checks(struct oscap_source *source)
+{
+	xmlDocPtr doc = oscap_source_get_xmlDoc(source);
+	xmlXPathContextPtr context = xmlXPathNewContext(doc);
+	if (context == NULL) {
+		oscap_seterr(OSCAP_EFAMILY_XML, "Error in xmlXPathNewContext");
+		return -1;
+	}
+	xmlXPathRegisterNs(context, BAD_CAST "xccdf",  BAD_CAST "http://checklists.nist.gov/xccdf/1.2");
+	xmlXPathRegisterNs(context, BAD_CAST "scap", BAD_CAST "http://scap.nist.gov/schema/scap/source/1.2");
+	xmlXPathRegisterNs(context, BAD_CAST "ds", BAD_CAST "http://scap.nist.gov/schema/scap/source/1.2");
+	xmlXPathRegisterNs(context, BAD_CAST "xlink", BAD_CAST "http://www.w3.org/1999/xlink");
+	xmlXPathRegisterNs(context, BAD_CAST "oval-def", BAD_CAST "http://oval.mitre.org/XMLSchema/oval-definitions-5");
+	xmlXPathRegisterNs(context, BAD_CAST "ocil", BAD_CAST "http://scap.nist.gov/schema/ocil/2.0");
+
+	int res = 0;
+	/* Assert ID: scap-use-case-conf-verification-benchmark-one-rule-ref-oval-ocil */
+	if (!_req_src_236_2(context))
+		res = 1;
+
+	xmlXPathFreeContext(context);
+	return res;
+}
+
 int oscap_source_validate_schematron_priv(struct oscap_source *source, oscap_document_type_t scap_type, const char *version, const char *outfile)
 {
 	const char *params[] = { NULL };
@@ -159,6 +473,10 @@ int oscap_source_validate_schematron_priv(struct oscap_source *source, oscap_doc
 		int validity = oscap_source_apply_xslt_path(source, entry->schema_path, outfile, params, oscap_path_to_schemas());
 		if (validity != 0) {
 			ret = 1;
+		}
+		if (scap_type == OSCAP_DOCUMENT_SDS) {
+			if (_additional_schematron_checks(source) != 0)
+				ret = 1;
 		}
 		printf("Schematron validation of '%s': %s\n\n", origin, validity == 0 ? "PASS" : "FAIL");
 		return ret;

--- a/src/source/schematron.c
+++ b/src/source/schematron.c
@@ -100,6 +100,7 @@ struct oscap_schema_table_entry OSCAP_SCHEMATRON_TABLE[] = {
 	{OSCAP_DOCUMENT_OVAL_DIRECTIVES,        "5.11.2",       "oval/5.11.2/oval-directives-schematron.xsl"},
 	{OSCAP_DOCUMENT_OVAL_DIRECTIVES,        "5.11.3",       "oval/5.11.3/oval-directives-schematron.xsl"},
 	{OSCAP_DOCUMENT_XCCDF,                  "1.2",          "xccdf/1.2/xccdf_1.2-schematron.xsl"},
+	{OSCAP_DOCUMENT_SDS,                    "1.3",          "sds/1.3/source-data-stream-1.3.xsl"}
 };
 
 int oscap_source_validate_schematron_priv(struct oscap_source *source, oscap_document_type_t scap_type, const char *version, const char *outfile)

--- a/src/source/schematron.c
+++ b/src/source/schematron.c
@@ -637,6 +637,16 @@ int oscap_source_validate_schematron_priv(struct oscap_source *source, oscap_doc
 		return -1;
 	}
 
+	/* Skip document types that don't have a schematron available */
+	if (scap_type == OSCAP_DOCUMENT_CPE_LANGUAGE ||
+			scap_type == OSCAP_DOCUMENT_CPE_DICTIONARY ||
+			scap_type == OSCAP_DOCUMENT_CVE_FEED ||
+			scap_type == OSCAP_DOCUMENT_SCE_RESULT ||
+			scap_type == OSCAP_DOCUMENT_OCIL ||
+			scap_type == OSCAP_DOCUMENT_CVRF_FEED) {
+		fprintf(outfile_fd, "Skipped\n");
+		return 0;
+	}
 
 	/* find a right schematron file */
 	const char *schematron_path = NULL;

--- a/src/source/schematron.c
+++ b/src/source/schematron.c
@@ -410,7 +410,7 @@ static bool _req_src_236_2(xmlXPathContextPtr context)
 		free(use_case);
 		if (!_req_src_236_2_sub1(data_stream_node, context)) {
 			char *data_stream_id = (char *) xmlGetProp(data_stream_node, BAD_CAST "id");
-			printf("SRC-236-2|scap:data-stream %s\n", data_stream_id);
+			printf("Error: SRC-236-2|scap:data-stream %s\n", data_stream_id);
 			free(data_stream_id);
 			res = false;
 			break;
@@ -560,7 +560,7 @@ static bool _req_src_346_1(xmlXPathContextPtr context)
 		xmlNodePtr data_stream_node = data_streams->nodesetval->nodeTab[i];
 		if (!_req_src_346_1_sub1(data_stream_node, context)) {
 			char *data_stream_id = (char *) xmlGetProp(data_stream_node, BAD_CAST "id");
-			printf("SRC-346-1|scap:data-stream %s\n", data_stream_id);
+			printf("Error: SRC-346-1|scap:data-stream %s\n", data_stream_id);
 			free(data_stream_id);
 			res = false;
 			break;

--- a/src/source/schematron_priv.h
+++ b/src/source/schematron_priv.h
@@ -30,6 +30,6 @@
 #include "source/public/oscap_source.h"
 
 
-int oscap_source_validate_schematron_priv(struct oscap_source *source, oscap_document_type_t scap_type, const char *version, const char *outfile);
+int oscap_source_validate_schematron_priv(struct oscap_source *source, oscap_document_type_t scap_type, const char *version, FILE *outfile_fd);
 
 #endif

--- a/tests/DS/CMakeLists.txt
+++ b/tests/DS/CMakeLists.txt
@@ -6,6 +6,7 @@ add_oscap_test("test_sds_fix_from_results.sh")
 add_oscap_test("test_sds_fix_from_source.sh")
 
 add_subdirectory("ds_sds_index")
+add_subdirectory("schematron")
 add_subdirectory("sds_detect_version")
 add_subdirectory("signed")
 add_subdirectory("validate")

--- a/tests/DS/schematron/CMakeLists.txt
+++ b/tests/DS/schematron/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_oscap_test("schematron.sh")

--- a/tests/DS/schematron/schematron.sh
+++ b/tests/DS/schematron/schematron.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 set -x
 
 output="$(mktemp)"
-$OSCAP xccdf validate --schematron "$srcdir/simple_ds.xml" >"$output" || ret=$? 
+$OSCAP xccdf validate --schematron "$srcdir/simple_ds.xml" >"$output" || ret=$?
 [ $ret = 2 ]
 grep -q "Schematron validation of 'test_single_rule.oval.xml': PASS" "$output"
 grep -q "Schematron validation of 'scap_org.open-scap_cref_test_single_rule.xccdf.xml': FAIL" "$output"

--- a/tests/DS/schematron/schematron.sh
+++ b/tests/DS/schematron/schematron.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+. $builddir/tests/test_common.sh
+set -e -o pipefail
+set -x
+
+output="$(mktemp)"
+$OSCAP xccdf validate --schematron "$srcdir/simple_ds.xml" >"$output" || ret=$? 
+[ $ret = 2 ]
+grep -q "Schematron validation of 'test_single_rule.oval.xml': PASS" "$output"
+grep -q "Schematron validation of 'scap_org.open-scap_cref_test_single_rule.xccdf.xml': FAIL" "$output"
+grep -q "Schematron validation of '$srcdir/simple_ds.xml': FAIL" "$output"
+rm -f "$output"

--- a/tests/DS/schematron/schematron.sh
+++ b/tests/DS/schematron/schematron.sh
@@ -2,12 +2,12 @@
 
 . $builddir/tests/test_common.sh
 set -e -o pipefail
-set -x
 
 output="$(mktemp)"
 $OSCAP xccdf validate --schematron "$srcdir/simple_ds.xml" >"$output" || ret=$?
 [ $ret = 2 ]
-grep -q "Schematron validation of 'test_single_rule.oval.xml': PASS" "$output"
-grep -q "Schematron validation of 'scap_org.open-scap_cref_test_single_rule.xccdf.xml': FAIL" "$output"
-grep -q "Schematron validation of '$srcdir/simple_ds.xml': FAIL" "$output"
+grep -q "Schematron validation of OVAL Definition component 'test_single_rule.oval.xml': PASS" "$output"
+grep -q "Schematron validation of XCCDF Checklist component 'scap_org.open-scap_cref_test_single_rule.xccdf.xml': FAIL" "$output"
+grep -q "Global schematron validation using the source data stream schematron: PASS" $output
+grep -q "Complete result of schematron validation of '$srcdir/simple_ds.xml': FAIL" $output
 rm -f "$output"

--- a/tests/DS/schematron/simple_ds.xml
+++ b/tests/DS/schematron/simple_ds.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ds:data-stream-collection xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_org.open-scap_collection_from_xccdf_test_single_rule.xccdf.xml" schematron-version="1.3" xsi:schemaLocation="http://scap.nist.gov/schema/scap/source/1.2 https://scap.nist.gov/schema/scap/1.3/scap-source-data-stream_1.3.xsd">
+  <ds:data-stream id="scap_org.open-scap_datastream_simple" scap-version="1.3" use-case="OTHER">
+    <ds:checklists>
+      <ds:component-ref id="scap_org.open-scap_cref_test_single_rule.xccdf.xml" xlink:href="#scap_org.open-scap_comp_test_single_rule.xccdf.xml">
+        <cat:catalog>
+          <cat:uri name="test_single_rule.oval.xml" uri="#scap_org.open-scap_cref_test_single_rule.oval.xml"/>
+        </cat:catalog>
+      </ds:component-ref>
+    </ds:checklists>
+    <ds:checks>
+      <ds:component-ref id="scap_org.open-scap_cref_test_single_rule.oval.xml" xlink:href="#scap_org.open-scap_comp_test_single_rule.oval.xml"/>
+    </ds:checks>
+  </ds:data-stream>
+  <ds:component id="scap_org.open-scap_comp_test_single_rule.oval.xml" timestamp="2021-02-01T08:07:06+01:00">
+    <oval_definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:win-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd    http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows windows-definitions-schema.xsd">
+      <generator>
+        <oval:schema_version>5.11.2</oval:schema_version>
+        <oval:timestamp>2021-02-01T08:07:06+01:00</oval:timestamp>
+      </generator>
+      <definitions>
+        <definition class="compliance" id="oval:x:def:1" version="1">
+          <metadata>
+            <title>PASS</title>
+            <description>pass</description>
+          </metadata>
+          <criteria>
+            <criterion comment="PASS test" test_ref="oval:x:tst:1"/>
+          </criteria>
+        </definition>
+      </definitions>
+      <tests>
+        <variable_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:tst:1" check="all" comment="always pass" version="1">
+          <object object_ref="oval:x:obj:1"/>
+        </variable_test>
+      </tests>
+      <objects>
+        <variable_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:obj:1" version="1" comment="x">
+          <var_ref>oval:x:var:1</var_ref>
+        </variable_object>
+      </objects>
+      <variables>
+        <constant_variable id="oval:x:var:1" version="1" comment="x" datatype="int">
+          <value>100</value>
+        </constant_variable>
+      </variables>
+    </oval_definitions>
+  </ds:component>
+  <ds:component id="scap_org.open-scap_comp_test_single_rule.xccdf.xml" timestamp="2021-02-01T08:07:06+01:00">
+    <Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_com.example.www_benchmark_dummy" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd" resolved="false" xml:lang="en-US">
+      <status date="2021-01-21">accepted</status>
+      <title>Test Benchmark</title>
+      <description>Description</description>
+      <version>1.0</version>
+      <metadata>
+        <dc:contributor xmlns:dc="http://purl.org/dc/elements/1.1/">OpenSCAP</dc:contributor>
+        <dc:publisher xmlns:dc="http://purl.org/dc/elements/1.1/">OpenSCAP</dc:publisher>
+        <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">OpenSCAP</dc:creator>
+        <dc:source xmlns:dc="http://purl.org/dc/elements/1.1/">http://scap.nist.gov</dc:source>
+      </metadata>
+      <Profile id="xccdf_com.example.www_profile_test_single_rule">
+        <title>xccdf_test_profile</title>
+        <description>This profile is for testing.</description>
+        <select idref="xccdf_com.example.www_rule_test-pass" selected="true"/>
+      </Profile>
+      <Rule selected="true" id="xccdf_com.example.www_rule_test-pass">
+        <title>This rule always passes</title>
+        <description>Description</description>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+          <check-content-ref href="test_single_rule.oval.xml" name="oval:x:def:1"/>
+        </check>
+      </Rule>
+    </Benchmark>
+  </ds:component>
+</ds:data-stream-collection>


### PR DESCRIPTION
This PR attempts to convert SCAP 1.3 source data stream XML schematron to use XPath 1.0 expressions. The original schematron contains XPath 2.0 but libxml can't process them. So this PR tries to workaround the lack of support for it.
We probably won't be able to convert all of the assertions to XPath 1.0, but let's try at least something.

The original schematron is located in `schemas/sds/1.3/source-data-stream-1.3.sch.original`.

The rules are added step-by step into `schemas/sds/1.3/source-data-stream-1.3.sch`.

~At this moment, please generate the XSLT file yourself! I won't regenerate it and commit the generated code after each change in the schematron file. When the PR will be ready for review we will of course generate the XSLT and commit it.~