### PR TITLE
Fix probe_reset

### DIFF
--- a/src/OVAL/probes/probe/probe_main.c
+++ b/src/OVAL/probes/probe/probe_main.c
@@ -87,10 +87,10 @@ static SEXP_t *probe_reset(SEXP_t *arg0, void *arg1)
          * FIXME: implement main loop locking & worker waiting
          */
 	probe_rcache_free(probe->rcache);
-        probe_ncache_free(probe->ncache);
 
         probe->rcache = probe_rcache_new();
-        probe->ncache = probe_ncache_new();
+        probe_ncache_clear(OSCAP_GSYM(ncache));
+        probe->ncache = OSCAP_GSYM(ncache);
 
         return(NULL);
 }
@@ -211,7 +211,7 @@ void *probe_common_main(void *arg)
 	if (probe.sd < 0)
 		fail(errno, "SEAP_openfd2", __LINE__ - 3);
 
-	if (SEAP_cmd_register(probe.SEAP_ctx, PROBECMD_RESET, 0, &probe_reset) != 0)
+	if (SEAP_cmd_register(probe.SEAP_ctx, PROBECMD_RESET, SEAP_CMDREG_USEARG, &probe_reset, &probe) != 0)
 		fail(errno, "SEAP_cmd_register", __LINE__ - 1);
 
 	/*


### PR DESCRIPTION
The probe_reset function didn't work properly, because its second argument was always NULL.

This changes fixes the probe_reset function by passing the probe as the second argument.

This change also call probe_ncache_clear to clear the ncache instead of calling probe_ncache_free and probe_ncache_new, like it was done in change 057873ac7c816b5e067c49442bd4f55b77121e9c.