### PR TITLE
Rename blacklist in tests

### DIFF
--- a/tests/codestyle/all.sh
+++ b/tests/codestyle/all.sh
@@ -22,9 +22,8 @@ function test_illicit_function_use {
 		return 1;
 	fi
 
-	whitelisted=$(echo $codebase | xsed 's/\S*\/source\/oscap_source.c / /g' -)
-
-	if grep xmlReadFile $whitelisted; then
+	codebase_without_xml_read_file=$(echo $codebase | xsed 's/\S*\/source\/oscap_source.c / /g' -)
+	if grep xmlReadFile $codebase_without_xml_read_file; then
 		echo "xmlReadFile is not allowed within OpenSCAP project. Please make a use of oscap_source facility."
 		return 1;
 	fi


### PR DESCRIPTION
Rename misleading `whitelisted` variable in `tests/codestyle/all.sh`.

Rename `SYSCTL_BLACKLIST*` variables in `tests/probes/sysctl/test_sysctl_probe_all.sh`

