### PR TITLE
Install Perl files in correct path

### DIFF
--- a/swig/perl/CMakeLists.txt
+++ b/swig/perl/CMakeLists.txt
@@ -20,7 +20,7 @@ if (APPLE OR (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD"))
                 DESTINATION ${CMAKE_INSTALL_DATADIR}/perl5/vendor_perl)
 else()
         install(TARGETS ${SWIG_MODULE_openscap_pm_REAL_NAME}
-               DESTINATION ${PERL_VENDORLIB})
-        install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/openscap_pm.pm
                DESTINATION ${PERL_VENDORARCH})
+        install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/openscap_pm.pm
+               DESTINATION ${PERL_VENDORLIB})
 endif()


### PR DESCRIPTION
The file destination variables `PERL_VENDORLIB` and `PERL_VENDORARCH` has been mixed. `PERL_VENDORARCH` is where architecture specific files should be placed, which is the file `SWIG_MODULE_openscap_pm_REAL_NAME`.

The behavior is also more in line with how the files is installed on Apple and FreeBSD.