### PR TITLE
GCC 14 compatibility fixes

### DIFF
--- a/src/source/validate.c
+++ b/src/source/validate.c
@@ -46,7 +46,7 @@ struct ctxt {
 	char *filename;
 };
 
-static void oscap_xml_validity_handler(void *user, xmlErrorPtr error)
+static void oscap_xml_validity_handler(void *user, const xmlError *error)
 {
 	struct ctxt * context = (struct ctxt *) user;
 
@@ -111,7 +111,7 @@ static inline int oscap_validate_xml(struct oscap_source *source, const char *sc
 		goto cleanup;
 	}
 
-	xmlSchemaSetParserStructuredErrors(parser_ctxt, oscap_xml_validity_handler, &context);
+	xmlSchemaSetParserStructuredErrors(parser_ctxt, (xmlStructuredErrorFunc) oscap_xml_validity_handler, &context);
 
 	schema = xmlSchemaParse(parser_ctxt);
 	if (schema == NULL) {
@@ -125,7 +125,7 @@ static inline int oscap_validate_xml(struct oscap_source *source, const char *sc
 		goto cleanup;
 	}
 
-	xmlSchemaSetValidStructuredErrors(ctxt, oscap_xml_validity_handler, &context);
+	xmlSchemaSetValidStructuredErrors(ctxt, (xmlStructuredErrorFunc) oscap_xml_validity_handler, &context);
 
 	doc = oscap_source_get_xmlDoc(source);
 	if (!doc)

--- a/swig/openscap.i
+++ b/swig/openscap.i
@@ -64,9 +64,9 @@
 }
 
 %typemap(in) void * {
-    $result = SWIG_ConvertPtr($input,%as_voidptrptr(&$1), 0, $disown);
-    if (!SWIG_IsOK($result)) {
-        %argument_fail($result, "$type", $symname, $argnum);
+    int ptrres = SWIG_ConvertPtr($input,%as_voidptrptr(&$1), 0, $disown);
+    if (!SWIG_IsOK(ptrres)) {
+        %argument_fail(ptrres, "$type", $symname, $argnum);
     }
 }
 


### PR DESCRIPTION
Without these changes, compilation with GCC 14 will fail due to type errors.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
