### PR TITLE
Cleanup CI for maint-1.3 branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ name: Gating
 # events but only for the main branch
 on:
   push:
-    branches: [ '*' ]
+    branches: [ maint-1.3 ]
   pull_request:
-    branches: [ main, maint-1.3 ]
+    branches: [ maint-1.3 ]
 
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-latest]
+        os: [ubuntu-22.04]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -51,10 +51,10 @@ jobs:
         ctest --output-on-failure
 
   build-fedora:
-    name: Build, Test on Fedora Latest (Container)
+    name: Build, Test on Fedora 40 (Container)
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: fedora:40
     steps:
     - name: Install Deps
       run: dnf install -y cmake git dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre2-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace python3-pytest
@@ -73,66 +73,6 @@ jobs:
         export $(dbus-launch)
         ctest --output-on-failure
 
-  build-fedora-nss:
-    name: Build with NSS, Test on Fedora Latest (Container)
-    runs-on: ubuntu-latest
-    container:
-      image: fedora:latest
-    steps:
-    - name: Install Deps
-      run: dnf install -y cmake git dbus-devel GConf2-devel libacl-devel libblkid-devel libcap-devel libcurl-devel nss-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre2-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace python3-pytest
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
-    - name: Build
-      working-directory: ./build
-      run: |
-        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_PCRE2=True -DWITH_CRYPTO=nss ../
-        make all
-    - name: Test
-      working-directory: ./build
-      run: |
-        export $(dbus-launch)
-        ctest --output-on-failure
-
-  build-macos:
-    # The type of runner that the job will run on
-    name: Build, Test on macOS Latest
-    runs-on: macos-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
-
-    # Runs a single command using the runners shell
-    - name: Install Deps
-      run: |
-        # Unlink and re-link to prevent errors when GitHub Mac runner images
-        # install Python outside of Brew:
-        brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
-        brew update
-        brew install doxygen
-        brew install opendbx
-        brew install pkg-config
-        brew install popt
-        brew install swig
-        brew install libxmlsec1
-        brew install openssl
-        brew install pcre2
-
-    # Runs a set of commands using the runners shell
-    - name: Build
-      run: |
-        cd $GITHUB_WORKSPACE/build
-        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_PCRE2=True -DENABLE_PROBES=False ../
-        make all
-
-    - name: Test
-      run: |
-        cd $GITHUB_WORKSPACE/build
-        echo "Tests are so broken for macOS :("
   build-windows:
     name: Build on Windows
     runs-on: windows-latest
@@ -148,7 +88,7 @@ jobs:
         path: ${{ github.workspace }}/vcpkg
         repository: microsoft/vcpkg
         fetch-depth: 1
-    
+
     - name: Bootstrap vcpkg
       shell: pwsh
       run: "${{ github.workspace }}\\vcpkg\\scripts\\bootstrap.ps1 -disableMetrics"
@@ -159,7 +99,6 @@ jobs:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
     - name: Install Deps
       run: "${{ github.workspace }}\\vcpkg\\vcpkg.exe install curl libxml2 libxslt bzip2 pcre pthreads zlib getopt-win32 xmlsec --triplet x64-windows"
 
@@ -170,7 +109,7 @@ jobs:
     - name: Build
       run: cmake --build . --config Release
       working-directory: ./build
-    
+
     - name: Package
       run: cpack
       working-directory: build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ 'maint-1.3', 'maint-1.2', 'master' ]
+    branches: [ 'maint-1.3' ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ 'maint-1.3' ]
@@ -54,6 +54,6 @@ jobs:
         make all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,7 +15,6 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-all-x86_64
     - centos-stream-8-x86_64
     - centos-stream-9-x86_64
 
@@ -23,7 +22,6 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-all-x86_64
     - centos-stream-8-x86_64
     - centos-stream-9-x86_64
 


### PR DESCRIPTION
We don't need fresh Fedoras or Ubuntus. We keep that version only for older RHELs and Ubuntu LTSes.

I've also removed MacOS X.