### PR TITLE
Fix coverity issues

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -101,6 +101,8 @@ static int _write_text_to_fd_and_free(int output_fd, char *text)
 
 static int _write_remediation_to_fd_and_free(int output_fd, const char* template, char* text)
 {
+	if (text == NULL)
+		return 0;
 	if (oscap_streq(template, "urn:xccdf:fix:script:ansible")) {
 		// Add required indentation in front of every single line
 


### PR DESCRIPTION
This PR fixes some issues found by Coverity scan. 

Addressing:
 openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy_remediate.c:115:38: warning[-Wanalyzer-possible-null-argument]: use of possibly-NULL 'current' where non-null expected