### PR TITLE
Remove Windows from release Guide

### DIFF
--- a/release_tools/README.adoc
+++ b/release_tools/README.adoc
@@ -66,19 +66,7 @@ Attach `openscap-X.Y.Z.tar.gz` and `openscap-X.Y.Z.tag.gz.sha512` files to the G
 This will create and push version tags, create new GitHub release and handle milestones swap.
 Finally, it will bump version numbers in `versions.sh` to be ready for the next (e.g. 1.3.3) upstream release.
 
-. Build OpenSCAP for Windows
-+
---
-The Windows build process is described in link:../docs/developer/developer.adoc[Developer Manual].
 
-The Windows Installer can be built by running `cpack` in the `build` directory.
-CPack will produce 2 files:
-
-* `OpenSCAP-${version}-win32.msi` which is the installer package
-* `OpenSCAP-${version}-win32.msi.sha512` that contains SHA512 checksum of the installer
-
-Upload both of the files to the GitHub release.
---
 
 == To be done ==
 


### PR DESCRIPTION
According to https://github.com/OpenSCAP/openscap/blob/maint-1.3/docs/windows.md we don't produce release builds.