### PR TITLE
Rename master socket to control socket

### DIFF
--- a/utils/oscap-ssh
+++ b/utils/oscap-ssh
@@ -96,31 +96,31 @@ function usage()
 
 # $1, $2, ... SSH options (pass them as separate arguments)
 function ssh_execute_with_options {
-    ssh -o ControlPath="$MASTER_SOCKET" $SSH_ADDITIONAL_OPTIONS "$@" -p "$SSH_PORT" "$SSH_HOST"
+    ssh -o ControlPath="$CONTROL_SOCKET" $SSH_ADDITIONAL_OPTIONS "$@" -p "$SSH_PORT" "$SSH_HOST"
 }
 
 # $1: The SSH command.
 # $2: More of additional options (optional, pass one space-separated string)
 function ssh_execute_with_command_and_options {
-    ssh -o ControlPath="$MASTER_SOCKET" $SSH_ADDITIONAL_OPTIONS $2 -p "$SSH_PORT" "$SSH_HOST" "$1"
+    ssh -o ControlPath="$CONTROL_SOCKET" $SSH_ADDITIONAL_OPTIONS $2 -p "$SSH_PORT" "$SSH_HOST" "$1"
 }
 
 # $1: Local filename to copy
 # $2: Remote destination
 function scp_copy_to_temp_dir {
-    scp -o ControlPath="$MASTER_SOCKET" -P "$SSH_PORT" $SSH_ADDITIONAL_OPTIONS "$1" "$SSH_HOST:$REMOTE_TEMP_DIR/$2"
+    scp -o ControlPath="$CONTROL_SOCKET" -P "$SSH_PORT" $SSH_ADDITIONAL_OPTIONS "$1" "$SSH_HOST:$REMOTE_TEMP_DIR/$2"
 }
 
 # $1: Local directory name to copy
 # $2: Remote destination
 function scp_copy_dir_to_temp_dir {
-    scp -r -o ControlPath="$MASTER_SOCKET" -P "$SSH_PORT" $SSH_ADDITIONAL_OPTIONS "$1" "$SSH_HOST:$REMOTE_TEMP_DIR/$2"
+    scp -r -o ControlPath="$CONTROL_SOCKET" -P "$SSH_PORT" $SSH_ADDITIONAL_OPTIONS "$1" "$SSH_HOST:$REMOTE_TEMP_DIR/$2"
 }
 
 # $1: Remote filename to get
 # $2: Local destination
 function scp_retreive_from_temp_dir {
-    scp -o ControlPath="$MASTER_SOCKET" -P "$SSH_PORT" $SSH_ADDITIONAL_OPTIONS "$SSH_HOST:$REMOTE_TEMP_DIR/$1" "$2"
+    scp -o ControlPath="$CONTROL_SOCKET" -P "$SSH_PORT" $SSH_ADDITIONAL_OPTIONS "$SSH_HOST:$REMOTE_TEMP_DIR/$1" "$2"
 }
 
 # $1: The name of the array holding command elements
@@ -190,8 +190,8 @@ shift 2
 
 check_oscap_arguments "$@"
 
-MASTER_SOCKET_DIR=$(mktemp -d)
-MASTER_SOCKET="$MASTER_SOCKET_DIR/ssh_socket"
+CONTROL_SOCKET_DIR=$(mktemp -d)
+CONTROL_SOCKET="$CONTROL_SOCKET_DIR/ssh_socket"
 
 echo "Connecting to '$SSH_HOST' on port '$SSH_PORT'..."
 ssh_execute_with_options -M -f -N -o ServerAliveInterval=60 || die "Failed to connect!"
@@ -332,8 +332,8 @@ fi
 
 echo "Removing remote temporary directory..."
 ssh_execute_with_command_and_options "rm -r $REMOTE_TEMP_DIR" || die "Failed to remove remote temporary directory!"
-echo "Disconnecting ssh and removing master ssh socket directory..."
+echo "Disconnecting ssh and removing control ssh socket directory..."
 ssh_execute_with_options -O exit || die "Failed to disconnect!"
-rm -r "$MASTER_SOCKET_DIR" || die "Failed to remove local master SSH socket directory!"
+rm -r "$CONTROL_SOCKET_DIR" || die "Failed to remove local control SSH socket directory!"
 
 exit $OSCAP_EXIT_CODE


### PR DESCRIPTION
The original name was misleading, as the ssh manual shows.