### PR TITLE
Check autotailor unit test dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,7 @@ message(STATUS "Testing:")
 message(STATUS "tests: ${ENABLE_TESTS}")
 message(STATUS "valgrind: ${ENABLE_VALGRIND}")
 message(STATUS "MITRE: ${ENABLE_MITRE}")
+message(STATUS "pytest: ${PY_PYTEST}")
 message(STATUS " ")
 
 message(STATUS "Documentation:")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ include(CheckIncludeFile)
 include(CheckIncludeFiles)
 include(CheckCSourceCompiles)
 include(CMakeDependentOption)
+include(FindPythonModule)
 
 # ---------- DEPENDENCIES
 
@@ -126,6 +127,8 @@ find_package(PythonLibs 3)
 
 set(PREFERRED_PYTHON_PATH "${PYTHON_EXECUTABLE}" CACHE PATH "Path to preferred Python")
 set(PYTHON3_PATH "${PYTHON_EXECUTABLE}" CACHE PATH "Path to Python3")
+
+find_python_module(pytest)
 
 find_package(RPM)
 if(RPM_FOUND)

--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -1,0 +1,41 @@
+# Find if a Python module is installed
+# Found at http://www.cmake.org/pipermail/cmake/2011-January/041666.html
+# To use do: find_python_module(PyQt4 REQUIRED)
+
+# Keep filename as is
+# lint_cmake: -convention/filename, -package/stdargs
+
+include(FindPackageHandleStandardArgs)
+
+function(find_python_module module)
+    string(TOUPPER ${module} module_upper)
+    if(NOT PY_${module_upper})
+        if(ARGC GREATER 1 AND ARGV1 STREQUAL "REQUIRED")
+            set(PY_${module}_FIND_REQUIRED TRUE)
+        endif()
+        if($ENV{SSG_USE_PIP_PACKAGES})
+            execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+                "import platform; print(''.join('python'+platform.python_version()[:-2]))"
+                RESULT_VARIABLE _python_version_status
+                OUTPUT_VARIABLE _python_version
+                ERROR_QUIET
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+            if(NOT ${_python_version_status})
+                set(ENV{PYTHONPATH} "/usr/local/lib/${_python_version}/site-packages:/usr/local/lib64/${_python_version}/site-packages")
+            endif()
+        endif()
+        # A module's location is usually a directory, but for binary modules
+        # it's a .so file.
+        execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+            "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+            RESULT_VARIABLE _${module}_status
+            OUTPUT_VARIABLE _${module}_location
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        if(NOT _${module}_status)
+            set(PY_${module_upper} ${_${module}_location} CACHE STRING
+                "Location of Python module ${module}")
+        endif()
+    endif()
+    find_package_handle_standard_args(PY_${module} DEFAULT_MSG PY_${module_upper})
+endfunction()

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_oscap_test("autotailor_integration_test.sh")
 add_oscap_test("test_utils_args.sh")
 
-add_test(
-    NAME "autotailor-unit-tests"
-    COMMAND ${PYTHON_EXECUTABLE} -m pytest -v "${CMAKE_CURRENT_SOURCE_DIR}/test_autotailor.py"
-)
+if(PY_PYTEST)
+    add_test(
+        NAME "autotailor-unit-tests"
+        COMMAND ${PYTHON_EXECUTABLE} -m pytest -v "${CMAKE_CURRENT_SOURCE_DIR}/test_autotailor.py"
+    )
+endif()


### PR DESCRIPTION
We will run autotailor unit tests only if pytest is installed on the system. CMake will check for the presence of pytest and enable or disable the unit tests test accordingly.

Fixes: #2153