### PR TITLE
Improve the curl test

### DIFF
--- a/tests/curl/test_curl_encoding.sh
+++ b/tests/curl/test_curl_encoding.sh
@@ -13,12 +13,12 @@ function curl_accept_encoding {
 
 	case $(uname) in
 		FreeBSD)
-			grep -iE "Accept-Encoding.*gzip" $LOG
+			grep -iE "Accept-Encoding.*gzip" "$LOG"
 			;;
 		*)
-			grep -iP "Accept-Encoding.*gzip" $LOG
+			grep -iP "Accept-Encoding.*gzip" "$LOG"
 			;;
-	esac
+	esac || die "Couldn't assert gzip encoding in the log: $(grep -i 'curl header' $LOG)"
 
 	return 0
 }

--- a/tests/test_common.sh.in
+++ b/tests/test_common.sh.in
@@ -314,4 +314,18 @@ xsed() {
 	esac
 }
 
+# Args:
+# $1: The text string to print to stderr
+# $2: The return code (optional, default is 1)
+log_and_fail() {
+	printf '%s' "$1" >&2
+	return ${2:-1}
+}
+
+# Args: Same as with log_and_fail
+die() {
+	log_and_fail "$1" "$2"
+	exit $?
+}
+
 export -f assert_exists


### PR DESCRIPTION
- Introduce `die` helper functions.
- Report what exactly could have gone wrong if the test went wrong.

Background: This test fails on the Fedora 34 CI, and it's difficult to tell why.