### PR TITLE
Add offline capabilities to the sysctl OVAL probe

### DIFF
--- a/src/OVAL/probes/probe-table.c
+++ b/src/OVAL/probes/probe-table.c
@@ -335,7 +335,7 @@ static const probe_table_entry_t probe_table[] = {
 	{OVAL_UNIX_SYMLINK, NULL, symlink_probe_main, NULL, symlink_probe_offline_mode_supported},
 #endif
 #ifdef OPENSCAP_PROBE_UNIX_SYSCTL
-	{OVAL_UNIX_SYSCTL, NULL, sysctl_probe_main, NULL, NULL},
+	{OVAL_UNIX_SYSCTL, NULL, sysctl_probe_main, NULL, sysctl_probe_offline_mode_supported},
 #endif
 #ifdef OPENSCAP_PROBE_UNIX_UNAME
 	{OVAL_UNIX_UNAME, NULL, uname_probe_main, NULL, NULL},

--- a/src/OVAL/probes/unix/sysctl_probe.c
+++ b/src/OVAL/probes/unix/sysctl_probe.c
@@ -70,8 +70,8 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
         oval_schema_version_t over;
         int over_cmp;
 
-	const char *ipv6_conf_path = "/proc/sys/net/ipv6/conf/";
-	size_t ipv6_conf_path_len = strlen(ipv6_conf_path);
+        const char *ipv6_conf_path = "/proc/sys/net/ipv6/conf/";
+        size_t ipv6_conf_path_len = strlen(ipv6_conf_path);
 
         probe_in    = probe_ctx_getobject(ctx);
         name_entity = probe_obj_getent(probe_in, "name", 1);
@@ -92,11 +92,11 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
                                      "recurse", r3 = SEXP_string_new("symlinks and directories", 24),
                                      NULL);
         bh_entity = probe_ent_creat1("behaviors", ent_attrs, NULL);
-	SEXP_free(r0);
-	SEXP_free(r1);
-	SEXP_free(r2);
-	SEXP_free(r3);
-	SEXP_free(ent_attrs);
+        SEXP_free(r0);
+        SEXP_free(r1);
+        SEXP_free(r2);
+        SEXP_free(r3);
+        SEXP_free(ent_attrs);
 
         /*
          * prepare path, filename
@@ -104,16 +104,16 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
         ent_attrs = probe_attr_creat("operation", r0 = SEXP_number_newi(OVAL_OPERATION_EQUALS),
                                      NULL);
         path_entity = probe_ent_creat1("path", ent_attrs, r1 = SEXP_string_new(PROC_SYS_DIR, strlen(PROC_SYS_DIR)));
-	SEXP_free(r0);
-	SEXP_free(r1);
-	SEXP_free(ent_attrs);
+        SEXP_free(r0);
+        SEXP_free(r1);
+        SEXP_free(ent_attrs);
 
         ent_attrs = probe_attr_creat("operation", r0 = SEXP_number_newi(OVAL_OPERATION_PATTERN_MATCH),
                                      NULL);
         filename_entity = probe_ent_creat1("filename", ent_attrs, r1 = SEXP_string_new(".*", 2));
-	SEXP_free(r0);
-	SEXP_free(r1);
-	SEXP_free(ent_attrs);
+        SEXP_free(r0);
+        SEXP_free(r1);
+        SEXP_free(ent_attrs);
 
         /*
          * collect sysctls
@@ -123,10 +123,10 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
 
         if (ofts == NULL) {
                 dE("oval_fts_open_prefixed(%s, %s) failed", PROC_SYS_DIR, ".\\+");
-		SEXP_free(path_entity);
-		SEXP_free(filename_entity);
-		SEXP_free(bh_entity);
-		SEXP_free(name_entity);
+                SEXP_free(path_entity);
+                SEXP_free(filename_entity);
+                SEXP_free(bh_entity);
+                SEXP_free(name_entity);
 
                 return (PROBE_EFATAL);
         }
@@ -135,22 +135,22 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
                 SEXP_t *se_mib;
                 char    mibpath[PATH_MAX], *mib;
                 size_t  miblen;
-		struct stat file_stat;
+                struct stat file_stat;
 
                 snprintf(mibpath, sizeof mibpath, "%s/%s", ofts_ent->path, ofts_ent->file);
 
-		/* Skip write-only files, eg. /proc/sys/net/ipv4/route/flush */
-		if (stat(mibpath, &file_stat) == -1) {
-			dE("Stat failed on %s: %u, %s", mibpath, errno, strerror(errno));
-			oval_ftsent_free(ofts_ent);
-			continue;
-		}
-		/* the sysctl utility uses same condition in sysctl.c in ReadSetting() */
-		if ((file_stat.st_mode & S_IRUSR) == 0) {
-			dD("Skipping write-only file %s", mibpath);
-			oval_ftsent_free(ofts_ent);
-			continue;
-		}
+                /* Skip write-only files, eg. /proc/sys/net/ipv4/route/flush */
+                if (stat(mibpath, &file_stat) == -1) {
+                        dE("Stat failed on %s: %u, %s", mibpath, errno, strerror(errno));
+                        oval_ftsent_free(ofts_ent);
+                        continue;
+                }
+                /* the sysctl utility uses same condition in sysctl.c in ReadSetting() */
+                if ((file_stat.st_mode & S_IRUSR) == 0) {
+                        dD("Skipping write-only file %s", mibpath);
+                        oval_ftsent_free(ofts_ent);
+                        continue;
+                }
 
                 mib    = strdup(mibpath + strlen(PROC_SYS_DIR) + 1);
                 miblen = strlen(mib);
@@ -189,35 +189,35 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
                         l = fread(sysval, 1, sizeof sysval - 1, fp);
 
                         if (ferror(fp)) {
-				/* Linux 4.1.0 introduced a per-NIC IPv6 stable_secret file.
-				 * The stable_secret file cannot be read until it is set,
-				 * so we skip it when it is not readable. Otherwise we collect it.
-				 */
-				if (strncmp(ofts_ent->path, ipv6_conf_path, ipv6_conf_path_len) == 0 &&
-						strcmp(ofts_ent->file, "stable_secret") == 0) {
-					dD("Skipping file %s", mibpath);
-					oval_ftsent_free(ofts_ent);
-					SEXP_free(se_mib);
-					fclose(fp);
-					continue;
-				} else {
-					dE("An error ocured when reading from \"%s\" (fp=%p): l=%ld, %u, %s",
-						mibpath, fp, l, errno, strerror(errno));
-					goto fail_item;
-				}
+                                /* Linux 4.1.0 introduced a per-NIC IPv6 stable_secret file.
+                                 * The stable_secret file cannot be read until it is set,
+                                 * so we skip it when it is not readable. Otherwise we collect it.
+                                 */
+                                if (strncmp(ofts_ent->path, ipv6_conf_path, ipv6_conf_path_len) == 0 &&
+                                                strcmp(ofts_ent->file, "stable_secret") == 0) {
+                                        dD("Skipping file %s", mibpath);
+                                        oval_ftsent_free(ofts_ent);
+                                        SEXP_free(se_mib);
+                                        fclose(fp);
+                                        continue;
+                                } else {
+                                        dE("An error occurred when reading from \"%s\" (fp=%p): l=%ld, %u, %s",
+                                                mibpath, fp, l, errno, strerror(errno));
+                                        goto fail_item;
+                                }
                         }
 
                         fclose(fp);
 
-			/* Skip empty values as sysctl tool does.
-			 * See https://bugzilla.redhat.com/show_bug.cgi?id=1473207
-			 */
-			if (l == 0) {
-				dD("Skipping file '%s' because it has no value.", mibpath);
-				oval_ftsent_free(ofts_ent);
-				SEXP_free(se_mib);
-				continue;
-			}
+                        /* Skip empty values as sysctl tool does.
+                         * See https://bugzilla.redhat.com/show_bug.cgi?id=1473207
+                         */
+                        if (l == 0) {
+                                dD("Skipping file '%s' because it has no value.", mibpath);
+                                oval_ftsent_free(ofts_ent);
+                                SEXP_free(se_mib);
+                                continue;
+                        }
 
                         /*
                          * sanitize the value
@@ -227,8 +227,8 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
                         sysvals[0] = sysval;
 
                         for(s = 0, i = 0; i < l && s < sizeof sysvals/sizeof(char *) - 1; ++i) {
-	                        if ((!isprint(sysval[i]) && !isspace(sysval[i]))
-	                            || (over_cmp >= 0 && sysval[i] == '\n' /* OVAL 5.10 and above */))
+                                if ((!isprint(sysval[i]) && !isspace(sysval[i]))
+                                    || (over_cmp >= 0 && sysval[i] == '\n' /* OVAL 5.10 and above */))
                                 {
                                         sysval[i] = '\0';
                                         sysvals[++s] = sysval + i + 1;
@@ -246,16 +246,16 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
                                 sysvals[++s] = NULL;
 
                         if (over_cmp >= 0) {
-	                        /* Only in OVAL 5.10 and above */
-	                        item = probe_item_create(OVAL_UNIX_SYSCTL, NULL,
-	                                                 "name",  OVAL_DATATYPE_SEXP,   se_mib,
-	                                                 "value", OVAL_DATATYPE_STRING_M, sysvals,
-	                                                 NULL);
+                                /* Only in OVAL 5.10 and above */
+                                item = probe_item_create(OVAL_UNIX_SYSCTL, NULL,
+                                                         "name",  OVAL_DATATYPE_SEXP,   se_mib,
+                                                         "value", OVAL_DATATYPE_STRING_M, sysvals,
+                                                         NULL);
                         } else {
-	                        item = probe_item_create(OVAL_UNIX_SYSCTL, NULL,
-	                                                 "name",  OVAL_DATATYPE_SEXP,   se_mib,
-	                                                 "value", OVAL_DATATYPE_STRING, sysval,
-	                                                 NULL);
+                                item = probe_item_create(OVAL_UNIX_SYSCTL, NULL,
+                                                         "name",  OVAL_DATATYPE_SEXP,   se_mib,
+                                                         "value", OVAL_DATATYPE_STRING, sysval,
+                                                         NULL);
                         }
 
                         goto add_item;
@@ -263,7 +263,7 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
                         if (fp != NULL)
                                 fclose(fp);
 
-			item = probe_item_create(OVAL_UNIX_SYSCTL, NULL, NULL);
+                        item = probe_item_create(OVAL_UNIX_SYSCTL, NULL, NULL);
                         probe_item_setstatus(item, SYSCHAR_STATUS_ERROR);
                 add_item:
                         probe_item_collect(ctx, item);
@@ -274,10 +274,10 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
         }
 
         oval_fts_close(ofts);
-	SEXP_free(path_entity);
-	SEXP_free(filename_entity);
-	SEXP_free(bh_entity);
-	SEXP_free(name_entity);
+        SEXP_free(path_entity);
+        SEXP_free(filename_entity);
+        SEXP_free(bh_entity);
+        SEXP_free(name_entity);
 
         return (0);
 }
@@ -285,80 +285,80 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
 #elif defined(OS_FREEBSD)
 int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
 {
-	FILE *fp;
-	char output[LINE_MAX];
-	const char* SEP = "=";
-	char* mib;
-	char* sysval;
-	SEXP_t *se_mib;
-	SEXP_t *name_entity, *probe_in;
+        FILE *fp;
+        char output[LINE_MAX];
+        const char* SEP = "=";
+        char* mib;
+        char* sysval;
+        SEXP_t *se_mib;
+        SEXP_t *name_entity, *probe_in;
 
-	probe_in    = probe_ctx_getobject(ctx);
-	name_entity = probe_obj_getent(probe_in, "name", 1);
+        probe_in    = probe_ctx_getobject(ctx);
+        name_entity = probe_obj_getent(probe_in, "name", 1);
 
-	if (name_entity == NULL) {
-		dE("Missing \"name\" entity in the input object");
-		return (PROBE_ENOENT);
-	}
-
-	/* FreeBSD's sysctl(8) uses undocumented, and potentially unstable,
-	 * kernel interfaces to obtain the list of system properties and values.
-	 * Hence we call the executable and parse its output rather than
-	 * implement the functionality ourselves which risks breakage if/when
-	 * the interfaces change.
-	 */
-	fp = popen(SYSCTL_CMD, "r");
-
-	if (!fp) {
-		dE("Failed to open output of %s", SYSCTL_CMD);
-		return (PROBE_EFATAL);
-	}
-
-	while (fgets(output, sizeof(output), fp)) {
-		char *strp;
-		mib = strtok_r(output, SEP, &strp);
-		sysval = strtok_r(NULL, SEP, &strp);
-
-		if (!mib)
-			continue;
-
-		if (!sysval)
-			continue;
-
-		se_mib = SEXP_string_new(mib, strlen(mib));
-
-		if (!se_mib) {
-			dE("Failed to allocate new SEXP_string for se_mib");
-			pclose(fp);
-			return (PROBE_ENOENT);
-		}
-
-		/* Remove newline */
-		sysval[strlen(sysval)-1] = '\0';
-
-		if (probe_entobj_cmp(name_entity, se_mib) == OVAL_RESULT_TRUE) {
-			SEXP_t *item;
-
-			item = probe_item_create(OVAL_UNIX_SYSCTL, NULL,
-						"name", OVAL_DATATYPE_SEXP, se_mib,
-						"value", OVAL_DATATYPE_STRING, sysval,
-						NULL);
-
-			if (!item) {
-				dE("probe_item_create() returned a null item");
-				pclose(fp);
-				SEXP_free(se_mib);
-				return (PROBE_ENOENT);
-			}
-
-			probe_item_collect(ctx, item);
-		}
-
-		SEXP_free(se_mib);
+        if (name_entity == NULL) {
+                dE("Missing \"name\" entity in the input object");
+                return (PROBE_ENOENT);
         }
 
-	pclose(fp);
-	return (0);
+        /* FreeBSD's sysctl(8) uses undocumented, and potentially unstable,
+         * kernel interfaces to obtain the list of system properties and values.
+         * Hence we call the executable and parse its output rather than
+         * implement the functionality ourselves which risks breakage if/when
+         * the interfaces change.
+         */
+        fp = popen(SYSCTL_CMD, "r");
+
+        if (!fp) {
+                dE("Failed to open output of %s", SYSCTL_CMD);
+                return (PROBE_EFATAL);
+        }
+
+        while (fgets(output, sizeof(output), fp)) {
+                char *strp;
+                mib = strtok_r(output, SEP, &strp);
+                sysval = strtok_r(NULL, SEP, &strp);
+
+                if (!mib)
+                        continue;
+
+                if (!sysval)
+                        continue;
+
+                se_mib = SEXP_string_new(mib, strlen(mib));
+
+                if (!se_mib) {
+                        dE("Failed to allocate new SEXP_string for se_mib");
+                        pclose(fp);
+                        return (PROBE_ENOENT);
+                }
+
+                /* Remove newline */
+                sysval[strlen(sysval)-1] = '\0';
+
+                if (probe_entobj_cmp(name_entity, se_mib) == OVAL_RESULT_TRUE) {
+                        SEXP_t *item;
+
+                        item = probe_item_create(OVAL_UNIX_SYSCTL, NULL,
+                                                "name", OVAL_DATATYPE_SEXP, se_mib,
+                                                "value", OVAL_DATATYPE_STRING, sysval,
+                                                NULL);
+
+                        if (!item) {
+                                dE("probe_item_create() returned a null item");
+                                pclose(fp);
+                                SEXP_free(se_mib);
+                                return (PROBE_ENOENT);
+                        }
+
+                        probe_item_collect(ctx, item);
+                }
+
+                SEXP_free(se_mib);
+        }
+
+        pclose(fp);
+        return (0);
 }
 #else
 int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)

--- a/src/OVAL/probes/unix/sysctl_probe.h
+++ b/src/OVAL/probes/unix/sysctl_probe.h
@@ -25,6 +25,8 @@
 
 #include "probe-api.h"
 
+int sysctl_probe_offline_mode_supported(void);
+
 int sysctl_probe_main(probe_ctx *ctx, void *arg);
 
 #endif /* OPENSCAP_SYSCTL_PROBE_H */

--- a/tests/probes/sysctl/CMakeLists.txt
+++ b/tests/probes/sysctl/CMakeLists.txt
@@ -1,4 +1,5 @@
 if(ENABLE_PROBES_UNIX)
 	add_oscap_test("test_sysctl_probe.sh")
 	add_oscap_test("test_sysctl_probe_all.sh")
+	add_oscap_test("test_sysctl_probe_offline_mode.sh")
 endif()

--- a/tests/probes/sysctl/test_sysctl_probe_offline_mode.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_offline_mode.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+. $builddir/tests/test_common.sh
+
+set -e -o pipefail
+
+function perform_test {
+	probecheck "sysctl" || return 255
+	[ $(uname) == "Linux" ] || return 255
+
+	result=`mktemp`
+	stderr=`mktemp`
+	hostname=`hostname`
+
+	tmpdir=$(make_temp_dir /tmp "test_offline_mode_sysctl")
+	ln -s -t "${tmpdir}" "/proc"
+	set_chroot_offline_test_mode "${tmpdir}"
+
+	$OSCAP oval eval --results $result $srcdir/test_sysctl_probe.oval.xml 2>$stderr
+
+	unset_chroot_offline_test_mode
+	rm -rf "${tmpdir}"
+
+	[ ! -s $stderr ]
+	assert_exists 1 "/oval_results/results/system/oval_system_characteristics/system_data/unix-sys:sysctl_item/unix-sys:name[text()='kernel.hostname']"
+	assert_exists 1 "/oval_results/results/system/oval_system_characteristics/system_data/unix-sys:sysctl_item/unix-sys:value[text()='$hostname']"
+
+	rm $result
+	rm $stderr
+}
+
+perform_test


### PR DESCRIPTION
Although the probe collects the data from `/proc/sys/...` filesystem it is useful for the so-called hybrid mode (OCP, etc).

Note: There are a lot of changes to the indentation, but they all are concentrated in the first commit, it makes sense to review just the second.