### PR TITLE
tests: Don't set -e for compound tests managed by test_run

### DIFF
--- a/tests/DS/test_ds_misc.sh
+++ b/tests/DS/test_ds_misc.sh
@@ -3,7 +3,7 @@
 # Author:
 #   Martin Preisler <mpreisle@redhat.com>
 
-set -e -o pipefail
+set -o pipefail
 
 . $builddir/tests/test_common.sh
 . $srcdir/test_ds_common.sh

--- a/tests/DS/test_rds.sh
+++ b/tests/DS/test_rds.sh
@@ -3,7 +3,7 @@
 # Author:
 #   Martin Preisler <mpreisle@redhat.com>
 
-set -e -o pipefail
+set -o pipefail
 
 . $builddir/tests/test_common.sh
 . $srcdir/test_ds_common.sh

--- a/tests/DS/test_sds_eval.sh
+++ b/tests/DS/test_sds_eval.sh
@@ -3,7 +3,7 @@
 # Author:
 #   Martin Preisler <mpreisle@redhat.com>
 
-set -e -o pipefail
+set -o pipefail
 
 . $builddir/tests/test_common.sh
 . $srcdir/test_ds_common.sh

--- a/tests/DS/test_sds_fix_from_results.sh
+++ b/tests/DS/test_sds_fix_from_results.sh
@@ -3,7 +3,7 @@
 # Author:
 #   Martin Preisler <mpreisle@redhat.com>
 
-set -e -o pipefail
+set -o pipefail
 
 . $builddir/tests/test_common.sh
 

--- a/tests/DS/test_sds_fix_from_source.sh
+++ b/tests/DS/test_sds_fix_from_source.sh
@@ -3,7 +3,7 @@
 # Author:
 #   Martin Preisler <mpreisle@redhat.com>
 
-set -e -o pipefail
+set -o pipefail
 
 . $builddir/tests/test_common.sh
 


### PR DESCRIPTION
The test_run wrapper should handle all return codes, we don't want to bail out early.

Fixes: https://github.com/OpenSCAP/openscap/issues/2110