### PR TITLE
test: use a unique temp dir in test_variable_in_filter

### DIFF
--- a/tests/API/OVAL/unittests/test_variable_in_filter.sh
+++ b/tests/API/OVAL/unittests/test_variable_in_filter.sh
@@ -4,11 +4,18 @@
 set -e
 set -o pipefail
 
-oval_def=`mktemp`
-result=`mktemp`
-stdout=`mktemp`
-stderr=`mktemp`
-temp_dir=`mktemp -d`
+oval_def=$(mktemp)
+result=$(mktemp)
+stdout=$(mktemp)
+stderr=$(mktemp)
+temp_dir=$(mktemp -d)
+
+cleanup() {
+	rm -f "$oval_def" "$result" "$stdout" "$stderr"
+	rm -rf "$temp_dir"
+}
+trap cleanup EXIT
+
 cp "$srcdir/test_variable_in_filter.xml" "$oval_def"
 sed -i "s;TEMP_DIR_PLACEHOLDER;$temp_dir;" "$oval_def"
 echo "secret_key" > "$temp_dir/key_file"
@@ -17,6 +24,3 @@ $OSCAP oval eval --results "$result" "$oval_def" > "$stdout" 2> "$stderr"
 grep "Failed to convert OVAL state to SEXP" "$stderr" && exit 1
 assert_exists 1 '//oval_results/results/system/definitions/definition[@result="true"]'
 assert_exists 0 '//oval_results/results/system/definitions/definition[@result!="true"]'
-
-rm -f "$oval_def" "$result" "$stdout" "$stderr"
-rm -rf "$temp_dir"

--- a/tests/API/OVAL/unittests/test_variable_in_filter.sh
+++ b/tests/API/OVAL/unittests/test_variable_in_filter.sh
@@ -4,14 +4,19 @@
 set -e
 set -o pipefail
 
+oval_def=`mktemp`
 result=`mktemp`
 stdout=`mktemp`
 stderr=`mktemp`
-echo "secret_key" > /tmp/key_file
+temp_dir=`mktemp -d`
+cp "$srcdir/test_variable_in_filter.xml" "$oval_def"
+sed -i "s;TEMP_DIR_PLACEHOLDER;$temp_dir;" "$oval_def"
+echo "secret_key" > "$temp_dir/key_file"
 
-$OSCAP oval eval --results "$result" "$srcdir/test_variable_in_filter.xml" > "$stdout" 2> "$stderr"
+$OSCAP oval eval --results "$result" "$oval_def" > "$stdout" 2> "$stderr"
 grep "Failed to convert OVAL state to SEXP" "$stderr" && exit 1
 assert_exists 1 '//oval_results/results/system/definitions/definition[@result="true"]'
 assert_exists 0 '//oval_results/results/system/definitions/definition[@result!="true"]'
 
-rm -f "$result" "$stdout" "$stderr" /tmp/key_file
+rm -f "$oval_def" "$result" "$stdout" "$stderr"
+rm -rf "$temp_dir"

--- a/tests/API/OVAL/unittests/test_variable_in_filter.xml
+++ b/tests/API/OVAL/unittests/test_variable_in_filter.xml
@@ -24,7 +24,7 @@
   </oval:tests>
   <oval:objects>
     <ns3:file_object comment="object with a filter" id="oval:x:obj:1" version="1">
-      <ns3:path>/tmp</ns3:path>
+      <ns3:path>TEMP_DIR_PLACEHOLDER</ns3:path>
       <ns3:filename operation="pattern match">^key_file$</ns3:filename>
       <oval:filter action="exclude">oval:x:ste:1</oval:filter>
     </ns3:file_object>
@@ -36,7 +36,7 @@
   </oval:objects>
   <oval:states>
     <ns3:file_state comment="state used in filter, references a variable" id="oval:x:ste:1" version="1">
-      <ns3:path>/tmp</ns3:path>
+      <ns3:path>TEMP_DIR_PLACEHOLDER</ns3:path>
       <ns3:filename operation="pattern match">^key_file$</ns3:filename>
       <ns3:group_id datatype="int" var_ref="oval:x:var:1"/>
       <ns3:user_id datatype="int">0</ns3:user_id>


### PR DESCRIPTION
## Problem

`tests/API/OVAL/unittests/test_variable_in_filter.sh` wrote its fixture to a
fixed path, `/tmp/key_file`, and the OVAL definition hardcoded `/tmp` as the
`file_object` / `file_state` path (#1924). A predictable, world-writable path
in a shared directory:

- races with parallel test runs (and with other users) on the same machine, and
- lets a pre-existing, unrelated `/tmp/key_file` left by someone else affect the
  result.

## Fix

Adopt the isolation pattern already used by `test_pcre_nonutf_characters.sh`:

- The OVAL definition now uses a `TEMP_DIR_PLACEHOLDER` token instead of `/tmp`.
- The test copies the definition to a temp file, `sed`-substitutes a per-run
  `mktemp -d` directory, and creates the `key_file` fixture inside it.
- The temporary directory is removed on completion.

The filename pattern (`^key_file$`) and the evaluation logic are unchanged, so
the test asserts exactly the same OVAL behavior — just in an isolated location.

## Verification

This is a test-only change. I verified mechanically (the full suite runs in CI):

- `bash -n` passes on the script.
- The `sed` substitution leaves zero `TEMP_DIR_PLACEHOLDER` occurrences and
  rewrites both `<ns3:path>` elements to the unique temp dir.
- The resulting OVAL definition is still well-formed XML.
- The `key_file` fixture is created in the temp dir as expected.

Fixes #1924
