### PR TITLE
Fix implicitly declared function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,7 +516,7 @@ if (MSVC)
 endif()
 
 if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -W -Wall -Wnonnull -Wshadow -Wformat -Wundef -Wno-unused-parameter -Wmissing-prototypes -Wno-unknown-pragmas -Wno-int-conversion -D_GNU_SOURCE -std=c99")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -W -Wall -Wnonnull -Wshadow -Wformat -Wundef -Wno-unused-parameter -Wmissing-prototypes -Wno-unknown-pragmas -Wno-int-conversion -Werror=implicit-function-declaration -D_GNU_SOURCE -std=c99")
 endif()
 if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
 	add_link_options(-lkvm -lm -lprocstat)

--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -30,6 +30,7 @@
 #include <rpm/rpmts.h>
 #include <rpm/rpmmacro.h>
 #include <rpm/rpmlog.h>
+#include <rpm/rpmpgp.h>
 #include <rpm/header.h>
 
 #include <pthread.h>


### PR DESCRIPTION
The function 'rpmFreeCrypto' is implicitly declared. This will be forbidden in future versions of GCC (the `-Werror=implicit-function-declaration` behaviour will be enforced).

On top of that, as an anti-regression measure, the flag `-Werror=implicit-function-declaration` is now part of the CMake config.

Follow-up on #1922. Kudos @tstellar and @fweimer-rh.