### PR TITLE
Fix Coverity issues found in the 1.3.7 release

### DIFF
--- a/src/OVAL/probes/independent/xmlfilecontent_probe.c
+++ b/src/OVAL/probes/independent/xmlfilecontent_probe.c
@@ -303,7 +303,7 @@ static int process_file(const char *prefix, const char *path, const char *filena
 			node_tab = nodes->nodeTab;
 			for (i = 0; i < node_cnt; ++i) {
 				cur_node = node_tab[i];
-				dD("node[%d] line: %d, name: '%s', type: %d.",
+				dD("node[%d] line: %ld, name: '%s', type: %d.",
 				   i, XML_GET_LINE(cur_node), cur_node->name, cur_node->type);
 				if (cur_node->type == XML_ATTRIBUTE_NODE
 				    || cur_node->type == XML_TEXT_NODE) {

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -382,7 +382,6 @@ int app_ds_sds_compose(const struct oscap_action *action) {
 	if (chdir(previous_cwd) < 0) {
 		goto cleanup;
 	}
-	free(previous_cwd);
 
 	if (action->validate)
 	{
@@ -399,6 +398,7 @@ int app_ds_sds_compose(const struct oscap_action *action) {
 cleanup:
 	oscap_print_error();
 
+	free(previous_cwd);
 	free(action->ds_action);
 	return ret;
 }

--- a/utils/oscap-ds.c
+++ b/utils/oscap-ds.c
@@ -368,6 +368,8 @@ int app_ds_sds_compose(const struct oscap_action *action) {
 	char* temp_cwd = strdup(action->ds_action->file);
 	char *temp_cwd_dirname = oscap_dirname(temp_cwd);
 	if (chdir(temp_cwd_dirname) < 0) {
+		free(temp_cwd_dirname);
+		free(temp_cwd);
 		goto cleanup;
 	}
 	free(temp_cwd_dirname);


### PR DESCRIPTION
Coverity has discovered 3 new issues in OpenSCAP 1.3.7 release.

For more details, please read commit messages of every commit.