### PR TITLE
Be able to delete temporary files on a different mount point

### DIFF
--- a/src/common/oscap_acquire.c
+++ b/src/common/oscap_acquire.c
@@ -210,7 +210,7 @@ void oscap_acquire_cleanup_dir(char **dir_path)
 {
 	if (*dir_path != NULL)
 	{
-		nftw(*dir_path, __unlink_cb, 64, FTW_DEPTH | FTW_PHYS | FTW_MOUNT);
+		nftw(*dir_path, __unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
 		free(*dir_path);
 		*dir_path = NULL;
 	}


### PR DESCRIPTION
We are able to create files on a different mount point, but not delete them. This is at most inconvenient, except when running tests.

A lot of the tests just checks of anything has been written to `stderr`, if it has, the test fail. Since we are not allowed to delete files, the parent directory is not empty when it is supposed to be removed, and an error message is printed to `stderr`.

If we are able to create files, we should be allowed to delete them as well.