### PR TITLE
Fix -Wint-conversion error building with clang

### DIFF
--- a/swig/openscap.i
+++ b/swig/openscap.i
@@ -475,7 +475,7 @@ char * sub_callback_wrapper(xccdf_subst_type_t type, const char *id, void *arg)
     arglist = Py_BuildValue("isO", type, id, usrdata);
     if (!PyCallable_Check(func)) {
       PyGILState_Release(state);
-      return 1;
+      return NULL;
     }
     result = PyEval_CallObject(func, arglist);
     if (result == NULL) {


### PR DESCRIPTION
openscapPYTHON_wrap.c:3734:14: error: incompatible integer to pointer conversion returning 'int' from a function with result type 'char *' [-Wint-conversion]
      return 1;
             ^

It seems like return 1 is a copy-and-paste error and the function should return NULL here.  It's possible this function (sub_callback_wrapper) is unused and can be deleted but I wasn't sure.