### PR TITLE
Fix build without crypto support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,7 +59,7 @@ if (ENABLE_PROBES)
 		)
 	endif()
 endif()
-if (HAVE_MMAN_H AND (GCRYPT_FOUND OR NSS_FOUND))
+if (HAVE_MMAN_H)
 	list(APPEND OBJECTS_TO_LINK_AGAINST
 		$<TARGET_OBJECTS:crapi_object>
 	)

--- a/src/OVAL/probes/CMakeLists.txt
+++ b/src/OVAL/probes/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory("SEAP")
 add_subdirectory("probe")
 
-if (HAVE_MMAN_H AND CRYPTO_FOUND)
+if (HAVE_MMAN_H)
 	add_subdirectory("crapi")
 endif()
 

--- a/src/OVAL/probes/crapi/CMakeLists.txt
+++ b/src/OVAL/probes/crapi/CMakeLists.txt
@@ -1,4 +1,9 @@
-file(GLOB_RECURSE CRAPI_SOURCES "*.c")
+if (CRYPTO_FOUND)
+	file(GLOB_RECURSE CRAPI_SOURCES "*.c")
+else()
+	# crapi_init has a no-op implementation for builds without a digest backend.
+	set(CRAPI_SOURCES "crapi.c")
+endif()
 file(GLOB_RECURSE CRAPI_HEADERS "*.h")
 
 add_library(crapi_object OBJECT ${CRAPI_SOURCES} ${CRAPI_HEADERS})


### PR DESCRIPTION
## Summary

- always build and link the CRAPI object on platforms with mmap support
- compile only the no-op `crapi.c` implementation when no digest backend is available
- keep the full CRAPI source set when Gcrypt or NSS is enabled

This lets non-crypto builds provide `crapi_init` without compiling digest code that requires a crypto backend.

Fixes #2310.

## Testing

Reproduced the failure on the unmodified commit: building the `oscap` target without Gcrypt fails to link with `undefined reference to 'crapi_init'`.

The patched tree builds successfully with:

```sh
cmake -DCMAKE_DISABLE_FIND_PACKAGE_GCrypt=TRUE \
  -DENABLE_OSCAP_UTIL_DOCKER=OFF \
  -DENABLE_TESTS=OFF ..
cmake --build . -j2
```

This builds `libopenscap`, `libopenscap_sce`, and the `oscap` CLI.