### PR TITLE
utils: Make schematron-based validation enabled by default for validate command of oval and xccdf modules

### DIFF
--- a/dist/bash_completion.d/oscap
+++ b/dist/bash_completion.d/oscap
@@ -3,7 +3,7 @@
 # returns number of params
 function _oscap_noarg {
     case "$1" in
-      --definitions|--syschar|--results|--schematron|-f|--force|-q|--quiet|--oval-results) return 0 ;;
+      --definitions|--syschar|--results|--skip-schematron|-f|--force|-q|--quiet|--oval-results) return 0 ;;
       --version|--help|-V|-h) return 256 ;; # stop cmdline processing
       *) return 1 ;;
     esac
@@ -26,13 +26,13 @@ function _oscap {
     # command options
     local -A opts=()
 	opts[oscap]="--version --quiet --help -V -q -h"
-    opts[oscap:oval:validate]="--version --definitions --variables --syschar --results --directives --schematron"
+    opts[oscap:oval:validate]="--version --definitions --variables --syschar --results --directives --skip-schematron"
     opts[oscap:oval:eval]="--datastream-id --oval-id --id --variables --directives --without-syschar --results --report --skip-valid --skip-validation --fetch-remote-resources --verbose --verbose-log-file"
     opts[oscap:oval:analyse]="--variables --directives --verbose --verbose-log-file --skip-valid --skip-validation"
     opts[oscap:oval:collect]="--id --syschar --skip-valid --skip-validation --variables --verbose --verbose-log-file"
     opts[oscap:oval:generate:report]="-o --output"
     opts[oscap:xccdf:eval]="--benchmark-id --check-engine-results --cpe --datastream-id --enforce-signature --export-variables --fetch-remote-resources --oval-results --profile --progress --remediate --report --results --results-arf --rule --skip-valid --skip-validation --skip-signature-validation --stig-viewer --tailoring-file --tailoring-id --thin-results --verbose --verbose-log-file --without-syschar --xccdf-id"
-    opts[oscap:xccdf:validate]="--schematron"
+    opts[oscap:xccdf:validate]="--skip-schematron"
     opts[oscap:xccdf:export-oval-variables]="--datastream-id --xccdf-id --profile --skip-valid --skip-validation --fetch-remote-resources --cpe"
     opts[oscap:xccdf:remediate]="--result-id --skip-valid --skip-validation --fetch-remote-resources --results --results-arf --report --oval-results --export-variables --cpe --check-engine-results --progress"
     opts[oscap:xccdf:resolve]="-o --output -f --force"

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -915,20 +915,26 @@ $ oscap ds sds-validate scap-ds.xml
 NOTE: Note that all SCAP components within the given data stream are validated
 automatically and none of the components is specified separately.
 
-You can also enable extra Schematron-based validation if you validate OVAL
-specification. This validation method is slower but it provides deeper analysis.
-Run the following command to validate an OVAL document using Schematron:
+There is an extra Schematron-based validation enabled when you validate OVAL or
+XCCDF specification. This validation method is slower but it provides deeper analysis.
+
+Run one of the following commands to validate an OVAL or XCCDF document without
+Schematron checks:
 
 ----
-$ oscap oval validate --schematron oval-file.xml
+$ oscap xccdf validate --skip-schematron xccdf-file.xml
+----
+
+----
+$ oscap oval validate --skip-schematron oval-file.xml
 ----
 
 The results of validation are printed to standard error stream (stderr).
 
 NOTE: Please note that for the rest of `oscap` functionality, unless you specify
 --skip-validation (--skip-valid), validation will automatically occur before
-files are used. Therefore, you do not need to explicitly validate a datastream
-before use.
+files are used. Therefore, you do not need to explicitly validate a data stream
+before use. Though it will not include the Schematron-based validation step.
 
 === Validating digital signature in SCAP source data stream
 

--- a/tests/API/XCCDF/applicability/test_remediate_fix_notapplicable.sh
+++ b/tests/API/XCCDF/applicability/test_remediate_fix_notapplicable.sh
@@ -22,7 +22,7 @@ $OSCAP xccdf remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr ||
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 [ ! -f test_file ]
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 assert_exists 2 '//TestResult'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile"]'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001"]'
@@ -34,6 +34,7 @@ assert_exists 0 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profil
 # one message expected signalling no suitable fix found.
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001"]/rule-result/message'
 
+
 #
 # Second, make sure that the fix is applied, when CPE is recognized as appplicable
 #
@@ -41,7 +42,8 @@ assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profil
 $OSCAP xccdf remediate --cpe $srcdir/cpe-dict.xml --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 [ -f test_file ]; rm test_file
-$OSCAP xccdf validate $result
+
+$OSCAP xccdf validate --skip-schematron $result
 assert_exists 2 '//TestResult'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001"]'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001"]'

--- a/tests/API/XCCDF/applicability/test_remediate_fix_processing.sh
+++ b/tests/API/XCCDF/applicability/test_remediate_fix_processing.sh
@@ -25,7 +25,7 @@ $OSCAP xccdf remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr ||
 [ ! -f wrong_test_file ]
 [ -f test_file_cpe_na ]
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 2 '//TestResult'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile"]'
@@ -54,7 +54,7 @@ $OSCAP xccdf remediate --cpe $srcdir/cpe-dict.xml --results $result $srcdir/${na
 [ -f test_file ]; rm test_file
 [ ! -f test_file_cpe_na ]
 [ ! -f wrong_test_file ]
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 assert_exists 2 '//TestResult'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001"]'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001"]'

--- a/tests/API/XCCDF/applicability/test_remediate_fix_processing_ds.sh
+++ b/tests/API/XCCDF/applicability/test_remediate_fix_processing_ds.sh
@@ -28,7 +28,7 @@ $OSCAP xccdf eval --remediate --results $resultx --results-arf $arf $sds 2> $std
 [ ! -f wrong_test_file ]
 [ -f test_file_cpe_na ]; rm test_file_cpe_na
 
-$OSCAP xccdf validate $resultx
+$OSCAP xccdf validate --skip-schematron $resultx
 $OSCAP ds rds-validate $arf
 
 result=$resultx
@@ -62,7 +62,7 @@ $OSCAP xccdf eval --cpe $srcdir/cpe-dict.xml --remediate --results $resultx --re
 [ ! -f wrong_test_file ]
 [ ! -f test_file_cpe_na ]
 
-$OSCAP xccdf validate $resultx
+$OSCAP xccdf validate --skip-schematron $resultx
 $OSCAP ds rds-validate $arf
 
 result=$resultx

--- a/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval.sh
+++ b/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 8 '//rule-result'
 assert_exists 8 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval2.sh
+++ b/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval2.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 2 '//rule-result'
 assert_exists 2 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval_multicheck.sh
+++ b/tests/API/XCCDF/unittests/test_deriving_xccdf_result_from_oval_multicheck.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 8 '//rule-result'
 assert_exists 8 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_empty_variable.sh
+++ b/tests/API/XCCDF/unittests/test_empty_variable.sh
@@ -16,7 +16,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_fix_instance.sh
+++ b/tests/API/XCCDF/unittests/test_fix_instance.sh
@@ -12,7 +12,7 @@ rm -f test_file
 
 $OSCAP xccdf eval --results $result $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/Rule/fix/instance'
 assert_exists 3 '//rule-result'
@@ -27,7 +27,7 @@ rm $result
 
 $OSCAP xccdf remediate --result-id xccdf_org.open-scap_testresult_default-profile --results $result $srcdir/${name}.xccdf.xml 2> $stderr || ret=$?
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/Rule/fix/instance'
 assert_exists 4 '//rule-result'

--- a/tests/API/XCCDF/unittests/test_multiple_oval_files_with_same_basename.sh
+++ b/tests/API/XCCDF/unittests/test_multiple_oval_files_with_same_basename.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 8 '//rule-result'
 assert_exists 8 '//rule-result/result'
@@ -89,7 +89,7 @@ done
 rmdir $split/oval
 
 mangle="scap_org.open-scap_cref_"
-$OSCAP xccdf validate $split/${mangle}${name}.xccdf.xml 2> $stderr
+$OSCAP xccdf validate --skip-schematron $split/${mangle}${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 rm $split/${mangle}${name}.xccdf.xml
 rmdir $split

--- a/tests/API/XCCDF/unittests/test_oval_without_definition.sh
+++ b/tests/API/XCCDF/unittests/test_oval_without_definition.sh
@@ -17,7 +17,7 @@ echo "Result file = $result"
 [ $ret -eq 2 ]
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_remediate_perl.sh
+++ b/tests/API/XCCDF/unittests/test_remediate_perl.sh
@@ -14,7 +14,7 @@ rm -f test_file
 $OSCAP xccdf remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 [ -f test_file ]; rm test_file
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 assert_exists 2 '//TestResult'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001"]'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001"]/rule-result'

--- a/tests/API/XCCDF/unittests/test_remediate_python.sh
+++ b/tests/API/XCCDF/unittests/test_remediate_python.sh
@@ -14,7 +14,7 @@ rm -f test_file
 $OSCAP xccdf remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 [ -f test_file ]; rm test_file
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 assert_exists 2 '//TestResult'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001"]'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001"]/rule-result'

--- a/tests/API/XCCDF/unittests/test_remediate_simple.sh
+++ b/tests/API/XCCDF/unittests/test_remediate_simple.sh
@@ -44,7 +44,7 @@ $OSCAP xccdf remediate --results $result  $srcdir/${name}.xccdf.xml 2> $stderr
 daytime="$(date +%Y-%m-%d)T$(date +%H:%M)" # Format like '2013-02-27T15:01:57'
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 [ ! -f test_file ]
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 assert_exists 4 '//TestResult'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile002001"]'
 starttime=`$XPATH 'string(//TestResult[@id="xccdf_org.open-scap_testresult_default-profile002001"]/@start-time)' < $result 2>/dev/null`
@@ -59,7 +59,7 @@ $OSCAP xccdf remediate --result-id xccdf_org.open-scap_testresult_default-profil
 daytime="$(date +%Y-%m-%d)T$(date +%H:%M)" # Format like '2013-02-27T15:01:57'
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 [ ! -f test_file ]
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 assert_exists 5 '//TestResult'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile002002"]'
 starttime=`$XPATH 'string(//TestResult[@id="xccdf_org.open-scap_testresult_default-profile002002"]/@start-time)' < $result 2>/dev/null`
@@ -77,7 +77,7 @@ daytime="$(date +%Y-%m-%d)T$(date +%H:%M)" # Format like '2013-02-27T15:01:57'
 [ $ret -eq 2 ]
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 [ -f test_file ]; rm test_file
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 assert_exists 6 '//TestResult'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001001"]'
 starttime=`$XPATH 'string(//TestResult[@id="xccdf_org.open-scap_testresult_default-profile001001"]/@start-time)' < $result 2>/dev/null`
@@ -97,7 +97,7 @@ $OSCAP xccdf remediate --result-id xccdf_org.open-scap_testresult_default-profil
 daytime="$(date +%Y-%m-%d)T$(date +%H:%M)" # Format like '2013-02-27T15:01:57'
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 [ -f test_file ]; rm test_file
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 assert_exists 7 '//TestResult'
 assert_exists 1 '//TestResult[@id="xccdf_org.open-scap_testresult_default-profile003"]'
 starttime=`$XPATH 'string(//TestResult[@id="xccdf_org.open-scap_testresult_default-profile003"]/@start-time)' < $result 2>/dev/null`

--- a/tests/API/XCCDF/unittests/test_remediation_amp_escaping.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_amp_escaping.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'
@@ -34,7 +34,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'

--- a/tests/API/XCCDF/unittests/test_remediation_bad_fix.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_bad_fix.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'
@@ -33,7 +33,7 @@ $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $st
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 [ ! -f test_file ]
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_remediation_cdata.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_cdata.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'
@@ -34,7 +34,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'

--- a/tests/API/XCCDF/unittests/test_remediation_fix_without_system.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_fix_without_system.sh
@@ -17,7 +17,7 @@ $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $st
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 [ ! -f test_file ]
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_remediation_invalid_characters.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_invalid_characters.sh
@@ -16,7 +16,7 @@ echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 [ -f $result ]; [ -s $result ]
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 "//message[contains(text(),'<tag>')]"
 

--- a/tests/API/XCCDF/unittests/test_remediation_simple.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_simple.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'
@@ -31,7 +31,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_plain_text.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_plain_text.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/plain-text'
 assert_exists 1 '/Benchmark/Rule'
@@ -35,7 +35,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/plain-text'
 assert_exists 1 '/Benchmark/Rule'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_plain_text_empty.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_plain_text_empty.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/plain-text'
 assert_exists 1 '/Benchmark/Rule'
@@ -35,7 +35,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/plain-text'
 assert_exists 1 '/Benchmark/Rule'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_unresolved.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_unresolved.sh
@@ -19,7 +19,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'
@@ -40,7 +40,7 @@ $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $st
 sed -i -E "/^W: oscap: The xccdf:rule-result\/xccdf:instance element was not found./d" "$stderr"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_refine_value.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_refine_value.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Value'
 assert_exists 4 '//Value/value'
@@ -37,7 +37,7 @@ $OSCAP xccdf eval --profile xccdf_moc.elpmaxe.www_profile_1 \
 	--remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Value'
 assert_exists 4 '//Value/value'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_take_first.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_take_first.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Value'
 assert_exists 3 '//Value/value'
@@ -37,7 +37,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Value'
 assert_exists 3 '//Value/value'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_title.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_title.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Value'
 assert_exists 1 '//Value/title'
@@ -38,7 +38,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Value'
 assert_exists 1 '//Value/title'

--- a/tests/API/XCCDF/unittests/test_remediation_subs_value_without_selector.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_subs_value_without_selector.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Value'
 assert_exists 3 '//Value/value'
@@ -37,7 +37,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Value'
 assert_exists 3 '//Value/value'

--- a/tests/API/XCCDF/unittests/test_remediation_xml_comments.sh
+++ b/tests/API/XCCDF/unittests/test_remediation_xml_comments.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'
@@ -34,7 +34,7 @@ assert_exists 1 '//score[text()="0.000000"]'
 $OSCAP xccdf eval --remediate --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/Rule'
 assert_exists 1 '/Benchmark/Rule/fix'

--- a/tests/API/XCCDF/unittests/test_single_rule.sh
+++ b/tests/API/XCCDF/unittests/test_single_rule.sh
@@ -24,7 +24,7 @@ $OSCAP xccdf eval --results $result --profile $prof1 \
 	$srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"pass\"]"
@@ -36,7 +36,7 @@ $OSCAP xccdf eval --results $result --profile $prof1 \
 	--rule $rule_pass $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"
@@ -49,7 +49,7 @@ $OSCAP xccdf eval --results $result --rule $rule_pass \
 	$srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"
@@ -62,7 +62,7 @@ $OSCAP xccdf eval --results $result --rule $rule_fail \
 [ $ret -eq 2 ]
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"notselected\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"fail\"]"
@@ -74,7 +74,7 @@ $OSCAP xccdf eval --results $result --profile $prof1 \
 	--rule $rule_fail $srcdir/${name}.xccdf.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"notselected\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"pass\"]"
@@ -102,7 +102,7 @@ $OSCAP xccdf eval --results $result --profile $prof1 \
 	--rule $rule_pass $srcdir/${name}.ds.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"
@@ -116,7 +116,7 @@ $OSCAP xccdf eval --tailoring-file $srcdir/${name}-tailoring.xml \
 	--rule $rule_pass $srcdir/${name}.ds.xml 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 "//rule-result[@idref=\"$rule_pass\"]/result[text()=\"pass\"]"
 assert_exists 1 "//rule-result[@idref=\"$rule_fail\"]/result[text()=\"notselected\"]"

--- a/tests/API/XCCDF/unittests/test_xccdf_check_content_ref_without_name_attr.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_content_ref_without_name_attr.sh
@@ -13,7 +13,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/status[not(@date)]'
 assert_exists 1 '//rule-result'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_multi_check.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_multi_check.sh
@@ -15,7 +15,7 @@ echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 [ "`cat $stdout`" == "XCCDF Results are exported correctly." ]; rm $stdout
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 0 '//check[not(@multi-check)]'
 assert_exists 1 '//Rule[@id="xccdf_moc.elpmaxe.www_rule_1"]/check[@multi-check="true"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_multi_check2.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_multi_check2.sh
@@ -28,7 +28,7 @@ grep '^OVAL Definition ID.*oval:moc.elpmaxe.www:def:2$' $stdout
 grep '^OVAL Definition Title.*DEFINITION_2_TITLE_EXPECTED_FAIL$' $stdout
 rm $stdout
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Rule[@id="xccdf_moc.elpmaxe.www_rule_1"]/check[@multi-check="true"]'
 assert_exists 1 '//check-content-ref[not(@name)]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_multi_check_zero_definitions.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_multi_check_zero_definitions.sh
@@ -19,7 +19,7 @@ echo "Result file = $result"
 grep '^Result.*unknown$' $stdout
 rm $stdout
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Rule[@id="xccdf_moc.elpmaxe.www_rule_1"]/check[@multi-check="true"]'
 assert_exists 2 '//check-content-ref'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_negate.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_negate.sh
@@ -13,7 +13,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 0 '//complex-check'
 assert_exists 1 '//Rule/check[@negate="true"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_ocil.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_ocil.sh
@@ -8,7 +8,7 @@ result=`mktemp`
 stderr=`mktemp`
 $OSCAP xccdf eval --results $result $srcdir/test_xccdf_check_ocil.xml 2> $stderr
 [ ! -s "$stderr" ]
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 assert_exists 1 '//rule-result[@idref="xccdf_moc.elpmaxe.www_rule_1"]/result[text()="notchecked"]'
 rm $stderr
 rm $result

--- a/tests/API/XCCDF/unittests/test_xccdf_check_processing_complex_priority.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_processing_complex_priority.sh
@@ -18,7 +18,7 @@ for args in "" "--profile xccdf_moc.elpmaxe.www_profile_1"; do
 	echo "Result file = $result"
 	[ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-	$OSCAP xccdf validate $result || [ $? == 2 ]
+	$OSCAP xccdf validate --skip-schematron $result || [ $? == 2 ]
 
 	assert_exists 1 '//rule-result'
 	assert_exists 1 '//rule-result/result[text()="pass"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_processing_invalid_content_refs.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_processing_invalid_content_refs.sh
@@ -19,7 +19,7 @@ echo "Result file = $result"
 grep '^Result.*notchecked$' $stdout
 rm $stdout
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Rule[@id="xccdf_moc.elpmaxe.www_rule_1"]/check[@multi-check="true"]'
 assert_exists 2 '//check-content-ref[not(@name)]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_bad.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_bad.sh
@@ -17,7 +17,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result[text()="pass"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_empty.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_processing_selector_empty.sh
@@ -16,7 +16,7 @@ echo "Result file = $result"
 grep "Skipping rule that requires an unregistered check system or incorrect content reference to evaluate." $stderr
 rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_xccdf_check_unsupported_check_system.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_unsupported_check_system.sh
@@ -12,7 +12,7 @@ echo "Stderr file = $stderr"
 grep "Skipping rule that requires an unregistered check system or incorrect content reference to evaluate." $stderr
 rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result[@idref="xccdf_moc.elpmaxe.www_rule_1"]/result[text()="notchecked"]'
 rm $result

--- a/tests/API/XCCDF/unittests/test_xccdf_check_without_content_refs.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_check_without_content_refs.sh
@@ -15,7 +15,7 @@ echo "Result file = $result"
 grep "Skipping rule that uses OVAL but is possibly malformed; an incorrect content reference prevents this check from being evaluated." $stderr
 rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '/Benchmark/status[not(@date)]'
 assert_exists 1 '//rule-result'

--- a/tests/API/XCCDF/unittests/test_xccdf_complex_check_and_notchecked.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_complex_check_and_notchecked.sh
@@ -17,7 +17,7 @@ echo "Result file = $result"
 [ "WARNING: Skipping $srcdir/_non_existent_.oval.xml file which is referenced from XCCDF content" == "`cat $stderr`" ]
 rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 2 '//complex-check'
 assert_exists 2 '//complex-check[@operator="AND"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_fix_attr_export.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_fix_attr_export.sh
@@ -15,7 +15,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 3 '//fix'
 assert_exists 3 '//fix/@id'

--- a/tests/API/XCCDF/unittests/test_xccdf_multiple_testresults.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_multiple_testresults.sh
@@ -20,7 +20,7 @@ for i in {1..5}; do
 	grep "Skipping $tmpdir/non_existent\.oval\.xml file which is referenced from XCCDF content" $stderr
 	:> $stderr
 
-	$OSCAP xccdf validate $result
+	$OSCAP xccdf validate --skip-schematron $result
 	assert_exists $i '//TestResult'
 	assert_exists $i '//TestResult/rule-result/result[text()="notchecked"]'
 	assert_exists $i '//TestResult/score'

--- a/tests/API/XCCDF/unittests/test_xccdf_notchecked_has_check.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_notchecked_has_check.sh
@@ -17,7 +17,7 @@ echo "Result file = $result"
 grep "Skipping $srcdir/_non_existent_\.oval\.xml file which is referenced from XCCDF content" $stderr
 rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_xccdf_refine_rule.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_refine_rule.sh
@@ -14,7 +14,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 0 '//refine-rule[@weight]'
 assert_exists 1 '//refine-rule[not(@weight)]'

--- a/tests/API/XCCDF/unittests/test_xccdf_refine_rule_refine.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_refine_rule_refine.sh
@@ -132,7 +132,7 @@ $OSCAP xccdf eval --profile child --results $result $xccdf > $stdout 2> $stderr 
 
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 RULE_COUNT=17
 

--- a/tests/API/XCCDF/unittests/test_xccdf_refine_value_bad.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_refine_value_bad.sh
@@ -16,6 +16,6 @@ echo "Result file = $result"
 grep -q "^OpenSCAP Error: Invalid selector '20' for xccdf:value/@id='var-passwd_min_len'. Using null value instead." $stderr
 rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 rm $result

--- a/tests/API/XCCDF/unittests/test_xccdf_resolve.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_resolve.sh
@@ -20,7 +20,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 
 $OSCAP xccdf resolve --output $result $srcdir/${name}.xccdf.xml > $stdout
-$OSCAP xccdf validate $result >> $stdout
+$OSCAP xccdf validate --skip-schematron $result >> $stdout
 
 assert_exists 1 '//Benchmark[@resolved="1"]' 
 

--- a/tests/API/XCCDF/unittests/test_xccdf_resolve_profile_platform.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_resolve_profile_platform.sh
@@ -19,7 +19,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 
 $OSCAP xccdf resolve --output $result $srcdir/${name}.xccdf.xml > $stdout
-$OSCAP xccdf validate $result >> $stdout
+$OSCAP xccdf validate --skip-schematron $result >> $stdout
 
 assert_exists 1 '//Benchmark[@resolved="1"]'
 

--- a/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_results_arf_no_oval.sh
@@ -16,7 +16,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 $OSCAP ds rds-validate $resultArf
 
 $OSCAP info $resultArf | sed 's/^[[:space:]]*//' > $stdout 2> $stderr

--- a/tests/API/XCCDF/unittests/test_xccdf_role_unchecked.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_role_unchecked.sh
@@ -14,7 +14,7 @@ $OSCAP xccdf eval --results $result $srcdir/${name}.xccdf.xml 2> $stderr
 
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_xccdf_role_unscored.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_role_unscored.sh
@@ -16,7 +16,7 @@ echo "Report file = $report"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 [ -f $report ]; [ -s $report ]; rm $report
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//rule-result'
 assert_exists 1 '//rule-result/result'

--- a/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster1.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster1.sh
@@ -15,7 +15,7 @@ echo "Output file = $output"
 echo "Result file = $result"
 [ -f $output ]; [ "`cat $output`" == "XCCDF Results are exported correctly." ]; rm $output
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Profile'
 assert_exists 2 '//Profile/select'

--- a/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster2.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster2.sh
@@ -19,7 +19,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Profile'
 assert_exists 1 '//Profile/select'

--- a/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster3.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_selectors_cluster3.sh
@@ -18,7 +18,7 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//Benchmark'
 assert_exists 1 '//Benchmark[@resolved="1"]'

--- a/tests/API/XCCDF/unittests/test_xccdf_sub_title.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_sub_title.sh
@@ -19,7 +19,7 @@ $OSCAP xccdf eval \
 	--results $result --report $report $srcdir/${name}.xccdf.xml > $stdout 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
 cat $stdout | grep "This title is variable: No profile"; :> $stdout
-$OSCAP xccdf validate $result; :> $result
+$OSCAP xccdf validate --skip-schematron $result; :> $result
 grep 'This description is substituted according to the selected policy:.*No profile' $report
 grep 'This title is variable:.*No profile' $report
 grep 'sub ' $report || x=1; [ "x$x" == "x1" ]; unset x; :> $report
@@ -32,7 +32,7 @@ $OSCAP xccdf eval --profile xccdf_moc.elpmaxe.www_profile_1 \
 	--results $result --report $report $srcdir/${name}.xccdf.xml > $stdout 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
 cat $stdout | grep "This title is variable: The First Profile"; :> $stdout
-$OSCAP xccdf validate $result; :> $result
+$OSCAP xccdf validate --skip-schematron $result; :> $result
 grep 'This description is substituted according to the selected policy:.*The First Profile' $report
 grep 'This title is variable:.*The First Profile' $report
 grep 'sub ' $report || x=1; [ "x$x" == "x1" ]; unset x; :> $report
@@ -45,7 +45,7 @@ $OSCAP xccdf eval --profile xccdf_moc.elpmaxe.www_profile_2 \
 	--results $result --report $report $srcdir/${name}.xccdf.xml > $stdout 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
 cat $stdout | grep "This title is variable: The Second Profile"; rm $stdout
-$OSCAP xccdf validate $result; rm $result
+$OSCAP xccdf validate --skip-schematron $result; rm $result
 grep 'This description is substituted according to the selected policy:.*The Second Profile' $report
 grep 'This title is variable:.*The Second Profile' $report
 grep 'sub ' $report || x=1; [ "x$x" == "x1" ]; unset x; rm $report

--- a/tests/API/XCCDF/unittests/test_xccdf_test_system.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_test_system.sh
@@ -16,7 +16,7 @@ echo "Result file = $result"
 
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//TestResult'
 assert_exists 1 '//TestResult[@test-system]'

--- a/tests/API/XCCDF/unittests/test_xccdf_transformation.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_transformation.sh
@@ -17,7 +17,7 @@ xsltproc --stringparam reverse_DNS com.example.www $srcdir/../../../../xsl/xccdf
 
 [ -s $result ]
 
-$OSCAP xccdf validate $result
+$OSCAP xccdf validate --skip-schematron $result
 
 assert_exists 1 '//*[namespace::*="http://checklists.nist.gov/xccdf/1.2"]'
 

--- a/tests/bz2/test_bz2_datastream.sh
+++ b/tests/bz2/test_bz2_datastream.sh
@@ -24,7 +24,7 @@ bzip2 $xccdf
 $OSCAP info "${xccdf}.bz2" 2> $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
 
-$OSCAP xccdf validate "${xccdf}.bz2" > $stderr
+$OSCAP xccdf validate --skip-schematron "${xccdf}.bz2" > $stderr
 [ ! -s $stderr ]
 bash $builddir/run ./test_bz2_memory_source "${xccdf}.bz2" | grep 'XCCDF Checklist'
 

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -754,37 +754,30 @@ static bool valid_inputs(const struct oscap_action *action) {
 
 static int app_oval_validate(const struct oscap_action *action) {
 	int ret;
-	int result = OSCAP_ERROR;
+	int result = OSCAP_OK;
 
 	struct oscap_source *source = oscap_source_new_from_file(action->f_oval);
 	ret = oscap_source_validate(source, reporter, (void *) action);
-	if (ret == -1) {
+
+	if (ret < 0) {
 		result = OSCAP_ERROR;
-		goto cleanup;
-	}
-	else {
-		result = ret == 1 ? OSCAP_FAIL : OSCAP_OK;
-	}
-
-	/* schematron-based validation requested
-	   We can only do schematron validation if the file isn't a source datastream
-	*/
-	if (action->schematron && oscap_source_get_scap_type(source) != OSCAP_DOCUMENT_SDS) {
-		ret = oscap_source_validate_schematron(source, NULL);
-		if (ret==-1) {
-			result=OSCAP_ERROR;
-		}
-		else if (ret>0) {
-			result=OSCAP_FAIL;
+	} else if (ret > 0) {
+		result = OSCAP_FAIL;
+	} else {
+		// We can only do schematron validation if the file isn't a source datastream
+		if (action->schematron && oscap_source_get_scap_type(source) != OSCAP_DOCUMENT_SDS) {
+			ret = oscap_source_validate_schematron(source, NULL);
+			if (ret < 0) {
+				result = OSCAP_ERROR;
+			} else if (ret > 0) {
+				result = OSCAP_FAIL;
+			}
 		}
 	}
 
-cleanup:
 	oscap_source_free(source);
-	if (oscap_err())
-		fprintf(stderr, "%s %s\n", OSCAP_ERR_MSG, oscap_err_desc());
+	oscap_print_error();
 
 	return result;
-
 }
 

--- a/utils/oscap-oval.c
+++ b/utils/oscap-oval.c
@@ -89,7 +89,7 @@ static struct oscap_module OVAL_VALIDATE = {
 	"   --variables                   - Validate external OVAL Variables\n"
 	"   --syschar                     - Validate OVAL System Characteristics\n"
 	"   --results                     - Validate OVAL Results\n"
-	"   --schematron                  - Use schematron-based validation in addition to XML Schema\n",
+	"   --skip-schematron             - Do not use schematron-based validation in addition to XML Schema\n",
     .opt_parser = getopt_oval_validate,
     .func = app_oval_validate
 };
@@ -670,8 +670,9 @@ bool getopt_oval_validate(int argc, char **argv, struct oscap_action *action)
 		{ "syschar",		no_argument, &action->doctype, OSCAP_DOCUMENT_OVAL_SYSCHAR     },
 		{ "results",		no_argument, &action->doctype, OSCAP_DOCUMENT_OVAL_RESULTS     },
 		{ "directives",		no_argument, &action->doctype, OSCAP_DOCUMENT_OVAL_DIRECTIVES  },
-		// force schematron validation
+		//TODO: force schematron validation (no-op, deprecate and remove)
 		{ "schematron",		no_argument, &action->schematron, 1 },
+		{ "skip-schematron",no_argument, &action->schematron, 0 },
         // end
 		{ 0, 0, 0, 0 }
 	};

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -58,6 +58,7 @@ static void oscap_action_init(struct oscap_action *action)
     assert(action != NULL);
     memset(action, 0, sizeof(*action));
     action->validate = 1;
+    action->schematron = 1;
     action->validate_signature = 1;
 }
 

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -113,7 +113,7 @@ static struct oscap_module XCCDF_VALIDATE = {
     .opt_parser = getopt_xccdf,
 	.func = app_xccdf_validate,
 	.help = "Options:\n"
-		"   --schematron                  - Use schematron-based validation in addition to XML Schema\n"
+		"   --skip-schematron             - Do not use schematron-based validation in addition to XML Schema\n"
 	,
 };
 
@@ -1167,7 +1167,9 @@ bool getopt_xccdf(int argc, char **argv, struct oscap_action *action)
 		{"remediate", no_argument, &action->remediate, 1},
 		{"hide-profile-info",	no_argument, &action->hide_profile_info, 1},
 		{"export-variables",	no_argument, &action->export_variables, 1},
+		//TODO: deprecate and remove
 		{"schematron",          no_argument, &action->schematron, 1},
+		{"skip-schematron",     no_argument, &action->schematron, 0},
 		{"without-syschar",    no_argument, &action->without_sys_chars, 1},
 		{"thin-results",        no_argument, &action->thin_results, 1},
 	// end

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -1251,34 +1251,28 @@ bool getopt_xccdf(int argc, char **argv, struct oscap_action *action)
 
 int app_xccdf_validate(const struct oscap_action *action) {
 	int ret;
-	int result;
-
+	int result = OSCAP_OK;
 
 	struct oscap_source *source = oscap_source_new_from_file(action->f_xccdf);
 	ret = oscap_source_validate(source, reporter, (void *) action);
-        if (ret==-1) {
-                result=OSCAP_ERROR;
-                goto cleanup;
-        }
-        else if (ret==1) {
-                result=OSCAP_FAIL;
-        }
-        else
-                result=OSCAP_OK;
 
-	if (action->schematron) {
-		ret = oscap_source_validate_schematron(source, NULL);
-		if (ret == -1) {
-			result = OSCAP_ERROR;
-		} else if (ret > 0) {
-			result = OSCAP_FAIL;
+	if (ret < 0) {
+		result = OSCAP_ERROR;
+	} else if (ret > 0) {
+		result = OSCAP_FAIL;
+	} else {
+		if (action->schematron) {
+			ret = oscap_source_validate_schematron(source, NULL);
+			if (ret < 0) {
+				result = OSCAP_ERROR;
+			} else if (ret > 0) {
+				result = OSCAP_FAIL;
+			}
 		}
 	}
 
-cleanup:
 	oscap_source_free(source);
 	oscap_print_error();
 
-        return result;
-
+	return result;
 }

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -284,8 +284,8 @@ Force resolving XCCDF document even if it is already marked as resolved.
 .RS
 Validate given XCCDF file against a XML schema. Every found error is printed to the standard error. Return code is 0 if validation succeeds, 1 if validation could not be performed due to some error, 2 if the XCCDF document is not valid.
 .TP
-\fB\-\-schematron\fR
-Turn on Schematron-based validation. It is able to find more errors and inconsistencies but is much slower. Schematron is available only for XCCDF version 1.2.
+\fB\-\-skip-schematron\fR
+Turn off Schematron-based validation. It is able to find more errors and inconsistencies but is much slower. Schematron is available only for XCCDF version 1.2.
 .RE
 .TP
 .B export-oval-variables\fR [\fIoptions\fR] xccdf-file [\fIoval-definitions-files\fR]
@@ -522,8 +522,8 @@ Validate given OVAL file against a XML schema. Every found error is printed to t
 \fB\-\-definitions\fR, \fB\-\-variables\fR, \fB\-\-syschar\fR, \fB\-\-results\fR \fB\-\-directives\fR
 Type of the OVAL document is automatically detected by default. If you want enforce certain document type, you can use one of these options.
 .TP
-\fB\-\-schematron\fR
-Turn on Schematron-based validation. It is able to find more errors and inconsistencies but is much slower.
+\fB\-\-skip-schematron\fR
+Turn off Schematron-based validation. It is able to find more errors and inconsistencies but is much slower.
 .RE
 .TP
 .B \fBgenerate\fR <submodule> [submodule-specific-options]


### PR DESCRIPTION
Also introduce disabling option `--skip-schematron`. The `--schematron` option is now obsolete; it is removed from the documentation and would be deprecated in the next API-breaking release.