### PR TITLE
Wrap Bash snippets in a subshell when generating a fix script

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -633,7 +633,7 @@ static int _write_fix_header_to_fd(const char *sys, int output_fd, struct xccdf_
 				"###############################################################################\n"
 				"# BEGIN fix (%i / %i) for '%s'\n"
 				"###############################################################################\n"
-				"(>&2 echo \"Remediating rule %i/%i: '%s'\")\n",
+				"(>&2 echo \"Remediating rule %i/%i: '%s'\"); (\n",
 				current, total, xccdf_rule_get_id(rule), current, total, xccdf_rule_get_id(rule));
 		return _write_text_to_fd_and_free(output_fd, fix_header);
 	} else {
@@ -644,7 +644,7 @@ static int _write_fix_header_to_fd(const char *sys, int output_fd, struct xccdf_
 static int _write_fix_footer_to_fd(const char *sys, int output_fd, struct xccdf_rule *rule)
 {
 	if (oscap_streq(sys, "") || oscap_streq(sys, "urn:xccdf:fix:script:sh") || oscap_streq(sys, "urn:xccdf:fix:commands")) {
-		char *fix_footer = oscap_sprintf("\n# END fix for '%s'\n\n", xccdf_rule_get_id(rule));
+		char *fix_footer = oscap_sprintf("\n) # END fix for '%s'\n\n", xccdf_rule_get_id(rule));
 		return _write_text_to_fd_and_free(output_fd, fix_footer);
 	} else {
 		return 0;

--- a/tests/API/XCCDF/fix/all.sh
+++ b/tests/API/XCCDF/fix/all.sh
@@ -16,7 +16,7 @@ function test_generate_fix {
     # `tail -n +2` to skip the first line with progress reporting
     local GENERATED_FIX RELEVANT_FIX_CONTENTS
     GENERATED_FIX=$($OSCAP xccdf generate fix --result-id "$TESTRESULT_ID" "$INPUT")
-    RELEVANT_FIX_CONTENTS=$(grep -v -E "^([\t ]*|[\t ]*#.*)$" <<< "$GENERATED_FIX" | tail -n +2)
+    RELEVANT_FIX_CONTENTS=$(grep -v -E "^([\t ]*|[\t ]*#.*|\) #.*)$" <<< "$GENERATED_FIX" | tail -n +2)
     if [ "$?" != "0" ]; then
         return 1
     fi


### PR DESCRIPTION
Bring the behavior of the generated Bash script closer to one we have with `oscap xccdf eval --remediate`.

This will ensure snippet isolation and protect the script flow from possible intrusive commands and settings (exit, trap etc).