### PR TITLE
Remove EPEL build targets from Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,8 +12,6 @@ jobs:
   metadata:
     targets:
     - fedora-all-x86_64
-    - epel-8-x86_64
-    - epel-9-x86_64
     - centos-stream-8-x86_64
     - centos-stream-9-x86_64
 


### PR DESCRIPTION
EPEL build targets are redundant as we now have CentOS Stream
build targets.