### PR TITLE
tests: Fix chrootable binary capabilities check

### DIFF
--- a/tests/test_common.sh.in
+++ b/tests/test_common.sh.in
@@ -231,7 +231,7 @@ set_chroot_offline_test_mode() {
 		return
 	fi
 	if test -x "$OSCAP_CHROOTABLE_EXEC"; then
-		if ! getcap "$OSCAP_CHROOTABLE_EXEC" | grep -q 'cap_sys_chroot+ep'; then
+		if ! getcap "$OSCAP_CHROOTABLE_EXEC" | grep -q -P 'cap_sys_chroot[=+]+ep'; then
 			echo "Skipping test '${FUNCNAME[1]}' as '$OSCAP_CHROOTABLE_EXEC' doesn't have the chroot capability." >&2
 			return 255
 		fi


### PR DESCRIPTION
Due to the change in `getcap` (or, to be precise, in `cap_to_text`) response format the check is not valid anymore.