### PR TITLE
Generate raw partitioning mode in Image Builder blueprints

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -1405,6 +1405,8 @@ static int _write_script_header_to_fd(struct xccdf_policy *policy, struct xccdf_
 			"name = \"hardened_%s\"\n"
 			"description = \"%s\"\n"
 			"version = \"%s\"\n\n"
+			"[customizations]\n"
+			"partitioning_mode = \"raw\"\n\n"
 			"[customizations.openscap]\n"
 			"profile_id = \"%s\"\n"
 			"%s\n",

--- a/tests/API/XCCDF/unittests/test_remediation_blueprint.toml
+++ b/tests/API/XCCDF/unittests/test_remediation_blueprint.toml
@@ -23,6 +23,9 @@ name = "hardened_xccdf_moc.elpmaxe.www_profile_common"
 description = "Profile title on one line"
 version = "1.0"
 
+[customizations]
+partitioning_mode = "raw"
+
 [customizations.openscap]
 profile_id = "xccdf_moc.elpmaxe.www_profile_common"
 # If your hardening data stream is not part of the 'scap-security-guide' package


### PR DESCRIPTION
## Summary
- emit `[customizations] partitioning_mode = "raw"` in generated Image Builder blueprints
- update the blueprint remediation golden fixture

Fixes #2334.

## Testing
- `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_PROBES=OFF -DENABLE_PYTHON3=OFF -DENABLE_PERL=OFF -DENABLE_DOCS=OFF -DENABLE_OSCAP_UTIL_DOCKER=OFF -DENABLE_OSCAP_UTIL_AS_RPM=OFF ..`
- `make -j2 oscap`
- `ctest -R 'API/XCCDF/unittests/test_remediation_blueprint.sh' --output-on-failure`\n- `git diff --check`