### PR TITLE
Fix groff warning for nested "tagged paragraph"

### DIFF
--- a/utils/oscap.8
+++ b/utils/oscap.8
@@ -539,7 +539,6 @@ Write OVAL System Characteristic into file.
 .TP
 \fB\-\-skip-validation\fR
 Do not validate input/output files.
-.TP
 .RE
 
 .TP


### PR DESCRIPTION
Warning can be reprodused with this command:
LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 \
    man --warnings -E UTF-8 -l -Tutf8 -Z utils/oscap.8 >/dev/null

One paragraph is indented differently after this fix is implemented.