### PR TITLE
Skip verifying RPM signatures in tests

### DIFF
--- a/tests/probes/rpm/rpm_common.sh
+++ b/tests/probes/rpm/rpm_common.sh
@@ -31,8 +31,8 @@ function rpm_prepare_offline {
     cp /usr/lib/rpm/rpmrc ${RPMTEST}/usr/lib/rpm/rpmrc
     cp /usr/lib/rpm/macros ${RPMTEST}/usr/lib/rpm/macros
     rpm_build
-    rpm -i ${RPMBUILD}/RPMS/noarch/foobar-1.0-1.noarch.rpm --badreloc --relocate="/etc=${RPMTEST}/etc/" --dbpath="${RPMTEST}${RPMDB_PATH}"
-    rpm -i ${RPMBUILD}/RPMS/noarch/foo-1.0-1.noarch.rpm --badreloc --relocate="/etc=${RPMTEST}/etc/" --dbpath="${RPMTEST}${RPMDB_PATH}"
+    rpm -i --nosignature ${RPMBUILD}/RPMS/noarch/foobar-1.0-1.noarch.rpm --badreloc --relocate="/etc=${RPMTEST}/etc/" --dbpath="${RPMTEST}${RPMDB_PATH}"
+    rpm -i --nosignature ${RPMBUILD}/RPMS/noarch/foo-1.0-1.noarch.rpm --badreloc --relocate="/etc=${RPMTEST}/etc/" --dbpath="${RPMTEST}${RPMDB_PATH}"
 }
 
 function rpm_cleanup_offline {


### PR DESCRIPTION
Our tests install some dummy test RPM pacakges. Starting from rpm version 6.0.0 rpm by default requires veryfing signatures. Our dummy packages aren't signed, which causes that they aren't installed and the tests fail.

This commit should fix the broken CI on Rawhide.

Addressing:
package foobar-1.0-1.noarch does not verify: no signature

The following tests FAILED:
	228 - probes/rpm/rpminfo/test_probes_rpminfo_offline.sh (Failed)
	230 - probes/rpm/rpmverify/test_probes_rpmverify_not_equals_operation_offline.sh (Failed)
	233 - probes/rpm/rpmverifyfile/test_probes_rpmverifyfile_offline.sh (Failed)
	235 - probes/rpm/rpmverifypackage/test_probes_rpmverifypackage_offline.sh (Failed)