### PR TITLE
Fix compile error with future versions of gcc

### DIFF
--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -30,6 +30,7 @@
 #include <rpm/rpmts.h>
 #include <rpm/rpmmacro.h>
 #include <rpm/rpmlog.h>
+#include <rpm/rpmcrypto.h>
 #include <rpm/header.h>
 
 #include <pthread.h>


### PR DESCRIPTION
Future versions of GCC (estimated version is 14) will have the behavior similar to setting the flag `-Werror=implicit-function-declaration`.
Related bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91092

/builddir/build/BUILD/openscap-1.3.6/src/OVAL/probes/unix/linux/rpminfo_probe.c: In function 'rpminfo_probe_fini': /builddir/build/BUILD/openscap-1.3.6/src/OVAL/probes/unix/linux/rpminfo_probe.c:307:9: error: implicit declaration of function 'rpmFreeCrypto'
  307 |         rpmFreeCrypto();
      |         ^~~~~~~~~~~~~