### PR TITLE
Restrict GITHUB_TOKEN permissions in CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches: [ maint-1.3 ]
 
+permissions:
+  contents: read
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,8 @@ on:
   schedule:
     - cron: '32 17 * * 0'
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Add explicit read-only permissions to reduce the risk of supply chain attacks exploiting an overly privileged workflow token.