### PR TITLE
Always use /var/lib/rpm as rpm dbpath

### DIFF
--- a/src/OVAL/probes/unix/linux/rpminfo_probe.c
+++ b/src/OVAL/probes/unix/linux/rpminfo_probe.c
@@ -294,6 +294,17 @@ void *rpminfo_probe_init(void)
 		return ((void *)g_rpm);
         }
 
+        /*
+        * Fedora >=36 changed the default dbpath in librpm from /var/lib/rpm to /usr/lib/sysimage/rpm
+        * See: https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
+        * Therefore, when running openscap on a Fedora >=36 system scanning another systems (such as RHEL, SLES, Fedora<36)
+        * openscap's librpm will try to read the rpm db from /usr/lib/sysimage/rpm which doesn't exist and therefore won't work.
+        * In implementing this change, /var/lib/rpm is still a symlink to /usr/lib/sysimage/rpm
+        * so /var/lib/rpm still works. So /var/lib/rpm is a dbpath that will work on all systems.
+        * Therefore, set the dbpath to be /var/lib/rpm, allow openscap running on any system to scan any system.
+        */
+        rpmPushMacro(NULL, "_dbpath", NULL, "/var/lib/rpm", RMIL_CMDLINE);
+
 	g_rpm->rpmts = rpmtsCreate();
 	pthread_mutex_init (&(g_rpm->mutex), NULL);
 

--- a/src/OVAL/probes/unix/linux/rpmverify_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverify_probe.c
@@ -234,6 +234,18 @@ void *rpmverify_probe_init(void)
                 dD("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
                 return (NULL);
         }
+
+        /*
+        * Fedora >=36 changed the default dbpath in librpm from /var/lib/rpm to /usr/lib/sysimage/rpm
+        * See: https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
+        * Therefore, when running openscap on a Fedora >=36 system scanning another systems (such as RHEL, SLES, Fedora<36)
+        * openscap's librpm will try to read the rpm db from /usr/lib/sysimage/rpm which doesn't exist and therefore won't work.
+        * In implementing this change, /var/lib/rpm is still a symlink to /usr/lib/sysimage/rpm
+        * so /var/lib/rpm still works. So /var/lib/rpm is a dbpath that will work on all systems.
+        * Therefore, set the dbpath to be /var/lib/rpm, allow openscap running on any system to scan any system.
+        */
+        rpmPushMacro(NULL, "_dbpath", NULL, "/var/lib/rpm", RMIL_CMDLINE);
+
 	struct rpm_probe_global *g_rpm = malloc(sizeof(struct rpm_probe_global));
 	g_rpm->rpmts = rpmtsCreate();
 

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -355,6 +355,18 @@ void *rpmverifyfile_probe_init(void)
 	}
 
 	struct rpm_probe_global *g_rpm = malloc(sizeof(struct rpm_probe_global));
+
+	/*
+	* Fedora >=36 changed the default dbpath in librpm from /var/lib/rpm to /usr/lib/sysimage/rpm
+	* See: https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
+	* Therefore, when running openscap on a Fedora >=36 system scanning another systems (such as RHEL, SLES, Fedora<36)
+	* openscap's librpm will try to read the rpm db from /usr/lib/sysimage/rpm which doesn't exist and therefore won't work.
+	* In implementing this change, /var/lib/rpm is still a symlink to /usr/lib/sysimage/rpm
+	* so /var/lib/rpm still works. So /var/lib/rpm is a dbpath that will work on all systems.
+	* Therefore, set the dbpath to be /var/lib/rpm, allow openscap running on any system to scan any system.
+	*/
+	rpmPushMacro(NULL, "_dbpath", NULL, "/var/lib/rpm", RMIL_CMDLINE);
+
 	g_rpm->rpmts = rpmtsCreate();
 
 	pthread_mutex_init(&(g_rpm->mutex), NULL);

--- a/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
@@ -271,6 +271,17 @@ static int rpmverify_collect(probe_ctx *ctx,
 			// so we have to reload everything again
 			rpmReadConfigFiles ((const char *)NULL, (const char *)NULL);
 
+			/*
+			* Fedora >=36 changed the default dbpath in librpm from /var/lib/rpm to /usr/lib/sysimage/rpm
+			* See: https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
+			* Therefore, when running openscap on a Fedora >=36 system scanning another systems (such as RHEL, SLES, Fedora<36)
+			* openscap's librpm will try to read the rpm db from /usr/lib/sysimage/rpm which doesn't exist and therefore won't work.
+			* In implementing this change, /var/lib/rpm is still a symlink to /usr/lib/sysimage/rpm
+			* so /var/lib/rpm still works. So /var/lib/rpm is a dbpath that will work on all systems.
+			* Therefore, set the dbpath to be /var/lib/rpm, allow openscap running on any system to scan any system.
+			*/
+			rpmPushMacro(NULL, "_dbpath", NULL, "/var/lib/rpm", RMIL_CMDLINE);
+
 			rpmts ts = rpmtsCreate();
 			char* const * args = (char* const *)poptGetArgs(rpmcli_context);
 
@@ -343,6 +354,17 @@ void *rpmverifypackage_probe_init(void)
 		g_rpm->rpm.rpmts = NULL;
 		return ((void *)g_rpm);
 	}
+
+	/*
+	* Fedora >=36 changed the default dbpath in librpm from /var/lib/rpm to /usr/lib/sysimage/rpm
+	* See: https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
+	* Therefore, when running openscap on a Fedora >=36 system scanning another systems (such as RHEL, SLES, Fedora<36)
+	* openscap's librpm will try to read the rpm db from /usr/lib/sysimage/rpm which doesn't exist and therefore won't work.
+	* In implementing this change, /var/lib/rpm is still a symlink to /usr/lib/sysimage/rpm
+	* so /var/lib/rpm still works. So /var/lib/rpm is a dbpath that will work on all systems.
+	* Therefore, set the dbpath to be /var/lib/rpm, allow openscap running on any system to scan any system.
+	*/
+	rpmPushMacro(NULL, "_dbpath", NULL, "/var/lib/rpm", RMIL_CMDLINE);
 
 	g_rpm->rpm.rpmts = rpmtsCreate();
 

--- a/tests/DS/test_ds_misc.sh
+++ b/tests/DS/test_ds_misc.sh
@@ -77,6 +77,7 @@ sds_add_multiple_twice(){
 
 function test_eval {
     probecheck "rpminfo" || return 255
+    [ -e "/var/lib/rpm" ] || return 255
     local stderr=$(mktemp -t ${name}.out.XXXXXX)
     $OSCAP xccdf eval "${srcdir}/$1" 2> $stderr
     diff /dev/null $stderr; rm $stderr

--- a/tests/DS/test_sds_eval.sh
+++ b/tests/DS/test_sds_eval.sh
@@ -12,6 +12,7 @@ set -e -o pipefail
 
 function test_eval {
     probecheck "rpminfo" || return 255
+    [ -e "/var/lib/rpm" ] || return 255
     local stderr=$(mktemp -t ${name}.out.XXXXXX)
     $OSCAP xccdf eval "${srcdir}/$1" 2> $stderr
     diff /dev/null $stderr; rm $stderr

--- a/tests/probes/rpm/rpm_common.sh
+++ b/tests/probes/rpm/rpm_common.sh
@@ -11,11 +11,10 @@ RPMBUILD="${RPMBASE}/build"
 
 # Since Fedora 36 RPM database location changed, see
 # https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
-if [ -d "/usr/lib/sysimage/rpm/" ]; then
-    RPMDB_PATH="/usr/lib/sysimage/rpm/"
-else
-    RPMDB_PATH="/var/lib/rpm/"
-fi
+# However, /var/lib/rpm/ still works as it is a symlink to
+# the new path, /usr/lib/sysimage/rpm/, in Fedora >= 36
+# Therefore, always use /var/lib/rpm/ as it always works.
+RPMDB_PATH="/var/lib/rpm/"
 
 function rpm_build {
     require "rpmbuild" || return 255


### PR DESCRIPTION
Fedora >=36 changed the default dbpath in librpm from /var/lib/rpm to /usr/lib/sysimage/rpm Therefore, when running openscap on a Fedora >=36 system scanning another systems (such as RHEL, SLES, Fedora<36) openscap's librpm will try to read the rpm db from /usr/lib/sysimage/rpm which doesn't exist and therefore won't work. In implementing this change, /var/lib/rpm is still a symlink to /usr/lib/sysimage/rpm so /var/lib/rpm still works. So /var/lib/rpm is a dbpath that will work on all systems. Therefore, set the dbpath to be /var/lib/rpm, allow openscap running on any system to scan any system.

See: https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
Fixes: https://github.com/OpenSCAP/openscap/issues/1942

`cd build && cmake ../ && make -j4 && ctest` shows all tests as passing on my Fedora 37 system.