### PR TITLE
Set project as C project in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 		"MinSizeRel" "RelWithDebInfo")
 endif()
 
-project("openscap")
+project("openscap" C)
 set(OPENSCAP_VERSION_MAJOR "1")
 set(OPENSCAP_VERSION_MINOR "3")
 set(OPENSCAP_VERSION_PATCH "15")


### PR DESCRIPTION
Hello,
this small PR just aims to backport to the maint-1.3 branch the fix that has been merged a few months ago to enforce the project as C project (and so, to get rid of a configuration failure when using a non-C++ toolchain), hoping to see this fix eventually released in a 1.3.X version

EDIT: to clarify, I have checked-out the maint-1.3 branch, created a new branch from it, and cherry-picked bbfb2d7b00cbb8e08d999546734d3ba6ae150736 from the main branch