### PR TITLE
Do not use deprecated type security_context_t

### DIFF
--- a/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c
+++ b/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c
@@ -167,7 +167,7 @@ static SEXP_t *create_file_probe_item_with_range(
 static int selinuxsecuritycontext_process_cb (SEXP_t *pid_ent, probe_ctx *ctx) {
 	char path[PATH_MAX];
 	SEXP_t *pid_sexp, *item;
-	security_context_t pid_context;
+	char *pid_context;
 	context_t context;
 	int pid_number;
 	DIR *proc;
@@ -236,7 +236,7 @@ static int selinuxsecuritycontext_file_cb(const char *prefix, const char *p, con
 	char   pbuf[PATH_MAX+1];
 	size_t plen, flen;
 
-	security_context_t file_context;
+	char *file_context;
 	int file_context_size;
 	context_t context;
 	const char *user, *role, *type, *range;

--- a/src/OVAL/probes/unix/process58_probe.c
+++ b/src/OVAL/probes/unix/process58_probe.c
@@ -246,7 +246,7 @@ static char *convert_time(unsigned long long t, char *tbuf, int tb_size)
 #ifdef SELINUX_FOUND
 static char *get_selinux_label(int pid) {
 	char *selinux_label;
-	security_context_t pid_context;
+	char *pid_context;
 	context_t context;
 
 	if (is_selinux_enabled() == 1) {


### PR DESCRIPTION
It's defined in selinux.h as a char *.

Addressing:
/home/jcerny/work/git/openscap/src/OVAL/probes/unix/process58_probe.c:249:2: warning: ‘security_context_t’ is deprecated [-Wdeprecated-declarations]
  249 |  security_context_t pid_context;
      |  ^~~~~~~~~~~~~~~~~~
/home/jcerny/work/git/openscap/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:170:2: warning: ‘security_context_t’ is deprecated [-Wdeprecated-declarations]
  170 |  security_context_t pid_context;
      |  ^~~~~~~~~~~~~~~~~~
/home/jcerny/work/git/openscap/src/OVAL/probes/unix/linux/selinuxsecuritycontext_probe.c:239:2: warning: ‘security_context_t’ is deprecated [-Wdeprecated-declarations]
  239 |  security_context_t file_context;
      |  ^~~~~~~~~~~~~~~~~~