### PR TITLE
Make a copy before spliting.

### DIFF
--- a/src/OVAL/probes/probe/worker.c
+++ b/src/OVAL/probes/probe/worker.c
@@ -974,7 +974,7 @@ static SEXP_t *probe_set_eval(probe_t *probe, SEXP_t *set, size_t depth)
 
 static void _add_blocked_paths(struct oscap_list *bpaths)
 {
-	char *envar = getenv("OSCAP_PROBE_IGNORE_PATHS");
+	char *envar = oscap_strdup(getenv("OSCAP_PROBE_IGNORE_PATHS"));
 	if (envar == NULL) {
 		return;
 	}
@@ -985,6 +985,7 @@ static void _add_blocked_paths(struct oscap_list *bpaths)
 	for (int i = 0; paths[i]; ++i) {
 		oscap_list_add(bpaths, strdup(paths[i]));
 	}
+	free(envar);
 	free(paths);
 #endif
 }


### PR DESCRIPTION
Currently the `oscap_split` will alter the environ string of "OSCAP_PROBE_IGNORE_PATHS". This leads to "OSCAP_PROBE_IGNORE_PATHS" does not work as expected in subsequent use. The small patch fixed this issue.