### PR TITLE
Support Blueprint services customization for masking

### DIFF
--- a/tests/API/XCCDF/unittests/test_remediation_blueprint.toml
+++ b/tests/API/XCCDF/unittests/test_remediation_blueprint.toml
@@ -49,4 +49,5 @@ append = "foo=bar audit=1"
 [customizations.services]
 enabled = ["sshd","usbguard"]
 disabled = ["kdump"]
+masked = ["evil"]
 

--- a/tests/API/XCCDF/unittests/test_remediation_blueprint.xccdf.xml
+++ b/tests/API/XCCDF/unittests/test_remediation_blueprint.xccdf.xml
@@ -99,4 +99,14 @@ enabled = ["sshd"]
       <check-content-ref href="test_remediation_simple.oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
     </check>
   </Rule>
+  <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_10">
+    <title>Enable sshd</title>
+    <fix system="urn:redhat:osbuild:blueprint">
+[customizations.services]
+masked = ["evil"]
+</fix>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref href="test_remediation_simple.oval.xml" name="oval:moc.elpmaxe.www:def:1"/>
+    </check>
+  </Rule>
 </Benchmark>


### PR DESCRIPTION
This will now be properly parsed and organized:

```toml
[customizations.services]
masked = ["service"]
```