### PR TITLE
Fix build on FreeBSD.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,7 +516,7 @@ if (MSVC)
 endif()
 
 if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -W -Wall -Wnonnull -Wshadow -Wformat -Wundef -Wno-unused-parameter -Wmissing-prototypes -Wno-unknown-pragmas -D_GNU_SOURCE -std=c99")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -W -Wall -Wnonnull -Wshadow -Wformat -Wundef -Wno-unused-parameter -Wmissing-prototypes -Wno-unknown-pragmas -Wno-int-conversion -D_GNU_SOURCE -std=c99")
 endif()
 if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
 	add_link_options(-lkvm -lm -lprocstat)

--- a/src/common/memusage.c
+++ b/src/common/memusage.c
@@ -56,7 +56,7 @@
 #include "memusage.h"
 #include "bfind.h"
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(__FreeBSD__)
 static int read_common_sizet(void *szp, char *strval)
 {
 	char *end;

--- a/src/common/memusage.c
+++ b/src/common/memusage.c
@@ -56,7 +56,7 @@
 #include "memusage.h"
 #include "bfind.h"
 
-#if defined(OS_LINUX) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(__FreeBSD__) || defined(OS_SOLARIS)
 static int read_common_sizet(void *szp, char *strval)
 {
 	char *end;


### PR DESCRIPTION
Now that FreeBSD has imported LLVM15, new errors are flagged.

Ideally the code that implicily converts integers should be fixed but a first step is to use a compiler option that ignores the errors like prior versions of LLVM and GCC do.

Additionaly, as in Linux, read_common_sizet() is also undefined in FreeBSD.