### PR TITLE
Fix OS X build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
         brew update
         brew install doxygen
         brew install opendbx
+        brew install pkg-config
         brew install popt
         brew install swig
         brew install libxmlsec1


### PR DESCRIPTION
OS X build can't find pkg-config. For example:
https://github.com/OpenSCAP/openscap/actions/runs/4202194906/jobs/7332722182

Addressing:
- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)