### PR TITLE
fix QA warnings with newer toolchain, add missing rpm header

### DIFF
--- a/src/OVAL/probes/unix/linux/rpminfo_probe.c
+++ b/src/OVAL/probes/unix/linux/rpminfo_probe.c
@@ -62,6 +62,9 @@
 /* RPM headers */
 #include "rpm-helper.h"
 
+/* Individual RPM headers */
+#include <rpm/rpmpgp.h>
+
 /* SEAP */
 #include "_seap.h"
 #include <probe-api.h>

--- a/src/OVAL/probes/unix/linux/rpmverify_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverify_probe.c
@@ -46,6 +46,7 @@
 /* Individual RPM headers */
 #include <rpm/rpmfi.h>
 #include <rpm/rpmcli.h>
+#include <rpm/rpmpgp.h>
 
 /* SEAP */
 #include <probe-api.h>

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -49,6 +49,7 @@
 /* Individual RPM headers */
 #include <rpm/rpmfi.h>
 #include <rpm/rpmcli.h>
+#include <rpm/rpmpgp.h>
 
 /* SEAP */
 #include <probe-api.h>

--- a/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
@@ -49,6 +49,7 @@
 /* Individual RPM headers */
 #include <rpm/rpmfi.h>
 #include <rpm/rpmcli.h>
+#include <rpm/rpmpgp.h>
 #include <popt.h>
 
 /* SEAP */


### PR DESCRIPTION
* implicit declaration of function ‘rpmFreeCrypto’
* fixes #2008 