### PR TITLE
CMakeLists.txt: make 2 variables configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,8 @@ endif()
 find_package(PythonInterp 3)
 find_package(PythonLibs 3)
 
-set(PREFERRED_PYTHON_PATH "${PYTHON_EXECUTABLE}")
-set(PYTHON3_PATH "${PYTHON_EXECUTABLE}")
+set(PREFERRED_PYTHON_PATH "${PYTHON_EXECUTABLE}" CACHE STRING "")
+set(PYTHON3_PATH "${PYTHON_EXECUTABLE}" CACHE STRING "")
 
 find_package(RPM)
 if(RPM_FOUND)


### PR DESCRIPTION
Variables PREFERRED_PYTHON_PATH and PYTHON3_PATH are set with ${PYTHON_EXECUTABLE}. For cross compile, ${PYTHON_EXECUTABLE} may point to other path rather thab standard dir such as /usr/bin. Then the generated library file contains such path which should NOT. Update to make variables PREFERRED_PYTHON_PATH and PYTHON3_PATH configurable to avoid such issue.