### PR TITLE
Fix failing test

### DIFF
--- a/tests/API/XCCDF/unittests/test_profile_selection_by_suffix.sh
+++ b/tests/API/XCCDF/unittests/test_profile_selection_by_suffix.sh
@@ -13,6 +13,9 @@ echo "Stderr file = $stderr"
 echo "Result file = $result"
 ret=0
 
+touch test_file
+[ -f test_file ]
+
 # Multiple matches should result in failure
 $OSCAP xccdf eval --profile common $benchmark 2> $stderr || ret=$?
 [ $ret -eq 1 ]
@@ -55,3 +58,5 @@ grep -Fq "No profile matching suffix \"another\" was found" $stderr
 
 [ -f $stderr ]; rm $stderr
 rm $result
+
+rm -f test_file


### PR DESCRIPTION
The test fails becuse the OVAL content in
`test_remediation_simple.oval.xml` used in rule
`xccdf_moc.elpmaxe.www_rule_1` in
`test_profile_selection_by_suffix.xccdf.xml` expects that a file named
`test_file` exists in the current working directory.

This test doesn't fail when executed as a part of complete test suite
run. I guess that it's because some other test creates the `test_file`
file and doesn't delete it. Unfortunately, I can't find which test
creates it. There are many test cases that use a file `test_file`
and it is also created often by remediation executed in some tests.