### PR TITLE
apt-devel to BuildRequires; apt-libs to Requires

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       image: fedora:latest
     steps:
     - name: Install Deps
-      run: dnf install -y cmake git dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace
+      run: dnf install -y cmake git dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace apt-devel
     - name: Checkout
       uses: actions/checkout@v3
       with:

--- a/docs/developer/developer.adoc
+++ b/docs/developer/developer.adoc
@@ -56,7 +56,7 @@ sudo yum install \
 cmake dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel \
 libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel \
 pcre-devel perl-XML-Parser perl-XML-XPath perl-devel python-devel rpm-devel swig \
-bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel
+bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel apt-devel
 ----
 
 On Fedora 24+, the command to install the build dependencies is:
@@ -66,7 +66,7 @@ sudo yum install \
 cmake dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel \
 libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel \
 pcre-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig \
-bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel
+bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel apt-devel
 ----
 
 On RHEL 8 / CentOS 8, the command to install the build dependencies is:
@@ -76,7 +76,7 @@ sudo yum install \
 cmake dbus-devel libacl-devel libblkid-devel libcap-devel libcurl-devel \
 libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel \
 pcre-devel perl-XML-Parser perl-XML-XPath perl-devel python36-devel rpm-devel swig \
-bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel
+bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel apt-devel
 ----
 
 On Ubuntu 16.04, Debian 8 or Debian 9, the command to install the build dependencies is:

--- a/openscap.spec
+++ b/openscap.spec
@@ -13,6 +13,9 @@ BuildRequires:  cmake >= 2.6
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  swig libxml2-devel libxslt-devel perl-generators perl-XML-Parser
+%if 0%{?fedora}
+BuildRequires:  apt-devel
+%endif
 BuildRequires:  rpm-devel
 BuildRequires:  libgcrypt-devel
 BuildRequires:  pcre-devel
@@ -41,6 +44,9 @@ Requires:       libacl
 Requires:       libblkid
 Requires:       libcap
 Requires:       libselinux
+%if 0%{?fedora}
+Requires:       apt-libs
+%endif
 Requires:       openldap
 Requires:       popt
 # Fedora has procps-ng, which provides procps


### PR DESCRIPTION
* Using openscap to scan a system that use apt (such as Debian or Ubuntu) returns incomplete results. This warning is logged: OVAL object 'dpkginfo_object' is not supported.
  The problem is that openscap is built without apt support.
  The fix, implemented in this commit, is to add apt as a build requirement.