### PR TITLE
Fix incorrect openscap-cpe-oval result filename

### DIFF
--- a/src/CPE/cpe_session.c
+++ b/src/CPE/cpe_session.c
@@ -114,7 +114,9 @@ struct oval_agent_session *cpe_session_lookup_oval_session(struct cpe_session *c
 			return NULL;
 		}
 
-		session = oval_agent_new_session(oval_model, prefixed_href);
+		char *base_name = oscap_basename(prefixed_href);
+		session = oval_agent_new_session(oval_model, base_name);
+		free(base_name);
 		if (session == NULL) {
 			oscap_seterr(OSCAP_EFAMILY_OSCAP, "Cannot create OVAL session for '%s' for CPE applicability checking", prefixed_href);
 			return NULL;


### PR DESCRIPTION
When using `oscap xccdf eval --oval-results` command, the oval result file is not expected one (`openscap-cpe-oval.xml.result.xml`), but `%2Fusr%2Fshare%2Fopenscap%2Fcpe%2Fopenscap-cpe-oval.xml.result.xml`.

This patch fixes the issue.