### PR TITLE
Extend oscap-bootc to install SCE dependencies

### DIFF
--- a/utils/oscap-bootc
+++ b/utils/oscap-bootc
@@ -61,6 +61,19 @@ def ensure_sce_installed():
             "installed.")
 
 
+def install_sce_dependencies():
+    required_packages = [
+        "setools-console"  # seinfo is used by the sebool template
+    ]
+    install_cmd = ["dnf", "-y", "install"] + required_packages
+    install_process = subprocess.run(
+        install_cmd, universal_newlines=True,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if install_process.returncode != 0:
+        raise RuntimeError(
+            f"{install_process.stdout}\nFailed to install SCE dependencies.")
+
+
 def add_args(option_args_list, cmd):
     for o, a in option_args_list:
         if a:
@@ -112,6 +125,7 @@ def scan_and_remediate(args):
 def main():
     args = parse_args()
     ensure_sce_installed()
+    install_sce_dependencies()
     pre_scan_fix(args)
     scan_and_remediate(args)
 


### PR DESCRIPTION
Some SCE checks which are used instead of OVAL checks when building a bootable container require additional packages. This commit introduces `install_sce_dependencies` function in `oscap-bootc` script which will handle their installation.

This is related to https://github.com/ComplianceAsCode/content/pull/12564

Marking it as a draft as I am not sure if this is the best solution. Maybe it would be better to make packages which are required by SCE checks as dependencies of `openscap-utils` RPM or even `scap-security-guide` RPM.