### PR TITLE
Plug a memory leak

### DIFF
--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -888,7 +888,10 @@ int ds_rds_create(const char* sds_file, const char* xccdf_result_file, const cha
 				result = -1;
 				oscap_source_free(oval_source);
 			} else {
-				oscap_htable_add(oval_result_sources, *oval_result_files, oval_source);
+				if (!oscap_htable_add(oval_result_sources, *oval_result_files, oval_source)) {
+					result = -1;
+					oscap_source_free(oval_source);
+				}
 			}
 			oval_result_files++;
 		}

--- a/src/DS/sds.c
+++ b/src/DS/sds.c
@@ -509,7 +509,9 @@ int ds_sds_dump_component_ref_as(const xmlNodePtr component_ref, struct ds_sds_s
 	// make a copy of xlink_href because ds_sds_dump_component_by_href modifies its second argument
 	char *xlink_href_copy = oscap_strdup(xlink_href);
 	int ret = ds_sds_dump_component_by_href(session, xlink_href, target_filename_dirname, relative_filepath, cref_id, &component_id);
-	oscap_htable_add(ds_sds_session_get_component_uris(session), cref_id, xlink_href_copy);
+	if (!oscap_htable_add(ds_sds_session_get_component_uris(session), cref_id, xlink_href_copy)) {
+		free(xlink_href_copy);
+	}
 
 	xmlFree(xlink_href);
 	xmlFree(cref_id);

--- a/src/OVAL/oval_generator.c
+++ b/src/OVAL/oval_generator.c
@@ -171,7 +171,10 @@ void oval_generator_update_timestamp(struct oval_generator *generator)
 
 void oval_generator_add_platform_schema_version(struct oval_generator *generator, const char *platform, const char *schema_version)
 {
-	oscap_htable_add(generator->platform_schema_versions, platform, oscap_strdup(schema_version));
+	char *schema_version_dup = oscap_strdup(schema_version);
+	if (!oscap_htable_add(generator->platform_schema_versions, platform, schema_version_dup)) {
+		free(schema_version_dup);
+	}
 }
 
 


### PR DESCRIPTION
When there already exists a value under the given key in the hash table, oscap_htable_add doesn't put the value to the hash table and therefore the value isn't freed when the hash table is freed. The caller of oscap_htable_add needs to check if oscap_htable_add failed and in this situation is responsible to free the value.

Addressing:

```
oscap  xccdf eval --profile '(all)' --rule xccdf_org.ssgproject.content_rule_accounts_tmout /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml --- Starting Evaluation ---

Title   Set Interactive Session Timeout
Rule    xccdf_org.ssgproject.content_rule_accounts_tmout
Result  fail

================================================================= ==85219==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 49 byte(s) in 1 object(s) allocated from:
    #0 0x4a3198 in strdup (/home/jcerny/work/git/openscap/build/utils/oscap+0x4a3198) (BuildId: 329fd48580c8ee52863c16be406cb9d7c3df95db)
    #1 0x7f090491f20c in oscap_strdup /home/jcerny/work/git/openscap/src/common/util.h:312:9
    #2 0x7f090491e9dd in ds_sds_dump_component_ref_as /home/jcerny/work/git/openscap/src/DS/sds.c:510:26
    #3 0x7f090491efce in ds_sds_dump_component_ref_as /home/jcerny/work/git/openscap/src/DS/sds.c:574:8
    #4 0x7f090491f7d3 in ds_sds_dump_component_ref /home/jcerny/work/git/openscap/src/DS/sds.c:601:15
    #5 0x7f0904917305 in ds_sds_session_register_component_with_dependencies /home/jcerny/work/git/openscap/src/DS/ds_sds_session.c:327:10
    #6 0x7f0904a0493c in xccdf_session_load_cpe /home/jcerny/work/git/openscap/src/XCCDF/xccdf_session.c:921:8
    #7 0x7f0904a03dc7 in xccdf_session_load /home/jcerny/work/git/openscap/src/XCCDF/xccdf_session.c:705:14
    #8 0x53333f in app_evaluate_xccdf /home/jcerny/work/git/openscap/utils/oscap-xccdf.c:641:6
    #9 0x52fedb in oscap_module_call /home/jcerny/work/git/openscap/utils/oscap-tool.c:295:10
    #10 0x5307fb in oscap_module_process /home/jcerny/work/git/openscap/utils/oscap-tool.c:389:19
    #11 0x53cee0 in main /home/jcerny/work/git/openscap/utils/oscap.c:88:15
    #12 0x7f090390950f in __libc_start_call_main (/lib64/libc.so.6+0x2750f) (BuildId: 81daba31ee66dbd63efdc4252a872949d874d136)

SUMMARY: AddressSanitizer: 49 byte(s) leaked in 1 allocation(s).
```