### PR TITLE
Python 3.13 compatibility

### DIFF
--- a/swig/openscap.i
+++ b/swig/openscap.i
@@ -318,7 +318,7 @@ int rule_result_output_callback_wrapper(struct xccdf_rule_result* rule_result, v
       PyGILState_Release(state);
       return 1;
     }
-    result = PyEval_CallObject(func,arglist);
+    result = PyObject_CallObject(func,arglist);
     if (result == NULL) {
         if (PyErr_Occurred() != NULL)
             PyErr_PrintEx(0);
@@ -355,7 +355,7 @@ int rule_start_callback_wrapper(struct xccdf_rule* rule, void *arg)
       PyGILState_Release(state);
       return 1;
     }
-    result = PyEval_CallObject(func,arglist);
+    result = PyObject_CallObject(func,arglist);
     if (result == NULL) {
         if (PyErr_Occurred() != NULL)
             PyErr_PrintEx(0);
@@ -392,7 +392,7 @@ int agent_reporter_callback_wrapper(const struct oval_result_definition* res_def
       PyGILState_Release(state);
       return 1;
     }
-    result = PyEval_CallObject(func,arglist);
+    result = PyObject_CallObject(func,arglist);
     if (result == NULL) {
         if (PyErr_Occurred() != NULL)
             PyErr_PrintEx(0);
@@ -427,7 +427,7 @@ int validate_callback_wrapper(const char* file, int line, const char* msg, void 
       PyGILState_Release(state);
       return 1;
     }
-    result = PyEval_CallObject(func,arglist);
+    result = PyObject_CallObject(func,arglist);
     if (result == NULL) {
         if (PyErr_Occurred() != NULL)
             PyErr_PrintEx(0);
@@ -463,7 +463,7 @@ char * sub_callback_wrapper(xccdf_subst_type_t type, const char *id, void *arg)
       PyGILState_Release(state);
       return NULL;
     }
-    result = PyEval_CallObject(func, arglist);
+    result = PyObject_CallObject(func, arglist);
     if (result == NULL) {
         if (PyErr_Occurred() != NULL)
             PyErr_PrintEx(0);


### PR DESCRIPTION
Use PyObject instead of PyEval for python 3.13 compatibility