### PR TITLE
Do not put footer to the user manual

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -29,6 +29,7 @@
 :toclevels: 4
 :toc-placement: preamble
 :numbered:
+:footer-style: none
 
 image::vertical-logo.png[align="center"]
 


### PR DESCRIPTION
The footer contains the date of the last build.

Different date can cause this problem of rpmdeplint:
Undeclared file conflicts:
openscap-1.3.5-8.el8.i686 provides /usr/share/doc/openscap/manual/manual.html which is also provided by openscap-1.3.5-8.el8.x86_64
openscap-1.3.5-8.el8.x86_64 provides /usr/share/doc/openscap/manual/manual.html which is also provided by openscap-1.3.5-8.el8.i686

We can avoid it by simply removing the date.