### PR TITLE
Revert "enable test_memusage only if OS_LINUX is defined"

### DIFF
--- a/tests/API/probes/CMakeLists.txt
+++ b/tests/API/probes/CMakeLists.txt
@@ -39,13 +39,11 @@ target_include_directories(oval_fts_list PUBLIC
 target_link_libraries(oval_fts_list openscap)
 add_oscap_test("fts.sh")
 
-if(OS_LINUX)
-	add_oscap_test_executable(test_memusage
-		"test_memusage.c"
-		"${CMAKE_SOURCE_DIR}/src/common/bfind.c"
-	)
-	target_include_directories(test_memusage PUBLIC
-		"${CMAKE_SOURCE_DIR}/src/common"
-	)
-	add_oscap_test("test_memusage.sh")
-endif(OS_LINUX)
+add_oscap_test_executable(test_memusage
+	"test_memusage.c"
+	"${CMAKE_SOURCE_DIR}/src/common/bfind.c"
+)
+target_include_directories(test_memusage PUBLIC
+	"${CMAKE_SOURCE_DIR}/src/common"
+)
+add_oscap_test("test_memusage.sh")


### PR DESCRIPTION
Actually this should be fixed in a different way, by adding `if defined (OS_SOLARIS)` to the internal implementation of the function. See: https://github.com/OpenSCAP/openscap/pull/1941

Reverts OpenSCAP/openscap#1946