### PR TITLE
Patch the "bz2_datastream" test for env with /tmp on a dedicated partition or LV

### DIFF
--- a/tests/bz2/test_bz2_datastream.sh
+++ b/tests/bz2/test_bz2_datastream.sh
@@ -48,12 +48,13 @@ bash $builddir/run ./test_bz2_memory_source "${sds}.bz2" | grep 'SCAP Source Dat
 #
 ret=0
 $OSCAP xccdf eval "${xccdf}.bz2" 2> $stderr || ret=$?
-[ $ret -eq 2 ]; ret=0
+[ $ret -eq 2 -o $ret -eq 0 ]
 [ ! -s $stderr ]
 
+ret=0
 arf=$dir/arf.xml
 $OSCAP xccdf eval --results-arf $arf "${sds}.bz2" 2> $stderr || ret=$?
-[ $ret -eq 2 ]
+[ $ret -eq 2 -o $ret -eq 0 ]
 [ ! -s $stderr ]
 
 #


### PR DESCRIPTION
The test is not working well on machines with a dedicated `/tmp` folder (LVM in my case).
When running the test, the following error occurs (I've added a `set -x -e -o pipefail` option at the start of the test):

```
$ ctest --output-on-failure -R '.*bz2.*'

...
+ ret=0
+ bash /home/mdedonno/openscapdev/build/run /home/mdedonno/openscapdev/build/utils/oscap xccdf eval /tmp/test_bz2_datastream.j8Ckf1/xccdf.xml.bz2
Title   Ensure that /tmp has its own partition or logical volume
Rule    xccdf_cdf_rule_first-oval
Result  pass

Title   Ensure that /tmp has its own partition or logical volume
Rule    xccdf_cdf_rule_second-oval
Result  pass

+ '[' 0 -eq 2 ']'


0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.63 sec

The following tests FAILED:
        161 - bz2/test_bz2_datastream.sh (Failed)
```

With the following `df -h`:

```
Filesystem                             Size  Used Avail Use% Mounted on
udev                                   974M     0  974M   0% /dev
tmpfs                                  199M  620K  198M   1% /run
/dev/mapper/debian11openscap--vg-root  3.9G  1.3G  2.4G  36% /
tmpfs                                  992M     0  992M   0% /dev/shm
tmpfs                                  5.0M     0  5.0M   0% /run/lock
/dev/vda1                              470M   48M  398M  11% /boot
/dev/mapper/debian11openscap--vg-tmp   343M  301K  320M   1% /tmp
/dev/mapper/debian11openscap--vg-var   1.6G  371M  1.2G  25% /var
/dev/mapper/debian11openscap--vg-home   13G  482M   12G   5% /home
tmpfs                                  199M     0  199M   0% /run/user/100
```

In my sense, the fact that the test has been sucessfully checked (and passed in my case) is an indication that the scanner is working.
I propose to check error codes `2` and `0` for success in the context of the `tests/bz2/test_bz2_datastream.sh` test.
