### PR TITLE
Reduce oscap info output

### DIFF
--- a/docs/manual/manual.adoc
+++ b/docs/manual/manual.adoc
@@ -198,13 +198,6 @@ Checklists:
 				system: http://scap.nist.gov/schema/ocil/2
 			security-data-oval-com.redhat.rhsa-RHEL8.xml
 				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
-Checks:
-	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-oval.xml
-	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-ocil.xml
-	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-cpe-oval.xml
-	Ref-Id: scap_org.open-scap_cref_security-data-oval-com.redhat.rhsa-RHEL8.xml
-Dictionaries:
-	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-cpe-dictionary.xml
 ----
 
 * **Document type** describes what format the file is in. Common types include
@@ -225,8 +218,6 @@ shown for XCCDF files and Checklists and is sourced from the XCCDF **Status**
 element.
 * **Profiles** lists available profiles, their titles and IDs that you can use for
 the `--profile` command line attribute.
-* **Checks** and **Dictionaries** lists OVAL checks components and CPE
-dictionaries components in the given data stream.
 
 To display more detailed information about a profile including the profile
 description, use the `--profile` option followed by the profile ID.

--- a/utils/oscap-info.c
+++ b/utils/oscap-info.c
@@ -209,8 +209,11 @@ static inline void _print_xccdf_referenced_files(struct xccdf_policy_model *poli
 	printf("%sReferenced check files:\n", prefix);
 	while (oscap_file_entry_iterator_has_more(files_it)) {
 		struct oscap_file_entry *file_entry = (struct oscap_file_entry *) oscap_file_entry_iterator_next(files_it);
-		printf("%s\t%s\n", prefix, oscap_file_entry_get_file(file_entry));
-		printf("%s\t\tsystem: %s\n", prefix, oscap_file_entry_get_system(file_entry));
+		const char *system = oscap_file_entry_get_system(file_entry);
+		if (strcmp(system, "http://open-scap.org/page/SCE")) {
+			printf("%s\t%s\n", prefix, oscap_file_entry_get_file(file_entry));
+			printf("%s\t\tsystem: %s\n", prefix, oscap_file_entry_get_system(file_entry));
+		}
 	}
 	oscap_file_entry_iterator_free(files_it);
 	oscap_file_entry_list_free(referenced_files);
@@ -490,26 +493,6 @@ static int app_info_single_ds_all(struct ds_stream_index_iterator* sds_it, struc
 		ds_sds_session_reset(session);
 	}
 	oscap_string_iterator_free(checklist_it);
-
-	printf("Checks:\n");
-	struct oscap_string_iterator* checks_it = ds_stream_index_get_checks(stream);
-	while (oscap_string_iterator_has_more(checks_it)) {
-		const char * id = oscap_string_iterator_next(checks_it);
-		printf("\tRef-Id: %s\n", id);
-	}
-	oscap_string_iterator_free(checks_it);
-
-	struct oscap_string_iterator* dict_it = ds_stream_index_get_dictionaries(stream);
-	if (oscap_string_iterator_has_more(dict_it)) {
-		printf("Dictionaries:\n");
-	} else {
-		printf("No dictionaries.\n");
-	}
-	while (oscap_string_iterator_has_more(dict_it)) {
-		const char * id = oscap_string_iterator_next(dict_it);
-		printf("\tRef-Id: %s\n", id);
-	}
-	oscap_string_iterator_free(dict_it);
 	return OSCAP_OK;
 }
 


### PR DESCRIPTION
After we added SCE checks to ComplianceAsCode data streams we discovered that the oscap info output is appalling because it's polluted by all the SCE check information. In this commit, we will address this problem by removing SCE checks from the "Referenced check files:" section. Then, we will completely remove the "Checks:" and "Dictionaries:" sections because they only list crefs and crefs are internal data stream identifiers that noone should be interested in.