### PR TITLE
ASAN, UBSAN, compiler warning fixes

### DIFF
--- a/src/OVAL/probes/SEAP/MurmurHash3.c
+++ b/src/OVAL/probes/SEAP/MurmurHash3.c
@@ -216,27 +216,27 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
 #endif
   switch(len & 15)
   {
-  case 15: k4 ^= tail[14] << 16;
-  case 14: k4 ^= tail[13] << 8;
-  case 13: k4 ^= tail[12] << 0;
+  case 15: k4 ^= (uint32_t)tail[14] << 16;
+  case 14: k4 ^= (uint32_t)tail[13] << 8;
+  case 13: k4 ^= (uint32_t)tail[12] << 0;
            k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
 
-  case 12: k3 ^= tail[11] << 24;
-  case 11: k3 ^= tail[10] << 16;
-  case 10: k3 ^= tail[ 9] << 8;
-  case  9: k3 ^= tail[ 8] << 0;
+  case 12: k3 ^= (uint32_t)tail[11] << 24;
+  case 11: k3 ^= (uint32_t)tail[10] << 16;
+  case 10: k3 ^= (uint32_t)tail[ 9] << 8;
+  case  9: k3 ^= (uint32_t)tail[ 8] << 0;
            k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
 
-  case  8: k2 ^= tail[ 7] << 24;
-  case  7: k2 ^= tail[ 6] << 16;
-  case  6: k2 ^= tail[ 5] << 8;
-  case  5: k2 ^= tail[ 4] << 0;
+  case  8: k2 ^= (uint32_t)tail[ 7] << 24;
+  case  7: k2 ^= (uint32_t)tail[ 6] << 16;
+  case  6: k2 ^= (uint32_t)tail[ 5] << 8;
+  case  5: k2 ^= (uint32_t)tail[ 4] << 0;
            k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
 
-  case  4: k1 ^= tail[ 3] << 24;
-  case  3: k1 ^= tail[ 2] << 16;
-  case  2: k1 ^= tail[ 1] << 8;
-  case  1: k1 ^= tail[ 0] << 0;
+  case  4: k1 ^= (uint32_t)tail[ 3] << 24;
+  case  3: k1 ^= (uint32_t)tail[ 2] << 16;
+  case  2: k1 ^= (uint32_t)tail[ 1] << 8;
+  case  1: k1 ^= (uint32_t)tail[ 0] << 0;
            k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
   };
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)

--- a/src/OVAL/probes/independent/xmlfilecontent_probe.c
+++ b/src/OVAL/probes/independent/xmlfilecontent_probe.c
@@ -296,7 +296,7 @@ static int process_file(const char *prefix, const char *path, const char *filena
 
 		node_cnt = nodes->nodeNr;
 		dD("node_cnt: %d.", node_cnt);
-		if (node_cnt == 0) {
+		if (node_cnt <= 0) {
 			probe_item_setstatus(item, SYSCHAR_STATUS_DOES_NOT_EXIST);
 			probe_item_ent_add(item, "value_of", NULL, NULL);
 			probe_itement_setstatus(item, "value_of", 1, SYSCHAR_STATUS_DOES_NOT_EXIST);
@@ -305,7 +305,7 @@ static int process_file(const char *prefix, const char *path, const char *filena
 			for (i = 0; i < node_cnt; ++i) {
 				cur_node = node_tab[i];
 				dD("node[%d] line: %d, name: '%s', type: %d.",
-				   i, cur_node->line, cur_node->name, cur_node->type);
+				   i, XML_GET_LINE(cur_node), cur_node->name, cur_node->type);
 				if (cur_node->type == XML_ATTRIBUTE_NODE
 				    || cur_node->type == XML_TEXT_NODE) {
 					xmlChar *value;

--- a/src/OVAL/probes/unix/interface_probe.c
+++ b/src/OVAL/probes/unix/interface_probe.c
@@ -402,8 +402,8 @@ static int get_ifs(SEXP_t *name_ent, probe_ctx *ctx, oval_schema_version_t over)
 		else {
 			struct sockaddr_in6 *sin6p;
 			char host_tmp[NI_MAXHOST];
-			int bit, byte, prefix = 0;
-			u_int32_t tmp;
+			int byte, prefix = 0;
+			u_int32_t bit, tmp;
 			int host_len;
 
 			sin6p = (struct sockaddr_in6 *) ifa->ifa_addr;

--- a/src/OVAL/probes/unix/linux/iflisteners_probe.c
+++ b/src/OVAL/probes/unix/linux/iflisteners_probe.c
@@ -88,7 +88,7 @@ typedef struct {
 } llist;
 
 struct interface_t {
-  char interface_name[255];
+  char interface_name[256];
   char hw_address[255];
 };
 
@@ -344,7 +344,7 @@ static int get_interface(const int ent_ifindex, struct interface_t *interface) {
 		fclose(fd);
 
 		if (ent_ifindex == ifindex) {
-			strncpy(interface->interface_name, d_ent->d_name, sizeof interface->interface_name);
+			strncpy(interface->interface_name, d_ent->d_name, sizeof interface->interface_name - 1);
 			interface->interface_name[sizeof interface->interface_name - 1] = '\0';
 			snprintf(buf, sizeof buf - 1, "/sys/class/net/%s/address", d_ent->d_name);
 			fd = fopen(buf, "rt");

--- a/src/OVAL/probes/unix/xinetd_probe.c
+++ b/src/OVAL/probes/unix/xinetd_probe.c
@@ -522,7 +522,8 @@ static xiconf_file_t *xiconf_read(const char *path, int flags)
 	{
 		/* fallback method - copy the contents into memory */
 
-		file->inmem = malloc(file->inlen);
+		file->inmem = malloc(file->inlen+1);
+		file->inmem[file->inlen] = '\0';
 
 		if (read (file->fd, file->inmem, file->inlen) != (ssize_t)file->inlen) {
 			/* Can't read the contents of the file */

--- a/src/common/memusage.c
+++ b/src/common/memusage.c
@@ -143,7 +143,10 @@ static int read_status(const char *source, void *base, struct stat_parser *spt, 
 				/* drop end of unread line */
 				while (strchr(strval, '\n') == NULL) {
 					linebuf[0] = '\n';
-					fgets(linebuf, sizeof linebuf - 1, fp);
+					if (fgets(linebuf, sizeof linebuf - 1, fp) == NULL) {
+						fclose(fp);
+						return (-1);
+					}
 					strval = linebuf;
 				}
 				continue;

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -367,7 +367,9 @@ int app_ds_sds_compose(const struct oscap_action *action) {
 
 	char* temp_cwd = strdup(action->ds_action->file);
 	char *temp_cwd_dirname = oscap_dirname(temp_cwd);
-	chdir(temp_cwd_dirname);
+	if (chdir(temp_cwd_dirname) < 0) {
+		goto cleanup;
+	}
 	free(temp_cwd_dirname);
 	free(temp_cwd);
 
@@ -377,7 +379,9 @@ int app_ds_sds_compose(const struct oscap_action *action) {
 	free(base_name);
 	free(source_xccdf);
 
-	chdir(previous_cwd);
+	if (chdir(previous_cwd) < 0) {
+		goto cleanup;
+	}
 	free(previous_cwd);
 
 	if (action->validate)


### PR DESCRIPTION
Assortment of changes I saw after I enabled ASAN and UBSAN.

Target here was for me to enable sanitizers and see that ctest passes and then see that my tailored DS passes too. I was not able to make ASAN to work with some plugins so I needed to modify testing etc to skip those.