### PR TITLE
Fix new compiler warnings

### DIFF
--- a/src/OVAL/results/oval_cmp_ip_address.c
+++ b/src/OVAL/results/oval_cmp_ip_address.c
@@ -274,7 +274,7 @@ static inline void ipv6addr_mask(struct in6_addr *addr, int prefix_len)
 	uint8_t mask = (~0u) << (8u - (prefix_len % 8));
 
 	/* First n (prefix_len/8 - 1) bytes are left untouched. */
-	for (int i = prefix_len/8; i < 128/8; i++)
+	for (unsigned int i = prefix_len/8; i < 128/8; i++)
 	{
 		/* The (n+1) byte is masked according to the prefix_len */
 		addr->s6_addr[i] &= mask;

--- a/src/common/_error.h
+++ b/src/common/_error.h
@@ -35,7 +35,7 @@
 
 #define oscap_setxmlerr(error) __oscap_setxmlerr (__FILE__, __LINE__, __PRETTY_FUNCTION__, error)
 
-void __oscap_setxmlerr(const char *file, uint32_t line, const char *func, xmlErrorPtr error);
+void __oscap_setxmlerr(const char *file, uint32_t line, const char *func, const xmlError *error);
 
 struct oscap_err_t {
 	oscap_errfamily_t family;

--- a/src/common/error.c
+++ b/src/common/error.c
@@ -85,7 +85,7 @@ static inline void _push_err(struct oscap_err_t *err)
 	(void)err_queue_push(q, err);
 }
 
-void __oscap_setxmlerr(const char *file, uint32_t line, const char *func, xmlErrorPtr error)
+void __oscap_setxmlerr(const char *file, uint32_t line, const char *func, const xmlError *error)
 {
 
 	if (error == NULL)

--- a/src/source/bz2.c
+++ b/src/source/bz2.c
@@ -124,8 +124,8 @@ static void bz2_mem_free(struct bz2_mem *bzmem)
 
 static struct bz2_mem *bz2_mem_open(const char *buffer, size_t size)
 {
-	struct bz2_mem *b = calloc(sizeof(struct bz2_mem), 1);
-	b->stream = calloc(sizeof(bz_stream), 1);
+	struct bz2_mem *b = calloc(1, sizeof(struct bz2_mem));
+	b->stream = calloc(1, sizeof(bz_stream));
 	// next_in should point at the compressed data
 	b->stream->next_in = (char *) buffer;
 	// and avail_in should indicate how many bytes the library may read


### PR DESCRIPTION
These compiler warnings appeared with latest GCC on F40 (gcc-14.1.1-4.fc40.x86_64).

This should solve the failing "Build, Test on Fedora Latest" CI job.

For more details, please read commit messages of each commit.