### PR TITLE
Free xmlDoc structure at the end of xccdf_session_load

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -716,7 +716,9 @@ int xccdf_session_load(struct xccdf_session *session)
 			return ret;
 		}
 	}
-	return xccdf_session_load_tailoring(session);
+	ret = xccdf_session_load_tailoring(session);
+	oscap_source_free_xmlDoc(session->source);
+	return ret;
 }
 
 static int _reporter(const char *file, int line, const char *msg, void *arg)

--- a/src/source/oscap_source.c
+++ b/src/source/oscap_source.c
@@ -153,6 +153,16 @@ void oscap_source_free(struct oscap_source *source)
 	}
 }
 
+void oscap_source_free_xmlDoc(struct oscap_source *source)
+{
+	if (source != NULL) {
+		if (source->xml.doc != NULL) {
+			xmlFreeDoc(source->xml.doc);
+			source->xml.doc = NULL;
+		}
+	}
+}
+
 /**
  * Returns human readable description of oscap_source origin
  */

--- a/src/source/public/oscap_source.h
+++ b/src/source/public/oscap_source.h
@@ -96,6 +96,12 @@ OSCAP_API struct oscap_source *oscap_source_clone(struct oscap_source *old);
 OSCAP_API void oscap_source_free(struct oscap_source *source);
 
 /**
+ * Dispose oscap_source xmlDoc structure.
+ * @param source Resource to dispose xmlDoc structure from
+ */
+OSCAP_API void oscap_source_free_xmlDoc(struct oscap_source *source);
+
+/**
  * Get filepath of the given resource
  * @memberof oscap_source
  * @param source


### PR DESCRIPTION
When calling the xccdf_session_load_(xccdf|cpe|oval) functions, the session->source structure is recopied to
session->ds.session->component_sources, including the source->xml.doc field, which contains the XML DOM.

This change adds a new oscap_source_free_xmlDoc function to the OSCAP source API and call it at the end of the xccdf_session_load function, so session->source->xml.doc is freed when it's not used anymore.