### PR TITLE
Remove changelog from SPEC

### DIFF
--- a/openscap.spec
+++ b/openscap.spec
@@ -214,5 +214,3 @@ ln -sf ../oscap-remediate.service %{buildroot}%{_unitdir}/system-update.target.w
 %{_bindir}/oscap-podman
 %{_mandir}/man8/oscap-podman.8*
 
-%changelog
-%autochangelog


### PR DESCRIPTION
This avoids this problem in the CentOS Stream 8 build in Packit.

```
error: %changelog entries must start with *
```

Most likely, the reason would be that the `%autochangelog` macro isn't supported on CS8.