### PR TITLE
Bump OVAL_SUPPORTED to 5.11.3

### DIFF
--- a/src/OVAL/oval_agent_api_impl.h
+++ b/src/OVAL/oval_agent_api_impl.h
@@ -35,7 +35,7 @@
 
 #define OVAL_ENUMERATION_INVALID (-1)
 
-#define OVAL_SUPPORTED "5.11.1"
+#define OVAL_SUPPORTED "5.11.3"
 
 #define OVAL_COMMON_NAMESPACE      BAD_CAST "http://oval.mitre.org/XMLSchema/oval-common-5"
 #define OVAL_DIGSIG_NAMESPACE      BAD_CAST "http://www.w3.org/2000/09/xmldsig#"


### PR DESCRIPTION
5.11.2 was added back in commit [141f6d2](https://github.com/OpenSCAP/openscap/commit/141f6d2)

I wonder if we should remove 5.11.3 though, as I believe it was never an official supported OVAL version.