### PR TITLE
Improve references in HTML guides and reports

### DIFF
--- a/xsl/xccdf-guide-impl.xsl
+++ b/xsl/xccdf-guide-impl.xsl
@@ -254,11 +254,9 @@ Authors:
                         </tr>
 
 
-                        <tr><td>Identifiers and References</td><td class="identifiers">
-                            <xsl:call-template name="item-idents-refs">
-                                <xsl:with-param name="item" select="$item"/>
-                            </xsl:call-template>
-                        </td></tr>
+                        <xsl:call-template name="item-idents-refs">
+                            <xsl:with-param name="item" select="$item"/>
+                        </xsl:call-template>
 
                         <tr><td colspan="2"><div class="remediation-description">
                             <xsl:for-each select="$item/cdf:fixtext">
@@ -515,7 +513,10 @@ Authors:
                         <table class="table table-striped table-bordered">
                             <tbody>
                                 <tr><td>Identifiers and References</td><td class="identifiers">
-                                    <xsl:call-template name="item-idents-refs">
+                                    <xsl:call-template name="item-idents">
+                                        <xsl:with-param name="item" select="$item"/>
+                                    </xsl:call-template>
+                                    <xsl:call-template name="item-refs">
                                         <xsl:with-param name="item" select="$item"/>
                                     </xsl:call-template>
                                 </td></tr>

--- a/xsl/xccdf-references.xsl
+++ b/xsl/xccdf-references.xsl
@@ -41,6 +41,9 @@ Authors:
 <xsl:template name="convert-reference-url-to-name">
     <xsl:param name="href"/>
     <xsl:choose>
+        <xsl:when test="key('reference_names', $href)">
+            <xsl:value-of select="key('reference_names', $href)"/>
+        </xsl:when>
         <xsl:when test="starts-with($href, 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53')">
             <xsl:text>NIST SP 800-53</xsl:text>
         </xsl:when>

--- a/xsl/xccdf-report-impl.xsl
+++ b/xsl/xccdf-report-impl.xsl
@@ -809,14 +809,9 @@ Authors:
                     </xsl:call-template>
                 </td>
             </tr>
-            <tr><td>Identifiers and References</td><td class="identifiers">
-                <!-- XCCDF 1.2 spec says that idents in rule-result should be copied from
-                    the Rule itself. That means that we can just use the same code as guide
-                    and just use idents from Rule. -->
-                <xsl:call-template name="item-idents-refs">
-                    <xsl:with-param name="item" select="$item"/>
-                </xsl:call-template>
-            </td></tr>
+            <xsl:call-template name="item-idents-refs">
+                <xsl:with-param name="item" select="$item"/>
+            </xsl:call-template>
             <xsl:if test="cdf:override">
                 <tr><td colspan="2">
                     <xsl:for-each select="cdf:override">

--- a/xsl/xccdf-share.xsl
+++ b/xsl/xccdf-share.xsl
@@ -31,6 +31,7 @@ Authors:
 <xsl:param name="verbosity"/>
 
 <xsl:key name="values" match="//cdf:Value" use="concat(ancestor::cdf:Benchmark/@id, '|', @id)"/>
+<xsl:key name="reference_names" match="//cdf:Benchmark/cdf:reference" use="@href"/>
 
 <xsl:template name="rule-result-tooltip">
     <xsl:param name="ruleresult"/>
@@ -64,26 +65,6 @@ Authors:
     </xsl:choose>
 </xsl:template>
 
-<xsl:template match="cdf:reference" mode="reference">
-    <xsl:choose>
-        <xsl:when test="@href">
-            <a href="{@href}">
-                <xsl:choose>
-                    <xsl:when test="text()">
-                        <xsl:value-of select="text()"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="@href"/>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </a>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:value-of select="text()"/>
-        </xsl:otherwise>
-    </xsl:choose>
-</xsl:template>
-
 <xsl:template name="item-title">
     <xsl:param name="item"/>
     <xsl:param name="profile"/>
@@ -104,25 +85,71 @@ Authors:
 
 <xsl:template name="item-idents-refs">
     <xsl:param name="item"/>
-
     <xsl:if test="$item/cdf:ident">
+        <tr>
+            <td>
+                <span class="label label-info" title="A globally meaningful identifiers for this rule. MAY be the name or identifier of a security configuration issue or vulnerability that the rule remediates. By setting an identifier on a rule, the benchmark author effectively declares that the rule instantiates, implements, or remediates the issue for which the name was assigned.">Identifiers:</span>
+            </td>
+            <td class="identifiers">
+                <xsl:call-template name="item-idents">
+                    <xsl:with-param name="item" select="$item"/>
+                </xsl:call-template>
+            </td>
+        </tr>
+    </xsl:if>
+    <xsl:if test="$item/cdf:reference">
+        <tr>
+            <td>
+                <span class="label label-default" title="Provide a reference to a document or resource where the user can learn more about the subject of the Rule or Group.">References:</span>
+            </td>
+            <td class="identifiers">
+                <xsl:call-template name="item-refs">
+                    <xsl:with-param name="item" select="$item"/>
+                </xsl:call-template>
+            </td>
+        </tr>
+    </xsl:if>
+</xsl:template>
+
+<xsl:template name="item-idents">
+    <xsl:param name="item"/>
         <p>
-            <span class="label label-info" title="A globally meaningful identifiers for this rule. MAY be the name or identifier of a security configuration issue or vulnerability that the rule remediates. By setting an identifier on a rule, the benchmark author effectively declares that the rule instantiates, implements, or remediates the issue for which the name was assigned.">Identifiers:</span>&#160;
             <xsl:for-each select="$item/cdf:ident">
                 <xsl:apply-templates mode="ident" select="."/>
                 <xsl:if test="position() != last()">, </xsl:if>
             </xsl:for-each>
         </p>
-    </xsl:if>
-    <xsl:if test="$item/cdf:reference">
-        <p>
-            <span class="label label-default" title="Provide a reference to a document or resource where the user can learn more about the subject of the Rule or Group.">References:</span>&#160;
-            <xsl:for-each select="$item/cdf:reference">
-                <xsl:apply-templates mode="reference" select="."/>
-                <xsl:if test="position() != last()">, </xsl:if>
-            </xsl:for-each>
-        </p>
-    </xsl:if>
+</xsl:template>
+
+<xsl:template name="item-refs">
+    <xsl:param name="item"/>
+    <table class="table table-striped table-bordered">
+        <xsl:for-each select="$item/cdf:reference">
+            <xsl:variable name="href" select="@href"/>
+            <xsl:if test="not(preceding-sibling::cdf:reference[@href=$href])">
+                <tr>
+                    <td>
+                        <a href="{@href}">
+                            <xsl:choose>
+                                <xsl:when test="key('reference_names', $href)">
+                                    <xsl:value-of select="key('reference_names', $href)"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="@href"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </a>
+                    </td>
+                    <td>
+                        <xsl:for-each select="$item/cdf:reference[@href=$href]">
+                            <xsl:value-of select="text()"/>
+                            <xsl:if test="position() != last()">, </xsl:if>
+                        </xsl:for-each>
+                    </td>
+                </tr>
+            </xsl:if>
+        </xsl:for-each>
+    </table>
 </xsl:template>
 
 <!-- works for both XCCDF Rule elements and rule-result elements -->


### PR DESCRIPTION
In this commit we will leverage the reference URI-to-title mapping within the `xccdf:Benchmark` element to visually improve the references in HTML guide and report.

This improvements needs SCAP content to contain reference URI-to-title mapping within the `xccdf:Benchmark` element to work nicely.  The ComplianceAsCode content upstream project started to provide this mapping in the SCAP content recently, starting from 62513c391dc5a3fafd12741bd02565ca0e1e8db2.

However, the enhancement is compatible with SCAP content that doesn't contain the reference URI-to-title mapping. If this mapping isn't present, URIs are shown instead of titles in the HTML guides and report. But it still provides a singificant UX improvement.

Moreover, the `Group by` dropdown feature will now also use the URI-to-title mapping in the content as an additional source of dropdown labels next to the hardcoded list. That means that addition of new reference type to ComplianceAsCode will no longer require a need to update OpenSCAP code to get nice labels for the new type to the `Group by` dropdown.