### PR TITLE
Implement xccdf_session_get_rule_results function in XCCDF session API

### DIFF
--- a/src/XCCDF/public/xccdf_session.h
+++ b/src/XCCDF/public/xccdf_session.h
@@ -575,6 +575,18 @@ OSCAP_API unsigned int xccdf_session_get_cpe_oval_agents_count(const struct xccd
 OSCAP_API bool xccdf_session_contains_fail_result(const struct xccdf_session *session);
 
 /**
+ * @struct xccdf_rule_result_iterator
+ */
+struct xccdf_rule_result_iterator;
+
+/**
+ * Get rule results.
+ * @memberof xccdf_session
+ * @param session XCCDF Session
+ */
+OSCAP_API struct xccdf_rule_result_iterator *xccdf_session_get_rule_results(const struct xccdf_session *session);
+
+/**
  * Run XCCDF Remediation. It uses XCCDF Policy and XCCDF TestResult from the session
  * and modifies the TestResult. This also drops and recreate OVAL Agent Session, thus
  * users are advised to run @ref xccdf_session_export_oval first.

--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1863,6 +1863,11 @@ bool xccdf_session_contains_fail_result(const struct xccdf_session *session)
 	return false;
 }
 
+struct xccdf_rule_result_iterator *xccdf_session_get_rule_results(const struct xccdf_session *session)
+{
+	return xccdf_result_get_rule_results(session->xccdf.result);
+}
+
 int xccdf_session_remediate(struct xccdf_session *session)
 {
 	int res = 0;


### PR DESCRIPTION
This change adds a new public `xccdf_session_get_rule_results` function to the XCCDF session API.

This function returns rule results.

Results could be iterated using the `xccdf_rule_result_iterator_has_more` function from the XCCDF benchmark API.