### PR TITLE
Fix autotailor overwriting `extends` attribute from JSON tailoring

### DIFF
--- a/tests/utils/autotailor_integration_test.sh
+++ b/tests/utils/autotailor_integration_test.sh
@@ -150,6 +150,15 @@ python3 $autotailor --id-namespace "com.example.www" --json-tailoring $json_tail
 $OSCAP xccdf eval --profile CMDL_P --progress --tailoring-file $tailoring --results $result $ds
 assert_exists 1 '/Benchmark/TestResult/rule-result[@idref="xccdf_com.example.www_rule_R3"]/result[text()="pass"]'
 
+# JSON tailoring with base_profile_id must set 'extends' attribute
+python3 $autotailor $ds --id-namespace "com.example.www" --json-tailoring $json_tailoring > $tailoring
+saved_result=$result
+result=$tailoring
+assert_exists 1 '/*[local-name()="Tailoring"]/*[local-name()="Profile"][@id="xccdf_com.example.www_profile_JSON_P1"][@extends="xccdf_com.example.www_profile_P1"]'
+assert_exists 1 '/*[local-name()="Tailoring"]/*[local-name()="Profile"][@id="xccdf_com.example.www_profile_JSON_P11"][@extends="xccdf_com.example.www_profile_P1"]'
+assert_exists 0 '/*[local-name()="Tailoring"]/*[local-name()="Profile"][@id="xccdf_com.example.www_profile_JSON_P12"][@extends]'
+result=$saved_result
+
 # test --local-path option with absolute path (should use basename)
 python3 $autotailor --id-namespace "com.example.www" --local-path --select R3 $ds $original_profile > $tailoring
 saved_result=$result

--- a/utils/autotailor
+++ b/utils/autotailor
@@ -670,7 +670,8 @@ if __name__ == "__main__":
 
     if args.profile or (args.json_tailoring and args.tailored_profile_id):
         p = t.get_or_create_tailored_profile_with_id(args.tailored_profile_id)
-        p.extends = args.profile
+        if args.profile:
+            p.extends = args.profile
 
         # Validate base profile
         try:


### PR DESCRIPTION
### Summary

- Fix autotailor ignoring `base_profile_id` from JSON tailoring files when no CLI base profile is provided
- Add integration tests for the `extends` attribute preservation

#### Fix
- Guard the assignment with `if args.profile:`, so the CLI argument only overrides `extends` when explicitly provided
- When omitted, the value from JSON's `base_profile_id` is preserved
- Fixes [RHEL-182992](https://redhat.atlassian.net/browse/RHEL-182992)

#### Testing hints
- fix was manually verified on RHEL10 VM
- all tests from `autotailor_integration_test.sh`, including the newly added one, passed
