### PR TITLE
fix un-expanded variable in xccdf report output

### DIFF
--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -254,7 +254,7 @@ Authors:
         <h3>Rule results</h3>
         <xsl:choose>
             <xsl:when test="$not_ignored_rules_count > 0" >
-                <div class="progress" title="Displays proportion of passed/fixed, failed/error, and other rules (in that order). There were $not_ignored_rules_count rules taken into account.">
+                <div class="progress" title="Displays proportion of passed/fixed, failed/error, and other rules (in that order). There were {$not_ignored_rules_count} rules taken into account.">
                     <div class="progress-bar progress-bar-success" style="width: {$passed_rules_count div $not_ignored_rules_count * 100}%">
                         <xsl:value-of select="$passed_rules_count"/> passed
                     </div>


### PR DESCRIPTION
I was making some openembedded patches and I saw this:
![Screenshot from 2023-07-28 19-57-39](https://github.com/OpenSCAP/openscap/assets/300461/7014c368-eaad-4572-b04e-99f5c86f1f71)

so I made a patch for that too.