### PR TITLE
Generate raw partitioning mode in blueprints

### DIFF
--- a/src/XCCDF_POLICY/xccdf_policy_remediate.c
+++ b/src/XCCDF_POLICY/xccdf_policy_remediate.c
@@ -1156,6 +1156,8 @@ static int _write_script_header_to_fd(struct xccdf_policy *policy, struct xccdf_
 			"name = \"hardened_%s\"\n"
 			"description = \"%s\"\n"
 			"version = \"%s\"\n\n"
+			"[customizations]\n"
+			"partitioning_mode = \"raw\"\n\n"
 			"[customizations.openscap]\n"
 			"profile_id = \"%s\"\n"
 			"# If your hardening data stream is not part of the 'scap-security-guide' package\n"

--- a/tests/API/XCCDF/unittests/test_remediation_blueprint.toml
+++ b/tests/API/XCCDF/unittests/test_remediation_blueprint.toml
@@ -23,6 +23,9 @@ name = "hardened_xccdf_moc.elpmaxe.www_profile_common"
 description = "Profile title on one line"
 version = "1.0"
 
+[customizations]
+partitioning_mode = "raw"
+
 [customizations.openscap]
 profile_id = "xccdf_moc.elpmaxe.www_profile_common"
 # If your hardening data stream is not part of the 'scap-security-guide' package


### PR DESCRIPTION
Emit partitioning_mode = "raw" in generated Image Builder blueprints so composer produces raw disk images instead of qcow2 output.

Update the blueprint remediation golden fixture to cover the generated customizations section.

Fixes #2334.

(cherry picked from commit 80b7c64f952ad1345036a63b069e361ede4305e8)