### PR TITLE
Improve RPM database path in RPM probes

### DIFF
--- a/src/OVAL/probes/unix/linux/rpm-helper.h
+++ b/src/OVAL/probes/unix/linux/rpm-helper.h
@@ -99,4 +99,7 @@ int rpmVerifyFile(const rpmts ts, const rpmfi fi,
  */
 void rpmLibsPreload(void);
 
+void set_rpm_db_path(void);
+
+
 #endif

--- a/src/OVAL/probes/unix/linux/rpminfo_probe.c
+++ b/src/OVAL/probes/unix/linux/rpminfo_probe.c
@@ -294,17 +294,7 @@ void *rpminfo_probe_init(void)
 		return ((void *)g_rpm);
         }
 
-        /*
-        * Fedora >=36 changed the default dbpath in librpm from /var/lib/rpm to /usr/lib/sysimage/rpm
-        * See: https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
-        * Therefore, when running openscap on a Fedora >=36 system scanning another systems (such as RHEL, SLES, Fedora<36)
-        * openscap's librpm will try to read the rpm db from /usr/lib/sysimage/rpm which doesn't exist and therefore won't work.
-        * In implementing this change, /var/lib/rpm is still a symlink to /usr/lib/sysimage/rpm
-        * so /var/lib/rpm still works. So /var/lib/rpm is a dbpath that will work on all systems.
-        * Therefore, set the dbpath to be /var/lib/rpm, allow openscap running on any system to scan any system.
-        */
-        rpmPushMacro(NULL, "_dbpath", NULL, "/var/lib/rpm", RMIL_CMDLINE);
-
+	set_rpm_db_path();
 	g_rpm->rpmts = rpmtsCreate();
 	pthread_mutex_init (&(g_rpm->mutex), NULL);
 

--- a/src/OVAL/probes/unix/linux/rpmverify_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverify_probe.c
@@ -236,16 +236,7 @@ void *rpmverify_probe_init(void)
                 return (NULL);
         }
 
-        /*
-        * Fedora >=36 changed the default dbpath in librpm from /var/lib/rpm to /usr/lib/sysimage/rpm
-        * See: https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
-        * Therefore, when running openscap on a Fedora >=36 system scanning another systems (such as RHEL, SLES, Fedora<36)
-        * openscap's librpm will try to read the rpm db from /usr/lib/sysimage/rpm which doesn't exist and therefore won't work.
-        * In implementing this change, /var/lib/rpm is still a symlink to /usr/lib/sysimage/rpm
-        * so /var/lib/rpm still works. So /var/lib/rpm is a dbpath that will work on all systems.
-        * Therefore, set the dbpath to be /var/lib/rpm, allow openscap running on any system to scan any system.
-        */
-        rpmPushMacro(NULL, "_dbpath", NULL, "/var/lib/rpm", RMIL_CMDLINE);
+	set_rpm_db_path();
 
 	struct rpm_probe_global *g_rpm = malloc(sizeof(struct rpm_probe_global));
 	g_rpm->rpmts = rpmtsCreate();

--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
@@ -358,16 +358,7 @@ void *rpmverifyfile_probe_init(void)
 
 	struct rpm_probe_global *g_rpm = malloc(sizeof(struct rpm_probe_global));
 
-	/*
-	* Fedora >=36 changed the default dbpath in librpm from /var/lib/rpm to /usr/lib/sysimage/rpm
-	* See: https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
-	* Therefore, when running openscap on a Fedora >=36 system scanning another systems (such as RHEL, SLES, Fedora<36)
-	* openscap's librpm will try to read the rpm db from /usr/lib/sysimage/rpm which doesn't exist and therefore won't work.
-	* In implementing this change, /var/lib/rpm is still a symlink to /usr/lib/sysimage/rpm
-	* so /var/lib/rpm still works. So /var/lib/rpm is a dbpath that will work on all systems.
-	* Therefore, set the dbpath to be /var/lib/rpm, allow openscap running on any system to scan any system.
-	*/
-	rpmPushMacro(NULL, "_dbpath", NULL, "/var/lib/rpm", RMIL_CMDLINE);
+	set_rpm_db_path();
 
 	g_rpm->rpmts = rpmtsCreate();
 

--- a/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
+++ b/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
@@ -354,16 +354,6 @@ void *rpmverifypackage_probe_init(void)
 		return ((void *)g_rpm);
 	}
 
-	/*
-	* Fedora >=36 changed the default dbpath in librpm from /var/lib/rpm to /usr/lib/sysimage/rpm
-	* See: https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
-	* Therefore, when running openscap on a Fedora >=36 system scanning another systems (such as RHEL, SLES, Fedora<36)
-	* openscap's librpm will try to read the rpm db from /usr/lib/sysimage/rpm which doesn't exist and therefore won't work.
-	* In implementing this change, /var/lib/rpm is still a symlink to /usr/lib/sysimage/rpm
-	* so /var/lib/rpm still works. So /var/lib/rpm is a dbpath that will work on all systems.
-	* Therefore, set the dbpath to be /var/lib/rpm, allow openscap running on any system to scan any system.
-	*/
-	rpmPushMacro(NULL, "_dbpath", NULL, "/var/lib/rpm", RMIL_CMDLINE);
 
 	g_rpm->rpm.rpmts = rpmtsCreate();
 
@@ -377,6 +367,7 @@ void *rpmverifypackage_probe_init(void)
 		rpmtsSetRootDir(g_rpm->rpm.rpmts, CHROOT_PATH());
 	}
 
+	set_rpm_db_path();
 	pthread_mutex_init(&(g_rpm->rpm.mutex), NULL);
 	return ((void *)g_rpm);
 }

--- a/tests/probes/rpm/rpm_common.sh
+++ b/tests/probes/rpm/rpm_common.sh
@@ -11,10 +11,7 @@ RPMBUILD="${RPMBASE}/build"
 
 # Since Fedora 36 RPM database location changed, see
 # https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
-# However, /var/lib/rpm/ still works as it is a symlink to
-# the new path, /usr/lib/sysimage/rpm/, in Fedora >= 36
-# Therefore, always use /var/lib/rpm/ as it always works.
-RPMDB_PATH="/var/lib/rpm/"
+RPMDB_PATH="/usr/lib/sysimage/rpm/"
 
 function rpm_build {
     require "rpmbuild" || return 255

--- a/tests/probes/rpm/rpmverifypackage/rpmverifypackage_common.sh
+++ b/tests/probes/rpm/rpmverifypackage/rpmverifypackage_common.sh
@@ -30,7 +30,7 @@ function test_probes_rpmverifypackage {
 
     rm -f $RF
 
-    $OSCAP oval eval --results $RF $DF
+    $OSCAP oval eval --verbose INFO --results $RF $DF
 
     result=$RF
 


### PR DESCRIPTION
### Description

The assumption that /var/lib/rpm is always a symlink to /usr/lib/sysimage/rpm was wrong. In bootc images, it isn't the case. As a result, all rules were evaluated as notapplicable when scanning a bootc image or container.

We will fix it the following way: We will first try if the "new" location /usr/lib/sysimage/rpm exists, and use it only if it exists.  If it doesn't exist, we will fall back to the "old" location /var/lib/rpm.

Fixes: https://issues.redhat.com/browse/RHEL-55251
Fixes: https://github.com/OpenSCAP/openscap/issues/2151

### Rationale

This would be a first step to get OpenSCAP ready for  bootc experience.

### Review hints

First, reproduce the problem and verify that we fixed it.
sudo podman pull quay.io/centos-bootc/centos-bootc:stream9
sudo oscap-podman quay.io/centos-bootc/centos-bootc:stream9 oval eval --results /tmp/results.xml oval.xml
sudo oscap-podman --oscap=/home/jcerny/work/git/openscap/build/oscap_wrapper quay.io/centos-bootc/centos-bootc:stream9 oval eval --results /tmp/results.xml oval.xml

Then, verify we haven't broken scanning old systems on example of the ubi8 image.
sudo podman pull ubi8
sudo oscap-podman ubi8 oval eval --results /tmp/results.xml oval.xml
sudo oscap-podman --oscap=/home/jcerny/work/git/openscap/build/oscap_wrapper ubi8 oval eval --results /tmp/results.xml oval.xml

Also, verify that the probes still work locally.
./oscap_wrapper oval eval --results /tmp/local.xml oval.xml

In each command examine the produced OVAL result carefully and check if there is an item matching every test and check if the collected data comes from the scanned target and not form the host or from elsewhere.