### PR TITLE
Print warning for local files

### DIFF
--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -407,7 +407,9 @@ static int _handle_disabled_downloads(struct ds_sds_session *session, const char
 	char *local_filepath = oscap_path_join(local_files, relative_filepath);
 	struct stat sb;
 	if (stat(local_filepath, &sb) == 0) {
-		dI("Using local file '%s' instead of '%s'", local_filepath, xlink_href);
+		ds_sds_session_remote_resources_progress(session)(true,
+			"WARNING: Using local file '%s' instead of '%s'",
+			local_filepath, xlink_href);
 		struct oscap_source *source_file = oscap_source_new_from_file(local_filepath);
 		xmlDoc *doc = oscap_source_get_xmlDoc(source_file);
 		if (doc == NULL) {

--- a/tests/DS/test_ds_use_local_remote_resources.sh
+++ b/tests/DS/test_ds_use_local_remote_resources.sh
@@ -24,6 +24,7 @@ $OSCAP xccdf eval --local-files "$tmpdir3" --profile "$PROFILE" --results "$resu
 
 grep -q "WARNING: Datastream component 'scap_org.open-scap_cref_remote.oval.xml' points out to the remote 'https://www.example.com/security/data/oval/remote.oval.xml'. Use '--fetch-remote-resources' option to download it." "$stderr" && false
 grep -q "WARNING: Skipping 'https://www.example.com/security/data/oval/remote.oval.xml' file which is referenced from datastream" "$stderr" && false
+grep -q "WARNING: Using local file '$tmpdir3/remote.oval.xml' instead of 'https://www.example.com/security/data/oval/remote.oval.xml'" "$stderr"
 
 assert_exists 1 '//rule-result[@idref="xccdf_com.example.www_rule_test-pass"]/result[text()="pass"]'
 # the remote_res rule is a multicheck with 2 oval definitions so it's twice here


### PR DESCRIPTION
This will explicitely display users that they're using local
files instead of the remote resource.

See https://bugzilla.redhat.com/show_bug.cgi?id=1970529#c6