### PR TITLE
Fix UBI 9 scan

### DIFF
--- a/src/OVAL/probes/independent/system_info_probe.c
+++ b/src/OVAL/probes/independent/system_info_probe.c
@@ -732,7 +732,7 @@ int system_info_probe_main(probe_ctx *ctx, void *arg)
 	if (!architecture)
 		architecture = strdup(unknown);
 
-	if (!hname)
+	if (!hname || *hname == '\0')
 		hname = strdup(unknown);
 
 	if (__sysinfo_saneval(os_name) < 1 ||


### PR DESCRIPTION
In offline mode when scanning a cointainer based on UBI 9 the
system_info probe failed because the function `_offline_get_hname` which
reads from `/etc/hostname` returns an empty string which causes
`__sysinfo_saneval(hname)` check to return zero which in turn causes the
probe returns an error. We can prevent this situation by replacing the
empty string by `"Unknown"`, which we already do when the `hname` is
`NULL`.

Addressing:

W: oscap: Can't receive message: 125, Operation canceled.
E: oscap: Recv: retry limit (0) reached.
OpenSCAP Error: Probe at sd=32 (system_info) reported an error: Invalid type, value or format [/home/jcerny/work/git/openscap/src/OVAL/oval_probe_ext.c:383]
Unable to receive a message from probe [/home/jcerny/work/git/openscap/src/OVAL/oval_probe_ext.c:572]

Resolves: rhbz#1953610