### PR TITLE
Avoid deleting COPR repository

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -31,3 +31,4 @@ jobs:
     targets:
     - centos-stream-8-x86_64
     - centos-stream-9-x86_64
+    preserve_project: True


### PR DESCRIPTION
By default the COPR projects are deleted 60 days after creation. The preserve_project option should prevent the deletion.

https://packit.dev/docs/configuration/upstream/copr_build#optional-parameters