### PR TITLE
textfilecontent54 probe: fix memory leaks in process_file

### DIFF
--- a/src/OVAL/probes/independent/textfilecontent54_probe.c
+++ b/src/OVAL/probes/independent/textfilecontent54_probe.c
@@ -229,10 +229,15 @@ static int process_file(const char *prefix, const char *path, const char *file, 
 
 		if (substr_cnt > 0) {
 			int k;
+			SEXP_t *item;
 			instance_count++;
 
-			SEXP_list_add(items, create_item(path, file, pfd->pattern,
-				instance_count, substrs, substr_cnt, over));
+			item = create_item(path, file, pfd->pattern,
+				instance_count, substrs, substr_cnt, over);
+			/* SEXP_list_add() takes its own reference, so release ours
+			 * to avoid leaking every created item. */
+			SEXP_list_add(items, item);
+			SEXP_free(item);
 
 			for (k = 0; k < substr_cnt; ++k)
 				free(substrs[k]);
@@ -278,6 +283,10 @@ static int process_file(const char *prefix, const char *path, const char *file, 
 	if (whole_path != NULL)
 		free(whole_path);
 	free(whole_path_with_prefix);
+	/* Free the accumulator list. Collected items are owned by the probe
+	 * result object; this releases the list's own references (and frees any
+	 * items that were created but not collected). */
+	SEXP_free(items);
 
 	/* coverity[leaked_storage] - substrs is not leaked */
 	return ret;


### PR DESCRIPTION
Found by fuzzing process_file() under ASan/LSan (see harnesses in https://github.com/OpenSCAP/openscap/pull/2365)

- create_item()'s returned object was passed to SEXP_list_add(), which takes its own reference, but the caller's reference was never released -> every collected item leaked. Free our reference after adding.
- The items accumulator list itself was never freed on return. Free it at cleanup; collected items are owned by the probe result object, so this only releases the list's references (and frees any uncollected items).