### PR TITLE
Display file is blocked or not.

### DIFF
--- a/src/OVAL/probes/probe-api.c
+++ b/src/OVAL/probes/probe-api.c
@@ -1807,7 +1807,7 @@ bool probe_path_is_blocked(const char *path, struct oscap_list *blocked_paths)
 		}
 	}
 	oscap_iterator_free(it);
-	dD("Path:%s, res:%d", path, res);
+	dD("Path: %s, blocked (res): %d", path, res);
 	return res;
 }
 


### PR DESCRIPTION
Showing the result can help isolating some memory consuming issue.