### PR TITLE
OVAL/sysctl: Fix offline mode

### DIFF
--- a/src/OVAL/probes/unix/sysctl_probe.c
+++ b/src/OVAL/probes/unix/sysctl_probe.c
@@ -150,10 +150,14 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
         while ((ofts_ent = oval_fts_read(ofts)) != NULL) {
                 SEXP_t *se_mib;
                 char    mibpath[PATH_MAX], *mib;
-                size_t  miblen;
+                size_t  miblen, mibstart;
                 struct stat file_stat;
 
-                snprintf(mibpath, sizeof mibpath, "%s/%s", ofts_ent->path, ofts_ent->file);
+                if (prefix != NULL) {
+                        snprintf(mibpath, sizeof mibpath, "%s/%s/%s", prefix, ofts_ent->path, ofts_ent->file);
+                } else {
+                        snprintf(mibpath, sizeof mibpath, "%s/%s", ofts_ent->path, ofts_ent->file);
+                }
 
                 /* Skip write-only files, eg. /proc/sys/net/ipv4/route/flush */
                 if (stat(mibpath, &file_stat) == -1) {
@@ -168,7 +172,10 @@ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)
                         continue;
                 }
 
-                mib    = strdup(mibpath + strlen(PROC_SYS_DIR) + 1);
+                mibstart = 0;
+                mibstart += prefix != NULL ? strlen(prefix)+1 : 0;
+                mibstart += strlen(PROC_SYS_DIR)+1;
+                mib    = strdup(mibpath + mibstart);
                 miblen = strlen(mib);
 
                 while (miblen > 0) {

--- a/tests/probes/sysctl/test_sysctl_probe_offline_mode.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_offline_mode.sh
@@ -10,10 +10,11 @@ function perform_test {
 
 	result=`mktemp`
 	stderr=`mktemp`
-	hostname=`hostname`
+	hostname="fake.host.name.me"
 
 	tmpdir=$(make_temp_dir /tmp "test_offline_mode_sysctl")
-	ln -s -t "${tmpdir}" "/proc"
+	mkdir -p "${tmpdir}/proc/sys/kernel"
+	echo "${hostname}" > "${tmpdir}/proc/sys/kernel/hostname"
 	set_chroot_offline_test_mode "${tmpdir}"
 
 	$OSCAP oval eval --results $result $srcdir/test_sysctl_probe.oval.xml 2>$stderr


### PR DESCRIPTION
The initial implementation was buggy: after correctly traversing prefixed PREFIX/proc/sys directory tree it would incorrectly read the data from the non-prefixed directory tree.