### PR TITLE
Ensure xlink namespace exists

### DIFF
--- a/src/DS/rds.c
+++ b/src/DS/rds.c
@@ -757,12 +757,7 @@ static int _ds_rds_create_from_dom(xmlDocPtr *ret, xmlDocPtr sds_doc,
 		free(tailoring_component_ref_id);
 		xmlNsPtr xlink_ns = xmlSearchNsByHref(doc, sds_res_node, BAD_CAST xlink_ns_uri);
 		if (!xlink_ns) {
-			oscap_seterr(OSCAP_EFAMILY_XML,
-					"Unable to find namespace '%s' in the XML DOM tree. "
-					"This is most likely an internal error!.",
-					xlink_ns_uri);
-			free(tailoring_component_id);
-			return -1;
+			xlink_ns = xmlNewNs(tailoring_component_ref, BAD_CAST xlink_ns_uri, BAD_CAST "xlink");
 		}
 		char *tailoring_cref_href = oscap_sprintf("#%s", tailoring_component_id);
 		free(tailoring_component_id);

--- a/tests/API/XCCDF/tailoring/all.sh
+++ b/tests/API/XCCDF/tailoring/all.sh
@@ -98,6 +98,26 @@ function test_api_xccdf_tailoring_simple_include_in_arf {
     rm -f $result
 }
 
+function test_api_xccdf_tailoring_simple_include_in_arf_xlink_namespace {
+    # This test case is a regression test for RHEL-34104
+
+    local INPUT=$srcdir/$1
+    local TAILORING=$srcdir/$2
+
+    result=`mktemp`
+    stderr=`mktemp`
+    $OSCAP xccdf eval --tailoring-file $TAILORING --results-arf $result $INPUT 2>"$stderr"
+    if [ "$?" != "0" ]; then
+        return 1
+    fi
+
+    [ ! -s "$stderr" ]
+    assert_exists 1 '/arf:asset-report-collection/arf:report-requests/arf:report-request/arf:content/ds:data-stream-collection/ds:component/Tailoring'
+
+    rm -f "$result"
+    rm -f "$stderr"
+}
+
 function test_api_xccdf_tailoring_profile_include_in_arf {
     local INPUT=$srcdir/$1
     local TAILORING=$srcdir/$2
@@ -167,6 +187,7 @@ test_run "test_api_xccdf_tailoring_oscap_info_11" test_api_xccdf_tailoring_oscap
 test_run "test_api_xccdf_tailoring_oscap_info_12" test_api_xccdf_tailoring_oscap_info simple-tailoring.xml 1
 test_run "test_api_xccdf_tailoring_autonegotiation" test_api_xccdf_tailoring_autonegotiation simple-tailoring-autonegotiation.xml xccdf_org.open-scap_profile_default 1
 test_run "test_api_xccdf_tailoring_simple_include_in_arf" test_api_xccdf_tailoring_simple_include_in_arf simple-xccdf.xml simple-tailoring.xml
+test_run "test_api_xccdf_tailoring_simple_include_in_arf_xlink_namespace" test_api_xccdf_tailoring_simple_include_in_arf_xlink_namespace xlink-test-simple-ds.xml simple-tailoring.xml
 test_run "test_api_xccdf_tailoring_profile_include_in_arf" test_api_xccdf_tailoring_profile_include_in_arf baseline.xccdf.xml baseline.tailoring.xml
 test_run "test_api_xccdf_tailoring_profile_generate_fix" test_api_xccdf_tailoring_profile_generate_fix baseline.xccdf.xml baseline.tailoring.xml
 test_run "test_api_xccdf_tailoring_profile_generate_guide" test_api_xccdf_tailoring_profile_generate_guide baseline.xccdf.xml baseline.tailoring.xml

--- a/tests/API/XCCDF/tailoring/xlink-test-simple-ds.xml
+++ b/tests/API/XCCDF/tailoring/xlink-test-simple-ds.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This content is a part of regression test for RHEL-34104. In this test
+     we don't define xlink namespace in the root element of this file but we
+     define the xlink namespace in each component-ref element. -->
+<ds:data-stream-collection xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" id="scap_org.open-scap_collection_from_xccdf_simple-xccdf.xml" schematron-version="1.2">
+  <ds:data-stream id="scap_org.open-scap_datastream_from_xccdf_simple-xccdf.xml" scap-version="1.2" use-case="OTHER">
+    <ds:checklists>
+      <ds:component-ref id="scap_org.open-scap_cref_simple-xccdf.xml" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#scap_org.open-scap_comp_simple-xccdf.xml">
+        <cat:catalog>
+          <cat:uri name="simple-oval.xml" uri="#scap_org.open-scap_cref_simple-oval.xml"/>
+        </cat:catalog>
+      </ds:component-ref>
+    </ds:checklists>
+    <ds:checks>
+      <ds:component-ref id="scap_org.open-scap_cref_simple-oval.xml" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#scap_org.open-scap_comp_simple-oval.xml"/>
+    </ds:checks>
+  </ds:data-stream>
+  <ds:component id="scap_org.open-scap_comp_simple-oval.xml" timestamp="2013-01-22T15:13:00">
+    <oval_definitions xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:lin-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
+      <generator>
+        <oval:schema_version>5.10</oval:schema_version>
+        <oval:timestamp>0001-01-01T00:00:00+00:00</oval:timestamp>
+      </generator>
+      <definitions>
+        <definition class="compliance" version="1" id="oval:x:def:1">
+          <metadata>
+            <title>x</title>
+            <description>x</description>
+            <affected family="unix">
+              <platform>x</platform>
+            </affected>
+          </metadata>
+          <criteria comment="x" operator="OR">
+            <criterion test_ref="oval:x:tst:1" comment="always pass"/>
+            <criterion test_ref="oval:x:tst:2" comment="always fail"/>
+          </criteria>
+        </definition>
+        <definition class="compliance" version="1" id="oval:x:def:2">
+          <metadata>
+            <title>x</title>
+            <description>x</description>
+            <affected family="unix">
+              <platform>x</platform>
+            </affected>
+          </metadata>
+          <criteria comment="x" operator="AND">
+            <criterion test_ref="oval:x:tst:1" comment="always pass"/>
+            <criterion test_ref="oval:x:tst:2" comment="always fail"/>
+          </criteria>
+        </definition>
+      </definitions>
+      <tests>
+        <variable_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:tst:1" check="all" comment="always pass" version="1">
+          <object object_ref="oval:x:obj:1"/>
+        </variable_test>
+        <variable_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:tst:2" check="all" check_existence="none_exist" comment="always fail" version="1">
+          <object object_ref="oval:x:obj:1"/>
+        </variable_test>
+      </tests>
+      <objects>
+        <variable_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:x:obj:1" version="1" comment="x">
+          <var_ref>oval:x:var:1</var_ref>
+        </variable_object>
+      </objects>
+      <variables>
+        <constant_variable id="oval:x:var:1" version="1" comment="x" datatype="string">
+          <value>x</value>
+        </constant_variable>
+      </variables>
+    </oval_definitions>
+  </ds:component>
+  <ds:component id="scap_org.open-scap_comp_simple-xccdf.xml" timestamp="2013-01-22T12:20:35">
+    <Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_moc.elpmaxe.www_benchmark_test">
+      <status>incomplete</status>
+      <version>1.0</version>
+      <Profile id="xccdf_org.open-scap_profile_override">
+        <title>Override</title>
+        <select idref="xccdf_moc.elpmaxe.www_rule_1" selected="false"/>
+      </Profile>
+      <Rule selected="true" id="xccdf_moc.elpmaxe.www_rule_1">
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+          <check-content-ref href="simple-oval.xml" name="oval:x:def:1"/>
+        </check>
+      </Rule>
+    </Benchmark>
+  </ds:component>
+</ds:data-stream-collection>


### PR DESCRIPTION
If the document doesn't contain the xlink namespace, we need to define it before we create the `xlink:href` attribute.

This situation happens if the `data-stream-collection` root element of the input SCAP source data stream doesn't have the xlink namespace defined.

Resolves: RHEL-34104