### PR TITLE
Update oscap-bootc to verify it runs in bootable container env

### DIFF
--- a/openscap.spec
+++ b/openscap.spec
@@ -92,7 +92,6 @@ Summary:        OpenSCAP Utilities
 Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 Requires:       rpmdevtools rpm-build
 Requires:       %{name}-scanner%{?_isa} = %{epoch}:%{version}-%{release}
-Requires:       %{name}-engine-sce%{?_isa} = %{epoch}:%{version}-%{release}
 
 %description    utils
 The %{name}-utils package contains command-line tools build on top

--- a/utils/oscap-bootc
+++ b/utils/oscap-bootc
@@ -21,6 +21,8 @@ import subprocess
 import sys
 import tempfile
 
+from pathlib import Path
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -52,17 +54,21 @@ def parse_args():
     return parser.parse_args()
 
 
-def ensure_sce_installed():
-    query_cmd = ["rpm", "-q", "openscap-engine-sce"]
-    query_process = subprocess.run(query_cmd, capture_output=True)
-    if query_process.returncode != 0:
+def verify_bootc_build_env():
+    rv = subprocess.run(
+        ["rpm", "-q", "bootc"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    bootc_env = (rv.returncode == 0)
+    container_env = Path("/run/.containerenv").exists()
+    if not bootc_env or not container_env:
         raise RuntimeError(
-            "The script requires to have the openscap-engine-sce package "
-            "installed.")
+            "This script is supposed to be used only in the bootable "
+            "container build environment.")
 
 
 def install_sce_dependencies():
     required_packages = [
+        "openscap-engine-sce",
         "setools-console"  # seinfo is used by the sebool template
     ]
     install_cmd = ["dnf", "-y", "install"] + required_packages
@@ -124,7 +130,7 @@ def scan_and_remediate(args):
 
 def main():
     args = parse_args()
-    ensure_sce_installed()
+    verify_bootc_build_env()
     install_sce_dependencies()
     pre_scan_fix(args)
     scan_and_remediate(args)


### PR DESCRIPTION
The script is updated to first verify that it runs in a bootable container environment - `bootc` package must be installed and `/run/.containerenv` file must exist which indicates we are running inside a container. If it is not running inside a bootable container environment it informs user and exits.

Another change is that installation of `openscap-engine-sce` package has been moved from specfile into the script as the script already installs other requirements which are needed by SCE checks from CaC/content.