### PR TITLE
fix missing declaration of PATH_MAX on Solaris

### DIFF
--- a/src/OVAL/oval_session.c
+++ b/src/OVAL/oval_session.c
@@ -33,6 +33,7 @@
 #if defined(OS_LINUX)
 #include <linux/limits.h>
 #endif
+#include <limits.h>
 
 #include "common/debug_priv.h"
 #include "common/util.h"


### PR DESCRIPTION
With new libxml2 version it's missing limits.h on Solaris.