### PR TITLE
Fix removal of imp module in Python 3.12

### DIFF
--- a/swig/openscap_api.py
+++ b/swig/openscap_api.py
@@ -31,31 +31,24 @@ import re
 
 logger = logging.getLogger("openscap")
 
-from sys import version_info
-if version_info >= (2, 6, 0):
-    def _import_helper():
-        from os.path import dirname
-        import imp
-        fp = None
-        try:
-            fp, pathname, description = imp.find_module(
-                '_openscap_py', [dirname(__file__)])
-        except ImportError:
-            import _openscap_py as OSCAP
-            return OSCAP
-        if fp is not None:
-            try:
-                _mod = imp.load_module(
-                    '_openscap_py', fp, pathname, description)
-            finally:
-                fp.close()
-            return _mod
-    OSCAP = _import_helper()
-    del _import_helper
-else:
-    import _openscap_py as OSCAP
 
-del version_info
+def _import_helper():
+    from os.path import dirname
+    import importlib.machinery
+    import importlib.util
+    spec = importlib.machinery.PathFinder.find_spec('_openscap_py', [dirname(__file__)])
+    if not spec:
+        spec = importlib.machinery.PathFinder.find_spec('_openscap_py')
+    if not spec:
+        raise ImportError("Unable to import _openscap_py module, extra path: '%s'."
+                          % dirname(__file__))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+OSCAP = _import_helper()
+del _import_helper
 
 import os
 


### PR DESCRIPTION
Python 3.12 got `imp` module removed: https://docs.python.org/3/whatsnew/3.12.html#imp

The workaround is based on `importlib` module. Python 2 branch is removed because we don't care about Python 2 anymore.