### PR TITLE
Improve naming and clarify comments

### DIFF
--- a/release_tools/naming.sh
+++ b/release_tools/naming.sh
@@ -4,7 +4,7 @@ declare -A name_mapping
 # name_mapping['<duplicate name>']='<canonical name>', e.g.
 # Keep the assignments lexicographicaly sorted by the canonical name and then by the duplicate name.
 
-# If you want to blacklist a name, do e.g.
+# If you want to remove a name completely from the deduplicated listing, do e.g.
 # name_mapping['root@localhost']=
 
 name_mapping['Martin Preisler <martin@preisler.me>']='Martin Preisler <mpreisle@redhat.com>'

--- a/src/OVAL/adt/oval_smc_iterator.c
+++ b/src/OVAL/adt/oval_smc_iterator.c
@@ -25,7 +25,7 @@
  * That is StringMap that points to the oval_collection objects.
  *
  * This module implements only sub set of iterator functionality for iterating
- * through map/list structure. Limits: It supposes that list (slave_col) is
+ * through map/list structure. Limits: It supposes that list (secondary_col) is
  * never empty.
  */
 
@@ -38,9 +38,9 @@
 #include "oval_smc_impl.h"
 
 struct oval_smc_iterator {
-	struct oval_collection *master_col;		///< list of lists
-	struct oval_iterator *master_it;		///< iterating through master_col
-	struct oval_iterator *slave_it;			///< iterating through a single item of master_col
+	struct oval_collection *primary_col;		///< list of lists
+	struct oval_iterator *primary_it;		///< iterating through primary_col
+	struct oval_iterator *secondary_it;			///< iterating through a single item of primary_col
 };
 
 struct oval_smc_iterator *oval_smc_iterator_new(struct oval_smc *mapping)
@@ -50,9 +50,9 @@ struct oval_smc_iterator *oval_smc_iterator_new(struct oval_smc *mapping)
 
 	struct oval_smc_iterator *it = calloc(1, sizeof(struct oval_smc_iterator));
 
-	it->master_col = oval_string_map_collect_values((struct oval_string_map *) mapping, NULL);
-	it->master_it = oval_collection_iterator(it->master_col);
-	it->slave_it = NULL;
+	it->primary_col = oval_string_map_collect_values((struct oval_string_map *) mapping, NULL);
+	it->primary_it = oval_collection_iterator(it->primary_col);
+	it->secondary_it = NULL;
 	return it;
 }
 
@@ -60,37 +60,37 @@ void oval_smc_iterator_free(struct oval_smc_iterator *it)
 {
 	if (it == NULL)
 		return;
-	oval_collection_free(it->master_col);
-	oval_collection_iterator_free(it->master_it);
-	oval_collection_iterator_free(it->slave_it);
+	oval_collection_free(it->primary_col);
+	oval_collection_iterator_free(it->primary_it);
+	oval_collection_iterator_free(it->secondary_it);
 	free(it);
 }
 
 bool oval_smc_iterator_has_more(struct oval_smc_iterator *it)
 {
 	return it != NULL &&
-		(oval_collection_iterator_has_more(it->master_it) ||
-		(it->slave_it &&
-			oval_collection_iterator_has_more(it->slave_it)));
+		(oval_collection_iterator_has_more(it->primary_it) ||
+		(it->secondary_it &&
+			oval_collection_iterator_has_more(it->secondary_it)));
 }
 
 void *oval_smc_iterator_next(struct oval_smc_iterator *it)
 {
 	if (it == NULL)
 		return NULL;
-	if (it->slave_it == NULL || !oval_collection_iterator_has_more(it->slave_it)) {
-		// Rewind master and find new slave
-		if (it->slave_it != NULL) {
-			oval_collection_iterator_free(it->slave_it);
-			it->slave_it = NULL;
+	if (it->secondary_it == NULL || !oval_collection_iterator_has_more(it->secondary_it)) {
+		// Rewind primary and find new secondary
+		if (it->secondary_it != NULL) {
+			oval_collection_iterator_free(it->secondary_it);
+			it->secondary_it = NULL;
 		}
-		if (!oval_collection_iterator_has_more(it->master_it)) {
+		if (!oval_collection_iterator_has_more(it->primary_it)) {
 			assert(false);
 			return NULL;
 		}
-		struct oval_collection *slave_col = (struct oval_collection *) oval_collection_iterator_next(it->master_it);
-		it->slave_it = oval_collection_iterator(slave_col);
+		struct oval_collection *secondary_col = (struct oval_collection *) oval_collection_iterator_next(it->primary_it);
+		it->secondary_it = oval_collection_iterator(secondary_col);
 	}
-	assert(oval_collection_iterator_has_more(it->slave_it));
-	return oval_collection_iterator_next(it->slave_it);
+	assert(oval_collection_iterator_has_more(it->secondary_it));
+	return oval_collection_iterator_next(it->secondary_it);
 }


### PR DESCRIPTION
This PR aims to make the code and comments more expressive - check out individual commits for more information.

- Fix naming of private iterators
- Reformulate a comment in a deduplication database