### PR TITLE
Remove unused variables

### DIFF
--- a/src/CPE/cpelang_priv.c
+++ b/src/CPE/cpelang_priv.c
@@ -313,7 +313,6 @@ struct cpe_testexpr *cpe_testexpr_parse(xmlTextReaderPtr reader)
 {
 
 	xmlChar *temp = NULL;
-	size_t elem_cnt = 0;
 	struct cpe_testexpr *ret = NULL;
 
 	__attribute__nonnull__(reader);
@@ -381,7 +380,6 @@ struct cpe_testexpr *cpe_testexpr_parse(xmlTextReaderPtr reader)
 			xmlTextReaderNextNode(reader);
 			continue;
 		}
-		elem_cnt++;
 
 		// We assume that the expression is a logical one (meaning that it
 		// can have subexpressions).
@@ -390,7 +388,6 @@ struct cpe_testexpr *cpe_testexpr_parse(xmlTextReaderPtr reader)
 		// .. and the next node is logical-test element, we need recursive call
 		if (!xmlStrcmp(xmlTextReaderConstLocalName(reader), TAG_LOGICAL_TEST_STR) &&
 		    xmlTextReaderNodeType(reader) == XML_READER_TYPE_ELEMENT) {
-			// ret->meta.expr[elem_cnt - 1] = *(cpe_testexpr_parse(reader));
 			oscap_list_add(ret->meta.expr, cpe_testexpr_parse(reader));
                         if (xmlTextReaderDepth(reader) < depth) {
                                 return ret;
@@ -420,7 +417,6 @@ struct cpe_testexpr *cpe_testexpr_parse(xmlTextReaderPtr reader)
 		}
 		xmlTextReaderNextNode(reader);
 	}
-	//ret->meta.expr[elem_cnt].oper = CPE_LANG_OPER_HALT;
 
 	return ret;
 }

--- a/src/OVAL/oval_object.c
+++ b/src/OVAL/oval_object.c
@@ -439,8 +439,7 @@ xmlNode *oval_object_to_dom(struct oval_object *object, xmlDoc * doc, xmlNode * 
 	oval_behavior_iterator_free(behaviors);
 
 	struct oval_object_content_iterator *contents = oval_object_get_object_contents(object);
-	int i;
-	for (i = 0; oval_object_content_iterator_has_more(contents); i++) {
+	while (oval_object_content_iterator_has_more(contents)) {
 		struct oval_object_content *content = oval_object_content_iterator_next(contents);
 		oval_object_content_to_dom(content, doc, object_node);
 	}

--- a/src/OVAL/oval_sysInfo.c
+++ b/src/OVAL/oval_sysInfo.c
@@ -307,7 +307,6 @@ void oval_sysinfo_to_dom(struct oval_sysinfo *sysinfo, xmlDoc * doc, xmlNode * t
 {
         xmlNode *nodestr, *nodelst;
         xmlDoc  *docstr;
-	int i;
 
 	if (sysinfo) {
 		xmlNs *ns_syschar = xmlSearchNsByHref(doc, tag_parent, OVAL_SYSCHAR_NAMESPACE);
@@ -320,7 +319,7 @@ void oval_sysinfo_to_dom(struct oval_sysinfo *sysinfo, xmlDoc * doc, xmlNode * t
 
 		xmlNode *tag_interfaces = xmlNewTextChild(tag_sysinfo, ns_syschar, BAD_CAST "interfaces", NULL);
 		struct oval_sysint_iterator *intrfcs = oval_sysinfo_get_interfaces(sysinfo);
-		for (i = 1; oval_sysint_iterator_has_more(intrfcs); i++) {
+		while (oval_sysint_iterator_has_more(intrfcs)) {
 			struct oval_sysint *intrfc = oval_sysint_iterator_next(intrfcs);
 			oval_sysint_to_dom(intrfc, doc, tag_interfaces);
 		}

--- a/src/OVAL/probes/probe-api.c
+++ b/src/OVAL/probes/probe-api.c
@@ -871,7 +871,6 @@ oval_syschar_collection_flag_t probe_cobj_compute_flag(SEXP_t *cobj)
 	SEXP_t *items, *item;
 	int error_cnt = 0;
 	int exists_cnt = 0;
-	int does_not_exist_cnt = 0;
 	int not_collected_cnt = 0;
 
 	items = probe_cobj_get_items(cobj);
@@ -884,7 +883,6 @@ oval_syschar_collection_flag_t probe_cobj_compute_flag(SEXP_t *cobj)
 			++exists_cnt;
 			break;
 		case SYSCHAR_STATUS_DOES_NOT_EXIST:
-			++does_not_exist_cnt;
 			break;
 		case SYSCHAR_STATUS_NOT_COLLECTED:
 			++not_collected_cnt;


### PR DESCRIPTION
The existence of these variables trigger CLang warnings about unused variables.