### PR TITLE
Sync problems. Experimental. `DO NOT MERGE` (1.3.x)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,7 +535,7 @@ if (MSVC)
 endif()
 
 if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -W -Wall -Wnonnull -Wshadow -Wformat -Wundef -Wno-unused-parameter -Wmissing-prototypes -Wno-unknown-pragmas -Wno-int-conversion -Werror=implicit-function-declaration -D_GNU_SOURCE -std=c99")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -W -Wall -Wnonnull -Wshadow -Wformat -Wundef -Wno-unused-parameter -Wmissing-prototypes -Wno-unknown-pragmas -Wno-int-conversion -Werror=implicit-function-declaration -D_GNU_SOURCE -DRBT_IMPLICIT_LOCKING=1 -std=c99")
 	add_link_options(-Wl,-z,now)
 endif()
 if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")

--- a/src/OVAL/probes/SEAP/seap-packet.c
+++ b/src/OVAL/probes/SEAP/seap-packet.c
@@ -206,9 +206,14 @@ static int SEAP_packet_sexp2msg (SEXP_t *sexp_msg, SEAP_msg_t *seap_msg)
         _A(attr_i >= (SEXP_list_length (sexp_msg) - 4)/2);
 
         seap_msg->attrs_cnt = attr_i;
-        void *new_attrs = realloc(seap_msg->attrs, sizeof(SEAP_attr_t) * seap_msg->attrs_cnt);
-        if (new_attrs != NULL || seap_msg->attrs_cnt == 0)
+        if (seap_msg->attrs_cnt == 0) {
+                free(seap_msg->attrs);
+                seap_msg->attrs = NULL;
+        } else {
+                void *new_attrs = realloc(seap_msg->attrs, sizeof(SEAP_attr_t) * seap_msg->attrs_cnt);
                 seap_msg->attrs = new_attrs;
+        }
+
         seap_msg->sexp = SEXP_list_last (sexp_msg);
 
         return (0);

--- a/src/OVAL/probes/probe/icache.c
+++ b/src/OVAL/probes/probe/icache.c
@@ -201,7 +201,7 @@ const char* thread_name = "icache_worker";
 	pair = &pair_mem;
         dD("icache worker ready");
 
-        switch (errno = pthread_barrier_wait(&OSCAP_GSYM(th_barrier)))
+        switch (errno = pthread_barrier_wait(cache->th_barrier))
         {
         case 0:
         case PTHREAD_BARRIER_SERIAL_THREAD:
@@ -309,7 +309,7 @@ const char* thread_name = "icache_worker";
         return (NULL);
 }
 
-probe_icache_t *probe_icache_new(void)
+probe_icache_t *probe_icache_new(pthread_barrier_t *th_barrier)
 {
         probe_icache_t *cache = malloc(sizeof(probe_icache_t));
         cache->tree = rbt_i64_new();
@@ -323,6 +323,7 @@ probe_icache_t *probe_icache_new(void)
         cache->queue_end = 0;
         cache->queue_cnt = 0;
         cache->queue_max = PROBE_IQUEUE_CAPACITY;
+        cache->th_barrier = th_barrier;
 
         if (pthread_cond_init(&cache->queue_notempty, NULL) != 0) {
                 dE("Can't initialize icache queue condition variable (notempty): %u, %s",

--- a/src/OVAL/probes/probe/icache.h
+++ b/src/OVAL/probes/probe/icache.h
@@ -25,6 +25,7 @@
 #include <stddef.h>
 #include <sexp.h>
 #include "../SEAP/generic/rbt/rbt.h"
+#include "common/compat_pthread_barrier.h"
 
 #ifndef PROBE_IQUEUE_CAPACITY
 #define PROBE_IQUEUE_CAPACITY 1024
@@ -41,6 +42,7 @@ typedef struct {
 typedef struct {
         rbt_t    *tree; /* XXX: rewrite to extensible or linear hashing */
         pthread_t thid;
+        pthread_barrier_t *th_barrier;
 
         pthread_mutex_t queue_mutex;
         pthread_cond_t  queue_notempty;
@@ -58,7 +60,7 @@ typedef struct {
         uint16_t  count;
 } probe_citem_t;
 
-probe_icache_t *probe_icache_new(void);
+probe_icache_t *probe_icache_new(pthread_barrier_t *th_barrier);
 int probe_icache_add(probe_icache_t *cache, SEXP_t *cobj, SEXP_t *item);
 int probe_icache_nop(probe_icache_t *cache);
 void probe_icache_free(probe_icache_t *cache);

--- a/src/OVAL/probes/probe/input_handler.c
+++ b/src/OVAL/probes/probe/input_handler.c
@@ -85,7 +85,7 @@ void *probe_input_handler(void *arg)
 
 	pthread_cleanup_push(pthread_attr_cleanup_handler, (void *)&pth_attr);
         
-        switch (errno = pthread_barrier_wait(&OSCAP_GSYM(th_barrier)))
+        switch (errno = pthread_barrier_wait(probe->th_barrier))
         {
         case 0:
         case PTHREAD_BARRIER_SERIAL_THREAD:

--- a/src/OVAL/probes/probe/probe.h
+++ b/src/OVAL/probes/probe/probe.h
@@ -66,6 +66,7 @@ typedef struct {
 
 	pthread_t th_input;
 	pthread_t th_signal;
+	pthread_barrier_t *th_barrier;
 
         rbt_t    *workers;
         uint32_t  max_threads;
@@ -104,7 +105,5 @@ typedef enum {
 	PROBE_OFFLINE_OWN = 0x04,
 	PROBE_OFFLINE_ALL = 0x0f
 } probe_offline_flags;
-
-extern pthread_barrier_t OSCAP_GSYM(th_barrier);
 
 #endif /* PROBE_H */

--- a/src/common/oscap_pcre.c
+++ b/src/common/oscap_pcre.c
@@ -142,7 +142,6 @@ oscap_pcre_t *oscap_pcre_compile(const char *pattern, oscap_pcre_options_t optio
 	int errno;
 	PCRE2_SIZE erroffset2;
 	res->re_ctx = NULL;
-	dD("pcre2_compile_8: patt=%s", pattern);
 	res->re = pcre2_compile_8((PCRE2_SPTR)pattern, PCRE2_ZERO_TERMINATED, _oscap_pcre_opts_to_pcre(options), &errno, &erroffset2, NULL);
 	if (res->re == NULL) {
 		PCRE2_UCHAR8 errmsg[PCRE2_ERR_BUF_SIZE];
@@ -206,13 +205,9 @@ int oscap_pcre_exec(const oscap_pcre_t *opcre, const char *subject,
 	// The ovecsize is multiplied by 3 in the code for compatibility with PCRE1
 	int ovecsize2 = ovecsize/3;
 	pcre2_match_data_8 *mdata = pcre2_match_data_create_8(ovecsize2, NULL);
-	dD("pcre2_match_8: subj=%s", subject);
 	rc = pcre2_match_8(opcre->re, (PCRE2_SPTR8)subject, length, startoffset, _oscap_pcre_opts_to_pcre(options), mdata, opcre->re_ctx);
-	dD("pcre2_match_8: rc=%d, ", rc);
 	if (rc > PCRE2_ERROR_NOMATCH) {
 		PCRE2_SIZE *ovecp = pcre2_get_ovector_pointer_8(mdata);
-		uint32_t ovecp_count = pcre2_get_ovector_count_8(mdata);
-		dD("pcre2_match_8: pcre2_get_ovector_count_8=%d", ovecp_count);
 		for (int i = 0; i < rc; i++) {
 			if (i < ovecsize2) {
 				ovector[i*2] = ovecp[i*2];


### PR DESCRIPTION
Seriously, DON'T!

Back-port of https://github.com/OpenSCAP/openscap/pull/2204

- [ ] OpenSCAP Error: Invalid OVAL family. [/builddir/build/BUILD/openscap-1.4.2/src/OVAL/oval_enumerations.c:880]
                out: uname_test 'oval:ssg-test_system_info_architecture_s390_64:tst:1' is not compatible with **INVALID**_object 'oval:ssg-object_system_info_architecture_s390_64:obj:1'. [/builddir/build/BUILD/openscap-1.4.2/src/OVAL/oval_probe.c:252]
- [ ] Invalid OVAL family. [/builddir/build/BUILD/openscap-1.4.2/src/OVAL/oval_enumerations.c:880]
                out: uname_test 'oval:ssg-test_system_info_architecture_ppc_64:tst:1' is not compatible with **INVALID**_object 'oval:ssg-object_system_info_architecture_ppc_64:obj:1'. [/builddir/build/BUILD/openscap-1.4.2/src/OVAL/oval_probe.c:252]
