### PR TITLE
Inherit environment for scanning and remediating in `oscap-im` wrapper

### DIFF
--- a/utils/oscap-im
+++ b/utils/oscap-im
@@ -17,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import argparse
+import os
 import subprocess
 import sys
 import tempfile
@@ -125,7 +126,7 @@ def scan_and_remediate(args):
     add_common_args(args, oscap_cmd)
     add_eval_args(args, oscap_cmd)
     oscap_cmd.append(args.data_stream)
-    env = {"OSCAP_PREFERRED_ENGINE": "SCE", "OSCAP_BOOTC_BUILD": "YES"}
+    env = {**os.environ, "OSCAP_PREFERRED_ENGINE": "SCE", "OSCAP_BOOTC_BUILD": "YES"}
     try:
         subprocess.run(oscap_cmd, env=env, check=True)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Bash remediations require PATH to be inherited by the oscap process to work correctly. 

Hard-coded PATH has been removed from openscap in https://github.com/OpenSCAP/openscap/pull/2227.

Fixes: #2242.