### PR TITLE
Patch the `segfault` in dpkginfo_fini()

### DIFF
--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
+++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
@@ -133,7 +133,9 @@ int dpkginfo_init()
 
 int dpkginfo_fini()
 {
-        cgCache->Close();
+        if (cgCache != NULL) {
+                cgCache->Close();
+        }
 
         delete cgCache;
         cgCache = NULL;


### PR DESCRIPTION
Full discussion with details and how the bug was found and solved: https://github.com/ComplianceAsCode/content/issues/7718

# Description of the problem

When using the scanner on a Debian based machine (debian 9, 10, 11, and ubuntu 20.04, and probably more, did not tested), the scanner write correctly the report.html on disk, but `segfault` after that.

```
mdedonno@debian11openscap:~/openscap/build$ /home/mdedonno/openscap/build/oscap_wrapper xccdf eval --profile xccdf_org.ssgproject.content_profile_anssi_np_nt28_restrictive --report /home/mdedonno/report.html /home/mdedonno/ssg-debian11-ds.xml
    ...
/home/mdedonno/openscap/build/oscap_wrapper: line 31: 60801 Segmentation fault      "$b/run" "$b/utils/oscap" "$@"
```

# Solution

By using `gdb` and adding some breakpoints, I've seen that the variable `cgCache` can be `0` in the `dpkginfo_fini` function.

```
...
(gdb) n
(gdb) s
dpkginfo_probe_fini (ptr=0x7ffff7fc95e0 <g_dpkg>) at /home/mdedonno/openscap/src/OVAL/probes/unix/linux/dpkginfo_probe.c:93

(gdb) b /home/mdedonno/openscap/src/OVAL/probes/unix/linux/dpkginfo_probe.c:93
Breakpoint 2 at 0x7ffff7f5eae0: file /home/mdedonno/openscap/src/OVAL/probes/unix/linux/dpkginfo_probe.c, line 93.

(gdb) n
(gdb) s
dpkginfo_fini () at /home/mdedonno/openscap/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx:136

(gdb) print cgCache
$3 = (pkgCacheFile *) 0x0
```
In this case when calling `cgCache->Close();`, we have the `segfault`.

This PR proposes to check for `NULL` before calling the `Close()` function.
