### PR TITLE
OPENSCAP-5235: Block remediation on deployed bootc system

### DIFF
--- a/src/XCCDF/xccdf_session.c
+++ b/src/XCCDF/xccdf_session.c
@@ -1906,6 +1906,27 @@ struct xccdf_rule_result_iterator *xccdf_session_get_rule_results(const struct x
 	return xccdf_result_get_rule_results(session->xccdf.result);
 }
 
+static int system_is_in_bootc_mode(void)
+{
+#ifdef OS_WINDOWS
+	return 0;
+#else
+	FILE *output = popen("bootc status --format json 2>/dev/null | jq \".status.booted\" 2>/dev/null", "r");
+	if (output == NULL) {
+		return 0;
+	}
+	char buf[1024] = {0};
+	int c;
+	size_t i = 0;
+	while (i < sizeof(buf) && (c = fgetc(output)) != EOF) {
+		buf[i] = c;
+		i++;
+	}
+	pclose(output);
+	return *buf != '\0' && strcmp(buf, "null\n") != 0;
+#endif
+}
+
 int xccdf_session_remediate(struct xccdf_session *session)
 {
 	int res = 0;
@@ -1915,6 +1936,14 @@ int xccdf_session_remediate(struct xccdf_session *session)
 		return 1;
 	if(getenv("OSCAP_PROBE_ROOT") != NULL) {
 		oscap_seterr(OSCAP_EFAMILY_OSCAP, "Can't perform remediation in offline mode: not implemented");
+		return 1;
+	}
+	if (system_is_in_bootc_mode()) {
+		oscap_seterr(OSCAP_EFAMILY_OSCAP,
+			"Detected running Image Mode operating system. OpenSCAP can't "
+			"perform remediation of this system because majority of the "
+			"system is read-only. Please apply remediation during bootable "
+			"container image build using 'oscap-im' instead.");
 		return 1;
 	}
 	xccdf_policy_model_unregister_engines(session->xccdf.policy_model, oval_sysname);

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -629,7 +629,7 @@ int app_evaluate_xccdf(const struct oscap_action *action)
 			"Detected running Image Mode operating system. OpenSCAP can't "
 			"perform remediation of this system because majority of the "
 			"system is read-only. Please apply remediation during bootable "
-			"container image build using 'oscap-im' instead.");
+			"container image build using 'oscap-im' instead.\n");
 		return result;
 	}
 
@@ -839,7 +839,7 @@ int app_xccdf_remediate(const struct oscap_action *action)
 			"Detected running Image Mode operating system. OpenSCAP can't "
 			"perform remediation of this system because majority of the "
 			"system is read-only. Please apply remediation during bootable "
-			"container image build using 'oscap-im' instead.");
+			"container image build using 'oscap-im' instead.\n");
 		return result;
 	}
 	session = xccdf_session_new(action->f_xccdf);

--- a/utils/oscap-xccdf.c
+++ b/utils/oscap-xccdf.c
@@ -604,6 +604,10 @@ static bool _system_is_in_bootc_mode(void)
 	}
 	size_t buf_size = CHUNK_SIZE;
 	char *buf = calloc(buf_size, sizeof(char));
+	if (buf == NULL) {
+		pclose(output);
+		return false;
+	}
 	int c;
 	size_t i = 0;
 	while ((c = fgetc(output)) != EOF) {
@@ -619,7 +623,9 @@ static bool _system_is_in_bootc_mode(void)
 		buf[i++] = c;
 	}
 	pclose(output);
-	return *buf != '\0' && strstr(buf, "\"booted\":null") == NULL;
+	bool result = (*buf != '\0' && strstr(buf, "\"booted\":null") == NULL);
+	free(buf);
+	return result;
 #endif
 }
 


### PR DESCRIPTION
OpenSCAP remediation is supposed to be used only at bootc container image build. Deployed bootc system is immutable, it can't be remediated with OpenSCAP and trying to do so would result in errors and bad user experience.

We will update OpenSCAP to print error message for users in case they try to run remediation on an already deployed bootc system, informing them that it is not possible and that the openscap remediation must be performed during container build.