### PR TITLE
Set install RPATH on macOS so binaries find libopenscap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,6 +564,11 @@ endif()
 if(APPLE)
 	#full Single Unix Standard v3 (SUSv3) conformance (the Unix API)
 	add_definitions(-D_DARWIN_C_SOURCE)
+
+	# So that installed binaries can find libopenscap.dylib without DYLD_LIBRARY_PATH.
+	set(CMAKE_MACOSX_RPATH ON)
+	set(CMAKE_INSTALL_NAME_DIR "@rpath")
+	set(CMAKE_INSTALL_RPATH "@loader_path/../lib;${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
 include_directories(


### PR DESCRIPTION
## Summary

After `make install` on macOS, `oscap` referenced `@rpath/libopenscap.<ver>.dylib` but the binary had no `LC_RPATH` entries, so `dyld` failed at startup:

```
dyld[…]: Library not loaded: @rpath/libopenscap.33.dylib
  Referenced from: /usr/local/bin/oscap
  Reason: no LC_RPATH's found
```

The library was installed correctly to `/usr/local/lib/libopenscap.33.dylib`; the binary just had no way to locate it without `DYLD_LIBRARY_PATH`. CMake on macOS strips the build-tree RPATH at install time and provides nothing in its place unless `CMAKE_INSTALL_RPATH` is set.

This adds, inside the existing `if(APPLE)` block in the root `CMakeLists.txt`:

- `CMAKE_MACOSX_RPATH ON`
- `CMAKE_INSTALL_NAME_DIR "@rpath"`
- `CMAKE_INSTALL_RPATH "@loader_path/../lib;${CMAKE_INSTALL_PREFIX}/lib"`

`@loader_path/../lib` keeps the install relocatable; the absolute prefix path is a fallback. Linux and Windows are unaffected — the block is `APPLE`-only.

This is a follow-on to the macOS/FreeBSD portability work in #2326.

## Test plan

- [x] Configure + build cleanly on macOS (Apple Silicon, Homebrew toolchain)
- [x] Staged install (`DESTDIR=…  make install`): `otool -l .../bin/oscap` shows both `LC_RPATH` entries (`@loader_path/../lib` and `/usr/local/lib`)
- [x] Real install to `/usr/local`: `oscap --version` and `oscap xccdf generate report …` run without `DYLD_LIBRARY_PATH`
- [x] Linux unaffected (block is gated on `APPLE`; no CMake variables Linux uses are touched)

No new automated test — existing CI (`.github/workflows/`) runs on Ubuntu and Fedora only, so an RPATH check wouldn't execute. The fix is verifiable manually with `otool -l` on macOS.