### PR TITLE
Ignore "Bad address" errors from the sysctl probe

### DIFF
--- a/tests/probes/sysctl/test_sysctl_probe_all.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_all.sh
@@ -73,10 +73,21 @@ if [ "$procps_ver" != "$lowest_ver" ]; then
 	sed -i '/.*vm.stat_refresh/d' "$sysctlNames"
 fi
 
+echo "Diff (sysctlNames / ourNames): ------"
 diff "$sysctlNames" "$ourNames"
+echo "-------------------------------------"
 
 # remove oscap error message related to permissions from stderr
 sed -i -E "/^E: oscap: +Can't read sysctl value from /d" "$stderr"
+
+# remove oscap error message related to gibberish binary entries
+# that can't fit into 8K buffer and result in errno 14
+# (for example /proc/sys/kernel/spl/hostid could be the case)
+sed -i -E "/^E: oscap: +An error.*14, Bad address/d" "$stderr"
+
+echo "Errors (without messages related to permissions):"
+cat "$stderr"
+
 [ ! -s $stderr ]
 
 rm $stderr $result $ourNames $sysctlNames


### PR DESCRIPTION
This problem manifests in the Travis CI environment: https://travis-ci.org/github/OpenSCAP/openscap/jobs/763932418.

`E: oscap:     An error ocured when reading from "/proc/sys/kernel/spl/hostid" (fp=0xaaaaea9d6cf0): l=0, 14, Bad address`.