### PR TITLE
Add additional tests for signature validation

### DIFF
--- a/tests/DS/signed/all.sh
+++ b/tests/DS/signed/all.sh
@@ -90,3 +90,143 @@ rm -f $stdout
 rm -f $stderr
 rm -f $verbose
 rm -f $result
+
+echo "Test a security guide generation from a signed SCAP source data stream with a valid signature"
+stdout=$(mktemp)
+stderr=$(mktemp)
+verbose=$(mktemp)
+html_guide=$(mktemp)
+$OSCAP xccdf generate guide --verbose INFO --verbose-log-file $verbose --output $html_guide $srcdir/simple_ds_valid_sign.xml >$stdout 2>$stderr
+! [ -s $stderr ]
+grep -q "XML signature is valid." $stdout
+grep -q "Validating XML signature" $verbose
+grep -q "Signature is OK" $verbose
+grep -q "SignedInfo references (ok/all): 3/3" $verbose
+grep -q "Manifests references (ok/all): 2/2" $verbose
+grep -q "<!DOCTYPE[^>]*html[^>]*>" $html_guide
+rm -f $stdout
+rm -f $stderr
+rm -f $verbose
+rm -f $html_guide
+
+echo "Test a security guide generation from a signed SCAP source data stream with an invalid signature"
+stdout=$(mktemp)
+stderr=$(mktemp)
+verbose=$(mktemp)
+html_guide=$(mktemp)
+$OSCAP xccdf generate guide --verbose INFO --verbose-log-file $verbose --output $html_guide $srcdir/simple_ds_invalid_sign.xml >$stdout 2>$stderr || ret=$?
+[ $ret = 1 ]
+[ -s $stderr ]
+! [ -s $html_guide ]
+! grep -q "XML signature is valid." $stdout
+grep -q "OpenSCAP Error: Invalid signature in SCAP Source Datastream (1.3) content in $srcdir/simple_ds_invalid_sign.xml" $stderr
+grep -q "Validating XML signature" $verbose
+grep -q "Signature is invalid" $verbose
+grep -q "SignedInfo references (ok/all): 3/3" $verbose
+grep -q "Manifests references (ok/all): 2/2" $verbose
+rm -f $stdout
+rm -f $stderr
+rm -f $verbose
+rm -f $html_guide
+
+echo "Test skipping signature validation on a security guide generation from a signed SCAP source data stream with an invalid signature"
+stdout=$(mktemp)
+stderr=$(mktemp)
+verbose=$(mktemp)
+html_guide=$(mktemp)
+$OSCAP xccdf generate guide --verbose INFO --verbose-log-file $verbose --skip-signature-validation --output $html_guide $srcdir/simple_ds_invalid_sign.xml >$stdout 2>$stderr
+! [ -s $stderr ]
+! grep -q "XML signature is valid." $stdout
+! grep -q "Validating XML signature" $verbose
+grep -q "<!DOCTYPE[^>]*html[^>]*>" $html_guide
+rm -f $stdout
+rm -f $stderr
+rm -f $verbose
+rm -f $html_guide
+
+echo "Test a security guide generation from an unsigned SCAP source data stream (with signature enforced)"
+stdout=$(mktemp)
+stderr=$(mktemp)
+verbose=$(mktemp)
+html_guide=$(mktemp)
+$OSCAP xccdf generate guide --verbose INFO --verbose-log-file $verbose --enforce-signature --output $html_guide $srcdir/simple_ds_no_sign.xml >$stdout 2>$stderr || ret=$?
+[ $ret = 1 ]
+[ -s $stderr ]
+! [ -s $html_guide ]
+! grep -q "XML signature is valid." $stdout
+grep -q "OpenSCAP Error: Signature not found" $stderr
+grep -q "Validating XML signature" $verbose
+rm -f $stdout
+rm -f $stderr
+rm -f $verbose
+rm -f $html_guide
+
+echo "Test a fix generation from a signed SCAP source data stream with a valid signature"
+stdout=$(mktemp)
+stderr=$(mktemp)
+verbose=$(mktemp)
+fix_script=$(mktemp)
+$OSCAP xccdf generate fix --verbose INFO --verbose-log-file $verbose --fix-type bash --output $fix_script $srcdir/simple_ds_valid_sign.xml >$stdout 2>$stderr
+! [ -s $stderr ]
+grep -q "XML signature is valid." $stdout
+grep -q "Validating XML signature" $verbose
+grep -q "Signature is OK" $verbose
+grep -q "SignedInfo references (ok/all): 3/3" $verbose
+grep -q "Manifests references (ok/all): 2/2" $verbose
+grep -q "#!\(/usr\)\?/bin/\(env \)\?bash" $fix_script
+rm -f $stdout
+rm -f $stderr
+rm -f $verbose
+rm -f $fix_script
+
+echo "Test a fix generation from a signed SCAP source data stream with an invalid signature"
+stdout=$(mktemp)
+stderr=$(mktemp)
+verbose=$(mktemp)
+fix_script=$(mktemp)
+$OSCAP xccdf generate fix --verbose INFO --verbose-log-file $verbose --fix-type bash --output $fix_script $srcdir/simple_ds_invalid_sign.xml >$stdout 2>$stderr || ret=$?
+[ $ret = 1 ]
+[ -s $stderr ]
+! [ -s $fix_script ]
+! grep -q "XML signature is valid." $stdout
+grep -q "OpenSCAP Error: Invalid signature in SCAP Source Datastream (1.3) content in $srcdir/simple_ds_invalid_sign.xml" $stderr
+grep -q "Validating XML signature" $verbose
+grep -q "Signature is invalid" $verbose
+grep -q "SignedInfo references (ok/all): 3/3" $verbose
+grep -q "Manifests references (ok/all): 2/2" $verbose
+rm -f $stdout
+rm -f $stderr
+rm -f $verbose
+rm -f $fix_script
+
+echo "Test skipping signature validation on a fix generation from a signed SCAP source data stream with an invalid signature"
+stdout=$(mktemp)
+stderr=$(mktemp)
+verbose=$(mktemp)
+fix_script=$(mktemp)
+$OSCAP xccdf generate fix --verbose INFO --verbose-log-file $verbose --skip-signature-validation --fix-type bash --output $fix_script $srcdir/simple_ds_invalid_sign.xml >$stdout 2>$stderr
+! [ -s $stderr ]
+! grep -q "XML signature is valid." $stdout
+! grep -q "Validating XML signature" $verbose
+grep -q "#!\(/usr\)\?/bin/\(env \)\?bash" $fix_script
+rm -f $stdout
+rm -f $stderr
+rm -f $verbose
+rm -f $fix_script
+
+echo "Test a fix generation from an unsigned SCAP source data stream (with signature enforced)"
+stdout=$(mktemp)
+stderr=$(mktemp)
+verbose=$(mktemp)
+fix_script=$(mktemp)
+$OSCAP xccdf generate fix --verbose INFO --verbose-log-file $verbose --enforce-signature --fix-type bash --output $fix_script $srcdir/simple_ds_no_sign.xml >$stdout 2>$stderr || ret=$?
+[ $ret = 1 ]
+[ -s $stderr ]
+! [ -s $fix_script ]
+! grep -q "XML signature is valid." $stdout
+grep -q "OpenSCAP Error: Signature not found" $stderr
+grep -q "Validating XML signature" $verbose
+rm -f $stdout
+rm -f $stderr
+rm -f $verbose
+rm -f $fix_script

--- a/tests/DS/signed/all.sh
+++ b/tests/DS/signed/all.sh
@@ -46,7 +46,7 @@ stdout=$(mktemp)
 stderr=$(mktemp)
 verbose=$(mktemp)
 result=$(mktemp)
-$OSCAP xccdf eval --skip-signature-validation --results-arf $result $srcdir/simple_ds_invalid_sign.xml >$stdout 2>$stderr
+$OSCAP xccdf eval --verbose INFO --verbose-log-file $verbose --skip-signature-validation --results-arf $result $srcdir/simple_ds_invalid_sign.xml >$stdout 2>$stderr
 ! [ -s $stderr ]
 ! grep -q "XML signature is valid." $stdout
 ! grep -q "Validating XML signature" $verbose
@@ -82,6 +82,7 @@ stderr=$(mktemp)
 verbose=$(mktemp)
 result=$(mktemp)
 $OSCAP xccdf eval --verbose INFO --verbose-log-file $verbose --enforce-signature --results-arf $result $srcdir/simple_ds_no_sign.xml >$stdout 2>$stderr || ret=$?
+[ $ret = 1 ]
 [ -s $stderr ]
 ! grep -q "XML signature is valid." $stdout
 grep -q "OpenSCAP Error: Signature not found" $stderr


### PR DESCRIPTION
Add more tests for signature validation feature to cover also `generate guide` and `generate fix` XCCDF operations.