### PR TITLE
Fix Blueprint template to be self-contained

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -1150,15 +1150,7 @@ static int _write_script_header_to_fd(struct xccdf_policy *policy, struct xccdf_
 			"profile_id = \"%s\"\n"
 			"# If your hardening data stream is not part of the 'scap-security-guide' package\n"
 			"# provide the absolute path to it (from the root of the image filesystem).\n"
-			"# datastream = \"/usr/share/xml/scap/ssg/content/ssg-xxxxx-ds.xml\"\n\n"
-			"# If your hardening data stream is not part of the 'scap-security-guide' package\n"
-			"# you don't need this package to be installed in the image (section can be removed).\n"
-			"[[packages]]\n"
-			"name = \"scap-security-guide\"\n"
-			"version = \"*\"\n\n"
-			"[[packages]]\n"
-			"name = \"openscap-scanner\"\n"
-			"version = \"*\"\n\n",
+			"# datastream = \"/usr/share/xml/scap/ssg/content/ssg-xxxxx-ds.xml\"\n\n",
 			fix_header, profile_id, profile_title, benchmark_version_info, profile_id);
 		free(fix_header);
 		free(profile_title);

--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -1143,10 +1143,23 @@ static int _write_script_header_to_fd(struct xccdf_policy *policy, struct xccdf_
 	} else if (oscap_streq(sys, "urn:redhat:osbuild:blueprint")) {
 		char *blueprint_fix_header = oscap_sprintf(
 			"%s"
-			"name = \"%s\"\n"
+			"name = \"hardened_%s\"\n"
 			"description = \"%s\"\n"
-			"version = \"%s\"\n",
-			fix_header, profile_id, profile_title, benchmark_version_info);
+			"version = \"%s\"\n\n"
+			"[customizations.openscap]\n"
+			"profile_id = \"%s\"\n"
+			"# If your hardening data stream is not part of the 'scap-security-guide' package\n"
+			"# provide the absolute path to it (from the root of the image filesystem).\n"
+			"# datastream = \"/usr/share/xml/scap/ssg/content/ssg-xxxxx-ds.xml\"\n\n"
+			"# If your hardening data stream is not part of the 'scap-security-guide' package\n"
+			"# you don't need this package to be installed in the image (section can be removed).\n"
+			"[[packages]]\n"
+			"name = \"scap-security-guide\"\n"
+			"version = \"*\"\n\n"
+			"[[packages]]\n"
+			"name = \"openscap-scanner\"\n"
+			"version = \"*\"\n\n",
+			fix_header, profile_id, profile_title, benchmark_version_info, profile_id);
 		free(fix_header);
 		free(profile_title);
 		return _write_text_to_fd_and_free(output_fd, blueprint_fix_header);

--- a/tests/API/XCCDF/unittests/test_remediation_blueprint.toml
+++ b/tests/API/XCCDF/unittests/test_remediation_blueprint.toml
@@ -19,9 +19,26 @@
 #
 ###############################################################################
 
-name = "xccdf_moc.elpmaxe.www_profile_common"
+name = "hardened_xccdf_moc.elpmaxe.www_profile_common"
 description = "Profile title on one line"
 version = "1.0"
+
+[customizations.openscap]
+profile_id = "xccdf_moc.elpmaxe.www_profile_common"
+# If your hardening data stream is not part of the 'scap-security-guide' package
+# provide the absolute path to it (from the root of the image filesystem).
+# datastream = "/usr/share/xml/scap/ssg/content/ssg-xxxxx-ds.xml"
+
+# If your hardening data stream is not part of the 'scap-security-guide' package
+# you don't need this package to be installed in the image (section can be removed).
+[[packages]]
+name = "scap-security-guide"
+version = "*"
+
+[[packages]]
+name = "openscap-scanner"
+version = "*"
+
 distro = rhel-80
 
 [[packages]]

--- a/tests/API/XCCDF/unittests/test_remediation_blueprint.toml
+++ b/tests/API/XCCDF/unittests/test_remediation_blueprint.toml
@@ -29,16 +29,6 @@ profile_id = "xccdf_moc.elpmaxe.www_profile_common"
 # provide the absolute path to it (from the root of the image filesystem).
 # datastream = "/usr/share/xml/scap/ssg/content/ssg-xxxxx-ds.xml"
 
-# If your hardening data stream is not part of the 'scap-security-guide' package
-# you don't need this package to be installed in the image (section can be removed).
-[[packages]]
-name = "scap-security-guide"
-version = "*"
-
-[[packages]]
-name = "openscap-scanner"
-version = "*"
-
 distro = rhel-80
 
 [[packages]]


### PR DESCRIPTION
Now the generated Blueprint file will be ready-to-use right after generation unless a custom data stream is used for hardening.

There are also instructions on how to adapt the Blueprint for a custom data stream.