### PR TITLE
tests: OVAL/API/skip_paths

### DIFF
--- a/tests/API/OVAL/skip_paths/test_skip_paths.sh
+++ b/tests/API/OVAL/skip_paths/test_skip_paths.sh
@@ -15,8 +15,8 @@ cp "$srcdir/test.xml" "$root/b/"
 mkdir -p "$root/c"
 touch "$root/c/z"
 cp "$srcdir/test.xml" "$root/c/"
-# oscap probes will skip directories "b" and "c"
-export OSCAP_PROBE_IGNORE_PATHS="$root/b:$root/c"
+# oscap probes will skip directories "$root/n", "$root/b" and "$root/c"
+export OSCAP_PROBE_IGNORE_PATHS="$root/n:$root/c:$root/b"
 $OSCAP oval eval --results $result "$srcdir/test_skip_paths.xml"
 assert_exists 1 '/oval_results/results/system/definitions/definition[@definition_id="oval:x:def:1" and @result="true"]'
 assert_exists 1 '/oval_results/results/system/oval_system_characteristics/collected_objects/object[@id="oval:x:obj:1" and @flag="complete"]'

--- a/tests/API/OVAL/skip_paths/test_skip_paths.xml
+++ b/tests/API/OVAL/skip_paths/test_skip_paths.xml
@@ -90,12 +90,12 @@
     <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" version="1" id="oval:x:obj:3">
       <filepath>/tmp/oscap_test_skip_paths/a/x</filepath>
       <pattern>^.*$</pattern>
-      <instance datatype="int" operation="greater than or equal">1</instance>
+      <instance datatype="int">1</instance>
     </textfilecontent54_object>
     <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" version="1" id="oval:x:obj:4">
       <filepath>/tmp/oscap_test_skip_paths/b/y</filepath>
       <pattern>^.*$</pattern>
-      <instance datatype="int" operation="greater than or equal">1</instance>
+      <instance datatype="int">1</instance>
     </textfilecontent54_object>
     <filehash58_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" version="1" id="oval:x:obj:5">
       <filepath>/tmp/oscap_test_skip_paths/a/x</filepath>


### PR DESCRIPTION
Modify the test so it could catch the regression
with environment variable modified during execution. See #2168.