### PR TITLE
Prevent fails of test_ds_misc.sh

### DIFF
--- a/tests/DS/test_ds_misc.sh
+++ b/tests/DS/test_ds_misc.sh
@@ -269,6 +269,8 @@ function test_source_date_epoch() {
 	local timestamp="2020-03-05T12:09:37"
 	export SOURCE_DATE_EPOCH="1583410177"
 	export TZ=UTC
+	# ensure the file mtime is always newer than the $timestamp
+	touch -c "$xccdf"
 	$OSCAP ds sds-compose "$xccdf" "$result"
 	assert_exists 3 '//ds:component[@timestamp="'$timestamp'"]'
 	rm -f "$result"


### PR DESCRIPTION
The SOURCE_DATE_EPOCH environment variable is effective only when it's
set to a value that's older than mtime of the processed file.  See the
implementation in ds_sds_compose_add_component_internal in src/DS/sds.c.
However, the file in our test suite has originally been created before
(in 2019) and this mtime can be used when a tarball is produced. To
avoid the test failing, we can modify the mtime using the touch command
just before we run the tests.