### PR TITLE
Fix signature obtaining in rpm_info probe

### DIFF
--- a/src/OVAL/probes/unix/linux/rpminfo_probe.c
+++ b/src/OVAL/probes/unix/linux/rpminfo_probe.c
@@ -137,7 +137,10 @@ static void pkgh2rep(Header h, struct rpminfo_rep *r, regex_t *keyid_regex)
 
         r->evr = str;
 
-        str = headerFormat (h, "%|SIGGPG?{%{SIGGPG:pgpsig}}:{%{SIGPGP:pgpsig}}|", &rpmerr);
+        str = headerFormat (
+            h,
+            "%|DSAHEADER?{%{DSAHEADER:pgpsig}}:{%|RSAHEADER?{%{RSAHEADER:pgpsig}}:{%|SIGGPG?{%{SIGGPG:pgpsig}}:{%|SIGPGP?{%{SIGPGP:pgpsig}}:{(none)}|}|}|}|",
+            &rpmerr);
 
 	if (regexec(keyid_regex, str, 1, keyid_match, 0) != 0) {
 		sid = NULL;


### PR DESCRIPTION
## Description

Fix rpminfo probe to correctly obtain `signature_keyid` in OL9, and possibly RHEL9

## Testing

With existing maint1.3 code the key isn't obtained in OL9:
```
## Executing any rule scan with --oval-results argument
$ ./oscap_wrapper xccdf eval --profile stig --rule xccdf_org.ssgproject.content_rule_set_password_hashing_min_rounds_logindefs --oval-results /usr/share/xml/scap/ssg/content/ssg-ol9-ds.xml
## Check the cpe oval results
$ grep signature_keyid ssg-ol9-cpe-oval.xml.result.xml 
            <lin-sys:signature_keyid>0</lin-sys:signature_keyid>
```
Applying this change this information is correctly filled:
```
$ grep signature_keyid ssg-ol9-cpe-oval.xml.result.xml 
            <lin-sys:signature_keyid>bc4d06a08d8b756f</lin-sys:signature_keyid>
```