### PR TITLE
Workaround OS X GitHub Actions CI problems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,9 @@ jobs:
     # Runs a single command using the runners shell
     - name: Install Deps
       run: |
+        # Unlink and re-link to prevent errors when GitHub Mac runner images
+        # install Python outside of Brew:
+        brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
         brew update
         brew install doxygen
         brew install opendbx


### PR DESCRIPTION
Inspired by:
https://github.com/drogue-iot/drogue-cloud/commit/b31e2baa482f5458541a29c991d2d3109085a0c6

Great thanks to @ggbecker for suggestion!

Addressing:
Error: The `brew link` step did not complete successfully The formula built, but is not symlinked into /usr/local Could not symlink bin/2to3-3.11
Target /usr/local/bin/2to3-3.11
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3-3.11'