### PR TITLE
Exit oscap-im if oscap fails

### DIFF
--- a/utils/oscap-im
+++ b/utils/oscap-im
@@ -111,9 +111,22 @@ def pre_scan_fix(args):
             "--output", remediation_script.name]
         add_common_args(args, gen_fix_cmd)
         gen_fix_cmd.append(args.data_stream)
-        subprocess.run(gen_fix_cmd, check=True)
-        subprocess.run(["bash", remediation_script.name], check=True)
-
+    try:
+        subprocess.run(gen_fix_cmd, check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"OpenSCAP generate fix failed with return code {e.returncode}.\n"
+            f"Output: {e.stderr.decode()}")
+    try:
+        subprocess.run(
+            ["bash", remediation_script.name], check=True,
+            capture_output=True)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"Remediation script failed with return code {e.returncode}.\n"
+            f"Output: {e.stderr.decode()}")
+    finally:
+        Path(remediation_script.name).unlink()
 
 def scan_and_remediate(args):
     oscap_cmd = ["oscap", "xccdf", "eval", "--progress", "--remediate"]
@@ -125,15 +138,20 @@ def scan_and_remediate(args):
         subprocess.run(oscap_cmd, env=env, check=True)
     except subprocess.CalledProcessError as e:
         if e.returncode not in [0, 2]:
-            print(e, file=sys.stderr)
+            raise RuntimeError(
+                f"OpenSCAP scan failed with return code {e.returncode}.\n")
 
 
 def main():
     args = parse_args()
     verify_bootc_build_env()
     install_sce_dependencies()
-    pre_scan_fix(args)
-    scan_and_remediate(args)
+    try:
+        pre_scan_fix(args)
+        scan_and_remediate(args)
+    except RuntimeError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/utils/oscap-im
+++ b/utils/oscap-im
@@ -105,7 +105,7 @@ def add_eval_args(args, cmd):
 
 
 def pre_scan_fix(args):
-    with tempfile.NamedTemporaryFile(delete=False) as remediation_script:
+    with tempfile.NamedTemporaryFile() as remediation_script:
         gen_fix_cmd = [
             "oscap", "xccdf", "generate", "fix", "--fix-type", "bootc",
             "--output", remediation_script.name]

--- a/utils/oscap-im
+++ b/utils/oscap-im
@@ -111,22 +111,19 @@ def pre_scan_fix(args):
             "--output", remediation_script.name]
         add_common_args(args, gen_fix_cmd)
         gen_fix_cmd.append(args.data_stream)
-    try:
-        subprocess.run(gen_fix_cmd, check=True, capture_output=True)
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(
-            f"OpenSCAP generate fix failed with return code {e.returncode}.\n"
-            f"Output: {e.stderr.decode()}")
-    try:
-        subprocess.run(
-            ["bash", remediation_script.name], check=True,
-            capture_output=True)
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(
-            f"Remediation script failed with return code {e.returncode}.\n"
-            f"Output: {e.stderr.decode()}")
-    finally:
-        Path(remediation_script.name).unlink()
+        try:
+            subprocess.run(gen_fix_cmd, check=True, capture_output=True)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"OpenSCAP generate fix failed with return code "
+                f"{e.returncode}.\nOutput: {e.stderr.decode()}")
+        try:
+            subprocess.run(["bash", remediation_script.name], check=True)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"Remediation script failed with return code "
+                f"{e.returncode}.")
+
 
 def scan_and_remediate(args):
     oscap_cmd = ["oscap", "xccdf", "eval", "--progress", "--remediate"]


### PR DESCRIPTION
This commit will cause that oscap-im will exit with exit code 1 if any of the called oscap calls will fail. This means that building hardened bootable container images will terminate if oscap crashes or doesn't work.

Resolves: https://issues.redhat.com/browse/OPENSCAP-5415