### PR TITLE
Waive the known issue with hugepages on ppc64/ppc64le

### DIFF
--- a/tests/probes/sysctl/test_sysctl_probe_all.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_all.sh
@@ -73,6 +73,10 @@ if [ "$procps_ver" != "$lowest_ver" ]; then
 	sed -i '/.*vm.stat_refresh/d' "$sysctlNames"
 fi
 
+if ! grep -q "hugepages" "$ourNames"; then
+	sed -i "/^.*hugepages.*$/d" "$sysctlNames"
+fi
+
 echo "Diff (sysctlNames / ourNames): ------"
 diff "$sysctlNames" "$ourNames"
 echo "-------------------------------------"
@@ -84,6 +88,7 @@ sed -i -E "/^E: oscap: +Can't read sysctl value from /d" "$stderr"
 # that can't fit into 8K buffer and result in errno 14
 # (for example /proc/sys/kernel/spl/hostid could be the case)
 sed -i -E "/^E: oscap: +An error.*14, Bad address/d" "$stderr"
+sed -i "/^.*hugepages.*$/d" "$stderr"
 
 echo "Errors (without messages related to permissions):"
 cat "$stderr"


### PR DESCRIPTION
The known issue has been reported in
https://bugzilla.redhat.com/show_bug.cgi?id=1642995

This modification is currently applied as a patch applied during setup
phase of Sanity/smoke-test in Fedora CI gating.
https://src.fedoraproject.org/tests/openscap/blob/main/f/Sanity/smoke-test
The patched file got changed recetly so the patch doesn't apply anymore
which causes the Rawhide gating to fail.
We have decided to propose the change to upstream to avoid the need
for modifying the patch in the tests and to prevent similar problems
in the future.