### PR TITLE
Create GitHub Action for upstream releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,9 @@ jobs:
         submodules: recursive
     - name: Build source tarball
       run: |
-        mkdir -p build
-        cd build
         cmake ../
         make package_source
+      working-directory: ./build
     - name: Attest build provenance
       uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - '[0-9]*.[0-9]*.[0-9]*'
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+    - name: Install Deps
+      run: dnf install -y cmake git procps-ng dbus-devel libacl-devel libblkid-devel libcap-devel libcurl-devel libgcrypt-devel libselinux-devel libxml2-devel libxslt-devel libattr-devel make openldap-devel pcre2-devel perl-XML-Parser perl-XML-XPath perl-devel python3-devel python3-dbusmock rpm-devel swig bzip2-devel gcc-c++ libyaml-devel xmlsec1-devel xmlsec1-openssl-devel hostname bzip2 lua rpm-build which strace python3-pytest
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        submodules: recursive
+    - name: Build source tarball
+      run: |
+        mkdir -p build
+        cd build
+        cmake ../
+        make package_source
+    - name: Attest build provenance
+      uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4
+      with:
+        subject-path: |
+          build/openscap-*.tar.gz
+          build/openscap-*.tar.gz.sha512
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+      with:
+        files: |
+          build/openscap-*.tar.gz
+          build/openscap-*.tar.gz.sha512

--- a/release_tools/README.adoc
+++ b/release_tools/README.adoc
@@ -95,20 +95,15 @@ Use it to update the `NEWS` file and commit it.
 +
 The last commit before the release has to have the `openscap-<version>` message (e.g. `openscap-1.3.2`).
 +
-Tag the commit and push the changes to upstream. You need to be allowed to push without pull requests in the GitHub repository settings.
-+
-   git tag $version
-   git push origin main
+Submit the changes in the NEWS file as a pull request and then merge the pull request to upstream.
 
-. Create tarballs and GitHub release.
+. Create the release tag and GitHub release.
 +
-In a clean copy of the release branch run `cmake .. && make package_source` in the `build` directory.
+Go to https://github.com/OpenSCAP/openscap/releases/new[GitHub New Release page]. Create a new tag matching the version (e.g. `1.4.5`) targeting the release commit on the release branch. Add the relevant part of the NEWS file as the release description and publish the release.
 +
-Create new GitHub release with the name of the version being released.
+Publishing the release creates the tag and triggers the Release GitHub Action (`.github/workflows/release.yml`), which automatically builds the source tarball and uploads the `openscap-X.Y.Z.tar.gz` and `openscap-X.Y.Z.tar.gz.sha512` files as release assets.
 +
-Add relevant part of the NEWS file as a release description. 
-+
-Attach `openscap-X.Y.Z.tar.gz` and `openscap-X.Y.Z.tag.gz.sha512` files to the GH release, created against the release tag.
+Verify that the https://github.com/OpenSCAP/openscap/actions/workflows/release.yml[Release action] completed successfully and that the release assets are available on the https://github.com/OpenSCAP/openscap/releases[Releases page].
 
 . Run `new-release.sh $new_version`.
 +
@@ -117,7 +112,7 @@ This will handle milestones swap on GitHub and it will bump version numbers in `
 +
 Then, change the version to expected next version in `/CMakeLists.txt`
 +
-Commit and push the changes.
+Commit and submit the changes as a PR.
 
 . Generate and publish documentation.
 +


### PR DESCRIPTION
This commit updates the upstream release process and introduces a GitHub Action that performs the upstream release and creates tarball automatically.

Having an automated, ephemeral and isolated release pipeline significantly reduces risk of releasing a compromised release. It helps ensure that the release tarballs don't contain unwanted artifacts and aren't affected by compromised environment.