### PR TITLE
Remove obsolete template options

### DIFF
--- a/dist/bash_completion.d/oscap
+++ b/dist/bash_completion.d/oscap
@@ -35,9 +35,9 @@ function _oscap {
     opts[oscap:xccdf:remediate]="--result-id --skip-validation --fetch-remote-resources --local-files --results --results-arf --report --oval-results --export-variables --cpe --check-engine-results --progress --progress-full"
     opts[oscap:xccdf:resolve]="-o --output -f --force"
     opts[oscap:xccdf:generate]="--profile"
-    opts[oscap:xccdf:generate:report]="-o --output --result-id --profile --oval-template --sce-template"
+    opts[oscap:xccdf:generate:report]="-o --output --result-id --profile"
     opts[oscap:xccdf:generate:guide]="-o --output --hide-profile-info --profile --benchmark-id --xccdf-id --tailoring-file --tailoring-id --skip-signature-validation --enforce-signature"
-    opts[oscap:xccdf:generate:fix]="-o --output --template --profile --result-id --profile --fix-type --xccdf-id --benchmark-id --tailoring-file --tailoring-id --skip-signature-validation --enforce-signature"
+    opts[oscap:xccdf:generate:fix]="-o --output --profile --result-id --profile --fix-type --xccdf-id --benchmark-id --tailoring-file --tailoring-id --skip-signature-validation --enforce-signature"
     opts[oscap:xccdf:generate:custom]="-o --output --stylesheet"
     opts[oscap:info]="--fetch-remote-resources --local-files --profile --profiles"
 
@@ -66,7 +66,7 @@ function _oscap {
         local cmd=${modpath##*:}
 
 		case "$prev" in
-			--results|-o|--output|--template|--oval-template) _filedir 'xml.bz2|xml' ;;
+			--results|-o|--output) _filedir 'xml.bz2|xml' ;;
             --report) _filedir 'html' ;;
 		esac
 

--- a/tests/API/XCCDF/applicability/test_report_anaconda_fixes.sh
+++ b/tests/API/XCCDF/applicability/test_report_anaconda_fixes.sh
@@ -14,7 +14,7 @@ line1='^\W*part /tmp$'
 line2='^\W*part /tmp --mountoptions=nodev$'
 line3='^\W*passwd --minlen=14$'
 
-$OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
+$OSCAP xccdf generate fix --fix-type anaconda \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
 grep "$line1" $result
@@ -22,7 +22,7 @@ grep "$line2" $result
 grep "$line3" $result && false
 :> $result
 
-$OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
+$OSCAP xccdf generate fix --fix-type anaconda \
 	--profile xccdf_moc.elpmaxe.www_profile_1 \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
@@ -31,7 +31,7 @@ grep "$line2" $result
 grep "$line3" $result
 :> $result
 
-$OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
+$OSCAP xccdf generate fix --fix-type anaconda \
 	--cpe $srcdir/cpe-dict.xml \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]
@@ -46,7 +46,7 @@ rm $result
 result=./${name}.out
 [ -f $result ] && rm $result
 
-$OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
+$OSCAP xccdf generate fix --fix-type anaconda \
 	--cpe $srcdir/cpe-dict.xml \
 	--profile xccdf_moc.elpmaxe.www_profile_1 \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr

--- a/tests/API/XCCDF/unittests/test_fix_arf.sh
+++ b/tests/API/XCCDF/unittests/test_fix_arf.sh
@@ -10,7 +10,6 @@ profile="xccdf_moc.elpmaxe.www_profile_standard"
 result_id="xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_standard"
 bash_line1="echo this_is_ok"
 bash_line2="echo fix_me_please"
-ansible_template="urn:xccdf:fix:script:ansible"
 ansible_task1a="\- name: ensure everything passes"
 ansible_task1b="shell: /bin/true"
 ansible_task2a="\- name: correct the failing case"
@@ -40,7 +39,7 @@ grep -q "$bash_line1" $script
 grep -q "$bash_line2" $script
 
 # Generate an Ansible playbook from a profile in ARF file
-$OSCAP xccdf generate fix --profile $profile --template $ansible_template $results_arf | grep -Ev $regex >$playbook 2>$stderr
+$OSCAP xccdf generate fix --profile $profile --fix-type ansible $results_arf | grep -Ev $regex >$playbook 2>$stderr
 diff -B $playbook $srcdir/$name.playbook1.yml
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 grep -q "$ansible_task1a" $playbook
@@ -56,7 +55,7 @@ grep -q -v "$bash_line1" $script
 grep -q "$bash_line2" $script
 
 # Generate  an Ansible playbook based on scan results stored in ARF file
-$OSCAP xccdf generate fix --result-id $result_id --template $ansible_template $results_arf | grep -Ev $regex >$playbook 2>$stderr
+$OSCAP xccdf generate fix --result-id $result_id --fix-type ansible $results_arf | grep -Ev $regex >$playbook 2>$stderr
 diff -B $playbook $srcdir/$name.playbook2.yml
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 grep -q -v "$ansible_task1a" $playbook

--- a/tests/API/XCCDF/unittests/test_fix_filtering.sh
+++ b/tests/API/XCCDF/unittests/test_fix_filtering.sh
@@ -13,7 +13,7 @@ echo "Result file = $result"
 
 line1='^\W*part /var$'
 
-$OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
+$OSCAP xccdf generate fix --fix-type anaconda \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 grep "$line1" $result

--- a/tests/API/XCCDF/unittests/test_fix_script_header.sh
+++ b/tests/API/XCCDF/unittests/test_fix_script_header.sh
@@ -4,8 +4,6 @@
 set -e
 set -o pipefail
 
-ansible_template="urn:xccdf:fix:script:ansible"
-bash_template="urn:xccdf:fix:script:sh"
 profile="xccdf_moc.elpmaxe.www_profile_standard"
 result_id="xccdf_org.open-scap_testresult_xccdf_moc.elpmaxe.www_profile_standard"
 title="Standard System Security Profile"
@@ -56,7 +54,7 @@ grep "$profile_header5" $script
 grep "$profile_header6" $script
 
 # Generate a bash script based on scan results
-$OSCAP xccdf generate fix --result-id $result_id --template $bash_template --output $script $results_arf >$stdout 2>$stderr
+$OSCAP xccdf generate fix --result-id $result_id --fix-type bash --output $script $results_arf >$stdout 2>$stderr
 [ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 grep "$result_header1a" $script
@@ -66,7 +64,7 @@ grep "$result_header5" $script
 
 
 # Generate an Ansible playbook from an OpenSCAP profile
-$OSCAP xccdf generate fix --profile $profile --template $ansible_template --output $playbook $srcdir/$name.xccdf.xml >$stdout 2>$stderr
+$OSCAP xccdf generate fix --profile $profile --fix-type ansible --output $playbook $srcdir/$name.xccdf.xml >$stdout 2>$stderr
 [ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 grep "$profile_header1b" $playbook
@@ -77,7 +75,7 @@ grep "$profile_header5" $playbook
 grep "$profile_header6" $playbook
 
 # Generate  an Ansible playbook based on scan results stored in ARF file
-$OSCAP xccdf generate fix --result-id $result_id --template $ansible_template --output $playbook $results_arf >$stdout 2>$stderr
+$OSCAP xccdf generate fix --result-id $result_id --fix-type ansible --output $playbook $results_arf >$stdout 2>$stderr
 [ -f $stdout ]; [ ! -s $stdout ]; rm $stdout
 [ -f $stderr ]; [ ! -s $stderr ]; rm $stderr
 grep "$result_header1b" $playbook

--- a/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars.sh
+++ b/tests/API/XCCDF/unittests/test_generate_fix_ansible_vars.sh
@@ -6,7 +6,6 @@ set -o pipefail
 
 profile="xccdf_com.example.www_profile_test_ansible_vars"
 profile_tailored="xccdf_com.example.www_profile_test_ansible_vars_tailored"
-ansible_template="urn:xccdf:fix:script:ansible"
 ds="test_generate_fix_ansible_vars_ds.xml"
 tailoring_file="test_generate_fix_ansible_vars_ds-tailoring.xml"
 golden="test_generate_fix_ansible_vars_golden.yml"
@@ -18,7 +17,7 @@ name=$(basename $0 .sh)
 playbook=$(make_temp_file /tmp ${name}.yml)
 out=$(make_temp_file /tmp ${name}.out)
 
-$OSCAP xccdf generate fix --profile $profile --template $ansible_template \
+$OSCAP xccdf generate fix --profile $profile --fix-type ansible \
 	$srcdir/$ds >$playbook 2>$out
 [ -f $out ]; [ ! -s $out ]; :> $out
 [ -f $playbook ]; [ -s $playbook ]
@@ -40,7 +39,7 @@ golden_altered_var=$(grep "$var:" $srcdir/$golden_altered | xsed "s|.*$var:[^0-9
 [ "$generated_var" != "$golden_altered_var" ]
 
 # Generates Ansible playbook using tailoring file.
-$OSCAP xccdf generate fix --template $ansible_template \
+$OSCAP xccdf generate fix --fix-type ansible \
 	--profile $profile_tailored --tailoring-file $srcdir/$tailoring_file \
 	$srcdir/$ds >$playbook 2>$out
 [ -f $out ]; [ ! -s $out ]; :> $out

--- a/tests/API/XCCDF/unittests/test_report_anaconda_fixes.sh
+++ b/tests/API/XCCDF/unittests/test_report_anaconda_fixes.sh
@@ -15,7 +15,7 @@ line1='^\W*part /tmp$'
 line2='^\W*part /tmp --mountoptions=nodev$'
 line3='^\W*passwd --minlen=14$'
 
-$OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
+$OSCAP xccdf generate fix --fix-type anaconda \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
 grep "$line1" $result
@@ -38,7 +38,7 @@ grep -v "$line1" $result | grep -v "$line2" | grep -v "$line3"
 
 :> $result
 
-$OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
+$OSCAP xccdf generate fix --fix-type anaconda \
 	--profile xccdf_moc.elpmaxe.www_profile_1 \
 	--output $result $srcdir/${name}.xccdf.xml 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
@@ -53,7 +53,7 @@ rm $result
 
 
 # And Now For Something Completely Different -- Tailoring:
-$OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
+$OSCAP xccdf generate fix --fix-type anaconda \
 	--tailoring-file $srcdir/${name}.tailoring.xml \
 	--profile xccdf_org.open-scap_profile_unselecting \
 	--output $result \
@@ -65,7 +65,7 @@ $OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
 rm $result
 
 line4='^\W*passwd --minlen=8$'
-$OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
+$OSCAP xccdf generate fix --fix-type anaconda \
 	--tailoring-file $srcdir/${name}.tailoring.xml \
 	--profile xccdf_org.open-scap_profile_override \
 	--output $result \

--- a/tests/API/XCCDF/unittests/test_report_anaconda_fixes_ds.sh
+++ b/tests/API/XCCDF/unittests/test_report_anaconda_fixes_ds.sh
@@ -28,7 +28,7 @@ component_id=scap_org.open-scap_cref_test_report_anaconda_fixes.xccdf.xml
 $OSCAP info $sds | grep $datastream_id
 $OSCAP info $sds | grep $component_id
 
-$OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
+$OSCAP xccdf generate fix --fix-type anaconda \
 	--datastream-id $datastream_id --xccdf-id $component_id \
 	--output $result $sds 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr
@@ -40,7 +40,7 @@ grep -v "$line1" $result | grep -v "$line2" | grep -v "$line3"
 
 :> $result
 
-$OSCAP xccdf generate fix --template urn:redhat:anaconda:pre \
+$OSCAP xccdf generate fix --fix-type anaconda \
 	--profile xccdf_moc.elpmaxe.www_profile_1 \
 	--output $result $sds 2>&1 > $stderr
 [ -f $stderr ]; [ ! -s $stderr ]; :> $stderr

--- a/utils/oscap-tool.h
+++ b/utils/oscap-tool.h
@@ -125,9 +125,7 @@ struct oscap_action {
 	struct oscap_stringlist *rules;
 	struct oscap_stringlist *skip_rules;
         char *format;
-        const char *tmpl;
         char *id;
-        char *oval_template;
         int hide_profile_info;
         char *stylesheet;
 	char *tailoring_file;
@@ -155,7 +153,6 @@ struct oscap_action {
 	int without_sys_chars;
 	int thin_results;
 	int remediate;
-	char *sce_template;
 	int check_engine_results;
 	int export_variables;
         int list_dynamic;

--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -408,12 +408,6 @@ Write the report to this file instead of standard output.
 .TP
 \fB\-\-result-id ID\fR
 ID of the XCCDF TestResult from which the report will be generated.
-.TP
-\fB\-\-oval-template \fItemplate-string\fR
-To use the ability to include additional information from OVAL in xccdf result file, a template which will be used to obtain OVAL result file names has to be specified. The template can be either a filename or a string containing wildcard character (percent sign '%'). Wildcard will be replaced by the original OVAL definition file name as referenced from the XCCDF file. This way it is possible to obtain OVAL information even from XCCDF documents referencing several OVAL files. To use this option with results from an XCCDF evaluation, specify \fI%.result.xml\fR as a OVAL file name template.
-.TP
-\fB\-\-sce-template \fItemplate-string\fR
-To use the ability to include additional information from SCE in XCCDF result file, a template which will be used to obtain SCE result file names has to be specified. The template can be either a filename or a string containing wildcard character (percent sign '%'). Wildcard will be replaced by the original SCE script file name as referenced from the XCCDF file. This way it is possible to obtain SCE information even from XCCDF documents referencing several SCE files. To use this option with results from an XCCDF evaluation, specify \fI%.result.xml\fR as a SCE file name template.
 .RE
 .TP
 .B \fBfix\fR  [\fIoptions\fR] xccdf-file
@@ -425,16 +419,13 @@ Result-oriented fixes are generated using result-id provided to select only the 
 Profile-oriented fixes are generated using all rules within the provided profile. If no result-id/profile are provided, (default) profile will be used to generate fixes.
 .TP
 \fB\-\-fix-type TYPE\fR
-Specify fix type. There are multiple programming languages in which the fix script can be generated. TYPE should be one of: bash, ansible, puppet, anaconda, ignition, kubernetes, blueprint. Default is bash. This option is mutually exclusive with --template, because fix type already determines the template URN.
+Specify fix type. There are multiple programming languages in which the fix script can be generated. TYPE should be one of: bash, ansible, puppet, anaconda, ignition, kubernetes, blueprint. Default is bash.
 .TP
 \fB\-\-output FILE\fR
 Write the report to this file instead of standard output.
 .TP
 \fB\-\-result-id \fIID\fR\fR
 Fixes will be generated for failed rule-results of the specified TestResult.
-.TP
-\fB\-\-template \fIID|FILE\fR\fR
-Template to be used to generate the script. If it contains a dot '.' it is interpreted as a location of a file with the template definition. Otherwise it identifies a template from standard set which currently includes: \fIbash\fR (default if no --template switch present). Brief explanation of the process of writing your own templates is in the XSL file \fIxsl/legacy-fix.xsl\fR in the openscap data directory. You can also take a look at the default template \fIxsl/legacy-fixtpl-bash.xml\fR.
 .TP
 \fB\-\-xccdf-id ID\fR
 Takes component ref with given ID from checklists. This allows one to select a particular XCCDF component even in cases where there are multiple XCCDFs in a single data stream. If none is given, the first component from the checklists element is used.


### PR DESCRIPTION
The option --template allows users to provide either a remediation system URN or a custome XSLT template path. Instead of using the --template with URN users should use --fix-type. A custom XSLT path have never really worked. Users can apply custom XSLTs on their XML files using xsltsproc tool or other third party tools, they don't need oscap for that. We advise users to use --fix-type to specify the remediation type.

The --oval-template and --sce-template options are also useless because the result file names are defined by oscap itself, therefore there is no other sensible value for these options than the default value (hardcoded in oscap).