### PR TITLE
Prevent file permissions errors

### DIFF
--- a/src/common/elements.c
+++ b/src/common/elements.c
@@ -227,29 +227,9 @@ int oscap_xml_save_filename(const char *filename, xmlDocPtr doc)
 		xmlCode = xmlSaveFormatFileEnc(filename, doc, "UTF-8", 1);
 	}
 	else {
-#ifdef OS_WINDOWS
-		int fd = open(filename, O_CREAT|O_TRUNC|O_WRONLY, S_IREAD|S_IWRITE);
-#else
-		int fd = open(filename, O_CREAT|O_TRUNC|O_WRONLY,
-				S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
-#endif
-		if (fd == -1) {
-			if (errno == EACCES) {
-				/* File already exists and we aren't allowed to create a new one
-				with the same name */
-#ifdef OS_WINDOWS
-				fd = open(filename, O_WRONLY|O_TRUNC, S_IREAD|S_IWRITE);
-#else
-				fd = open(filename, O_WRONLY|O_TRUNC,
-						S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
-#endif
-			}
-			if (fd == -1) {
-				oscap_seterr(OSCAP_EFAMILY_GLIBC,
-						"%s '%s'", strerror(errno), filename);
-				return -1;
-			}
-		}
+		int fd = oscap_open_writable(filename);
+		if (fd == -1)
+			return -1;
 
 		buff = xmlOutputBufferCreateFd(fd, NULL);
 		if (buff == NULL) {

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -524,4 +524,16 @@ wchar_t *oscap_windows_str_to_wstr(const char *str);
 char *oscap_windows_error_message(unsigned long error_code);
 #endif
 
-#endif				/* OSCAP_UTIL_H_ */
+/**
+ * Open a file for writing.
+ * The main difference from fopen() is that if the file exists but its opening
+ * for writing fails as permission denied, it will attempt to open it again
+ * without the O_CREAT flag. This is useful when writing to world-writeable
+ * directories with sticky bit such as /tmp on systems with fs.protected_regular
+ * turned on.
+ * @param filename name of the file to be opened
+ * @return file descriptor or -1 on error
+ */
+int oscap_open_writable(const char *filename);
+
+#endif              /* OSCAP_UTIL_H_ */

--- a/src/source/xslt.c
+++ b/src/source/xslt.c
@@ -85,7 +85,11 @@ static int xccdf_ns_xslt_workaround(xmlDocPtr doc, xmlNodePtr node)
 
 static inline int save_stylesheet_result_to_file(xmlDoc *resulting_doc, xsltStylesheet *stylesheet, const char *outfile)
 {
+#ifdef OS_WINDOWS
+	int fd = _fileno(stdout);
+#else
 	int fd = STDOUT_FILENO;
+#endif
 	if (outfile) {
 #ifdef OS_WINDOWS
 		fd = open(outfile, O_WRONLY|O_CREAT|O_TRUNC, S_IREAD|S_IWRITE);
@@ -115,7 +119,11 @@ static inline int save_stylesheet_result_to_file(xmlDoc *resulting_doc, xsltStyl
 	if (ret < 0) {
 		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Could not save result document");
 	}
+#ifdef OS_WINDOWS
+	if (fd != _fileno(stdout))
+#else
 	if (fd != STDOUT_FILENO)
+#endif
 		close(fd);
 	return ret;
 }

--- a/src/source/xslt.c
+++ b/src/source/xslt.c
@@ -30,6 +30,8 @@
 #include <libxslt/xsltutils.h>
 #include <libexslt/exslt.h>
 #include <string.h>
+#include <sys/stat.h>
+
 #ifdef OS_WINDOWS
 #include <io.h>
 #else

--- a/tests/API/XCCDF/unittests/CMakeLists.txt
+++ b/tests/API/XCCDF/unittests/CMakeLists.txt
@@ -2,6 +2,8 @@ add_oscap_test_executable(test_oscap_common
 	"test_oscap_common.c"
 	${CMAKE_SOURCE_DIR}/src/common/util.c
 	${CMAKE_SOURCE_DIR}/src/common/list.c
+	${CMAKE_SOURCE_DIR}/src/common/error.c
+	${CMAKE_SOURCE_DIR}/src/common/err_queue.c
 )
 
 add_oscap_test_executable(test_xccdf_overrides

--- a/tests/API/XCCDF/unittests/test_oscap_common.c
+++ b/tests/API/XCCDF/unittests/test_oscap_common.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include "common/list.h"
 #include "common/util.h"
+#include "common/_error.h"
 #include "oscap_assert.h"
 
 #define SEEN_LEN 9


### PR DESCRIPTION
The sysctl setting `fs.protected_regular` doesn't allow `O_CREAT` open
on regular files that we don't own in world writable sticky directories
(think `/tmp`). This causes permission denied error when writing HTML
report to a temporary files created by the `mktemp` command executed as
a normal user and then executing `sudo oscap`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2048571

If OpenSCAP fails to open the file because of permissions, it will retry
to open the file without O_CREAT flag.

Supersedes #1845 .