### PR TITLE
Build OpenSCAP with clang sanitizers

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,16 +12,32 @@ srpm_build_deps:
 jobs:
 - job: copr_build
   trigger: pull_request
-  metadata:
-    targets:
-    - fedora-all-x86_64
-    - centos-stream-8-x86_64
-    - centos-stream-9-x86_64
+  identifier: standard
+  targets:
+  - fedora-all-x86_64
+  - centos-stream-8-x86_64
+  - centos-stream-9-x86_64
 
 - job: tests
   trigger: pull_request
-  metadata:
-    targets:
-    - fedora-all-x86_64
-    - centos-stream-8-x86_64
-    - centos-stream-9-x86_64
+  identifier: standard-tests
+  targets:
+  - fedora-all-x86_64
+  - centos-stream-8-x86_64
+  - centos-stream-9-x86_64
+
+- job: copr_build
+  trigger: pull_request
+  specfile_path: custom_specs/openscap_clang.spec
+  identifier: clang
+  targets:
+  - epel-8-x86_64
+  - epel-9-x86_64
+
+- job: tests
+  trigger: pull_request
+  identifier: clang_tests
+  skip_build: true
+  targets:
+  - epel-8-x86_64
+  - epel-9-x86_64

--- a/custom_specs/openscap_clang.spec
+++ b/custom_specs/openscap_clang.spec
@@ -1,0 +1,230 @@
+%global toolchain clang
+# This spec file is not synchronized to the Fedora downstream.
+# It serves as Fedora CI configuration and as support for downstream updates.
+Name:           openscap
+Release:        0%{?dist}
+Version:        1.3.0
+Epoch:          1
+Summary:        Set of open source libraries enabling integration of the SCAP line of standards
+License:        LGPLv2+
+URL:            http://www.open-scap.org/
+Source0:        https://github.com/OpenSCAP/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
+BuildRequires:  make
+BuildRequires:  cmake >= 2.6
+BuildRequires:  clang compiler-rt
+BuildRequires:  swig libxml2-devel libxslt-devel perl-generators perl-XML-Parser
+BuildRequires:  rpm-devel
+BuildRequires:  libgcrypt-devel
+BuildRequires:  pcre-devel
+BuildRequires:  libacl-devel
+BuildRequires:  libselinux-devel
+BuildRequires:  libcap-devel
+BuildRequires:  libblkid-devel
+BuildRequires:  bzip2-devel
+BuildRequires:  asciidoc
+BuildRequires:  openldap-devel
+BuildRequires:  glib2-devel
+BuildRequires:  dbus-devel
+BuildRequires:  libyaml-devel
+BuildRequires:  xmlsec1-devel xmlsec1-openssl-devel
+BuildRequires:  systemd
+%if %{?_with_check:1}%{!?_with_check:0}
+BuildRequires:  perl-XML-XPath
+BuildRequires:  bzip2
+BuildRequires:  python3-dbusmock
+%endif
+Requires:       bash
+Requires:       bzip2-libs
+Requires:       dbus
+Requires:       glib2
+Requires:       libacl
+Requires:       libblkid
+Requires:       libcap
+Requires:       libselinux
+Requires:       openldap
+Requires:       popt
+# Fedora has procps-ng, which provides procps
+Requires:       procps
+Requires:       xmlsec1 xmlsec1-openssl
+
+%description
+OpenSCAP is a set of open source libraries providing an easier path
+for integration of the SCAP line of standards. SCAP is a line of standards
+managed by NIST with the goal of providing a standard language
+for the expression of Computer Network Defense related information.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libxml2-devel
+Requires:       pkgconfig
+BuildRequires:  doxygen
+
+%description    devel
+The %{name}-devel package contains libraries and header files for
+developing applications that use %{name}.
+
+%package        python3
+Summary:        Python 3 bindings for %{name}
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+BuildRequires:  python3-devel
+
+%description    python3
+The %{name}-python3 package contains the bindings so that %{name}
+libraries can be used by python3.
+
+%package        scanner
+Summary:        OpenSCAP Scanner Tool (oscap)
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libcurl >= 7.12.0
+BuildRequires:  libcurl-devel >= 7.12.0
+
+%description    scanner
+The %{name}-scanner package contains oscap command-line tool. The oscap
+is configuration and vulnerability scanner, capable of performing
+compliance checking using SCAP content.
+
+%package        utils
+Summary:        OpenSCAP Utilities
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       rpmdevtools rpm-build
+Requires:       %{name}-scanner%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description    utils
+The %{name}-utils package contains command-line tools build on top
+of OpenSCAP library. Historically, openscap-utils included oscap
+tool which is now separated to %{name}-scanner sub-package.
+
+%package        engine-sce
+Summary:        Script Check Engine plug-in for OpenSCAP
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+
+%description    engine-sce
+The Script Check Engine is non-standard extension to SCAP protocol. This
+engine allows content authors to avoid OVAL language and write their assessment
+commands using a scripting language (Bash, Perl, Python, Ruby, ...).
+
+%package        engine-sce-devel
+Summary:        Development files for %{name}-engine-sce
+Requires:       %{name}-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-engine-sce%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       pkgconfig
+
+%description    engine-sce-devel
+The %{name}-engine-sce-devel package contains libraries and header files
+for developing applications that use %{name}-engine-sce.
+
+%package        containers
+Summary:        Utils for scanning containers
+Requires:       %{name} = %{epoch}:%{version}-%{release}
+Requires:       %{name}-scanner
+BuildArch:      noarch
+
+%description    containers
+Tool for scanning Atomic containers.
+
+%prep
+%autosetup -p1
+
+%build
+echo "Toolchain is %toolchain"
+%undefine __cmake_in_source_build
+%set_build_flags
+CFLAGS="$CFLAGS -fsanitize=thread"
+# gconf is a legacy system not used any more, and it blocks testing of oscap-anaconda-addon
+# as gconf is no longer part of the installation medium
+cmake \
+    -S "." \
+    -B "%{__cmake_builddir}" \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DENABLE_PERL=OFF \
+    -DENABLE_DOCS=ON \
+    -DOPENSCAP_PROBE_UNIX_GCONF=OFF \
+    -DGCONF_LIBRARY= \
+    -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+    -DINCLUDE_INSTALL_DIR:PATH=/usr/include \
+    -DLIB_INSTALL_DIR:PATH=/usr/lib64 \
+    -DSYSCONF_INSTALL_DIR:PATH=/etc \
+    -DSHARE_INSTALL_PREFIX:PATH=/usr/share \
+    ..
+%cmake_build
+make docs
+
+%check
+%if %{?_with_check:1}%{!?_with_check:0}
+ctest -V %{?_smp_mflags}
+%endif
+
+%install
+%cmake_install
+
+find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
+
+# fix python shebangs
+pathfix.py -i %{__python3} -p -n $RPM_BUILD_ROOT%{_bindir}/scap-as-rpm
+
+%ldconfig_scriptlets
+
+# enable oscap-remediate.service here for now
+# https://github.com/hughsie/PackageKit/issues/401
+# https://bugzilla.redhat.com/show_bug.cgi?id=1833176
+mkdir -p %{buildroot}%{_unitdir}/system-update.target.wants/
+ln -sf ../oscap-remediate.service %{buildroot}%{_unitdir}/system-update.target.wants/oscap-remediate.service
+
+%files
+%doc AUTHORS NEWS README.md
+%license COPYING
+%doc %{_pkgdocdir}/manual/
+%dir %{_datadir}/openscap
+%dir %{_datadir}/openscap/schemas
+%dir %{_datadir}/openscap/xsl
+%dir %{_datadir}/openscap/cpe
+%{_libdir}/libopenscap.so.*
+%{_datadir}/openscap/schemas/*
+%{_datadir}/openscap/xsl/*
+%{_datadir}/openscap/cpe/*
+
+%files python3
+%{python3_sitearch}/*
+
+%files devel
+%doc %{_pkgdocdir}/html/
+%{_libdir}/libopenscap.so
+%{_libdir}/pkgconfig/*.pc
+%{_includedir}/openscap
+%exclude %{_includedir}/openscap/sce_engine_api.h
+
+%files engine-sce-devel
+%{_libdir}/libopenscap_sce.so
+%{_includedir}/openscap/sce_engine_api.h
+
+%files scanner
+%{_mandir}/man8/oscap.8*
+%{_bindir}/oscap
+%{_bindir}/oscap-chroot
+%{_sysconfdir}/bash_completion.d
+%{_libexecdir}/oscap-remediate
+%{_unitdir}/oscap-remediate.service
+%{_unitdir}/system-update.target.wants/
+
+%files utils
+%doc docs/oscap-scan.cron
+%{_mandir}/man8/*
+%exclude %{_mandir}/man8/oscap.8*
+%exclude %{_mandir}/man8/oscap-docker.8*
+%{_bindir}/*
+%exclude %{_bindir}/oscap
+%exclude %{_bindir}/oscap-docker
+%exclude %{_bindir}/oscap-chroot
+
+%files engine-sce
+%{_libdir}/libopenscap_sce.so.*
+
+%files containers
+%{_bindir}/oscap-docker
+%{_mandir}/man8/oscap-docker.8*
+%{python3_sitelib}/oscap_docker_python/*
+%{_bindir}/oscap-podman
+%{_mandir}/man8/oscap-podman.8*
+


### PR DESCRIPTION
This PR will create a special COPR build where OpenSCAP will be built with the Clang compiler with special options.

The special option is a ThreadSanitizer https://clang.llvm.org/docs/ThreadSanitizer.html  is a tool that detects data races.

This way we will be able to use and download the build and use it instead of normal OpenSCAP package to debug issues like freezing or thread crashes. The `oscap` will work as usual but at the same time it will print warnings when a data race happens.

To get  meaningful warnings you should install also the openscap-debuginfo rpm package, you will get tracebacks with exact file names and line numbers of the problematic code.

I propose creating COPR builds for EPEL 8 and 9.