### PR TITLE
Add firewall command to Kickstart remediation

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1155,6 +1155,8 @@ Supported commands:
 * `logvol path size` - adds `logvol` entry to the commands section of the kickstart that will mount a partition of the given `size` in MB to the given `path` as a mount point
 * `bootloader option` or `bootloader option=value` - adds `option` or `option=value` to the list in the `--append=` option in the `bootloader` command in commands section in the kickstart
 * `kdump disable` - this will disable K-Dump by adding the `com_redhat_kdump` Addon section to the kickstart with a `--disable` option
+* `firewall enable service_name` - adds `service_name` to list in the `--service=` option in the `firewall` command in commands section in the kickstart
+* `firewall disable service_name` - adds `service_name` to list in the `--remove-service=` option in the `firewall` command in commands section in the kickstart
 
 For example, to generate a kickstart for RHEL 9 STIG profile, run:
 

--- a/tests/API/XCCDF/unittests/test_remediation_kickstart.ds.xml
+++ b/tests/API/XCCDF/unittests/test_remediation_kickstart.ds.xml
@@ -62,6 +62,7 @@
         <select idref="xccdf_org.openscap.www_rule_7" selected="true"/>
         <select idref="xccdf_org.openscap.www_rule_8" selected="true"/>
         <select idref="xccdf_org.openscap.www_rule_9" selected="true"/>
+        <select idref="xccdf_org.openscap.www_rule_10" selected="true"/>
       </Profile>
       <Rule selected="false" id="xccdf_org.openscap.www_rule_1">
         <title>Rule 1: Enable Audit Service</title>
@@ -135,6 +136,13 @@
           %end
           package install podman
           kdump disable
+        </fix>
+      </Rule>
+      <Rule selected="false" id="xccdf_org.openscap.www_rule_10">
+        <title>Rule 10: Firewall</title>
+        <fix system="urn:xccdf:fix:script:kickstart">
+          firewall enable sshd
+          firewall disable httpd
         </fix>
       </Rule>
     </Benchmark>

--- a/tests/API/XCCDF/unittests/test_remediation_kickstart_expected.cfg
+++ b/tests/API/XCCDF/unittests/test_remediation_kickstart_expected.cfg
@@ -49,6 +49,9 @@ bootloader --append="quick audit=1"
 %addon com_redhat_kdump --disable
 %end
 
+# Disable and enable services in firewall (required for security compliance)
+firewall --remove-service=httpd --service=sshd
+
 # Disable and enable systemd services (required for security compliance)
 services --disabled=telnet,httpd --enabled=auditd,rsyslog,sshd
 


### PR DESCRIPTION
In this commit, we will add option for managing firewall rules
during the installation:

* `firewall enable service_name` - adds `service_name` to list in the
  `--service=` option in the `firewall` command in commands section in
  the kickstart
* `firewall disable service_name` - adds `service_name` to list in the
  `--remove-service=` option in the `firewall` command in commands
  section in the kickstart

Also, the test will be extended for these new commands.

Related to:
https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#firewall