### PR TITLE
OVAL/probes: Make 'proc' and 'sysfs' filesystems non-local

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1516,6 +1516,32 @@ the presence of a matching SWID tag:
 $ oscap oval eval --results results.xml r2860-rhel-oval.xml
 ----
 
+
+=== Notes on specifics of OVAL implementation
+
+==== Excluding non-local filesystems using the recurse_file_system="local" attribute of a FileBehaviors entity
+
+The scanner loosely follows the OVAL's idea behind this attribute to behave like
+the coreutils utility *df* (`df -l`). This is the list of filesystems, that are
+not considered local by the scanner:
+
+* proc, sysfs
+* afs
+* ceph
+* cifs
+* smb3, smbfs
+* sshfs
+* ncpfs, ncp
+* nfs, nfs4
+* gfs, gfs2
+* glusterfs
+* gpfs
+* pvfs2
+* ocfs2
+* lustre
+* davfs
+
+
 == List of accepted environment variables
 
 * `OSCAP_CHECK_ENGINE_PLUGIN_DIR` - Defines path to a directory that contains plug-in libraries implementing additonal check engines, eg. SCE.

--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -106,6 +106,12 @@ static int is_local_fs(struct mntent *ment)
 	if (oscap_str_startswith(fstype, "fuse.")) {
 		fstype += strlen("fuse.");
 	}
+	// OVAL's idea behind 'local' is to follow the 'df -l' behaviour
+	const char *pseudo_fs[] = {
+		"proc",
+		"sysfs",
+		NULL
+	};
 	const char *network_fs[] = {
 		"afs",
 		"ceph",
@@ -127,10 +133,13 @@ static int is_local_fs(struct mntent *ment)
 		"davfs",
 		NULL
 	};
-	for (int i = 0; network_fs[i]; i++) {
-		if (!strcmp(network_fs[i], fstype)) {
+	for (int i = 0; pseudo_fs[i]; i++) {
+		if (!strcmp(pseudo_fs[i], fstype))
 			return 0;
-		}
+	}
+	for (int i = 0; network_fs[i]; i++) {
+		if (!strcmp(network_fs[i], fstype))
+			return 0;
 	}
 	return 1;
 }

--- a/tests/API/probes/fake_mtab
+++ b/tests/API/probes/fake_mtab
@@ -4,5 +4,6 @@ tmpfs /tmp tmpfs rw,seclabel,nosuid,nodev 0 0
 192.168.122.231:/test /nfs/test nfs4 rw,relatime,vers=4.2,rsize=262144,wsize=262144,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.1,local_lock=none,addr=192.168.122.231 0 0
 /dev/mapper/fedora-home /home ext4 rw,seclabel,relatime 0 0
 proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime,seclabel 0 0
 //192.168.0.5/storage /media/movies cifs guest,uid=myuser,iocharset=utf8,file_mode=0777,dir_mode=0777,noperm 0 0
 /dev/gpfsdev /gpfs gpfs rw,relatime 0 0

--- a/tests/API/probes/test_fsdev_is_local_fs.c
+++ b/tests/API/probes/test_fsdev_is_local_fs.c
@@ -44,8 +44,8 @@ static int test_single_call()
 static int test_multiple_calls(const char *fake_mtab)
 {
 	/*
-	 * fake mtab contains only 4 local filesystems:
-	 * /, /tmp, /home and /proc
+	 * fake mtab contains only 3 local filesystems:
+	 * /, /tmp, and /home
 	 */
 	FILE *f = setmntent(fake_mtab, "r");
 	if (f == NULL) {
@@ -60,7 +60,7 @@ static int test_multiple_calls(const char *fake_mtab)
 		}
 	}
 	endmntent(f);
-	return (locals == 4);
+	return (locals == 3);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
More recently, we've come to use the -l switch in the df command to identify the "local" filesystems. We feel this is probably a better reflection of the intention behind the local attribute value.

The df utility considers 'proc' and 'sysfs' as "dummy" and does not produce results for them.