### PR TITLE
Add 'auristorfs' to list of network fileystems

### DIFF
--- a/src/OVAL/probes/fsdev.c
+++ b/src/OVAL/probes/fsdev.c
@@ -114,6 +114,7 @@ static int is_local_fs(struct mntent *ment)
 	};
 	const char *network_fs[] = {
 		"afs",
+		"auristorfs",
 		"ceph",
 		"cifs",
 		"smb3",


### PR DESCRIPTION
Auristor is a commercial version of the AFS filesystem and has type of 'auristorfs'.  Add it to the list of network fileystems so it is excluded when the scan is restricted to local filesystems.