### PR TITLE
Restrict GITHUB_TOKEN permissions in CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [ main, maint-1.3 ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,8 @@ on:
   schedule:
     - cron: '32 17 * * 0'
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Add explicit read-only permissions to reduce the risk of supply chain attacks exploiting an overly privileged workflow token.