### PR TITLE
fix implicit declaration

### DIFF
--- a/src/common/xml_iterate.c
+++ b/src/common/xml_iterate.c
@@ -22,6 +22,7 @@
 #endif
 
 #include <string.h>
+#include <libxml/parser.h>
 #include "debug_priv.h"
 #include "xml_iterate.h"
 #include "oscap_helpers.h"


### PR DESCRIPTION
this would show of on gcc 3.13 + -Werror
```
[ 10%] Building C object src/common/CMakeFiles/common_object.dir/xml_iterate.c.o
cd /builddir/build/BUILD/openscap-1.3.9/redhat-linux-build/src/common && /usr/bin/gcc -DHAVE_CONFIG_H -DOSCAP_BUILD_SHARED -DXMLSEC_CRYPTO_OPENSSL=1 -DXMLSEC_DL_LIBLTDL=1 -DXMLSEC_NO_GOST2012=1 -DXMLSEC_NO_GOST=1 -DXMLSEC_NO_SIZE_T -D__XMLSEC_FUNCTION__=__func__ -I/builddir/build/BUILD/openscap-1.3.9/compat -I/builddir/build/BUILD/openscap-1.3.9/src -I/builddir/build/BUILD/openscap-1.3.9/src/common -I/builddir/build/BUILD/openscap-1.3.9/src/common/public -I/builddir/build/BUILD/openscap-1.3.9/src/CPE/public -I/builddir/build/BUILD/openscap-1.3.9/src/CVE/public -I/builddir/build/BUILD/openscap-1.3.9/src/CVRF/public -I/builddir/build/BUILD/openscap-1.3.9/src/CVSS/public -I/builddir/build/BUILD/openscap-1.3.9/src/DS/public -I/builddir/build/BUILD/openscap-1.3.9/src/OVAL/public -I/builddir/build/BUILD/openscap-1.3.9/src/OVAL/probes/public -I/builddir/build/BUILD/openscap-1.3.9/src/OVAL/probes/SEAP -I/builddir/build/BUILD/openscap-1.3.9/src/OVAL/probes/SEAP/public -I/builddir/build/BUILD/openscap-1.3.9/src/OVAL -I/builddir/build/BUILD/openscap-1.3.9/src/source/public -I/builddir/build/BUILD/openscap-1.3.9/src/XCCDF -I/builddir/build/BUILD/openscap-1.3.9/src/XCCDF/public -I/builddir/build/BUILD/openscap-1.3.9/src/XCCDF_POLICY -I/builddir/build/BUILD/openscap-1.3.9/src/XCCDF_POLICY/public -I/builddir/build/BUILD/openscap-1.3.9/yaml-filter/src -I/builddir/build/BUILD/openscap-1.3.9/redhat-linux-build -I/usr/include/libxml2 -I/usr/include/xmlsec1 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Werror=implicit-function-declaration -Werror=implicit-int -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64   -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -pipe -W -Wall -Wnonnull -Wshadow -Wformat -Wundef -Wno-unused-parameter -Wmissing-prototypes -Wno-unknown-pragmas -Wno-int-conversion -Werror=implicit-function-declaration -D_GNU_SOURCE -std=c99 -D_POSIX_C_SOURCE=200112L -DNDEBUG -fPIC -fvisibility=hidden -MD -MT src/common/CMakeFiles/common_object.dir/xml_iterate.c.o -MF CMakeFiles/common_object.dir/xml_iterate.c.o.d -o CMakeFiles/common_object.dir/xml_iterate.c.o -c /builddir/build/BUILD/openscap-1.3.9/src/common/xml_iterate.c
/builddir/build/BUILD/openscap-1.3.9/src/common/xml_iterate.c: In function â€˜xml_iterate_dfsâ€™:
/builddir/build/BUILD/openscap-1.3.9/src/common/xml_iterate.c:58:20: error: implicit declaration of function â€˜xmlParseMemoryâ€™ [-Werror=implicit-function-declaration]
   58 |         if ((doc = xmlParseMemory(input_document, strlen(input_document))) == NULL) {
      |                    ^~~~~~~~~~~~~~
cc1: some warnings being treated as errors

```