### PR TITLE
Fix `unterminated-string-initialization` errors

### DIFF
--- a/compat/dev_to_tty.c
+++ b/compat/dev_to_tty.c
@@ -142,7 +142,7 @@ static int driver_name(char *restrict const buf, unsigned maj, unsigned min){
 }
 
 // major 204 is a mess -- "Low-density serial ports"
-static const char low_density_names[][6] = {
+static const char low_density_names[][7] = {
 "LU0",  "LU1",  "LU2",  "LU3",
 "FB0",
 "SA0",  "SA1",  "SA2",

--- a/src/OVAL/probes/SEAP/generic/xbase64.c
+++ b/src/OVAL/probes/SEAP/generic/xbase64.c
@@ -28,7 +28,7 @@
 #include "xbase64.h"
 
 #if defined(WANT_XBASE64)
-static const char xb64_enc_alphabet[64] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ:_";
+static const char xb64_enc_alphabet[65] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ:_";
 static const char xb64_dec_alphabet[75] = {
         0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 62,  0,  0,  0,  0,  0, 0, 36, 37, 38,
         39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
@@ -152,7 +152,7 @@ size_t xbase64_decode (const char *data, size_t size, uint8_t **buffer) {
 #endif /* WANT_XBASE64 */
 
 #if defined(WANT_BASE64)
-static const char b64_enc_alphabet[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char b64_enc_alphabet[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 static const char b64_dec_alphabet[75] = {
         /* 0 */ 52,
         /* 1 */ 53,


### PR DESCRIPTION
Add more space for `low_density_name` elements in `compat/dev_to_tty.c`

```
dev_to_tty.c:170:71: error: initializer-string for array of 'char'
truncates NUL terminator but destination lacks 'nonstring' attribute
(7 chars into 6 available)
[-Werror=unterminated-string-initialization].
```

Add more space for `xbase64.c` alphabets

```
xbase64.c:155:42: error: initializer-string for array of 'char'
truncates NUL terminator but destination lacks 'nonstring' attribute
(65 chars into 64 available)
[-Werror=unterminated-string-initialization]
```