### PR TITLE
FreeBSD build and test fixes

### DIFF
--- a/src/OVAL/probes/unix/password_probe.c
+++ b/src/OVAL/probes/unix/password_probe.c
@@ -120,9 +120,8 @@ static time_t get_last_login(char *username) {
 
         return t;
 }
-#endif
 
-static void _process_struct_passwd(struct passwd *pw, const char *lastlog, SEXP_t *un_ent, probe_ctx *ctx, oval_schema_version_t over)
+static void _freebsd_process_struct_passwd(struct passwd *pw, SEXP_t *un_ent, probe_ctx *ctx, oval_schema_version_t over)
 {
 	SEXP_t *un;
 	struct result_info r;
@@ -144,24 +143,67 @@ static void _process_struct_passwd(struct passwd *pw, const char *lastlog, SEXP_
 	r.last_login = -1;
 
 	if (oval_schema_version_cmp(over, OVAL_SCHEMA_VERSION(5.10)) >= 0) {
-#if defined(OS_FREEBSD)
 		r.last_login = get_last_login(pw->pw_name);
-#else
-		FILE *ll_fp = fopen(lastlog, "r");
-
-		if (ll_fp != NULL) {
-			struct lastlog ll;
-
-			if (fseeko(ll_fp, (off_t)pw->pw_uid * sizeof(ll), SEEK_SET) == 0)
-				if (fread((char *)&ll, sizeof(ll), 1, ll_fp) == 1)
-					r.last_login = (int64_t)ll.ll_time;
-			fclose(ll_fp);
-		}
-#endif
 	}
 
 	report_finding(&r, ctx, over);
 	SEXP_free(un);
+}
+
+static int read_password(SEXP_t *un_ent, probe_ctx *ctx, oval_schema_version_t over)
+{
+	struct passwd *pw;
+
+	while ((pw = getpwent())) {
+		_freebsd_process_struct_passwd(pw, un_ent, ctx, over);
+	}
+
+	endpwent();
+	return 0;
+}
+
+int password_probe_offline_mode_supported()
+{
+	return PROBE_OFFLINE_NONE;
+}
+
+#else
+static void _process_struct_passwd(struct passwd *pw, const char *lastlog, SEXP_t *un_ent, probe_ctx *ctx, oval_schema_version_t over)
+{
+        SEXP_t *un;
+        struct result_info r;
+
+        dI("Have user: %s", pw->pw_name);
+        un = SEXP_string_newf("%s", pw->pw_name);
+        if (probe_entobj_cmp(un_ent, un) != OVAL_RESULT_TRUE) {
+                SEXP_free(un);
+                return;
+        }
+
+        r.username = pw->pw_name;
+        r.password = pw->pw_passwd;
+        r.user_id = pw->pw_uid;
+        r.group_id = pw->pw_gid;
+        r.gcos = pw->pw_gecos;
+        r.home_dir = pw->pw_dir;
+        r.login_shell = pw->pw_shell;
+        r.last_login = -1;
+
+        if (oval_schema_version_cmp(over, OVAL_SCHEMA_VERSION(5.10)) >= 0) {
+                FILE *ll_fp = fopen(lastlog, "r");
+
+                if (ll_fp != NULL) {
+                        struct lastlog ll;
+
+                        if (fseeko(ll_fp, (off_t)pw->pw_uid * sizeof(ll), SEEK_SET) == 0)
+                                if (fread((char *)&ll, sizeof(ll), 1, ll_fp) == 1)
+                                        r.last_login = (int64_t)ll.ll_time;
+                        fclose(ll_fp);
+                }
+        }
+
+        report_finding(&r, ctx, over);
+        SEXP_free(un);
 }
 
 static int read_password(SEXP_t *un_ent, probe_ctx *ctx, oval_schema_version_t over)
@@ -200,6 +242,7 @@ int password_probe_offline_mode_supported()
 {
 	return PROBE_OFFLINE_OWN;
 }
+#endif
 
 int password_probe_main(probe_ctx *ctx, void *arg)
 {

--- a/src/XCCDF/result.c
+++ b/src/XCCDF/result.c
@@ -49,6 +49,8 @@
 #include <sys/utsname.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <pwd.h>
+#include <sys/types.h>
 #endif
 
 #if defined(OS_LINUX)
@@ -65,8 +67,8 @@
 #include <net/if.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <sys/sockio.h>
 #include <sys/ioctl.h>
+#include <sys/sockio.h>
 #endif
 
 #include "item.h"
@@ -205,6 +207,21 @@ static inline void _xccdf_result_fill_scanner(struct xccdf_result *result)
 	xccdf_result_add_target_fact(result, fact);
 }
 
+#if defined(OSCAP_UNIX)
+static inline char *_unix_get_name_fallback(void) {
+	struct passwd *passwd;
+
+	errno = 0;
+	passwd = getpwuid(getuid());
+	if (passwd == NULL || passwd->pw_name == NULL) {
+		dW("Error when calling getpwuid(): %d, %s\n", errno, strerror(errno));
+		return "\0";
+	}
+
+	return passwd->pw_name;
+}
+#endif
+
 static inline void _xccdf_result_fill_identity(struct xccdf_result *result)
 {
 	struct xccdf_identity *id = xccdf_identity_new();
@@ -219,7 +236,7 @@ static inline void _xccdf_result_fill_identity(struct xccdf_result *result)
 #ifdef OSCAP_UNIX
 	char *name = getlogin();
 	if (name == NULL)
-		name = cuserid(NULL);
+		name = _unix_get_name_fallback();
 	xccdf_identity_set_name(id, name);
 #elif defined(OS_WINDOWS)
 	GetUserName((TCHAR *) w32_username, &w32_usernamesize); /* XXX: Check the return value? */

--- a/tests/API/XCCDF/default_cpe/test_cpe_applicability.sh
+++ b/tests/API/XCCDF/default_cpe/test_cpe_applicability.sh
@@ -25,7 +25,7 @@ function test_cpe {
 	# Create XCCDF file with CPE based on RHEL/FEDORA version.
 	rm -f $builddir/$XCCDF
 	cp $srcdir/$XCCDF $builddir/$XCCDF
-	sed -i "s|<<CPE>>|${CPE}|" $builddir/$XCCDF
+	xsed -i "s|<<CPE>>|${CPE}|" $builddir/$XCCDF
 
 	echo "Tested CPE: $CPE"
 	$OSCAP xccdf eval --cpe $builddir/$CPE_DICT --results $TMP_RESULTS $builddir/$XCCDF

--- a/tests/API/XCCDF/unittests/test_report_check_with_empty_selector.sh
+++ b/tests/API/XCCDF/unittests/test_report_check_with_empty_selector.sh
@@ -40,4 +40,4 @@ case $(uname) in
 		grep -P '<a href="http://open-scap.org">OpenSCAP</a> (([0-9]+)\.){2}[0-9]+' $result
 		;;
 esac
-#rm $result
+rm $result

--- a/tests/API/XCCDF/unittests/test_xccdf_results_arf_asset.sh
+++ b/tests/API/XCCDF/unittests/test_xccdf_results_arf_asset.sh
@@ -20,7 +20,17 @@ function test_xccdf_results_arf_asset {
 
     local asset='/arf:asset-report-collection/arf:assets/arf:asset[@id="asset0"]/ai:computing-device'
 
-    local fqdn=`hostname --fqdn`
+    case $(uname) in
+	FreeBSD)
+		local name=`hostname`
+		local domain=`grep search /etc/resolv.conf | cut -d " " -f 2`
+		local fqdn=$name.$domain
+		;;
+	*)
+		local fqdn=`hostname --fqdn`
+		;;
+    esac
+
     echo $asset'/ai:fqdn[text()="'$fqdn'"]'
     assert_exists 1 $asset'/ai:fqdn[text()="'$fqdn'"]'
 


### PR DESCRIPTION
This pull request contains both fixes that allow OpenSCAP to be built on FreeBSD (tested on 13.0-RELEASE), as well as some trivial test compatibility fixes. If it is better to split these into two separate pull requests just let me know.

**Compilation fixes:**

1. The changes to the password probe are due to FreeBSD not supporting the same functions as glibc (e.g. `fgetpwent()`). Now FreeBSD uses separate `read_password()` and `_freebsd_process_struct_passwd()` instead. I believe this should also help avoid future breakages in the future.

2. In `XCCDF/result.c` switch to using `getpwuid(getuid())` instead of `cuserid()`. This was done for two reasons, the first is that macOS and FreeBSD do not support this by default, and the second is that glibc recommends not using the function. From the bugs section of the GNU man page for cuserid(3) [1]: 

    "Nobody knows precisely what cuserid() does; avoid it in portable programs. Or avoid it altogether: use getpwuid(geteuid()) instead, if that is what you meant. Do not use cuserid()."

After reading the commit that introduced `cuserid()` (b31cff1) I believe that `getpwuid(getuid())` should provide the same functionality as a fallback if/when `getlogin()` returns nothing , but let me know if there are concerns with this change.


[1] https://linux.die.net/man/3/cuserid