### PR TITLE
utils/oscap-im: Inherit environment for scanning and remediating

### DIFF
--- a/utils/oscap-im
+++ b/utils/oscap-im
@@ -17,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import argparse
+import os
 import subprocess
 import sys
 import tempfile
@@ -130,7 +131,7 @@ def scan_and_remediate(args):
     add_common_args(args, oscap_cmd)
     add_eval_args(args, oscap_cmd)
     oscap_cmd.append(args.data_stream)
-    env = {"OSCAP_PREFERRED_ENGINE": "SCE"}
+    env = {**os.environ, "OSCAP_PREFERRED_ENGINE": "SCE"}
     try:
         subprocess.run(oscap_cmd, env=env, check=True)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Bash remediations require PATH to be inherited by the oscap process to work correctly.

@jan-cerny in `main` we still have `"OSCAP_BOOTC_BUILD": "YES"` in the environment: https://github.com/OpenSCAP/openscap/blob/8bc18a7ed6daca6c73cb49c86597c72b23e3a6e2/utils/oscap-im#L129

So I've put it back here. Should I instead remove it from both branches?