### PR TITLE
Fix CI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,16 +16,16 @@ jobs:
   metadata:
     targets:
     - fedora-all-x86_64
-    - centos-stream-8-x86_64
     - centos-stream-9-x86_64
+    - centos-stream-10-x86_64
 
 - job: tests
   trigger: pull_request
   metadata:
     targets:
     - fedora-all-x86_64
-    - centos-stream-8-x86_64
     - centos-stream-9-x86_64
+    - centos-stream-10-x86_64
 
 - <<: *build
   trigger: commit

--- a/openscap.spec
+++ b/openscap.spec
@@ -14,12 +14,8 @@ BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  swig libxml2-devel libxslt-devel perl-generators perl-XML-Parser
 BuildRequires:  rpm-devel
-BuildRequires:  libgcrypt-devel
-%if 0%{?fedora}
+BuildRequires:  nss-devel
 BuildRequires:  pcre2-devel
-%else
-BuildRequires:  pcre-devel
-%endif
 BuildRequires:  libacl-devel
 BuildRequires:  libselinux-devel
 BuildRequires:  libcap-devel
@@ -131,12 +127,10 @@ Tool for scanning Atomic containers.
 
 %build
 %undefine __cmake_in_source_build
-# gconf is a legacy system not used any more, and it blocks testing of oscap-anaconda-addon
-# as gconf is no longer part of the installation medium
 %cmake \
     -DENABLE_PERL=OFF \
-    -DENABLE_DOCS=ON \
-    -DGCONF_LIBRARY=
+    -DWITH_CRYPTO=nss \
+    -DENABLE_DOCS=ON
 %cmake_build
 make docs
 
@@ -151,7 +145,7 @@ ctest -V %{?_smp_mflags}
 find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
 
 # fix python shebangs
-%if 0%{?fedora}
+%if 0%{?rhel} >= 10 || 0%{?fedora}
 %{__python3} %{_rpmconfigdir}/redhat/pathfix.py -i %{__python3} -p -n $RPM_BUILD_ROOT%{_bindir}/scap-as-rpm
 %else
 pathfix.py -i %{__python3} -p -n $RPM_BUILD_ROOT%{_bindir}/scap-as-rpm

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -325,7 +325,7 @@ char *oscap_strerror_r(int errnum, char *buf, size_t buflen)
 #ifdef OS_WINDOWS
 	strerror_s(buf, buflen, errnum);
 	return buf;
-#elif defined(OS_FREEBSD)
+#elif defined(OS_APPLE) || defined(OS_FREEBSD)
 	strerror_r(errnum, buf, buflen);
 	return buf;
 #else


### PR DESCRIPTION
Stop building/testing on c8s (we are not going to release 1.4 there).

Start building/testing on c10s.

Fix MacOS X build. (Fixes: https://github.com/OpenSCAP/openscap/issues/2131)

Throw away PCREv1 from spec file (we don't care about it in 1.4+).

Switch to NSS.