### PR TITLE
Add dev.tty.legacy_tiocsti to skiplist

### DIFF
--- a/tests/probes/sysctl/test_sysctl_probe_all.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_all.sh
@@ -11,6 +11,7 @@ PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 # non root users are not able to access some kernel params, so they get excluded
 SYSCTL_EXCLUDE='
 	dev.parport.parport0.autoprobe
+	dev.tty.legacy_tiocsti
 	fs.protected_hardlinks
 	fs.protected_fifos
 	fs.protected_regular


### PR DESCRIPTION
This sysctl setting seems to be a new feature in kernel 6.2 and we don't process it.

This fixes the broken CI gating job testing farm on Rawhide.

Addressing:

230/265 Test #230: probes/sysctl/test_sysctl_probe_all.sh .............................................***Failed    0.81 sec
Result file: test_sysctl_probe_all.res.out.ADW5oP
Our names file: test_sysctl_probe_all.our.out.gW7nKh
Sysctl names file: test_sysctl_probe_all.sysctl.out.PMtj7U
Errors file: test_sysctl_probe_all.err.out.oDjUwy
Diff (sysctlNames / ourNames): ------
23d22
< dev.tty.legacy_tiocsti