### PR TITLE
fix: apply tar extraction filter

### DIFF
--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -126,7 +126,7 @@ class OscapDockerScan(object):
             self.mountpoint = tempfile.mkdtemp()
             self.extracted_container = True
             with tarfile.open(fileobj=tar) as tf:
-                tf.extractall(path=self.mountpoint, filter="fully_trusted")
+                tf.extractall(path=self.mountpoint, filter="tar")
             Path(os.path.join(self.mountpoint, '.dockerenv')).touch()
 
 

--- a/utils/oscap_docker_python/oscap_docker_util.py
+++ b/utils/oscap_docker_python/oscap_docker_util.py
@@ -126,7 +126,7 @@ class OscapDockerScan(object):
             self.mountpoint = tempfile.mkdtemp()
             self.extracted_container = True
             with tarfile.open(fileobj=tar) as tf:
-                tf.extractall(path=self.mountpoint)
+                tf.extractall(path=self.mountpoint, filter="fully_trusted")
             Path(os.path.join(self.mountpoint, '.dockerenv')).touch()
 
 


### PR DESCRIPTION
Addresses #2373

Compatible Python versions:

- `~3.8.17`
- `~3.9.17`
- `~3.10.12`
- `~3.11.4`
- `>=3.12`

Therefore, this change shouldn't create any regressions for the currently [supported Python versions](https://devguide.python.org/versions/#supported-versions).
