### PR TITLE
Include correct header for rpmFreeCrypto()

### DIFF
--- a/src/OVAL/probes/unix/linux/rpminfo_probe.c
+++ b/src/OVAL/probes/unix/linux/rpminfo_probe.c
@@ -60,6 +60,9 @@
 #include <regex.h>
 
 /* RPM headers */
+#ifdef RPM418_FOUND
+#include <rpm/rpmcrypto.h>
+#endif
 #include "rpm-helper.h"
 
 /* SEAP */

--- a/src/OVAL/probes/unix/linux/rpmverify_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverify_probe.c
@@ -44,6 +44,9 @@
 #include "rpm-helper.h"
 
 /* Individual RPM headers */
+#ifdef RPM418_FOUND
+#include <rpm/rpmcrypto.h>
+#endif
 #include <rpm/rpmfi.h>
 #include <rpm/rpmcli.h>
 

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -47,6 +47,9 @@
 #include "oscap_helpers.h"
 
 /* Individual RPM headers */
+#ifdef RPM418_FOUND
+#include <rpm/rpmcrypto.h>
+#endif
 #include <rpm/rpmfi.h>
 #include <rpm/rpmcli.h>
 

--- a/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
@@ -47,6 +47,9 @@
 #include "probe-chroot.h"
 
 /* Individual RPM headers */
+#ifdef RPM418_FOUND
+#include <rpm/rpmcrypto.h>
+#endif
 #include <rpm/rpmfi.h>
 #include <rpm/rpmcli.h>
 #include <popt.h>


### PR DESCRIPTION
In RPM version < 4.18, `rpmFreeCrypto()` was located in _rpmgpg.h_. This function and various other generic crypto API has now been moved to _rpmcrypto.h_.

Since the header doesn't exists in earlier version, it was wrapped in an ifdef, to retain compatibility with older version of RPM.

This can of course also be moved into the header _rpm-helper.h_ if you prefer. 