### PR TITLE
Set the default value of role attribute

### DIFF
--- a/src/XCCDF/profile.c
+++ b/src/XCCDF/profile.c
@@ -97,6 +97,7 @@ struct xccdf_refine_value * xccdf_refine_value_clone(const struct xccdf_refine_v
 struct xccdf_refine_rule *xccdf_refine_rule_new(void)
 {
 	struct xccdf_refine_rule *foo = calloc(1, sizeof(struct xccdf_refine_rule));
+	foo->role = XCCDF_ROLE_FULL;
 	foo->remarks = oscap_list_new();
 	return foo;
 }


### PR DESCRIPTION
By default the value of role member of struct xccdf_refine_rule was set
to zero when created which happened usually when parsing a
xccdf:refine-rule element. But the value of 0 doesn't map to the default
value of the role attribute of xccdf:refine-rule element. The default
value of this attribute is "full" according to the XCCDF specification.
As a result when creating XCDF results or ARF results the role attribute
of xccdf:rule-result hasn't been created. That's a problem according to
scapval.
Fixes: #1729