### PR TITLE
Build Windows on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
 
   build-macos:
     # The type of runner that the job will run on
-    name: Build, Test on MacOS X Latest
+    name: Build, Test on macOS Latest
     runs-on: macos-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -109,4 +109,53 @@ jobs:
     - name: Test
       run: |
         cd $GITHUB_WORKSPACE/build
-        echo "Tests are so broken for MacOS :("
+        echo "Tests are so broken for macOS :("
+  build-windows:
+    name: Build on Windows
+    runs-on: windows-latest
+    env:
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Checkout vcpkg
+      uses: actions/checkout@v3
+      with:
+        path: ${{ github.workspace }}/vcpkg
+        repository: microsoft/vcpkg
+        fetch-depth: 1
+    
+    - name: Bootstrap vcpkg
+      shell: pwsh
+      run: "${{ github.workspace }}\\vcpkg\\scripts\\bootstrap.ps1 -disableMetrics"
+
+    - name: Export GitHub Actions cache environment variables
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+    - name: Install Deps
+      run: "${{ github.workspace }}\\vcpkg\\vcpkg.exe install curl libxml2 libxslt bzip2 pcre pthreads zlib getopt-win32 xmlsec --triplet x64-windows"
+
+    - name: Configure
+      working-directory: ./build
+      run: cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_PYTHON3=FALSE -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+
+    - name: Build
+      run: cmake --build . --config Release
+      working-directory: ./build
+    
+    - name: Package
+      run: cpack
+      working-directory: build
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: openscap-win64
+        path: |-
+          build\OpenSCAP*.msi
+          build\OpenSCAP*.msi.sha512


### PR DESCRIPTION
Add GitHub Actions to build Windows version and will upload the artifact so it can be used elsewhere.