### PR TITLE
Allow preferring SCE

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -1658,6 +1658,7 @@ If OpenSCAP is executed with verbosity level INFO or DEVEL their runtime values 
 * `OSCAP_PROBE_MEMORY_USAGE_RATIO` - maximum memory usage ratio (used/total) for OpenSCAP probes, default: 0.1
 * `OSCAP_PROBE_MAX_COLLECTED_ITEMS` - maximal count of collected items by OpenSCAP probe for a single OVAL object evaluation
 * `OSCAP_PROBE_IGNORE_PATHS` - Skip given paths during evaluation. If multiple paths should be skipped they need to be separated by a colon. The paths should be absolute canonical paths.
+* `OSCAP_PREFERRED_ENGINE` - Set a preffered check engine for XCCDF rules. If a rule has multiple checks, the checks for the preffered check engine will be used. Allowed values: `SCE`, `OVAL`. If this variable is set to `SCE` and a rule has both SCE and OVAL checks the SCE check will be used. If this variable is set to `OVAL` and a rule has both SCE and OVAL checks the OVAL check will be used. If this environment variable isn't set, the standard XCCDF mechanism will be used for check selection.
 
 Also, OpenSCAP uses `libcurl` library which also can be configured using environment variables. See https://curl.se/libcurl/c/libcurl-env.html[the list of libcurl environment variables].
 

--- a/src/SCE/sce_engine.c
+++ b/src/SCE/sce_engine.c
@@ -370,6 +370,7 @@ xccdf_test_result_type_t sce_engine_eval_rule(struct xccdf_policy *policy, const
 		struct xccdf_check_import_iterator *check_import_it,
 		void *usr)
 {
+	dI("Executing SCE check '%s'", href);
 	struct sce_parameters* parameters = (struct sce_parameters*)usr;
 	const char* xccdf_directory = parameters->xccdf_directory;
 	bool use_sce_wrapper = false; // use osca-run-sce-script ?

--- a/src/XCCDF_POLICY/xccdf_policy.c
+++ b/src/XCCDF_POLICY/xccdf_policy.c
@@ -588,6 +588,16 @@ _xccdf_policy_rule_get_applicable_check(struct xccdf_policy *policy, struct xccd
 			struct xccdf_check *check = xccdf_check_iterator_next(candidate_it);
 			if (_xccdf_policy_is_engine_registered(policy, (char *) xccdf_check_get_system(check))) {
 				result = check;
+				char *preferred_engine = getenv("OSCAP_PREFERRED_ENGINE");
+				if (preferred_engine) {
+					if (strcmp("SCE", preferred_engine) && strcmp("OVAL", preferred_engine))  {
+						dW("Unknown value of OSCAP_PREFFERED_ENGINE: '%s'. It will be ignored.", preferred_engine);
+					}
+					if ((!strcmp("SCE", preferred_engine) && !strcmp("http://open-scap.org/page/SCE", check->system)) ||
+							(!strcmp("OVAL", preferred_engine) && !strcmp("http://oval.mitre.org/XMLSchema/oval-definitions-5", check->system))) {
+						break;
+					}
+				}
 			} else if (strcmp("http://oval.mitre.org/XMLSchema/oval-definitions-5", check->system) == 0) {
 				print_oval_warning = true;
 			} else if (strcmp("http://scap.nist.gov/schema/ocil/2", check->system) == 0) {

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -311,6 +311,7 @@ void oscap_print_env_vars()
 		"OSCAP_PROBE_MEMORY_USAGE_RATIO",
 		"OSCAP_PROBE_MAX_COLLECTED_ITEMS",
 		"OSCAP_PROBE_IGNORE_PATHS",
+		"OSCAP_PREFERRED_ENGINE",
 		NULL
 	};
 	dI("Using environment variables:");

--- a/tests/sce/CMakeLists.txt
+++ b/tests/sce/CMakeLists.txt
@@ -1,4 +1,5 @@
 if(ENABLE_SCE)
+	add_oscap_test("test_prefer_sce.sh")
 	if(${PYTHON_VERSION_MAJOR} EQUAL "3")
 		add_oscap_test("test_sce.sh")
 	endif()

--- a/tests/sce/test_prefer_sce.ds.xml
+++ b/tests/sce/test_prefer_sce.ds.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ds:data-stream-collection xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:sce="http://open-scap.org/page/SCE_xccdf_stream" id="scap_org.openscap.www_collection_from_xccdf_test_single_rule.xccdf.xml" schematron-version="1.3" xsi:schemaLocation="http://scap.nist.gov/schema/scap/source/1.2 https://scap.nist.gov/schema/scap/1.3/scap-source-data-stream_1.3.xsd">
+  <ds:data-stream id="scap_org.openscap.www_datastream_simple" scap-version="1.3" use-case="OTHER">
+    <ds:checklists>
+      <ds:component-ref id="scap_org.openscap.www_cref_test_single_rule.xccdf.xml" xlink:href="#scap_org.openscap.www_comp_test_single_rule.xccdf.xml">
+        <cat:catalog>
+          <cat:uri name="test_single_rule.oval.xml" uri="#scap_org.openscap.www_cref_test_single_rule.oval.xml"/>
+          <cat:uri name="fedora/checks/sce/rule_1.sh" uri="#scap_org.openscap.www_cref_fedora-checks-sce-rule_1.sh"/>
+        </cat:catalog>
+      </ds:component-ref>
+      <ds:component-ref id="scap_org.openscap.www_cref_fedora-checks-sce-rule_1.sh" xlink:href="#scap_org.openscap.www_ecomp_fedora-checks-sce-rule_1.sh"/>
+    </ds:checklists>
+    <ds:checks>
+      <ds:component-ref id="scap_org.openscap.www_cref_test_single_rule.oval.xml" xlink:href="#scap_org.openscap.www_comp_test_single_rule.oval.xml"/>
+    </ds:checks>
+  </ds:data-stream>
+  <ds:component id="scap_org.openscap.www_comp_test_single_rule.oval.xml" timestamp="2021-02-01T08:07:06+01:00">
+    <oval_definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:win-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd    http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows windows-definitions-schema.xsd">
+      <generator>
+        <oval:schema_version>5.11.2</oval:schema_version>
+        <oval:timestamp>2021-02-01T08:07:06+01:00</oval:timestamp>
+      </generator>
+      <definitions>
+        <definition class="compliance" id="oval:org.openscap.www:def:1" version="1">
+          <metadata>
+            <title>OVAL check for rule 1</title>
+            <description>pass</description>
+          </metadata>
+          <criteria>
+            <criterion comment="PASS test" test_ref="oval:org.openscap.www:tst:1"/>
+          </criteria>
+        </definition>
+      </definitions>
+      <tests>
+        <variable_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.openscap.www:tst:1" check="all" comment="always pass" version="1">
+          <object object_ref="oval:org.openscap.www:obj:1"/>
+        </variable_test>
+      </tests>
+      <objects>
+        <variable_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:org.openscap.www:obj:1" version="1" comment="x">
+          <var_ref>oval:org.openscap.www:var:1</var_ref>
+        </variable_object>
+      </objects>
+      <variables>
+        <constant_variable id="oval:org.openscap.www:var:1" version="1" comment="x" datatype="int">
+          <value>100</value>
+        </constant_variable>
+      </variables>
+    </oval_definitions>
+  </ds:component>
+  <ds:component id="scap_org.openscap.www_comp_test_single_rule.xccdf.xml" timestamp="2021-02-01T08:07:06+01:00">
+    <Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_org.openscap.www_benchmark_test">
+      <status>accepted</status>
+      <version>1.0</version>
+      <Profile id="xccdf_org.openscap.www_profile_common">
+        <title>Common hardening profile</title>
+        <description>This is a very cool profile</description>
+        <select idref="xccdf_org.openscap.www_rule_1" selected="true"/>
+      </Profile>
+      <Rule selected="false" id="xccdf_org.openscap.www_rule_1">
+        <title>Rule 1: Enable Audit Service</title>
+        <check system="http://open-scap.org/page/SCE">
+          <check-import import-name="stdout"/>
+          <check-content-ref href="fedora/checks/sce/rule_1.sh"/>
+        </check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+          <check-content-ref href="test_single_rule.oval.xml" name="oval:org.openscap.www:def:1"/>
+        </check>
+      </Rule>
+    </Benchmark>
+  </ds:component>
+  <ds:extended-component id="scap_org.openscap.www_ecomp_fedora-checks-sce-rule_1.sh" timestamp="2024-10-09T18:03:34">
+    <sce:script>#!/bin/bash
+echo "Hello how are you"
+exit "$XCCDF_RESULT_FAIL"
+</sce:script>
+  </ds:extended-component>
+</ds:data-stream-collection>

--- a/tests/sce/test_prefer_sce.sh
+++ b/tests/sce/test_prefer_sce.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+. $builddir/tests/test_common.sh
+
+set -e -o pipefail
+
+
+function test_prefer_sce_on () {
+    stdout=$(mktemp)
+    stderr=$(mktemp)
+    arf=$(mktemp)
+
+    OSCAP_PREFERRED_ENGINE="SCE" $OSCAP xccdf eval --verbose INFO --progress --profile common --results-arf "$arf" > "$stdout" 2> "$stderr" "$srcdir/test_prefer_sce.ds.xml" || ret="$?"
+    grep -q "xccdf_org.openscap.www_rule_1:fail" "$stdout"
+    ! grep -q "I: oscap: Evaluating definition 'oval:org.openscap.www:def:1': OVAL check for rule 1." "$stderr"
+    grep -q "I: oscap: Executing SCE check 'fedora/checks/sce/rule_1.sh'" "$stderr"
+
+    rm -rf "$stdout" "$stderr" "$arf"
+}
+
+test_prefer_sce_off () {
+    stdout=$(mktemp)
+    stderr=$(mktemp)
+    arf=$(mktemp)
+
+    $OSCAP xccdf eval --verbose INFO --progress --profile common --results-arf "$arf" > "$stdout" 2> "$stderr" "$srcdir/test_prefer_sce.ds.xml" || ret="$?"
+    grep -q "xccdf_org.openscap.www_rule_1:pass" "$stdout"
+    grep -q "I: oscap: Evaluating definition 'oval:org.openscap.www:def:1': OVAL check for rule 1." "$stderr"
+    ! grep -q "I: oscap: Executing SCE check 'fedora/checks/sce/rule_1.sh'" "$stderr"
+
+    rm -rf "$stdout" "$stderr" "$arf"
+}
+
+test_prefer_oval_explicit () {
+    stdout=$(mktemp)
+    stderr=$(mktemp)
+    arf=$(mktemp)
+
+    OSCAP_PREFERRED_ENGINE="OVAL" $OSCAP xccdf eval --verbose INFO --progress --profile common --results-arf "$arf" > "$stdout" 2> "$stderr" "$srcdir/test_prefer_sce.ds.xml" || ret="$?"
+    grep -q "xccdf_org.openscap.www_rule_1:pass" "$stdout"
+    grep -q "I: oscap: Evaluating definition 'oval:org.openscap.www:def:1': OVAL check for rule 1." "$stderr"
+    ! grep -q "I: oscap: Executing SCE check 'fedora/checks/sce/rule_1.sh'" "$stderr"
+
+    rm -rf "$stdout" "$stderr" "$arf"
+}
+
+
+test_prefer_sce_on
+test_prefer_sce_off
+test_prefer_oval_explicit


### PR DESCRIPTION
This commit introduces a new environment variable
`OSCAP_PREFERRED_ENGINE`. This variable allows users to set a preffered check engine for XCCDF rules. If a rule has multiple checks, the checks for the preffered check engine will be used. Allowed values: `SCE`, `OVAL`. If this variable is set to `SCE` and a rule has both SCE and OVAL checks the SCE check will be used. If this variable is set to `OVAL` and a rule has both SCE and OVAL checks the OVAL check will be used. If this environment variable isn't set, the standard XCCDF mechanism will be used for check selection.

This will allow us to explicitely prefer SCE checks when executing `oscap` in Containerfile in the `podman build` process when building hardened bootc images.

Also a small test is added to test this feature.