### PR TITLE
Reset errno before call to strtoll

### DIFF
--- a/src/common/memusage.c
+++ b/src/common/memusage.c
@@ -71,6 +71,8 @@ static int read_common_sizet(void *szp, char *strval)
 		return (-1);
 
 	*end = '\0';
+
+	errno = 0;
 	*(size_t *)szp = strtoll(strval, NULL, 10);
 
 	if (errno == EINVAL ||


### PR DESCRIPTION
While debugging https://github.com/OpenSCAP/openscap/issues/1858, I see that strtoll was being called before resetting errno. In some cases, it can result in false positives.