### PR TITLE
Add .github to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
-/tests/ @jan-cerny @evgenyz @mab879 @matusmarhefka
-/CODEOWNERS @jan-cerny @evgenyz @mab879 @matusmarhefka
+/tests/ @jan-cerny @mab879 @matusmarhefka
+/CODEOWNERS @jan-cerny @mab879 @matusmarhefka
+/.github/ @jan-cerny @mab879 @matusmarhefka


### PR DESCRIPTION
Require code owners' approval for changes in the GitHub actions CI definitions to reduce risks of accidental changes and supply chain attacks.