### PR TITLE
Install pcre on OS X CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
         brew install swig
         brew install libxmlsec1
         brew install openssl
+        brew install pcre
 
     # Runs a set of commands using the runners shell
     - name: Build


### PR DESCRIPTION
With the latest version of OS X image in GitHub CI, the pcre library isn't present by default but needs to be installed explicitely. The pcre library is mandatory for the build.