### PR TITLE
Fix build due to unresolved unitdir

### DIFF
--- a/openscap.spec
+++ b/openscap.spec
@@ -27,6 +27,7 @@ BuildRequires:  glib2-devel
 BuildRequires:  dbus-devel
 BuildRequires:  libyaml-devel
 BuildRequires:  xmlsec1-devel xmlsec1-openssl-devel
+BuildRequires:  systemd
 %if %{?_with_check:1}%{!?_with_check:0}
 BuildRequires:  perl-XML-XPath
 BuildRequires:  bzip2


### PR DESCRIPTION
According to Fedora packaging guidelines
https://fedoraproject.org/wiki/Packaging:Systemd#Filesystem_locations in order for the %{_unitdir} macro to exist, our package must have BuildRequires: systemd.

Addressing:
error: File not found: /builddir/build/BUILDROOT/openscap-1.3.7-0.20220830091921540256.pr1882.62.g2bc28fe27.fc38.x86_64/usr/libexec/oscap-remediate
error: File must begin with "/": %{_unitdir}/oscap-remediate.service
error: File must begin with "/": %{_unitdir}/system-update.target.wants/
    File not found: /builddir/build/BUILDROOT/openscap-1.3.7-0.20220830091921540256.pr1882.62.g2bc28fe27.fc38.x86_64/usr/libexec/oscap-remediate
    File must begin with "/": %{_unitdir}/oscap-remediate.service
    File must begin with "/": %{_unitdir}/system-update.target.wants/