### PR TITLE
Build COPR builds for maint-1.3

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -27,3 +27,5 @@ jobs:
 
 - <<: *build
   trigger: commit
+  metadata:
+    branch: maint-1.3


### PR DESCRIPTION
This change will cause automatic building of COPR builds after committing to `maint-1.3` branch. The `maint-1.3` branch isn't the project default branch. Without specifying the branch, Packit builds after committing only to the project's default branch, which is the `main` branch at this moment. The `maint-1.3` branch used to be default branch, but after we switched the default branch to main, the COPR builds on maint-1.3 stopped to be built.

Related documentation:
https://packit.dev/docs/configuration/upstream/copr_build