### PR TITLE
Improve counting collected items

### DIFF
--- a/src/OVAL/probes/probe/icache.c
+++ b/src/OVAL/probes/probe/icache.c
@@ -570,19 +570,11 @@ static int _mark_collected_object_as_incomplete(struct probe_ctx *ctx, const cha
  */
 int probe_item_collect(struct probe_ctx *ctx, SEXP_t *item)
 {
-	SEXP_t *cobj_content;
-	size_t  cobj_itemcnt;
-	int memcheck_ret;
-
 	if (ctx == NULL || ctx->probe_out == NULL || item == NULL) {
 		return -1;
 	}
 
-	cobj_content = SEXP_listref_nth(ctx->probe_out, 3);
-	cobj_itemcnt = SEXP_list_length(cobj_content);
-	SEXP_free(cobj_content);
-
-	if (ctx->max_collected_items != OSCAP_PROBE_COLLECT_UNLIMITED && cobj_itemcnt >= ctx->max_collected_items) {
+	if (ctx->max_collected_items != OSCAP_PROBE_COLLECT_UNLIMITED && ctx->collected_items >= ctx->max_collected_items) {
 		char *message = oscap_sprintf("Object is incomplete because the object matches more than %ld items.", ctx->max_collected_items);
 		if (_mark_collected_object_as_incomplete(ctx, message) != 0) {
 			free(message);
@@ -592,7 +584,7 @@ int probe_item_collect(struct probe_ctx *ctx, SEXP_t *item)
 		return 2;
 	}
 
-	memcheck_ret = probe_cobj_memcheck(cobj_itemcnt, ctx->max_mem_ratio);
+	int memcheck_ret = probe_cobj_memcheck(ctx->collected_items, ctx->max_mem_ratio);
 	if (memcheck_ret == -1) {
 		dE("Failed to check available memory");
 		SEXP_free(item);
@@ -619,6 +611,7 @@ int probe_item_collect(struct probe_ctx *ctx, SEXP_t *item)
                 return (-1);
         }
 
+        ctx->collected_items++;
         return (0);
 }
 

--- a/src/OVAL/probes/probe/probe.h
+++ b/src/OVAL/probes/probe/probe.h
@@ -93,6 +93,7 @@ struct probe_ctx {
         probe_icache_t *icache;    /**< item cache */
 	int offline_mode;
 	double max_mem_ratio;
+	size_t collected_items;
 	size_t max_collected_items;
 	struct oscap_list *blocked_paths;
 };

--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -1091,6 +1091,7 @@ SEXP_t *probe_worker(probe_t *probe, SEAP_msg_t *msg_in, int *ret)
 			if (max_ratio > 0)
 				pctx.max_mem_ratio = max_ratio;
 		}
+		pctx.collected_items = 0;
 		pctx.max_collected_items = OSCAP_PROBE_COLLECT_UNLIMITED;
 		char *max_collected_items_str = getenv("OSCAP_PROBE_MAX_COLLECTED_ITEMS");
 		if (max_collected_items_str != NULL) {


### PR DESCRIPTION
The function SEXP_list_length turns out to be an unreliable provider of information about the length of the list of the collected items. It is unclear what this function returns. Instead of using SEXP_list_length we will have a counter variable that will count the amount of collected items by the probe.

Fixes: #2076