### PR TITLE
Add a message that signature is valid

### DIFF
--- a/src/source/signature.c
+++ b/src/source/signature.c
@@ -241,6 +241,9 @@ static int _oscap_signature_validate_doc(xmlDocPtr doc, oscap_document_type_t sc
 	if (good != size) {
 		res = 1;
 	}
+	if (res == 0) {
+		printf("XML signature is valid.\n");
+	}
 
 cleanup:
 	/* cleanup */

--- a/tests/DS/signed/all.sh
+++ b/tests/DS/signed/all.sh
@@ -10,6 +10,7 @@ verbose=$(mktemp)
 result=$(mktemp)
 $OSCAP xccdf eval --verbose INFO --verbose-log-file $verbose --results-arf $result $srcdir/simple_ds_valid_sign.xml >$stdout 2>$stderr
 ! [ -s $stderr ]
+grep -q "XML signature is valid." $stdout
 grep -q "Validating XML signature" $verbose
 grep -q "Signature is OK" $verbose
 grep -q "SignedInfo references (ok/all): 3/3" $verbose
@@ -29,6 +30,7 @@ $OSCAP xccdf eval --verbose INFO --verbose-log-file $verbose --results-arf $resu
 [ $ret = 1 ]
 [ -s $stderr ]
 ! [ -s $result ]
+! grep -q "XML signature is valid." $stdout
 grep -q "OpenSCAP Error: Invalid signature in SCAP Source Datastream (1.3) content in $srcdir/simple_ds_invalid_sign.xml" $stderr
 grep -q "Validating XML signature" $verbose
 grep -q "Signature is invalid" $verbose
@@ -46,6 +48,7 @@ verbose=$(mktemp)
 result=$(mktemp)
 $OSCAP xccdf eval --skip-signature-validation --results-arf $result $srcdir/simple_ds_invalid_sign.xml >$stdout 2>$stderr
 ! [ -s $stderr ]
+! grep -q "XML signature is valid." $stdout
 ! grep -q "Validating XML signature" $verbose
 assert_exists 1 '//TestResult/rule-result[@idref="xccdf_com.example.www_rule_test-pass"]/result[text()="pass"]'
 rm -f $stdout
@@ -62,6 +65,7 @@ $OSCAP xccdf eval --verbose INFO --verbose-log-file $verbose --results-arf $resu
 [ $ret = 1 ]
 [ -s $stderr ]
 ! [ -s $result ]
+! grep -q "XML signature is valid." $stdout
 grep -q "OpenSCAP Error: Invalid signature in SCAP Source Datastream (1.3) content in $srcdir/simple_ds_modified.xml" $stderr
 grep -q "Validating XML signature" $verbose
 grep -q "Signature is OK" $verbose
@@ -79,6 +83,7 @@ verbose=$(mktemp)
 result=$(mktemp)
 $OSCAP xccdf eval --verbose INFO --verbose-log-file $verbose --enforce-signature --results-arf $result $srcdir/simple_ds_no_sign.xml >$stdout 2>$stderr || ret=$?
 [ -s $stderr ]
+! grep -q "XML signature is valid." $stdout
 grep -q "OpenSCAP Error: Signature not found" $stderr
 grep -q "Validating XML signature" $verbose
 rm -f $stdout


### PR DESCRIPTION
According to the Quick guide for using consolidated datastream page 24
the test procedure which is used to test the signature validation
capability SCAP.T.900.2 says this: The tested SHALL provide evidence
indicating the digital of the signed content was validated.