### PR TITLE
Add CMake option to disable oscap-remediate service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,7 @@ cmake_dependent_option(ENABLE_OSCAP_UTIL_VM "enables the oscap-vm utility, this 
 cmake_dependent_option(ENABLE_OSCAP_UTIL_PODMAN "enables the oscap-podman utility, this lets you scan Podman containers and container images" ON "NOT WIN32" OFF)
 cmake_dependent_option(ENABLE_OSCAP_UTIL_CHROOT "enables the oscap-chroot utility, this lets you scan entire chroots using offline scanning" ON "NOT WIN32" OFF)
 option(ENABLE_OSCAP_UTIL_AUTOTAILOR "enables the autotailor utility that is able to perform command-line tailoring" TRUE)
+option(ENABLE_OSCAP_REMEDIATE_SERVICE "enables the oscap-remediate service" TRUE)
 
 # ---------- TEST-SUITE SWITCHES
 
@@ -609,12 +610,14 @@ if(NOT WIN32)
 		DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 	)
 	if(WITH_SYSTEMD)
-		# systemd service for offline (boot-time) remediation
-		configure_file("oscap-remediate.service.in" "oscap-remediate.service" @ONLY)
-		install(FILES
-			${CMAKE_CURRENT_BINARY_DIR}/oscap-remediate.service
-			DESTINATION ${SYSTEMD_UNITDIR}
-		)
+		if(ENABLE_OSCAP_REMEDIATE_SERVICE)
+			# systemd service for offline (boot-time) remediation
+			configure_file("oscap-remediate.service.in" "oscap-remediate.service" @ONLY)
+			install(FILES
+				${CMAKE_CURRENT_BINARY_DIR}/oscap-remediate.service
+				DESTINATION ${SYSTEMD_UNITDIR}
+			)
+		endif()
 	endif()
 endif()
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -59,15 +59,17 @@ if(ENABLE_OSCAP_UTIL)
 		)
 
 		if(WITH_SYSTEMD)
-			install(PROGRAMS "oscap-remediate"
-				DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}
-			)
-			install(PROGRAMS "oscap-remediate-offline"
-				DESTINATION ${CMAKE_INSTALL_BINDIR}
-			)
-			install(FILES "oscap-remediate-offline.8"
-				DESTINATION "${CMAKE_INSTALL_MANDIR}/man8"
-			)
+			if (ENABLE_OSCAP_REMEDIATE_SERVICE)
+				install(PROGRAMS "oscap-remediate"
+					DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}
+				)
+				install(PROGRAMS "oscap-remediate-offline"
+					DESTINATION ${CMAKE_INSTALL_BINDIR}
+				)
+				install(FILES "oscap-remediate-offline.8"
+					DESTINATION "${CMAKE_INSTALL_MANDIR}/man8"
+				)
+			endif()
 		endif()
 	endif()
 endif()


### PR DESCRIPTION
This patch introduces a new CMake build option
ENABLE_OSCAP_REMEDIATE_SERVICE which can be used to disable the
installation of the files related to the oscap-remediate systemd
service. Downstream packagers can use this option to disable shipping
the oscap-remediate service in their RPM spec files.

Resolves: rhbz#2111358
Resolves: rhbz#2111360