### PR TITLE
Fix compiling with musl

### DIFF
--- a/src/OVAL/probes/unix/linux/systemdshared.h
+++ b/src/OVAL/probes/unix/linux/systemdshared.h
@@ -35,7 +35,7 @@
 #include <config.h>
 #endif
 
-#include <limits.h>
+#include <libgen.h>
 #include <stdio.h>
 #include "common/debug_priv.h"
 #include "oscap_helpers.h"

--- a/src/OVAL/probes/unix/process58_probe.c
+++ b/src/OVAL/probes/unix/process58_probe.c
@@ -59,6 +59,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <limits.h>
 #ifdef HAVE_STDIO_EXT_H
 # include <stdio_ext.h>
 #endif


### PR DESCRIPTION
Fix two includes in OVAL. Those are minor but they fail the compilation with the musl library.

The include <limits.h> is included to provide PATH_MAX. The include <libgen.h> is required for 'basename'. The include <limits.h> is just unrequired and can be removed from systemdshared.h.