### PR TITLE
Add the Fedora 35 CPE

### DIFF
--- a/cpe/openscap-cpe-dict.xml
+++ b/cpe/openscap-cpe-dict.xml
@@ -49,4 +49,8 @@
             <title xml:lang="en-us">Fedora 34</title>
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.fedora:def:34</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:fedoraproject:fedora:35">
+            <title xml:lang="en-us">Fedora 35</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="openscap-cpe-oval.xml">oval:org.open-scap.cpe.fedora:def:35</check>
+      </cpe-item>
 </cpe-list>

--- a/cpe/openscap-cpe-oval.xml
+++ b/cpe/openscap-cpe-oval.xml
@@ -472,6 +472,19 @@
                         <criterion comment="Fedora 34 is installed" test_ref="oval:org.open-scap.cpe.fedora:tst:34"/>
                   </criteria>
             </definition>
+            <definition class="inventory" id="oval:org.open-scap.cpe.fedora:def:35" version="1">
+                  <metadata>
+                        <title>Fedora 35</title>
+                        <affected family="unix">
+                            <platform>Fedora 35</platform>
+                        </affected>
+                        <reference ref_id="cpe:/o:fedoraproject:fedora:35" source="CPE"/>
+                        <description>The operating system installed on the system is Fedora 35</description>
+                  </metadata>
+                  <criteria>
+                        <criterion comment="Fedora 35 is installed" test_ref="oval:org.open-scap.cpe.fedora:tst:35"/>
+                  </criteria>
+            </definition>
 
 
             <definition class="inventory" id="oval:org.open-scap.cpe.sle:def:1" version="1">
@@ -988,6 +1001,11 @@
                   <object object_ref="oval:org.open-scap.cpe.fedora-release:obj:2"/>
                   <state state_ref="oval:org.open-scap.cpe.fedora:ste:34"/>
             </rpminfo_test>
+            <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.fedora:tst:35" version="1" check="at least one" comment="fedora-release is version Fedora 35"
+                  xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+                  <object object_ref="oval:org.open-scap.cpe.fedora-release:obj:2"/>
+                  <state state_ref="oval:org.open-scap.cpe.fedora:ste:35"/>
+            </rpminfo_test>
             <rpminfo_test check_existence="at_least_one_exists" id="oval:org.open-scap.cpe.sles:tst:1" version="1" check="at least one" comment="/etc/sles-release is provided by sles-release package"
                   xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <object object_ref="oval:org.open-scap.cpe.sles-release:obj:1"/>
@@ -1345,6 +1363,9 @@
             </rpminfo_state>
             <rpminfo_state id="oval:org.open-scap.cpe.fedora:ste:34" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <version operation="pattern match">^34$</version>
+            </rpminfo_state>
+            <rpminfo_state id="oval:org.open-scap.cpe.fedora:ste:35" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+                  <version operation="pattern match">^35$</version>
             </rpminfo_state>
             <rpminfo_state id="oval:org.open-scap.cpe.sles:ste:1" version="1" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
                   <name operation="pattern match">^sles-release</name>


### PR DESCRIPTION
That CPE can already be encountered in Fedora CI. Although we aim to get rid of the CPE dictionary, we don't have the new major version, and Fedora 35 already technically exists. Therefore, let's kick the ball one step further.