### PR TITLE
Fixing inverted fields in HTML report

### DIFF
--- a/xsl/xccdf-report-oval-details.xsl
+++ b/xsl/xccdf-report-oval-details.xsl
@@ -182,14 +182,15 @@ Authors:
         <td>
             <xsl:choose>
                 <xsl:when test="@var_ref">
+                    <xsl:variable name="matching_var" select="$tested_var[@variable_id = current()/@var_ref]"/>
                     <xsl:choose>
-                        <xsl:when test="count($tested_var) > 1">
+                        <xsl:when test="count($matching_var) > 1">
                             <table>
-                                <xsl:apply-templates mode='tableintable' select="$tested_var"/>
+                                <xsl:apply-templates mode='tableintable' select="$matching_var"/>
                             </table>
                         </xsl:when>
                         <xsl:otherwise>
-                            <xsl:apply-templates mode='normal' select="$tested_var"/>
+                            <xsl:apply-templates mode='normal' select="$matching_var"/>
                         </xsl:otherwise>
                     </xsl:choose>
                     <xsl:apply-templates mode='message' select='key("ovalsys-object", $object_id)'/>


### PR DESCRIPTION
#### Description:

-  Fixing a XSL template, responsible for incorrect/inverted fields in the report tables

Wrong table content examples:

<img width="1364" height="582" alt="image" src="https://github.com/user-attachments/assets/198ebea9-24d7-4a8c-ab52-f648498fbf82" />
<img width="1357" height="157" alt="image" src="https://github.com/user-attachments/assets/3403aeac-e0e6-41d8-8042-a79e43128ea3" />

Example XML object, that is processed by a template:  
```
<ind-def:textfilecontent54_object id="oval:ssg-obj_pam_faillock_password_auth_pam_faillock_account:obj:1" version="1" comment="Check common definition of pam_faillock.so in account section of password-auth">
    <ind-def:filepath operation="pattern match">^/etc/pam.d/password-auth$</ind-def:filepath>
    <ind-def:pattern operation="pattern match" var_ref="oval:ssg-var_pam_faillock_password_auth_pam_faillock_account_regex:var:1" var_check="all"/>
    <ind-def:instance datatype="int">1</ind-def:instance>
</ind-def:textfilecontent54_object>
```

#### Rationale:

- Originaly, template would select any `var_ref` attribute in a `textfilecontent54_object` and print it's value in to the first table column
- After that, it would print other values in to the remaining columns, ignoring `pattern` field, for the lack of plain text value
- Fixes #2245, [RHEL-104073](https://issues.redhat.com/browse/RHEL-104073).

#### Review Hints:

- Fixed tables:
<img width="1375" height="324" alt="image" src="https://github.com/user-attachments/assets/ec06dafb-76ce-43ad-a683-25b82c0572f2" />


#### NOTE: This PR fixes described issue on Jira, but there are other issues related to this XSL template. Remaining issues, that were noticed (extra columns): 

<img width="1380" height="1035" alt="image" src="https://github.com/user-attachments/assets/2eebd578-2d5c-4bd8-b65e-f668640b4059" />
<img width="1397" height="236" alt="image" src="https://github.com/user-attachments/assets/6f466ed2-9f85-48f9-a9be-ba5c98b82801" />

