### PR TITLE
Closes #1928 gh-action to run shellcheck static analyzer

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,25 @@
+name: "ShellCheck"
+
+# please read https://github.com/ludeeus/action-shellcheck 
+# to configure output
+# this tool is more useful when false positives are supressed
+
+on:
+  push:
+    branches: [ 'maint-1.3' ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ 'maint-1.3' ]
+  schedule:
+    - cron: '32 17 * * 0'
+
+jobs:
+  shellcheck-analyze:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: ShellCheck
+      uses: ludeeus/action-shellcheck@2.0.0
+      with:
+        severity: warning


### PR DESCRIPTION
This is a minimal gh-action to run shellcheck.

Please see the ShellCheck step for example output: https://github.com/eslerm/openscap/actions/runs/4147791418/jobs/7175079791

shellcheck exits with an error if issues are found.

If the PR is accepted I'll add false positives for shellcheck to ignore.

I set the severity level to `warning`, since `note`s are mostly noise.