### PR TITLE
Lower memory limits and improve their checking

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1925,6 +1925,7 @@ behaviour.
 
 * *OSCAP_FULL_VALIDATION=1* - validate all exported documents (slower)
 * *SEXP_VALIDATE_DISABLE=1* - do not validate SEXP expressions (faster)
+* *OSCAP_PROBE_MEMORY_USAGE_RATIO* - maximum memory usage ratio (used/total) for OpenSCAP probes, default: 0.1
 
 
 

--- a/src/OVAL/probes/probe/icache.c
+++ b/src/OVAL/probes/probe/icache.c
@@ -458,13 +458,12 @@ int probe_icache_nop(probe_icache_t *cache)
 }
 
 #define PROBE_RESULT_MEMCHECK_CTRESHOLD  1000  /* item count */
-#define PROBE_RESULT_MEMCHECK_MAXRATIO   0.1   /* max. memory usage ratio - used/total */
 
 /**
  * Returns 0 if the memory constraints are not reached. Otherwise, 1 is returned.
  * In case of an error, -1 is returned.
  */
-static int probe_cobj_memcheck(size_t item_cnt)
+static int probe_cobj_memcheck(size_t item_cnt, double max_ratio)
 {
 	if (item_cnt > PROBE_RESULT_MEMCHECK_CTRESHOLD) {
 		struct proc_memusage mu_proc;
@@ -479,9 +478,9 @@ static int probe_cobj_memcheck(size_t item_cnt)
 
 		c_ratio = (double)mu_proc.mu_rss/(double)(mu_sys.mu_total);
 
-		if (c_ratio > PROBE_RESULT_MEMCHECK_MAXRATIO) {
+		if (c_ratio > max_ratio) {
 			dW("Memory usage ratio limit reached! limit=%f, current=%f, used=%ld MB, free=%ld MB, total=%ld MB, count of items=%ld",
-			   PROBE_RESULT_MEMCHECK_MAXRATIO, c_ratio, mu_proc.mu_rss / 1024, mu_sys.mu_realfree / 1024, mu_sys.mu_total / 1024, item_cnt);
+			max_ratio, c_ratio, mu_proc.mu_rss / 1024, mu_sys.mu_realfree / 1024, mu_sys.mu_total / 1024, item_cnt);
 			errno = ENOMEM;
 			return (1);
 		}
@@ -520,7 +519,7 @@ int probe_item_collect(struct probe_ctx *ctx, SEXP_t *item)
 	cobj_itemcnt = SEXP_list_length(cobj_content);
 	SEXP_free(cobj_content);
 
-	memcheck_ret = probe_cobj_memcheck(cobj_itemcnt);
+	memcheck_ret = probe_cobj_memcheck(cobj_itemcnt, ctx->max_mem_ratio);
 	if (memcheck_ret == -1) {
 		dE("Failed to check available memory");
 		return -1;

--- a/src/OVAL/probes/probe/probe.h
+++ b/src/OVAL/probes/probe/probe.h
@@ -73,6 +73,7 @@ struct probe_ctx {
         SEXP_t         *filters;   /**< object filters (OVAL 5.8 and higher) */
         probe_icache_t *icache;    /**< item cache */
 	int offline_mode;
+	double max_mem_ratio;
 };
 
 typedef enum {

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -37,6 +37,10 @@
 
 #include "worker.h"
 
+/* default max. memory usage ratio - used/total */
+/* can be overridden by environment variable OSCAP_PROBE_MEMORY_USAGE_RATIO */
+#define OSCAP_PROBE_MEMORY_USAGE_RATIO_DEFAULT 0.1
+
 extern bool  OSCAP_GSYM(varref_handling);
 extern void *OSCAP_GSYM(probe_arg);
 
@@ -923,6 +927,14 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 		SEXP_t *varrefs, *mask;
 
 		pctx.offline_mode = probe->selected_offline_mode;
+
+		pctx.max_mem_ratio = OSCAP_PROBE_MEMORY_USAGE_RATIO_DEFAULT;
+		char *max_ratio_str = getenv("OSCAP_PROBE_MEMORY_USAGE_RATIO");
+		if (max_ratio_str != NULL) {
+			double max_ratio = strtod(max_ratio_str, NULL);
+			if (max_ratio != 0)
+				pctx.max_mem_ratio = max_ratio;
+		}
 
 		/* simple object */
                 pctx.icache  = probe->icache;

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -932,7 +932,7 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 		char *max_ratio_str = getenv("OSCAP_PROBE_MEMORY_USAGE_RATIO");
 		if (max_ratio_str != NULL) {
 			double max_ratio = strtod(max_ratio_str, NULL);
-			if (max_ratio != 0)
+			if (max_ratio > 0)
 				pctx.max_mem_ratio = max_ratio;
 		}
 

--- a/src/common/memusage.c
+++ b/src/common/memusage.c
@@ -117,8 +117,6 @@ static int read_status(const char *source, void *base, struct stat_parser *spt, 
 			sp = oscap_bfind(spt, spt_size, sizeof(struct stat_parser),
 			                 linebuf, (int(*)(void *, void *))&cmpkey);
 
-			dI("spt: %s", linebuf);
-
 			if (sp == NULL) {
 				/* drop end of unread line */
 				while (strchr(strval, '\n') == NULL) {


### PR DESCRIPTION
This patch attempts to mitigate problems caused by a large amount of
collected objects such as rhbz#1932833.

Specifically, these changes are made:
- Lower the threshold so that the amount of used memory is checked when
  only 1000 items are collected for the given OVAL object. That's
  because 32768 items (the original value) is already a large amount which
  occupies a lot of memory during further processing.
- Lower the memory usage ratio limit for the probe to 10 %. We have
  found experimentally that giving the probe 15 % or more will cause the
  oscap process to be killed when processing the collected data and
  generating results.
- In the calling function probe_item_collect, distinguish between return
  codes which means different behavior when there is insufficient memory
  than when the memory consumption can't be checked.
- Improve the warning message to show greater details about memory
  consumption to the user.
- Remove the check for the absolute amount of remaining free memory. As
  we can see on the example of rhbz#1932833, on systems with large
  amount of memory the remaining memory of 512 MB isn't enough memory for
  openscap to process the collected data. At the same time, if we lowered
  the usage ratio, we don't need this anymore.
- Remove useless message "spt:" from the verbose log because it's
  produced many times and pollutes the log extremely.