### PR TITLE
Request CentOS Stream builds explicitly

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,8 +10,7 @@ srpm_build_deps:
   - bash
 
 jobs:
-- &build
-  job: copr_build
+- job: copr_build
   trigger: pull_request
   metadata:
     targets:
@@ -25,7 +24,10 @@ jobs:
     - centos-stream-8-x86_64
     - centos-stream-9-x86_64
 
-- <<: *build
+- job: copr_build
   trigger: commit
   metadata:
     branch: maint-1.3
+    targets:
+    - centos-stream-8-x86_64
+    - centos-stream-9-x86_64


### PR DESCRIPTION
The current configuration makes build Fedora builds on commit to the maint-1.3 branch.
https://copr.fedorainfracloud.org/coprs/packit/OpenSCAP-openscap-maint-1.3/ But, we wanted to have CentOS Stream builds instead.