### PR TITLE
fix: oval_cmp_evr_string: fixed undefined reference to risdigit when rpm is not available.

### DIFF
--- a/src/OVAL/results/oval_cmp_evr_string.c
+++ b/src/OVAL/results/oval_cmp_evr_string.c
@@ -50,11 +50,12 @@
 #include <alloca.h>
 #endif
 static int rpmvercmp(const char *a, const char *b);
+#endif
+
 static int risdigit(int c) {
 	// locale independent
 	return (c >= '0' && c <= '9');
 }
-#endif
 
 static inline int rpmevrcmp(const char *a, const char *b);
 static int compare_values(const char *str1, const char *str2);


### PR DESCRIPTION
If `HAVE_RPMCMP` is not defined, build fails with ``ld: src/libopenscap.so.25.2.0: undefined reference to `risdigit'``.