### PR TITLE
Add AppArmor sysctl entries to exception list

### DIFF
--- a/tests/probes/sysctl/test_sysctl_probe_all.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_all.sh
@@ -16,9 +16,12 @@ SYSCTL_EXCLUDE='
 	fs.protected_fifos
 	fs.protected_regular
 	fs.protected_symlinks
+	kernel.apparmor_display_secid_mode
+	kernel.apparmor_restrict_unprivileged_userns
+	kernel.apparmor_restrict_unprivileged_userns_complain
+	kernel.apparmor_restrict_unprivileged_userns_force
 	kernel.cad_pid
 	kernel.unprivileged_userns_apparmor_policy
-	kernel.apparmor_display_secid_mode
 	kernel.usermodehelper.bset
 	kernel.usermodehelper.inheritable
 	net.core.bpf_jit_harden


### PR DESCRIPTION
Fixes failing CI on Ubuntu and Fedora caused by new sysctl options.

Addressing:
```
239/278 Test #239: probes/sysctl/test_sysctl_probe_all.sh .............................................***Failed    0.48 sec
Result file: test_sysctl_probe_all.res.out.49w9xN
Our names file: test_sysctl_probe_all.our.out.o4wjUZ
Sysctl names file: test_sysctl_probe_all.sysctl.out.3nEoMb
Errors file: test_sysctl_probe_all.err.out.YeCCxH
Diff (sysctlNames / ourNames): ------
56,58d55
< kernel.apparmor_restrict_unprivileged_userns
< kernel.apparmor_restrict_unprivileged_userns_complain
< kernel.apparmor_restrict_unprivileged_userns_force
```