### PR TITLE
Avoid grep warning on oscap-podman invocation

### DIFF
--- a/utils/oscap-podman
+++ b/utils/oscap-podman
@@ -61,7 +61,7 @@ fi
 if [ "$(id -u)" -ne 0 ]; then
     die "This script cannot run in rootless mode."
 fi
-if grep -q "\-\-remediate" <<< "$@"; then
+if grep -q -- "--remediate" <<< "$@"; then
     die "This script does not support '--remediate' option."
 fi
 


### PR DESCRIPTION
  grep: warning: stray \ before -

is printed by GNU grep 3.11. This can be fixed by terminating the argument parsing before by using ' -- ' which then avoids the quoting alltogether.