### PR TITLE
Fix `requires` and warnings

### DIFF
--- a/src/CPE/cpe_session.c
+++ b/src/CPE/cpe_session.c
@@ -114,7 +114,9 @@ struct oval_agent_session *cpe_session_lookup_oval_session(struct cpe_session *c
 			return NULL;
 		}
 
-		char *base_name = oscap_basename(prefixed_href);
+		char *prefixed_href_dup = oscap_strdup(prefixed_href);
+		char *base_name = oscap_basename(prefixed_href_dup);
+		free(prefixed_href_dup);
 		session = oval_agent_new_session(oval_model, base_name);
 		free(base_name);
 		if (session == NULL) {

--- a/src/OVAL/probes/independent/yamlfilecontent_probe.c
+++ b/src/OVAL/probes/independent/yamlfilecontent_probe.c
@@ -392,13 +392,15 @@ static int process_yaml_file(const char *prefix, const char *path, const char *f
 {
 	int ret = 0;
 
+	char *filepath = oscap_path_join(path, filename);
+	if (probe_path_is_blocked(filepath, ctx->blocked_paths)) {
+		free(filepath);
+		return 0;
+	}
+
 	yaml_parser_t parser;
 	yaml_parser_initialize(&parser);
 
-	char *filepath = oscap_path_join(path, filename);
-	if (probe_path_is_blocked(filepath, ctx->blocked_paths)) {
-		goto cleanup;
-	}
 	char *filepath_with_prefix = oscap_path_join(prefix, filepath);
 
 	FILE *yaml_file = fopen(filepath_with_prefix, "r");

--- a/src/OVAL/probes/unix/xinetd_probe.c
+++ b/src/OVAL/probes/unix/xinetd_probe.c
@@ -746,7 +746,7 @@ xiconf_t *xiconf_parse(const char *path, unsigned int max_depth)
 
 				switch (inctype) {
 				case XICONF_INCTYPE_FILE:
-					strncpy (pathbuf, inclarg, sizeof(pathbuf));
+					strncpy (pathbuf, inclarg, sizeof(pathbuf)-1);
 
 					dD("includefile: %s", pathbuf);
 

--- a/src/OVAL/results/oval_cmp_evr_string.c
+++ b/src/OVAL/results/oval_cmp_evr_string.c
@@ -91,8 +91,8 @@ static inline int rpmevrcmp(const char *a, const char *b)
 	/* This mimics rpmevrcmp which is not exported by rpmlib version 4.
 	 * Code inspired by rpm.labelCompare() from rpm4/python/header-py.c
 	 */
-	const char *a_epoch, *a_version, *a_release;
-	const char *b_epoch, *b_version, *b_release;
+	const char *a_epoch = NULL, *a_version = NULL, *a_release = NULL;
+	const char *b_epoch = NULL, *b_version = NULL, *b_release = NULL;
 	char *a_copy, *b_copy;
 	int result;
 
@@ -399,8 +399,8 @@ static int dpkg_version_compare(struct dpkg_version *a, struct dpkg_version *b)
 oval_result_t oval_debian_evr_string_cmp(const char *state, const char *sys, oval_operation_t operation)
 {
 	struct dpkg_version a, b;
-	const char *a_epoch, *a_version, *a_release;
-	const char *b_epoch, *b_version, *b_release;
+	const char *a_epoch = NULL, *a_version = NULL, *a_release = NULL;
+	const char *b_epoch = NULL, *b_version = NULL, *b_release = NULL;
 	char *a_copy, *b_copy;
 	long aux;
 

--- a/src/XCCDF/item.c
+++ b/src/XCCDF/item.c
@@ -1190,7 +1190,7 @@ void xccdf_rule_item_clone(struct xccdf_rule_item *clone, const struct xccdf_rul
 	clone->idents = oscap_list_clone(item->idents, (oscap_clone_func) xccdf_ident_clone );
 	clone->checks = oscap_list_clone(item->checks, (oscap_clone_func) xccdf_check_clone );
 	//requires is an oscap_list of oscap_lists of char *
-	clone->requires = oscap_list_clone(item->requires, (oscap_clone_func) oscap_stringlist_clone);
+	clone->requires_ = oscap_list_clone(item->requires_, (oscap_clone_func) oscap_stringlist_clone);
 	//conflicts is an oscap_list of char *
 	clone->conflicts = oscap_list_clone(item->conflicts, (oscap_clone_func) oscap_strdup);
 	clone->profile_notes = oscap_list_clone(item->profile_notes, (oscap_clone_func) xccdf_profile_note_clone);
@@ -1202,7 +1202,7 @@ void xccdf_group_item_clone(struct xccdf_item *parent, const struct xccdf_group_
 {
     struct xccdf_group_item *clone = &parent->sub.group;
 	//requires is an oscap_list of oscap_lists of char *
-	clone->requires = oscap_list_clone(item->requires, (oscap_clone_func) oscap_stringlist_clone);
+	clone->requires_ = oscap_list_clone(item->requires_, (oscap_clone_func) oscap_stringlist_clone);
 	//conflicts is an oscap_list of char *
 	clone->conflicts = oscap_list_clone(item->conflicts, (oscap_clone_func) oscap_strdup);
 	clone->values = oscap_list_clone(item->values, (oscap_clone_func) xccdf_value_clone);

--- a/src/XCCDF/item.h
+++ b/src/XCCDF/item.h
@@ -92,7 +92,7 @@ struct xccdf_rule_item {
 	xccdf_role_t role;
 	xccdf_level_t severity;
 
-	struct oscap_list *requires;
+	struct oscap_list *requires_;
 	struct oscap_list *conflicts;
 
 	struct oscap_list *profile_notes;
@@ -103,7 +103,7 @@ struct xccdf_rule_item {
 };
 
 struct xccdf_group_item {
-	struct oscap_list *requires;
+	struct oscap_list *requires_;
 	struct oscap_list *conflicts;
 
 	struct oscap_list *values;

--- a/src/XCCDF/public/xccdf_benchmark.h
+++ b/src/XCCDF/public/xccdf_benchmark.h
@@ -3343,11 +3343,11 @@ OSCAP_API bool xccdf_item_add_warning(struct xccdf_item *item, struct xccdf_warn
 OSCAP_API bool xccdf_refine_rule_add_remark(struct xccdf_refine_rule *obj, struct oscap_text *item);
 
 /// @memberof xccdf_rule
-OSCAP_API bool xccdf_rule_add_requires(struct xccdf_rule *rule, struct oscap_stringlist *requires);
+OSCAP_API bool xccdf_rule_add_requires(struct xccdf_rule *rule, struct oscap_stringlist *requires_);
 /// @memberof xccdf_group
-OSCAP_API bool xccdf_group_add_requires(struct xccdf_group *group, struct oscap_stringlist *requires);
+OSCAP_API bool xccdf_group_add_requires(struct xccdf_group *group, struct oscap_stringlist *requires_);
 /// @memberof xccdf_item
-OSCAP_API bool xccdf_item_add_requires(struct xccdf_item *item, struct oscap_stringlist *requires);
+OSCAP_API bool xccdf_item_add_requires(struct xccdf_item *item, struct oscap_stringlist *requires_);
 /// @memberof xccdf_rule
 OSCAP_API bool xccdf_rule_add_conflicts(struct xccdf_rule *rule, const char *conflicts);
 /// @memberof xccdf_group

--- a/src/XCCDF/rule.c
+++ b/src/XCCDF/rule.c
@@ -83,13 +83,13 @@ static void xccdf_deps_get(struct xccdf_item *item, struct oscap_list **conflict
 		if (conflicts)
 			*conflicts = item->sub.rule.conflicts;
 		if (requires)
-			*requires = item->sub.rule.requires;
+			*requires = item->sub.rule.requires_;
 		break;
 	case XCCDF_GROUP:
 		if (conflicts)
 			*conflicts = item->sub.group.conflicts;
 		if (requires)
-			*requires = item->sub.group.requires;
+			*requires = item->sub.group.requires_;
 		break;
 	default:
 		assert(false);
@@ -182,7 +182,7 @@ struct xccdf_item *xccdf_group_new_internal(struct xccdf_item *parent)
 {
 	struct xccdf_item *group = xccdf_item_new(XCCDF_GROUP, parent);
 	group->sub.group.content = oscap_list_new();
-	group->sub.group.requires = oscap_list_new();
+	group->sub.group.requires_ = oscap_list_new();
 	group->sub.group.conflicts = oscap_list_new();
 	group->sub.group.values = oscap_list_new();
 	return group;
@@ -265,7 +265,7 @@ void xccdf_group_free(struct xccdf_item *group)
 	if (group) {
 		oscap_list_free(group->sub.group.content, (oscap_destruct_func) xccdf_item_free);
 		oscap_list_free(group->sub.group.values, (oscap_destruct_func) xccdf_value_free);
-		oscap_list_free(group->sub.group.requires, (oscap_destruct_func) xccdf_free_strlist);
+		oscap_list_free(group->sub.group.requires_, (oscap_destruct_func) xccdf_free_strlist);
 		oscap_list_free(group->sub.group.conflicts, free);
 		xccdf_item_release(group);
 	}
@@ -279,7 +279,7 @@ struct xccdf_item *xccdf_rule_new_internal(struct xccdf_item *parent)
 
 	rule->sub.rule.idents = oscap_list_new();
 	rule->sub.rule.checks = oscap_list_new();
-	rule->sub.rule.requires = oscap_list_new();
+	rule->sub.rule.requires_ = oscap_list_new();
 	rule->sub.rule.conflicts = oscap_list_new();
 	rule->sub.rule.profile_notes = oscap_list_new();
 	rule->sub.rule.fixes = oscap_list_new();
@@ -393,7 +393,7 @@ void xccdf_rule_free(struct xccdf_item *rule)
 		oscap_list_free(rule->sub.rule.profile_notes, (oscap_destruct_func) xccdf_profile_note_free);
 		oscap_list_free(rule->sub.rule.fixes, (oscap_destruct_func) xccdf_fix_free);
 		oscap_list_free(rule->sub.rule.fixtexts, (oscap_destruct_func) xccdf_fixtext_free);
-		oscap_list_free(rule->sub.rule.requires, (oscap_destruct_func) xccdf_free_strlist);
+		oscap_list_free(rule->sub.rule.requires_, (oscap_destruct_func) xccdf_free_strlist);
 		oscap_list_free(rule->sub.rule.conflicts, free);
 		xccdf_item_release(rule);
 	}
@@ -883,28 +883,28 @@ struct oscap_stringlist_iterator *xccdf_item_get_requires(const struct xccdf_ite
 }
 struct oscap_stringlist_iterator *xccdf_rule_get_requires(const struct xccdf_rule* rule)
 {
-	return oscap_iterator_new(XITEM(rule)->sub.rule.requires);
+	return oscap_iterator_new(XITEM(rule)->sub.rule.requires_);
 }
 struct oscap_stringlist_iterator *xccdf_group_get_requires(const struct xccdf_group* group)
 {
-	return oscap_iterator_new(XITEM(group)->sub.group.requires);
+	return oscap_iterator_new(XITEM(group)->sub.group.requires_);
 }
 
-bool xccdf_rule_add_requires(struct xccdf_rule* rule, struct oscap_stringlist* requires)
+bool xccdf_rule_add_requires(struct xccdf_rule* rule, struct oscap_stringlist* requires_)
 {
-    oscap_list_add(XITEM(rule)->sub.rule.requires, requires);
+    oscap_list_add(XITEM(rule)->sub.rule.requires_, requires_);
     return true;
 }
-bool xccdf_group_add_requires(struct xccdf_group* group, struct oscap_stringlist* requires)
+bool xccdf_group_add_requires(struct xccdf_group* group, struct oscap_stringlist* requires_)
 {
-    oscap_list_add(XITEM(group)->sub.group.requires, requires);
+    oscap_list_add(XITEM(group)->sub.group.requires_, requires_);
     return true;
 }
-bool xccdf_item_add_requires(struct xccdf_item* item, struct oscap_stringlist* requires)
+bool xccdf_item_add_requires(struct xccdf_item* item, struct oscap_stringlist* requires_)
 {
 	if (item == NULL) return NULL;
-	if (item->type == XCCDF_RULE)  return xccdf_rule_add_requires ( XRULE(item), requires);
-	if (item->type == XCCDF_GROUP) return xccdf_group_add_requires(XGROUP(item), requires);
+	if (item->type == XCCDF_RULE)  return xccdf_rule_add_requires ( XRULE(item), requires_);
+	if (item->type == XCCDF_GROUP) return xccdf_group_add_requires(XGROUP(item), requires_);
     return false;
 }
 

--- a/swig/python3/CMakeLists.txt
+++ b/swig/python3/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${PYTHON_INCLUDE_PATH})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-set(CMAKE_SWIG_FLAGS "-module" "openscap_py" "-py3")
+set(CMAKE_SWIG_FLAGS "-module" "openscap_py")
 if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
 	swig_add_module(openscap_py python ../openscap.i)
 else()


### PR DESCRIPTION
Fixes https://github.com/OpenSCAP/openscap/issues/1992.

Fixes warnings:
```
/__w/openscap/openscap/src/CPE/cpe_session.c: In function 'cpe_session_lookup_oval_session':
/__w/openscap/openscap/src/CPE/cpe_session.c:117:50: warning: passing argument 1 of 'oscap_basename' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  117 |                 char *base_name = oscap_basename(prefixed_href);
      |                                                  ^~~~~~~~~~~~~
In file included from /__w/openscap/openscap/src/CPE/cpe_session.c:37:
/__w/openscap/openscap/src/common/public/oscap_helpers.h:52:38: note: expected 'char *' but argument is of type 'const char *'
   52 | OSCAP_API char *oscap_basename(char *path);
      |                                ~~~~~~^~~~
```
```
/__w/openscap/openscap/src/OVAL/probes/independent/yamlfilecontent_probe.c: In function 'process_yaml_file.isra':
/__w/openscap/openscap/src/OVAL/probes/independent/yamlfilecontent_probe.c:430:12: warning: 'yaml_file' may be used uninitialized [-Wmaybe-uninitialized]
  430 |         if (yaml_file != NULL)
      |            ^
/__w/openscap/openscap/src/OVAL/probes/independent/yamlfilecontent_probe.c:404:15: note: 'yaml_file' was declared here
  404 |         FILE *yaml_file = fopen(filepath_with_prefix, "r");
      |               ^~~~~~~~~
/__w/openscap/openscap/src/OVAL/probes/independent/yamlfilecontent_probe.c:433:9: warning: 'filepath_with_prefix' may be used uninitialized [-Wmaybe-uninitialized]
  433 |         free(filepath_with_prefix);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/openscap/openscap/src/OVAL/probes/independent/yamlfilecontent_probe.c:402:15: note: 'filepath_with_prefix' was declared here
  402 |         char *filepath_with_prefix = oscap_path_join(prefix, filepath);
      |               ^~~~~~~~~~~~~~~~~~~~
```
```
/__w/openscap/openscap/src/OVAL/probes/unix/xinetd_probe.c: In function 'xiconf_parse':
/__w/openscap/openscap/src/OVAL/probes/unix/xinetd_probe.c:749:41: warning: 'strncpy' specified bound 4097 equals destination size [-Wstringop-truncation]
  749 |                                         strncpy (pathbuf, inclarg, sizeof(pathbuf));
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
Deprecated command line option: -py3. Ignored, this option is no longer supported.
```