### PR TITLE
Add unit test for read_common_sizet function

### DIFF
--- a/tests/API/probes/CMakeLists.txt
+++ b/tests/API/probes/CMakeLists.txt
@@ -38,3 +38,12 @@ target_include_directories(oval_fts_list PUBLIC
 )
 target_link_libraries(oval_fts_list openscap)
 add_oscap_test("fts.sh")
+
+add_oscap_test_executable(test_memusage
+	"test_memusage.c"
+	"${CMAKE_SOURCE_DIR}/src/common/bfind.c"
+)
+target_include_directories(test_memusage PUBLIC
+	"${CMAKE_SOURCE_DIR}/src/common"
+)
+add_oscap_test("test_memusage.sh")

--- a/tests/API/probes/test_memusage.c
+++ b/tests/API/probes/test_memusage.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * Authors:
+ *      "Jan Černý" <jcerny@redhat.com>
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include "memusage.h"
+#include "memusage.c"
+#define OS_LINUX
+
+static int test_basic()
+{
+	size_t size;
+	char *strval = strdup("17 MB");
+	read_common_sizet(&size, strval);
+	free(strval);
+	return (size == 17);
+}
+
+static int test_errno()
+{
+	size_t size;
+	char *strval = strdup("17 MB");
+
+	/* Test that setting errno outside of the read_common_sizet function
+	 * doesn't influence the function and doesn't make the function fail.
+	 */
+	errno = EINVAL;
+
+	int ret = read_common_sizet(&size, strval);
+	free(strval);
+	return (ret != -1);
+}
+
+int main(int argc, char *argv[])
+{
+	if (!test_basic()) {
+		fprintf(stderr, "test_basic has failed\n");
+		return 1;
+	}
+	if (!test_errno()) {
+		fprintf(stderr, "test_errno has failed\n");
+		return 1;
+	}
+	return 0;
+}

--- a/tests/API/probes/test_memusage.c
+++ b/tests/API/probes/test_memusage.c
@@ -12,16 +12,34 @@
 static int test_basic()
 {
 	size_t size;
-	char *strval = strdup("17 MB");
-	read_common_sizet(&size, strval);
+	char *strval = strdup("17 kB\n");
+	int ret = read_common_sizet(&size, strval);
 	free(strval);
-	return (size == 17);
+	return (size == 17 && ret == 0);
+}
+
+static int test_no_unit()
+{
+	size_t size;
+	char *strval = strdup("42");
+	int ret = read_common_sizet(&size, strval);
+	free(strval);
+	return (ret == -1);
+}
+
+static int test_invalid_number()
+{
+	size_t size;
+	char *strval = strdup("www kB\n");
+	int ret = read_common_sizet(&size, strval);
+	free(strval);
+	return (size == 0 && ret == 0);
 }
 
 static int test_errno()
 {
 	size_t size;
-	char *strval = strdup("17 MB");
+	char *strval = strdup("17 kB\n");
 
 	/* Test that setting errno outside of the read_common_sizet function
 	 * doesn't influence the function and doesn't make the function fail.
@@ -37,6 +55,14 @@ int main(int argc, char *argv[])
 {
 	if (!test_basic()) {
 		fprintf(stderr, "test_basic has failed\n");
+		return 1;
+	}
+	if (!test_no_unit()) {
+		fprintf(stderr, "test_no_unit has failed\n");
+		return 1;
+	}
+	if (!test_invalid_number()) {
+		fprintf(stderr, "test_invalid_number has failed\n");
 		return 1;
 	}
 	if (!test_errno()) {

--- a/tests/API/probes/test_memusage.c
+++ b/tests/API/probes/test_memusage.c
@@ -1,24 +1,4 @@
-/*
- * Copyright 2022 Red Hat Inc., Durham, North Carolina.
- * All Rights Reserved.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- *
- * Authors:
- *      "Jan Černý" <jcerny@redhat.com>
- */
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>

--- a/tests/API/probes/test_memusage.sh
+++ b/tests/API/probes/test_memusage.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+. $builddir/tests/test_common.sh
+
+if [ -n "${CUSTOM_OSCAP+x}" ] ; then
+    exit 255
+fi
+
+./test_memusage


### PR DESCRIPTION
The unit test will cover the missing set errno
to 0 which was the root cause of:
https://github.com/OpenSCAP/openscap/issues/1867

Therefore, this test can be used during verification of:
https://bugzilla.redhat.com/show_bug.cgi?id=2109485