### PR TITLE
Add support for containers with no entrypoint/cmd

### DIFF
--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -64,7 +64,7 @@ class OscapDockerScan(object):
 
                 try:
                     tmp_cont = self.client.create_container(
-                        self.image_name, name=self.container_name)
+                        self.image_name, name=self.container_name, command="\x00")
 
                     self.container_name = tmp_cont["Id"]
                     self.config = self.client.inspect_container(self.container_name)


### PR DESCRIPTION
The API call to create a docker image (e.g. the docker command `docker create`) does not support creating a non-running container with no entrypoint or command specified. This will cause `oscap-docker` to fail with the HTTP 400 error from the Docker service:
```
docker.errors.APIError: 400 Client Error for http+docker://localhost/v1.45/containers/create: Bad Request 
("no command specified")
```
To solve this, for scanning purposes only, pass a null character as the explicit command for all containers.

An example Dockerfile for a container with no command is below. It is more common for container images designed to be used as a base container to have no command as they are not intended to be run directly.

```dockerfile
FROM scratch
COPY . /
```