### PR TITLE
Fix a test

### DIFF
--- a/tests/DS/schematron/schematron.sh
+++ b/tests/DS/schematron/schematron.sh
@@ -15,10 +15,14 @@ rm -f "$output"
 
 # XCCDF schematron reports an error
 output="$(mktemp)"
-$OSCAP xccdf validate --schematron "$srcdir/simple_ds_xccdf_schematron_error.xml" >"$output" || ret=$?
+stderr="$(mktemp)"
+$OSCAP xccdf validate --schematron "$srcdir/simple_ds_xccdf_schematron_error.xml" >"$output" 2>"$stderr" || ret=$?
 [ $ret = 2 ]
+grep -q "Error: The given @idref attribute 'xccdf_com.example.www_rule_test-pass2' must match a the @id or @cluster-id attributes of a 'Rule' or 'Group' element. See the XCCDF 1.2.1 specification, Section 6.5.3." $output
 grep -q "Schematron validation of OVAL Definition component 'test_single_rule.oval.xml': PASS" "$output"
 grep -q "Schematron validation of XCCDF Checklist component 'scap_org.open-scap_cref_test_single_rule.xccdf.xml': FAIL" "$output"
 grep -q "Global schematron validation using the source data stream schematron: PASS" $output
 grep -q "Complete result of schematron validation of '$srcdir/simple_ds_xccdf_schematron_error.xml': FAIL" $output
+grep -q "OpenSCAP Error: Invalid SCAP Source Datastream (1.3) content in $srcdir/simple_ds_xccdf_schematron_error.xml" "$stderr"
 rm -f "$output"
+rm -f "$stderr"

--- a/tests/DS/schematron/simple_ds_xccdf_schematron_error.xml
+++ b/tests/DS/schematron/simple_ds_xccdf_schematron_error.xml
@@ -63,10 +63,10 @@
         <description>This profile is for testing.</description>
         <select idref="xccdf_com.example.www_rule_test-pass" selected="true"/>
       </Profile>
-      <Profile id="xccdf_com.example.www_profile_test_single_rule2" extends="xccdf_com.example.www_rule_test-pass">
+      <Profile id="xccdf_com.example.www_profile_test_single_rule2">
         <title>xccdf_test_profile</title>
         <description>This profile is for testing.</description>
-        <select idref="xccdf_com.example.www_rule_test-pass" selected="true"/>
+        <select idref="xccdf_com.example.www_rule_test-pass2" selected="true"/>
       </Profile>
       <Rule selected="true" id="xccdf_com.example.www_rule_test-pass">
         <title>This rule always passes</title>


### PR DESCRIPTION
The test introduced by #1732 doesn't pass because the
tests/DS/schematron/simple_ds_xccdf_schematron_error.xml wan't invalid
only according to schematron but also according to XSD. We can fix it by
creating a different problem in the data stream which will pass XSD
validation but fail schematron validation.