### PR TITLE
Print environment variables

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1636,6 +1636,9 @@ not considered local by the scanner:
 
 == List of accepted environment variables
 
+OpenSCAP accepts the following environment variables.
+If OpenSCAP is executed with verbosity level INFO or DEVEL their runtime values will be listed at the beginning of the log.
+
 * `OSCAP_CHECK_ENGINE_PLUGIN_DIR` - Defines path to a directory that contains plug-in libraries implementing additional check engines, eg. SCE.
 * `OSCAP_CONTAINER_VARS` - Additional environment variables read by environmentvariable58_probe. The variables are separated by `\n`. It is used by `oscap-podman` and `oscap-docker` scripts during container scanning.
 * `OSCAP_EVALUATION_TARGET` - Change value of target facts `urn:xccdf:fact:identifier` and `urn:xccdf:fact:asset:identifier:ein` in XCCDF results. Used during offline scanning to pass the name of the target system.

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -295,3 +295,27 @@ void __oscap_debuglog_object (const char *file, const char *fn, size_t line, int
 	debug_message_devel_metadata(file, fn, line);
 	debug_message_end();
 }
+
+void oscap_print_env_vars()
+{
+	const char *known_env_vars[] = {
+		"OSCAP_CHECK_ENGINE_PLUGIN_DIR",
+		"OSCAP_CONTAINER_VARS",
+		"OSCAP_EVALUATION_TARGET",
+		"OSCAP_FULL_VALIDATION",
+		"OSCAP_OVAL_COMMAND_OPTIONS",
+		"OSCAP_PCRE_EXEC_RECURSION_LIMIT",
+		"OSCAP_PROBE_ROOT",
+		"SEXP_VALIDATE_DISABLE",
+		"SOURCE_DATE_EPOCH",
+		"OSCAP_PROBE_MEMORY_USAGE_RATIO",
+		"OSCAP_PROBE_MAX_COLLECTED_ITEMS",
+		"OSCAP_PROBE_IGNORE_PATHS",
+		NULL
+	};
+	dI("Using environment variables:");
+	for (int i = 0; known_env_vars[i]; i++) {
+		char *env_var_val = getenv(known_env_vars[i]);
+		dI("%s='%s'", known_env_vars[i], env_var_val ? env_var_val : "");
+	}
+}

--- a/src/common/public/oscap_debug.h
+++ b/src/common/public/oscap_debug.h
@@ -62,6 +62,13 @@ OSCAP_API bool oscap_set_verbose(const char *verbosity_level, const char *filena
  */
 OSCAP_API oscap_verbosity_levels oscap_verbosity_level_from_cstr(const char *level_name);
 
+/**
+ * Print an informational message (verbose level INFO) listing the values
+ * of all environment variables known by oscap.
+ * See the "List of accepted environment variables" section of the OpenSCAP User Manual.
+ */
+OSCAP_API void oscap_print_env_vars(void);
+
 #if defined(_WIN32)
 int setenv(const char *name, const char *value, int overwrite);
 #endif

--- a/utils/oscap-tool.c
+++ b/utils/oscap-tool.c
@@ -386,6 +386,7 @@ int oscap_module_process(struct oscap_module *module, int argc, char **argv)
 			if (!oscap_set_verbose(action.verbosity_level, action.f_verbose_log)) {
 				goto cleanup;
 			}
+            oscap_print_env_vars();
             ret = oscap_module_call(&action);
             goto cleanup;
         }


### PR DESCRIPTION
If OpenSCAP is executed with verbosity level INFO or DEVEL all environment variable values that can affect OpenSCAP behavior will be listed at the beginning of the log.

Fixes: #2063