### PR TITLE
Packit: fix build issue on Fedora Rawhide

### DIFF
--- a/openscap.spec
+++ b/openscap.spec
@@ -212,3 +212,6 @@ ln -sf ../oscap-remediate.service %{buildroot}%{_unitdir}/system-update.target.w
 %{python3_sitelib}/oscap_docker_python/*
 %{_bindir}/oscap-podman
 %{_mandir}/man8/oscap-podman.8*
+
+%changelog
+%autochangelog


### PR DESCRIPTION
If the `source_date_epoch_from_changelog` is set to true,
the `SOURCE_DATE_EPOCH` environment variable is set to the timestamp
of the topmost changelog entry. As we do not have a changelog
in the upstream spec file we auto generate it.