### PR TITLE
Python 3.13 compatibility

### DIFF
--- a/swig/openscap.i
+++ b/swig/openscap.i
@@ -332,7 +332,7 @@ int rule_result_output_callback_wrapper(struct xccdf_rule_result* rule_result, v
       PyGILState_Release(state);
       return 1;
     }
-    result = PyEval_CallObject(func,arglist);
+    result = PyObject_CallObject(func,arglist);
     if (result == NULL) {
         if (PyErr_Occurred() != NULL)
             PyErr_PrintEx(0);
@@ -369,7 +369,7 @@ int rule_start_callback_wrapper(struct xccdf_rule* rule, void *arg)
       PyGILState_Release(state);
       return 1;
     }
-    result = PyEval_CallObject(func,arglist);
+    result = PyObject_CallObject(func,arglist);
     if (result == NULL) {
         if (PyErr_Occurred() != NULL)
             PyErr_PrintEx(0);
@@ -406,7 +406,7 @@ int agent_reporter_callback_wrapper(const struct oval_result_definition* res_def
       PyGILState_Release(state);
       return 1;
     }
-    result = PyEval_CallObject(func,arglist);
+    result = PyObject_CallObject(func,arglist);
     if (result == NULL) {
         if (PyErr_Occurred() != NULL)
             PyErr_PrintEx(0);
@@ -441,7 +441,7 @@ int validate_callback_wrapper(const char* file, int line, const char* msg, void 
       PyGILState_Release(state);
       return 1;
     }
-    result = PyEval_CallObject(func,arglist);
+    result = PyObject_CallObject(func,arglist);
     if (result == NULL) {
         if (PyErr_Occurred() != NULL)
             PyErr_PrintEx(0);
@@ -477,7 +477,7 @@ char * sub_callback_wrapper(xccdf_subst_type_t type, const char *id, void *arg)
       PyGILState_Release(state);
       return NULL;
     }
-    result = PyEval_CallObject(func, arglist);
+    result = PyObject_CallObject(func, arglist);
     if (result == NULL) {
         if (PyErr_Occurred() != NULL)
             PyErr_PrintEx(0);


### PR DESCRIPTION
Use PyObject instead of PyEval for python 3.13 compatibility

This is a cherry pick of 851f33df9606402c901bbf301afb41d4435184b7 to the maint-1.3 branch.