### PR TITLE
Fix last remaining warning and enable CMAKE_COMPILE_WARNING_AS_ERROR in Gating CI jobs (Fedora/Ubuntu)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Build
       working-directory: ./build
       run: |
-        cmake -DCMAKE_COMPILE_WARNING_AS_ERROR=True -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_PCRE2=True ../
+        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_PCRE2=True ../
         make all
 
     - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Build
       working-directory: ./build
       run: |
-        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_PCRE2=True ../
+        cmake -DCMAKE_COMPILE_WARNING_AS_ERROR=True -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_PCRE2=True ../
         make all
 
     - name: Test
@@ -65,7 +65,7 @@ jobs:
     - name: Build
       working-directory: ./build
       run: |
-        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_PCRE2=True ../
+        cmake -DCMAKE_COMPILE_WARNING_AS_ERROR=True -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_PCRE2=True ../
         make all
     - name: Test
       working-directory: ./build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       image: fedora:latest
     steps:
     - name: Install Deps
-      run: dnf install -y cmake git dbus-devel libacl-devel libblkid-devel libcap-devel libcurl-devel libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre2-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace python3-pytest
+      run: dnf install -y cmake git procps-ng dbus-devel libacl-devel libblkid-devel libcap-devel libcurl-devel libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre2-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace python3-pytest
     - name: Checkout
       uses: actions/checkout@v3
       with:
@@ -80,7 +80,7 @@ jobs:
       image: fedora:latest
     steps:
     - name: Install Deps
-      run: dnf install -y cmake git dbus-devel libacl-devel libblkid-devel libcap-devel libcurl-devel nss-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre2-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace python3-pytest
+      run: dnf install -y cmake git procps-ng dbus-devel libacl-devel libblkid-devel libcap-devel libcurl-devel nss-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre2-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace python3-pytest
     - name: Checkout
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install Deps
       run: |
         sudo apt-get update
-        sudo apt-get -y install lcov swig xsltproc rpm-common lua5.3 libpcre2-dev libyaml-dev libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt-dev libselinux1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libxslt1-dev libxml-parser-perl libxml-xpath-perl libperl-dev librpm-dev librtmp-dev libxmlsec1-dev libxmlsec1-openssl python3-dbusmock python3-pytest
+        sudo apt-get -y install lcov swig xsltproc rpm-common lua5.3 libpcre2-dev libyaml-dev libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt-dev libselinux1-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libxslt1-dev libxml-parser-perl libxml-xpath-perl libperl-dev librpm-dev librtmp-dev libxmlsec1-dev libxmlsec1-openssl python3-dbusmock python3-pytest
         sudo apt-get -y remove rpm
 
     # Runs a set of commands using the runners shell
@@ -57,7 +57,7 @@ jobs:
       image: fedora:latest
     steps:
     - name: Install Deps
-      run: dnf install -y cmake git dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre2-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace python3-pytest
+      run: dnf install -y cmake git dbus-devel libacl-devel libblkid-devel libcap-devel libcurl-devel libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre2-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace python3-pytest
     - name: Checkout
       uses: actions/checkout@v3
       with:
@@ -80,7 +80,7 @@ jobs:
       image: fedora:latest
     steps:
     - name: Install Deps
-      run: dnf install -y cmake git dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel nss-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre2-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace python3-pytest
+      run: dnf install -y cmake git dbus-devel libacl-devel libblkid-devel libcap-devel libcurl-devel nss-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre2-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace python3-pytest
     - name: Checkout
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ 'maint-1.3', 'maint-1.2', 'master' ]
+    branches: [ 'maint-1.3', 'maint-1.2', 'main' ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ 'maint-1.3' ]

--- a/src/CPE/cpedict_priv.c
+++ b/src/CPE/cpedict_priv.c
@@ -87,9 +87,9 @@ struct cpe_item {		// the node <cpe-item>
 	} export;
 };
 OSCAP_GETTER(struct cpe_name *, cpe_item, name)
-OSCAP_SETTER_GENERIC(cpe_item, const struct cpe_name *, name, cpe_name_free, )
+OSCAP_SETTER_GENERIC(cpe_item, struct cpe_name *, name, cpe_name_free, )
 OSCAP_GETTER(struct cpe_name *, cpe_item, deprecated_by)
-OSCAP_SETTER_GENERIC(cpe_item, const struct cpe_name *, deprecated_by, cpe_name_free, )
+OSCAP_SETTER_GENERIC(cpe_item, struct cpe_name *, deprecated_by, cpe_name_free, )
 OSCAP_ACCESSOR_STRING(cpe_item, deprecation_date)
 OSCAP_GETTER(struct cpe_item_metadata *, cpe_item, metadata)
 OSCAP_IGETINS_GEN(cpe_reference, cpe_item, references, reference)

--- a/src/CPE/public/cpe_dict.h
+++ b/src/CPE/public/cpe_dict.h
@@ -421,10 +421,10 @@ OSCAP_API struct cpe_item_metadata *cpe_item_metadata_new(void);
  */
 
 /// @memberof cpe_item
-OSCAP_API bool cpe_item_set_name(struct cpe_item *item, const struct cpe_name *new_name);
+OSCAP_API bool cpe_item_set_name(struct cpe_item *item, struct cpe_name *new_name);
 
 /// @memberof cpe_item
-OSCAP_API bool cpe_item_set_deprecated_by(struct cpe_item *item, const struct cpe_name *new_deprecated_by);
+OSCAP_API bool cpe_item_set_deprecated_by(struct cpe_item *item, struct cpe_name *new_deprecated_by);
 
 /// @memberof cpe_item
 OSCAP_API bool cpe_item_set_deprecation_date(struct cpe_item *item, const char *new_deprecation_date);

--- a/src/OVAL/probes/independent/filehash58_probe.c
+++ b/src/OVAL/probes/independent/filehash58_probe.c
@@ -168,8 +168,9 @@ static int filehash58_cb(const char *prefix, const char *p, const char *f, const
 	}
 
 	if (fd < 0) {
-		strerror_r (errno, pbuf, PATH_MAX);
-		pbuf[PATH_MAX] = '\0';
+		#define __ERRBUF_SIZE 128
+		char errbuf[__ERRBUF_SIZE] = {0};
+		oscap_strerror_r(errno, errbuf, sizeof errbuf - 1);
 
 		itm = probe_item_create (OVAL_INDEPENDENT_FILE_HASH58, NULL,
 					"filepath", OVAL_DATATYPE_STRING, pbuf,
@@ -178,7 +179,7 @@ static int filehash58_cb(const char *prefix, const char *p, const char *f, const
 					"hash_type",OVAL_DATATYPE_STRING, h,
 					NULL);
 		probe_item_add_msg(itm, OVAL_MESSAGE_LEVEL_ERROR,
-			"Can't open \"%s\": errno=%d, %s.", pbuf, errno, strerror (errno));
+			"Can't open \"%s\": %s (errno=%d).", pbuf, errbuf, errno);
 		probe_item_setstatus(itm, SYSCHAR_STATUS_ERROR);
 
 		probe_item_collect(ctx, itm);

--- a/src/OVAL/probes/independent/filehash_probe.c
+++ b/src/OVAL/probes/independent/filehash_probe.c
@@ -121,8 +121,9 @@ static int filehash_cb (const char *prefix, const char *p, const char *f, probe_
 	}
 
         if (fd < 0) {
-                strerror_r (errno, pbuf, PATH_MAX);
-                pbuf[PATH_MAX] = '\0';
+		#define __ERRBUF_SIZE 128
+		char errbuf[__ERRBUF_SIZE] = {0};
+		oscap_strerror_r(errno, errbuf, sizeof errbuf - 1);
 
 		itm = probe_item_create(OVAL_INDEPENDENT_FILE_HASH, NULL,
 				"filepath", OVAL_DATATYPE_STRING, include_filepath ? pbuf : NULL,
@@ -131,7 +132,7 @@ static int filehash_cb (const char *prefix, const char *p, const char *f, probe_
 				NULL
 				);
 		probe_item_add_msg(itm, OVAL_MESSAGE_LEVEL_ERROR,
-				"Can't open \"%s\": errno=%d, %s.", pbuf, errno, strerror (errno));
+				"Can't open \"%s\": %s (errno=%d).", pbuf, errbuf, errno);
 		probe_item_setstatus(itm, SYSCHAR_STATUS_ERROR);
 
        } else {

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -363,8 +363,10 @@ static inline void *oscap_aligned_malloc(size_t size, size_t alignment) {
 	return _aligned_malloc(size, alignment);
 #else
 	void *ptr = NULL;
-	posix_memalign(&ptr, alignment, size);
-	return ptr;
+	int ret = posix_memalign(&ptr, alignment, size);
+	if (ret == 0)
+		return ptr;
+	return NULL;
 #endif
 }
 


### PR DESCRIPTION
Finally fixes #1558.