### PR TITLE
utils/oscap.8: fix indentation of --enforce-signature option in man page

### DIFF
--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -362,10 +362,8 @@ Use tailoring component in input source data stream for XCCDF tailoring. The tai
 .TP
 \fB\-\-skip-signature-validation\fR
 Do not validate digital signatures in digitally signed SCAP source data streams.
-.RE
 .TP
 \fB\-\-enforce-signature\fR
-.RS
 Process only digitally signed SCAP source data streams. Data streams without a signature would be rejected if this switch is used.
 .RE
 .TP
@@ -420,10 +418,8 @@ Use tailoring component in input source data stream for XCCDF tailoring. The tai
 .TP
 \fB\-\-skip-signature-validation\fR
 Do not validate digital signatures in digitally signed SCAP source data streams.
-.RE
 .TP
 \fB\-\-enforce-signature\fR
-.RS
 Process only digitally signed SCAP source data streams. Data streams without a signature would be rejected if this switch is used.
 .RE
 .TP


### PR DESCRIPTION
The `--enforce-signature` option was not indented properly in man page under `generate guide` and `generate fix`.