### PR TITLE
Initialize crypto API only once

### DIFF
--- a/src/OVAL/oval_probe_session.c
+++ b/src/OVAL/oval_probe_session.c
@@ -93,6 +93,11 @@ static void oval_probe_session_libinit(void)
 	SEXP_free((SEXP_t *)exp);
 
         ncache_libinit();
+	/*
+	 * Initialize crypto API
+	 */
+	if (crapi_init (NULL) != 0)
+		return (NULL);
 }
 
 /**

--- a/src/OVAL/oval_probe_session.c
+++ b/src/OVAL/oval_probe_session.c
@@ -48,6 +48,7 @@
 #include "oval_probe_ext.h"
 #include "probe-table.h"
 #include "oval_types.h"
+#include "crapi/crapi.h"
 
 #if defined(OSCAP_THREAD_SAFE)
 #include <pthread.h>

--- a/src/OVAL/oval_probe_session.c
+++ b/src/OVAL/oval_probe_session.c
@@ -97,8 +97,10 @@ static void oval_probe_session_libinit(void)
 	/*
 	 * Initialize crypto API
 	 */
+#ifndef OS_WINDOWS
 	if (crapi_init (NULL) != 0)
 		return (NULL);
+#endif
 }
 
 /**

--- a/src/OVAL/probes/independent/filehash58_probe.c
+++ b/src/OVAL/probes/independent/filehash58_probe.c
@@ -211,12 +211,6 @@ int filehash58_probe_offline_mode_supported()
 void *filehash58_probe_init(void)
 {
 	/*
-	 * Initialize crypto API
-	 */
-	if (crapi_init (NULL) != 0)
-		return (NULL);
-
-	/*
 	 * Initialize mutex.
 	 */
 	pthread_mutex_t *filehash58_probe_mutex = malloc(sizeof(pthread_mutex_t));

--- a/src/OVAL/probes/independent/filehash_probe.c
+++ b/src/OVAL/probes/independent/filehash_probe.c
@@ -191,12 +191,6 @@ int filehash_probe_offline_mode_supported()
 void *filehash_probe_init(void)
 {
         /*
-         * Initialize crypto API
-         */
-        if (crapi_init (NULL) != 0)
-                return (NULL);
-
-        /*
          * Initialize mutex.
          */
 	pthread_mutex_t *filehash_probe_mutex = malloc(sizeof(pthread_mutex_t));

--- a/src/OVAL/probes/independent/filemd5_probe.c
+++ b/src/OVAL/probes/independent/filemd5_probe.c
@@ -164,12 +164,6 @@ int probe_offline_mode_supported()
 void *probe_init (void)
 {
         /*
-         * Initialize crypto API
-         */
-        if (crapi_init (NULL) != 0)
-                return (NULL);
-
-        /*
          * Initialize mutex.
          */
         switch (pthread_mutex_init (&__filemd5_probe_mutex, NULL)) {


### PR DESCRIPTION
The function `crapi_init` calls `gcry_check_version` which must be
called before any other function from the Libgcrypt library. That might
be violated when multiple threads executing multiple probes are running.
The mitigation proposed in this PR is to call `crapi_init` only once
when the session is initialized which means before any threads are
spawned.

See also: https://www.gnupg.org/documentation/manuals/gcrypt/Multi_002dThreading.html#Multi_002dThreading

Resolves: RHBZ#1959570