### PR TITLE
OVAL/SEAP: Allocate aligned memory in SEXP_rawval_lblk_new

### DIFF
--- a/src/OVAL/probes/SEAP/sexp-value.c
+++ b/src/OVAL/probes/SEAP/sexp-value.c
@@ -106,8 +106,10 @@ uintptr_t SEXP_rawval_lblk_new (uint8_t sz)
 {
         _A(sz < 16);
 
-	struct SEXP_val_lblk *lblk = malloc(sizeof(struct SEXP_val_lblk));
-	lblk->memb = malloc(sizeof(SEXP_t) * (1 << sz));
+        struct SEXP_val_lblk *lblk = oscap_aligned_malloc(
+                sizeof(struct SEXP_val_lblk),
+                SEXP_LBLK_ALIGN);
+        lblk->memb = malloc(sizeof(SEXP_t) * (1 << sz));
 
         lblk->nxsz = ((uintptr_t)(NULL) & SEXP_LBLKP_MASK) | ((uintptr_t)sz & SEXP_LBLKS_MASK);
         lblk->refs = 1;
@@ -517,8 +519,8 @@ void SEXP_rawval_lblk_free (uintptr_t lblkp, void (*func) (SEXP_t *))
                         func (lblk->memb + lblk->real);
                 }
 
-		free(lblk->memb);
-		free(lblk);
+                free(lblk->memb);
+                oscap_aligned_free(lblk);
 
                 if (next != NULL)
                         SEXP_rawval_lblk_free ((uintptr_t)next, func);
@@ -539,8 +541,8 @@ void SEXP_rawval_lblk_free1 (uintptr_t lblkp, void (*func) (SEXP_t *))
                         func (lblk->memb + lblk->real);
                 }
 
-		free(lblk->memb);
-		free(lblk);
+                free(lblk->memb);
+                oscap_aligned_free(lblk);
         }
 
         return;


### PR DESCRIPTION
The lblk pointer is affected by 2-bit LSB magic SEAP uses for reference-counting. On 32-bit platforms it requires extra alignment.

Fixes #1852.

Now it passes all the tests in the test suite on RPi (32-bit, ARMv7).