### PR TITLE
Add entry for XCCDF tailoring files in Schematron table

### DIFF
--- a/src/source/schematron.c
+++ b/src/source/schematron.c
@@ -107,6 +107,7 @@ struct oscap_schema_table_entry OSCAP_SCHEMATRON_TABLE[] = {
 	{OSCAP_DOCUMENT_OVAL_DIRECTIVES,        "5.11.2",       "oval/5.11.2/oval-directives-schematron.xsl"},
 	{OSCAP_DOCUMENT_OVAL_DIRECTIVES,        "5.11.3",       "oval/5.11.3/oval-directives-schematron.xsl"},
 	{OSCAP_DOCUMENT_XCCDF,                  "1.2",          "xccdf/1.2/xccdf_1.2-schematron.xsl"},
+	{OSCAP_DOCUMENT_XCCDF_TAILORING,        "1.2",          "xccdf/1.2/xccdf_1.2-schematron.xsl"},
 	{OSCAP_DOCUMENT_SDS,                    "1.3",          "sds/1.3/source-data-stream-1.3.xsl"}
 };
 


### PR DESCRIPTION
When validating an XCCDF tailoring file, oscap will complain about not finding the Schematron rules. 

This happens because the `OSCAP_DOCUMENT_XCCDF_TAILORING` is not listed in the table.