### PR TITLE
Fix test test_sysctl_probe_all.sh

### DIFF
--- a/tests/probes/sysctl/test_sysctl_probe_all.sh
+++ b/tests/probes/sysctl/test_sysctl_probe_all.sh
@@ -49,7 +49,7 @@ function perform_test {
 			# sysctl has duplicities in output
 			# hide permission errors like: "sysctl: permission denied on key 'fs.protected_hardlinks'"
 			# kernel parameters might use "/" and "." separators interchangeably - normalizing
-			sysctl -a --deprecated 2> /dev/null | tr "/" "." | cut -d "=" -f 1 | tr -d " " | sort -u > "$sysctlNames"
+			sysctl -a --deprecated 2> /dev/null | tr "/" "." | cut -d "=" -f 1 | tr -d " " | sort -u > "$sysctlNames" || true
 			;;
 		*)
 			return 255


### PR DESCRIPTION
The test `probes/sysctl/test_sysctl_probe_all.sh` fails in CI on Rawhide. The root cause is that the exit code of the `sysctl` command is 1, which causes the test script to termianate because it has `set -e -o pipefail`.