### PR TITLE
Replace getlogin by cuserid

### DIFF
--- a/src/XCCDF/result.c
+++ b/src/XCCDF/result.c
@@ -217,7 +217,10 @@ static inline void _xccdf_result_fill_identity(struct xccdf_result *result)
 	xccdf_identity_set_authenticated(id, 0);
 	xccdf_identity_set_privileged(id, 0);
 #ifdef OSCAP_UNIX
-	xccdf_identity_set_name(id, getlogin());
+	char *name = getlogin();
+	if (name == NULL)
+		name = cuserid(NULL);
+	xccdf_identity_set_name(id, name);
 #elif defined(OS_WINDOWS)
 	GetUserName((TCHAR *) w32_username, &w32_usernamesize); /* XXX: Check the return value? */
 	xccdf_identity_set_name(id, w32_username);


### PR DESCRIPTION
The getlogin() is used here to fill in the xccdf:identity element which
shall contain information about the system identity or user employed
during application of the benchmark. But, the getlogin() can return NULL
when there is no controlling terminal. This happened when testing oscap
on a test system with no pty.  As an alternative, the system provides
also cuserid() function which gets the effective user ID of the process.
However, these 2 values differ when the program is executed under sudo.
From the user experience point of view, it would be better to have
displayed there the user logged in on the controlling terminal. As a
compromise, we will first attempt to obtain the name using getlogin()
and if that fails we will run cuserid().