### PR TITLE
Reset errno before strtol

### DIFF
--- a/src/OVAL/probes/independent/sql57_probe.c
+++ b/src/OVAL/probes/independent/sql57_probe.c
@@ -216,6 +216,7 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 			matchitem1(tok, 'c',
 				   "onnecttimeout", tmp);
 			if (tmp != NULL) {
+				errno = 0;
 				info->conn_timeout = strtol(tmp, NULL, 10);
 
 				if (errno == ERANGE || errno == EINVAL)

--- a/src/OVAL/probes/independent/sql_probe.c
+++ b/src/OVAL/probes/independent/sql_probe.c
@@ -216,6 +216,7 @@ static int dbURIInfo_parse(dbURIInfo_t *info, const char *conn)
 			matchitem1(tok, 'c',
 				   "onnecttimeout", tmp);
 			if (tmp != NULL) {
+				errno = 0;
 				info->conn_timeout = strtol(tmp, NULL, 10);
 
 				if (errno == ERANGE || errno == EINVAL)

--- a/src/OVAL/probes/oval_fts.c
+++ b/src/OVAL/probes/oval_fts.c
@@ -729,6 +729,7 @@ OVAL_FTS *oval_fts_open_prefixed(const char *prefix, SEXP_t *path, SEXP_t *filen
 	/* max_depth */
 	PROBE_ENT_AREF(behaviors, r0, "max_depth", return NULL;);
 	SEXP_string_cstr_r(r0, cstr_buff, sizeof cstr_buff - 1);
+	errno = 0;
 	max_depth = strtol(cstr_buff, NULL, 10);
 	if (errno == EINVAL || errno == ERANGE) {
 		dE("Invalid value of the `%s' attribute: %s", "recurse_direction", cstr_buff);

--- a/src/OVAL/probes/unix/xinetd_probe.c
+++ b/src/OVAL/probes/unix/xinetd_probe.c
@@ -1280,6 +1280,7 @@ int op_assign_bool(void *var, char *val)
 		*((bool *)(var)) = false;
 	} else {
 		char *endptr = NULL;
+		errno = 0;
 		*((bool *)(var)) = (bool) strtol (val, &endptr, 2);
 		if (errno == EINVAL || errno == ERANGE) {
 			return -1;


### PR DESCRIPTION
This sets errno to 0 before strotol calls after which the errno
is being checked.

Per man 3 strtol:
Since  strtol()  can  legitimately  return 0, LONG_MAX, or
LONG_MIN (LLONG_MAX or LLONG_MIN for strtoll()) on both success and
failure, the calling program should set errno to 0 before the call, and
then determine if an error occurred by checking whether errno has a
nonzero value after the call.

This is inspired by https://github.com/OpenSCAP/openscap/pull/1861.