### PR TITLE
Fix leak of dpkginfo_reply_t fields

### DIFF
--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
+++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
@@ -116,6 +116,11 @@ void dpkginfo_free_reply(struct dpkginfo_reply_t *reply)
 {
         if (reply) {
                 free(reply->name);
+                free(reply->arch);
+                free(reply->epoch);
+                free(reply->release);
+                free(reply->version);
+                free(reply->evr);
                 delete reply;
         }
 }


### PR DESCRIPTION
The arch, epoch, releasem version and evr strings are allocated in dpkginfo_get_by_name, but were not freed in dpkginfo_free_reply.