### PR TITLE
Fix double-free in xccdf_policy_remediate.c

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -716,7 +716,6 @@ static inline int _parse_blueprint_fix(const char *fix_text, struct blueprint_cu
 		tab[i].re = oscap_pcre_compile(tab[i].pattern, OSCAP_PCRE_OPTS_UTF8, &err, &errofs);
 		if (tab[i].re == NULL) {
 			dE("Unable to compile /%s/ regex pattern, oscap_pcre_compile() returned error (offset: %d): '%s'.\n", tab[i].pattern, errofs, err);
-			oscap_pcre_err_free(err);
 			ret = 1;
 			goto exit;
 		}


### PR DESCRIPTION
Fixes this:

```
3. openscap-1.4.2/src/XCCDF_POLICY/xccdf_policy_remediate.c:719:4: freed_arg: "oscap_pcre_err_free" frees "err".
5. openscap-1.4.2/src/common/oscap_pcre.c:239:3: freed_arg: "free" frees parameter "err".
7. openscap-1.4.2/src/XCCDF_POLICY/xccdf_policy_remediate.c:761:2: double_free: Calling "oscap_pcre_err_free" frees pointer "err" which has already been freed.
9. openscap-1.4.2/src/common/oscap_pcre.c:239:3: freed_arg: "free" frees parameter "err".
#   759|
#   760|   exit:
#   761|-> 	oscap_pcre_err_free(err);
#   762|   	for (int i = 0; tab[i].pattern != NULL; i++)
#   763|   		oscap_pcre_free(tab[i].re);
```