### PR TITLE
OVAL/yamlfilecontent: Add <content> entity support

### DIFF
--- a/schemas/oval/5.11.3/independent-definitions-schema.xsd
+++ b/schemas/oval/5.11.3/independent-definitions-schema.xsd
@@ -2112,6 +2112,18 @@
                                                                   </xsd:annotation>
                                                             </xsd:element>
                                                       </xsd:sequence>
+                                                      <xsd:element name="content" type="oval-def:EntityObjectStringType">
+                                                            <xsd:annotation>
+                                                                  <xsd:documentation>The content element specifies the YAML document body. It also could reference a variable containing the document using var_ref attribute. Note that "equals" is the only valid operator for the content entity.</xsd:documentation>
+                                                                  <xsd:appinfo>
+                                                                        <sch:pattern id="ind-def_yamlobjcontent">
+                                                                              <sch:rule context="ind-def:yamlfilecontent_object/ind-def:content">
+                                                                                    <sch:assert test="not(@operation) or @operation='equals'"><sch:value-of select="../@id"/> - operation attribute for the content entity of a yamlfilecontent_object should be 'equals', note that this overrules the general operation attribute validation (i.e. follow this one)</sch:assert>
+                                                                              </sch:rule>
+                                                                        </sch:pattern>
+                                                                  </xsd:appinfo>
+                                                            </xsd:annotation>
+                                                      </xsd:element>
                                                 </xsd:choice>
                                                 <xsd:element name="yamlpath" type="oval-def:EntityObjectStringType">
                                                       <xsd:annotation>
@@ -2154,6 +2166,11 @@
                                     <xsd:element name="filename" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
                                                 <xsd:documentation>The filename element specifies the name of the file.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                                    <xsd:element name="content" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The content element specifies the YAML document body. Note that "equals" is the only valid operator for the content entity.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="yamlpath" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">

--- a/schemas/oval/5.11.3/independent-definitions-schema.xsd
+++ b/schemas/oval/5.11.3/independent-definitions-schema.xsd
@@ -2114,7 +2114,7 @@
                                                       </xsd:sequence>
                                                       <xsd:element name="content" type="oval-def:EntityObjectStringType">
                                                             <xsd:annotation>
-                                                                  <xsd:documentation>The content element specifies the YAML document body. It also could reference a variable containing the document using var_ref attribute. Note that "equals" is the only valid operator for the content entity.</xsd:documentation>
+                                                                  <xsd:documentation>The content element specifies the YAML document body. It also could reference a variable containing the document using var_ref attribute. Note that "equals" is the only valid operation for the content entity.</xsd:documentation>
                                                                   <xsd:appinfo>
                                                                         <sch:pattern id="ind-def_yamlobjcontent">
                                                                               <sch:rule context="ind-def:yamlfilecontent_object/ind-def:content">
@@ -2170,7 +2170,7 @@
                                     </xsd:element>
                                     <xsd:element name="content" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>The content element specifies the YAML document body. Note that "equals" is the only valid operator for the content entity.</xsd:documentation>
+                                                <xsd:documentation>The content element specifies the YAML document body. Note that "equals" is the only valid operation for the content entity.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="yamlpath" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">

--- a/schemas/oval/5.11.3/independent-system-characteristics-schema.xsd
+++ b/schemas/oval/5.11.3/independent-system-characteristics-schema.xsd
@@ -604,9 +604,14 @@
                                         <xsd:documentation>The filename element specifies the name of the file.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
+                              <xsd:element name="content" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The content element specifies the YAML document body.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
                               <xsd:element name="yamlpath" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>Specifies an YAML Path expression to evaluate against the YAML file specified by the filename entity. Note that "equals" is the only valid operator for the yamlpath entity.</xsd:documentation>
+                                        <xsd:documentation>Specifies an YAML Path expression to evaluate against the YAML file specified by the filename entity.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="value" type="oval-sc:EntityItemRecordType" minOccurs="0" maxOccurs="unbounded">

--- a/tests/probes/yamlfilecontent/CMakeLists.txt
+++ b/tests/probes/yamlfilecontent/CMakeLists.txt
@@ -3,5 +3,6 @@ if(ENABLE_PROBES_INDEPENDENT)
 	add_oscap_test("test_probes_yamlfilecontent_array.sh")
 	add_oscap_test("test_probes_yamlfilecontent_offline_mode.sh")
 	add_oscap_test("test_probes_yamlfilecontent_types.sh")
+	add_oscap_test("test_probes_yamlfilecontent_content.sh")
 endif()
 

--- a/tests/probes/yamlfilecontent/test_probes_yamlfilecontent_content.sh
+++ b/tests/probes/yamlfilecontent/test_probes_yamlfilecontent_content.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+. $builddir/tests/test_common.sh
+
+set -e -o pipefail
+
+probecheck "yamlfilecontent" || return 255
+
+oval_file="${srcdir}/test_probes_yamlfilecontent_content.xml"
+result="results.xml"
+
+[ -f $result ] && rm -f $result
+
+$OSCAP oval eval --results $result $oval_file
+
+[ -f $result ]
+
+sd='/oval_results/results/system/oval_system_characteristics/system_data'
+
+assert_exists 1 $sd'/ind-sys:yamlfilecontent_item/ind-sys:value/field[@name="foo" and text()="bar"]'
+assert_exists 1 $sd'/ind-sys:yamlfilecontent_item/ind-sys:value/field[@name="#" and @datatype="boolean" and text()="true"]'

--- a/tests/probes/yamlfilecontent/test_probes_yamlfilecontent_content.sh
+++ b/tests/probes/yamlfilecontent/test_probes_yamlfilecontent_content.sh
@@ -19,3 +19,6 @@ sd='/oval_results/results/system/oval_system_characteristics/system_data'
 
 assert_exists 1 $sd'/ind-sys:yamlfilecontent_item/ind-sys:value/field[@name="foo" and text()="bar"]'
 assert_exists 1 $sd'/ind-sys:yamlfilecontent_item/ind-sys:value/field[@name="#" and @datatype="boolean" and text()="true"]'
+assert_exists 2 $sd'/ind-sys:yamlfilecontent_item/ind-sys:value/field[@name="#" and text()="<value>"]'
+
+rm -f "$result"

--- a/tests/probes/yamlfilecontent/test_probes_yamlfilecontent_content.xml
+++ b/tests/probes/yamlfilecontent/test_probes_yamlfilecontent_content.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<oval_definitions xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
+
+  <generator>
+    <oval:product_name>yamlfilecontent</oval:product_name>
+    <oval:product_version>1.0</oval:product_version>
+    <oval:schema_version>5.11.3</oval:schema_version>
+    <oval:timestamp>2020-02-13T00:00:00-00:00</oval:timestamp>
+  </generator>
+
+  <definitions>
+
+    <definition class="compliance" version="1" id="oval:0:def:1">
+      <metadata>
+        <title></title>
+        <description></description>
+      </metadata>
+      <criteria operator="AND">
+        <criterion comment="comment" test_ref="oval:0:tst:1"/>
+        <criterion comment="comment" test_ref="oval:0:tst:2"/>
+      </criteria>
+    </definition>
+
+  </definitions>
+
+  <tests>
+
+    <ind-def:yamlfilecontent_test version="1" id="oval:0:tst:1" check="all" comment="true">
+      <ind-def:object object_ref="oval:0:obj:1"/>
+    </ind-def:yamlfilecontent_test>
+
+    <ind-def:yamlfilecontent_test version="1" id="oval:0:tst:2" check="all" comment="true">
+      <ind-def:object object_ref="oval:0:obj:2"/>
+    </ind-def:yamlfilecontent_test>
+
+  </tests>
+
+  <objects>
+
+    <ind-def:yamlfilecontent_object version="1" id="oval:0:obj:1">
+      <ind-def:content>{foo: bar, yaml: '{baz: true}'}</ind-def:content>
+      <ind-def:yamlpath>.*</ind-def:yamlpath>
+    </ind-def:yamlfilecontent_object>
+
+    <ind-def:yamlfilecontent_object version="1" id="oval:0:obj:2">
+      <ind-def:content var_ref="oval:0:var:1"/>
+      <ind-def:yamlpath>.baz</ind-def:yamlpath>
+    </ind-def:yamlfilecontent_object>
+
+  </objects>
+
+  <variables>
+
+    <local_variable id="oval:0:var:1" comment="variable with embedded YAML document, {baz: true}" version="1" datatype="string">
+      <object_component object_ref="oval:0:obj:1" item_field="value" record_field="yaml"/>
+    </local_variable>
+
+  </variables>
+
+</oval_definitions>

--- a/tests/probes/yamlfilecontent/test_probes_yamlfilecontent_content.xml
+++ b/tests/probes/yamlfilecontent/test_probes_yamlfilecontent_content.xml
@@ -18,6 +18,8 @@
       <criteria operator="AND">
         <criterion comment="comment" test_ref="oval:0:tst:1"/>
         <criterion comment="comment" test_ref="oval:0:tst:2"/>
+        <criterion comment="comment" test_ref="oval:0:tst:3"/>
+        <criterion comment="comment" test_ref="oval:0:tst:4"/>
       </criteria>
     </definition>
 
@@ -33,18 +35,36 @@
       <ind-def:object object_ref="oval:0:obj:2"/>
     </ind-def:yamlfilecontent_test>
 
+    <ind-def:yamlfilecontent_test version="1" id="oval:0:tst:3" check="all" comment="true">
+      <ind-def:object object_ref="oval:0:obj:3"/>
+    </ind-def:yamlfilecontent_test>
+
+    <ind-def:yamlfilecontent_test version="1" id="oval:0:tst:4" check="all" comment="true">
+      <ind-def:object object_ref="oval:0:obj:4"/>
+    </ind-def:yamlfilecontent_test>
+
   </tests>
 
   <objects>
 
     <ind-def:yamlfilecontent_object version="1" id="oval:0:obj:1">
-      <ind-def:content>{foo: bar, yaml: '{baz: true}'}</ind-def:content>
+      <ind-def:content>{foo: bar, yaml: '{baz: true, ancored: &amp;anc "&lt;value&gt;"}'}</ind-def:content>
       <ind-def:yamlpath>.*</ind-def:yamlpath>
     </ind-def:yamlfilecontent_object>
 
     <ind-def:yamlfilecontent_object version="1" id="oval:0:obj:2">
       <ind-def:content var_ref="oval:0:var:1"/>
       <ind-def:yamlpath>.baz</ind-def:yamlpath>
+    </ind-def:yamlfilecontent_object>
+
+    <ind-def:yamlfilecontent_object version="1" id="oval:0:obj:3">
+      <ind-def:content var_ref="oval:0:var:1"/>
+      <ind-def:yamlpath>.ancored</ind-def:yamlpath>
+    </ind-def:yamlfilecontent_object>
+
+    <ind-def:yamlfilecontent_object version="1" id="oval:0:obj:4">
+      <ind-def:content var_ref="oval:0:var:1"/>
+      <ind-def:yamlpath>&amp;anc</ind-def:yamlpath>
     </ind-def:yamlfilecontent_object>
 
   </objects>


### PR DESCRIPTION
The `<ind-def:content>` entity is used to represent a YAML document embedded into the data stream or captured in a variable. These entities, `<content>`, `<file>` + `<path>` and `<filepath>` are mutually exclusive.