### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/contribute/testing.adoc
+++ b/docs/contribute/testing.adoc
@@ -11,7 +11,7 @@ its utilities. When you contribute to some part of the OpenSCAP project you
 should put a test for your contribution into the corresponding subdirectory
 in the link:../../tests[tests] directory. Use your best judgement when deciding
 where to put the test for your pull request and if you are not sure don't be
-affraid to ask in the pull request, someone will definitely help you with that.
+afraid to ask in the pull request, someone will definitely help you with that.
 
 NOTE: OpenSCAP project uses the **CMake** buildsystem which has built-in
 testing support through the
@@ -42,7 +42,7 @@ an XCCDF rule using `<check-content-ref>` element, for example:
 
 === Deciding where to put a new test
 In our example, we are testing the SCE module, therefore we will look for
-its subdirectory in the link:../../tests[tests] direcotory and we will find it
+its subdirectory in the link:../../tests[tests] directory and we will find it
 at the following link: link:../../tests/sce[tests/sce]. We will add our new test
 into this subdirectory.
 

--- a/docs/developer/developer.adoc
+++ b/docs/developer/developer.adoc
@@ -324,7 +324,7 @@ behaviour.
 
 
 == Generating of code coverage
-Code coverage can be usefull during writing of test or performance profiling.
+Code coverage can be useful during writing of test or performance profiling.
 We could separate the process into five phases.
 
 1) *Get dependencies*

--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1608,7 +1608,7 @@ not considered local by the scanner:
 
 == List of accepted environment variables
 
-* `OSCAP_CHECK_ENGINE_PLUGIN_DIR` - Defines path to a directory that contains plug-in libraries implementing additonal check engines, eg. SCE.
+* `OSCAP_CHECK_ENGINE_PLUGIN_DIR` - Defines path to a directory that contains plug-in libraries implementing additional check engines, eg. SCE.
 * `OSCAP_CONTAINER_VARS` - Additional environment variables read by environmentvariable58_probe. The variables are separated by `\n`. It is used by `oscap-podman` and `oscap-docker` scripts during container scanning.
 * `OSCAP_EVALUATION_TARGET` - Change value of target facts `urn:xccdf:fact:identifier` and `urn:xccdf:fact:asset:identifier:ein` in XCCDF results. Used during offline scanning to pass the name of the target system.
 * `OSCAP_FULL_VALIDATION` - If set, XML schema validation will be performed in every step of SCAP content processing.
@@ -1806,7 +1806,7 @@ $ oscap xccdf eval --results results.xml --report report.html com.redhat.rhsa-al
 The files we used above cover multiple Red Hat products. If you only want to
 scan one product - for example a specific version of Red Hat Enterprise Linux -
 we advise to download a smaller specialized file covering just this one version.
-Using a smaller file will utilitize less bandwidth and make the evaluation
+Using a smaller file will utilize less bandwidth and make the evaluation
 quicker.
 
 For example for Red Hat Enterprise Linux 7 the plain OVAL file is located at:
@@ -1951,7 +1951,7 @@ $ oscap oval generate report --output oval-report-1.html usgcb-rhel5desktop-oval
 $ oscap oval generate report --output oval-report-2.html http%3A%2F%2Fwww.redhat.com%2Fsecurity%2Fdata%2Foval%2Fcom.redhat.rhsa-all.xml.result.xml
 ----
 
-If you're interested in runing evaluation of the USGCB on a remote machine using
+If you're interested in running evaluation of the USGCB on a remote machine using
 a GUI please see:
 https://open-scap.org/resources/documentation/evaluate-remote-machine-for-usgcb-compliance-with-scap-workbench/[Evaluate
 Remote Machine for USGCB Compliance with SCAP Workbench] tutorial.


### PR DESCRIPTION
Fixes a few typographical errors across the docs:

- `affraid` -> `afraid`
- `direcotory` -> `directory`
- `usefull` -> `useful`
- `additonal` -> `additional`
- `utilitize` -> `utilize`
- `runing` -> `running`
